### PR TITLE
add shell tab completions feature to neptune-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,6 +472,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4110a1e6af615a9e6d0a36f805d5c99099f8bab9b8042f5bc1fa220a4a89e36f"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1303,6 +1312,7 @@ dependencies = [
  "cargo-husky",
  "chrono",
  "clap",
+ "clap_complete",
  "crossterm",
  "directories",
  "field_count",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ triton-vm = "0.33.0"
 twenty-first = "0.32.1"
 tui = "0"
 unicode-width = "0"
+clap_complete = "4.4.1"
 
 [dev-dependencies]
 pin-project-lite = "0.2.12"

--- a/install-bash-completions.sh
+++ b/install-bash-completions.sh
@@ -1,0 +1,9 @@
+SCRIPT="$HOME/.bash_neptune_cli"
+LINE="source $SCRIPT"
+FILE="$HOME/.bashrc"
+
+cargo run --bin neptune-cli -- completions > $SCRIPT && \
+grep -qF -- "$LINE" "$FILE" || echo "$LINE" >> "$FILE" && \
+source $SCRIPT && \
+echo "completions installed to $SCRIPT and added to $FILE"
+

--- a/src/bin/neptune-cli.rs
+++ b/src/bin/neptune-cli.rs
@@ -1,5 +1,6 @@
-use anyhow::Result;
-use clap::Parser;
+use anyhow::{bail, Result};
+use clap::{CommandFactory, Parser};
+use clap_complete::{generate, Shell};
 
 use neptune_core::config_models::network::Network;
 use neptune_core::models::blockchain::transaction::amount::Amount;
@@ -11,6 +12,7 @@ use tarpc::{client, context, tokio_serde::formats::Json};
 
 use neptune_core::models::state::wallet::wallet_status::WalletStatus;
 use neptune_core::rpc_server::RPCClient;
+use std::io::stdout;
 use twenty_first::shared_math::digest::Digest;
 
 #[derive(Debug, Parser)]
@@ -40,6 +42,9 @@ enum Command {
     MempoolTxCount,
     MempoolSize,
     PruneAbandonedMonitoredUtxos,
+
+    /// Dump shell completions.
+    Completions,
 }
 
 #[derive(Debug, Parser)]
@@ -157,6 +162,14 @@ async fn main() -> Result<()> {
                 .prune_abandoned_monitored_utxos(context::current())
                 .await?;
             println!("{prunt_res_count} monitored UTXOs marked as abandoned");
+        }
+
+        Command::Completions => {
+            if let Some(shell) = Shell::from_env() {
+                generate(shell, &mut Config::command(), "neptune-cli", &mut stdout());
+            } else {
+                bail!("Unknown shell.  Shell completions not available.")
+            }
         }
     }
 


### PR DESCRIPTION
addresses #43

Add `completions` sub-command that prints out completion code for present shell. Eg in bash do:

    neptune-cli completions > ~/.bash_neptune_cli
    echo "source ~/.bash_neptune_cli" >> ~/.bashrc

Supports bash, elvish, fish, powershell, zsh

Adds dependency on crate [clap_complete](https://docs.rs/clap_complete/latest/clap_complete/).

Notes:
* The present implementation is intended to make neptune-cli more ergonomic during development.
* `clap_complete` also supports compile time generation of completion shell scripts using build.rs.  Useful when installing binary for end user.  That solution is a little more complex, perhaps in the future and/or we can discuss if its worth doing in this PR.
* The `clap` project is working on a completion overhaul that would enable dynamic shell completion by invoking the binary from the shell with a special hidden flag.  That should be a better solution once available.  See:
  https://github.com/clap-rs/clap/issues/1232 and 
  https://github.com/clap-rs/clap/issues/3166
* We could possibly hide this behind a `completions` feature flag to enable building without the clap_complete crate.   Please let me know if this is desired.
* I did not add completions for other binaries such as neptune-core.  I figured I would see how this PR is received first.