### PR TITLE
Reduce wallet disk usage issue 14

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,8 +71,10 @@ pub async fn initialize(cli_args: cli_args::Args) -> Result<()> {
     DataDirectory::create_dir_if_not_exists(&wallet_dir)?;
     let (wallet_secret, _) =
         WalletSecret::read_from_file_or_create(&data_dir.wallet_directory_path())?;
+    info!("Now getting wallet state. This may take a while if the database needs pruning.");
     let wallet_state =
         WalletState::new_from_wallet_secret(Some(&data_dir), wallet_secret, &cli_args).await;
+    info!("Got wallet state.");
 
     // Connect to or create databases for block index, peers, mutator set, block sync
     let block_index_db = ArchivalState::initialize_block_index_database(&data_dir)?;

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -1136,6 +1136,13 @@ impl MainLoopHandler {
     }
 
     async fn resync_membership_proofs(&self) -> Result<()> {
+        // Do not fix memberhip proofs if node is in sync mode, as we would otherwise
+        // have to sync many times, instead of just *one* time once we have caught up.
+        if *self.global_state.net.syncing.read().unwrap() {
+            debug!("Not syncing MS membership proofs because we are syncing");
+            return Ok(());
+        }
+
         // is it necessary?
         let current_tip_digest = self
             .global_state

--- a/src/models/state/wallet/rusty_wallet_database.rs
+++ b/src/models/state/wallet/rusty_wallet_database.rs
@@ -91,6 +91,16 @@ impl StorageWriter<RustyKey, RustyValue> for RustyWalletDatabase {
             .expect("RustyWallet: StorageWriter -- could not get lock on database for writing.")
             .write(write_batch, true)
             .expect("Could not persist to database.");
+
+        // Calling `flush` here *seems* to reduce the used disk space, although I cannot quite
+        // explain why. See https://github.com/Neptune-Crypto/neptune-core/issues/14 for a
+        // discussion. Either way, calling `flush` explicitly here shouldn't incur a huge
+        // overhead, so the downside is limited.
+        self.db
+            .lock()
+            .expect("Must be able to acquire DB lock in persist")
+            .flush()
+            .expect("Flushing must succeed in persist");
     }
 
     fn restore_or_new(&mut self) {


### PR DESCRIPTION
- flush DB explicitly as this seems to reduce the size used by the wallet DB, see #14 
- Add some log output on startup before and after a step of the startup that might take a long time
- Only attempt to resync mutator set membership proofs once the client is caught up, i.e. has the most canonical tip known to peers.