### PR TITLE
Fix clippy warnings pr

### DIFF
--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -909,7 +909,7 @@ impl MainLoopHandler {
 
         // List of digests, ordered after which block we would like to find descendents from,
         // from highest to lowest.
-        let most_canonical_digests = vec![vec![tip_digest], most_canonical_digests].concat();
+        let most_canonical_digests = [vec![tip_digest], most_canonical_digests].concat();
 
         // Send message to the relevant peer loop to request the blocks
         let chosen_peer = chosen_peer.unwrap();

--- a/src/models/blockchain/transaction/mod.rs
+++ b/src/models/blockchain/transaction/mod.rs
@@ -277,8 +277,10 @@ impl Transaction {
         let merged_kernel = TransactionKernel {
             inputs: [self.kernel.inputs, other.kernel.inputs].concat(),
             outputs: [self.kernel.outputs, other.kernel.outputs].concat(),
-            pubscript_hashes_and_inputs: [self.kernel.pubscript_hashes_and_inputs,
-                other.kernel.pubscript_hashes_and_inputs]
+            pubscript_hashes_and_inputs: [
+                self.kernel.pubscript_hashes_and_inputs,
+                other.kernel.pubscript_hashes_and_inputs,
+            ]
             .concat(),
             fee: self.kernel.fee + other.kernel.fee,
             coinbase: merged_coinbase,
@@ -289,20 +291,30 @@ impl Transaction {
         let merged_witness = match (&self.witness, &other.witness) {
             (Witness::Primitive(self_witness), Witness::Primitive(other_witness)) => {
                 Witness::Primitive(PrimitiveWitness {
-                    input_utxos: [self_witness.input_utxos.clone(),
-                        other_witness.input_utxos.clone()]
+                    input_utxos: [
+                        self_witness.input_utxos.clone(),
+                        other_witness.input_utxos.clone(),
+                    ]
                     .concat(),
-                    lock_script_witnesses: [self_witness.lock_script_witnesses.clone(),
-                        other_witness.lock_script_witnesses.clone()]
+                    lock_script_witnesses: [
+                        self_witness.lock_script_witnesses.clone(),
+                        other_witness.lock_script_witnesses.clone(),
+                    ]
                     .concat(),
-                    input_membership_proofs: [self_witness.input_membership_proofs.clone(),
-                        other_witness.input_membership_proofs.clone()]
+                    input_membership_proofs: [
+                        self_witness.input_membership_proofs.clone(),
+                        other_witness.input_membership_proofs.clone(),
+                    ]
                     .concat(),
-                    output_utxos: [self_witness.output_utxos.clone(),
-                        other_witness.output_utxos.clone()]
+                    output_utxos: [
+                        self_witness.output_utxos.clone(),
+                        other_witness.output_utxos.clone(),
+                    ]
                     .concat(),
-                    pubscripts: [self_witness.pubscripts.clone(),
-                        other_witness.pubscripts.clone()]
+                    pubscripts: [
+                        self_witness.pubscripts.clone(),
+                        other_witness.pubscripts.clone(),
+                    ]
                     .concat(),
                     mutator_set_accumulator: self_witness.mutator_set_accumulator.clone(),
                     input_lock_scripts: [

--- a/src/models/blockchain/transaction/mod.rs
+++ b/src/models/blockchain/transaction/mod.rs
@@ -275,12 +275,10 @@ impl Transaction {
         };
 
         let merged_kernel = TransactionKernel {
-            inputs: vec![self.kernel.inputs, other.kernel.inputs].concat(),
-            outputs: vec![self.kernel.outputs, other.kernel.outputs].concat(),
-            pubscript_hashes_and_inputs: vec![
-                self.kernel.pubscript_hashes_and_inputs,
-                other.kernel.pubscript_hashes_and_inputs,
-            ]
+            inputs: [self.kernel.inputs, other.kernel.inputs].concat(),
+            outputs: [self.kernel.outputs, other.kernel.outputs].concat(),
+            pubscript_hashes_and_inputs: [self.kernel.pubscript_hashes_and_inputs,
+                other.kernel.pubscript_hashes_and_inputs]
             .concat(),
             fee: self.kernel.fee + other.kernel.fee,
             coinbase: merged_coinbase,
@@ -291,30 +289,20 @@ impl Transaction {
         let merged_witness = match (&self.witness, &other.witness) {
             (Witness::Primitive(self_witness), Witness::Primitive(other_witness)) => {
                 Witness::Primitive(PrimitiveWitness {
-                    input_utxos: vec![
-                        self_witness.input_utxos.clone(),
-                        other_witness.input_utxos.clone(),
-                    ]
+                    input_utxos: [self_witness.input_utxos.clone(),
+                        other_witness.input_utxos.clone()]
                     .concat(),
-                    lock_script_witnesses: vec![
-                        self_witness.lock_script_witnesses.clone(),
-                        other_witness.lock_script_witnesses.clone(),
-                    ]
+                    lock_script_witnesses: [self_witness.lock_script_witnesses.clone(),
+                        other_witness.lock_script_witnesses.clone()]
                     .concat(),
-                    input_membership_proofs: vec![
-                        self_witness.input_membership_proofs.clone(),
-                        other_witness.input_membership_proofs.clone(),
-                    ]
+                    input_membership_proofs: [self_witness.input_membership_proofs.clone(),
+                        other_witness.input_membership_proofs.clone()]
                     .concat(),
-                    output_utxos: vec![
-                        self_witness.output_utxos.clone(),
-                        other_witness.output_utxos.clone(),
-                    ]
+                    output_utxos: [self_witness.output_utxos.clone(),
+                        other_witness.output_utxos.clone()]
                     .concat(),
-                    pubscripts: vec![
-                        self_witness.pubscripts.clone(),
-                        other_witness.pubscripts.clone(),
-                    ]
+                    pubscripts: [self_witness.pubscripts.clone(),
+                        other_witness.pubscripts.clone()]
                     .concat(),
                     mutator_set_accumulator: self_witness.mutator_set_accumulator.clone(),
                     input_lock_scripts: [

--- a/src/models/blockchain/transaction/utxo.rs
+++ b/src/models/blockchain/transaction/utxo.rs
@@ -129,7 +129,7 @@ impl LockScript {
     pub fn anyone_can_spend() -> Self {
         Self {
             program: Program::new(
-                &vec![triton_asm![read_io; DIGEST_LENGTH], triton_asm!(halt)].concat(),
+                &[triton_asm![read_io; DIGEST_LENGTH], triton_asm!(halt)].concat(),
             ),
         }
     }
@@ -226,7 +226,7 @@ mod utxo_tests {
             .filter(|name| !difficult_instructions.contains(name))
             .collect_vec();
 
-        let generators = vec![vec!["simple"], difficult_instructions].concat();
+        let generators = [vec!["simple"], difficult_instructions].concat();
         // Test difficult instructions more frequently.
         let weights = vec![simple_instructions.len(), 2, 6, 6, 2, 10];
 

--- a/src/models/blockchain/transaction/validity/tasm/compute_indices.rs
+++ b/src/models/blockchain/transaction/validity/tasm/compute_indices.rs
@@ -394,7 +394,7 @@ mod tests {
         // test against rust shadow
         let rust_index_sets = items
             .into_iter()
-            .zip(membership_proofs.into_iter())
+            .zip(membership_proofs)
             .map(|(item, mp)| {
                 get_swbf_indices::<Hash>(
                     &item,

--- a/src/models/state/archival_state.rs
+++ b/src/models/state/archival_state.rs
@@ -650,7 +650,7 @@ impl ArchivalState {
                     block_db_lock,
                 )
             };
-        let forwards = vec![forwards, vec![new_block.hash]].concat();
+        let forwards = [forwards, vec![new_block.hash]].concat();
 
         for digest in backwards {
             // Roll back mutator set

--- a/src/models/state/wallet/address/generation_address.rs
+++ b/src/models/state/wallet/address/generation_address.rs
@@ -348,7 +348,7 @@ impl ReceivingAddress {
         let mut ciphertext = vec![GENERATION_FLAG, self.receiver_identifier];
         ciphertext.append(&mut self.encrypt(utxo, sender_randomness)?);
 
-        let pubscript = vec![triton_asm![read_io; ciphertext.len()], triton_asm!(halt)].concat();
+        let pubscript = [triton_asm![read_io; ciphertext.len()], triton_asm!(halt)].concat();
 
         Ok((pubscript.into(), ciphertext))
     }
@@ -379,7 +379,7 @@ impl ReceivingAddress {
         // ]
         // .concat();
 
-        let mut instructions = vec![
+        let mut instructions = [
             vec![triton_instr!(divine); DIGEST_LENGTH],
             triton_asm!(hash),
             vec![triton_instr!(pop); DIGEST_LENGTH],

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -265,7 +265,7 @@ impl WalletState {
         // TODO: These spending keys should probably be derived dynamically from some
         // state in the wallet. And we should allow for other types than just generation
         // addresses.
-        let spending_keys = vec![self.wallet_secret.nth_generation_spending_key(0)];
+        let spending_keys = [self.wallet_secret.nth_generation_spending_key(0)];
 
         // get recognized UTXOs
         let recognized_utxos = spending_keys

--- a/src/util_types/mutator_set/ms_membership_proof.rs
+++ b/src/util_types/mutator_set/ms_membership_proof.rs
@@ -223,9 +223,11 @@ impl<H: AlgebraicHasher + BFieldCodec> MsMembershipProof<H> {
 
         // Gather the indices the are returned. These indices indicate which membership
         // proofs that have been mutated.
-        let mut all_mutated_mp_indices: Vec<usize> = [swbf_mutated_indices,
+        let mut all_mutated_mp_indices: Vec<usize> = [
+            swbf_mutated_indices,
             indices_for_updated_mps,
-            mps_for_new_chunk_dictionary_entry]
+            mps_for_new_chunk_dictionary_entry,
+        ]
         .concat();
         all_mutated_mp_indices.sort_unstable();
         all_mutated_mp_indices.dedup();

--- a/src/util_types/mutator_set/ms_membership_proof.rs
+++ b/src/util_types/mutator_set/ms_membership_proof.rs
@@ -223,11 +223,9 @@ impl<H: AlgebraicHasher + BFieldCodec> MsMembershipProof<H> {
 
         // Gather the indices the are returned. These indices indicate which membership
         // proofs that have been mutated.
-        let mut all_mutated_mp_indices: Vec<usize> = vec![
-            swbf_mutated_indices,
+        let mut all_mutated_mp_indices: Vec<usize> = [swbf_mutated_indices,
             indices_for_updated_mps,
-            mps_for_new_chunk_dictionary_entry,
-        ]
+            mps_for_new_chunk_dictionary_entry]
         .concat();
         all_mutated_mp_indices.sort_unstable();
         all_mutated_mp_indices.dedup();

--- a/src/util_types/test_shared/mutator_set.rs
+++ b/src/util_types/test_shared/mutator_set.rs
@@ -212,11 +212,7 @@ pub fn pseudorandom_mmra_with_mps<H: AlgebraicHasher>(
             (original_index, mmr_index, mt_index, peak_index)
         })
         .collect_vec();
-    let leafs_and_indices = leafs
-        .iter()
-        .copied()
-        .zip(leaf_indices)
-        .collect_vec();
+    let leafs_and_indices = leafs.iter().copied().zip(leaf_indices).collect_vec();
 
     // iterate over all trees
     let mut peaks = vec![];

--- a/src/util_types/test_shared/mutator_set.rs
+++ b/src/util_types/test_shared/mutator_set.rs
@@ -215,7 +215,7 @@ pub fn pseudorandom_mmra_with_mps<H: AlgebraicHasher>(
     let leafs_and_indices = leafs
         .iter()
         .copied()
-        .zip(leaf_indices.into_iter())
+        .zip(leaf_indices)
         .collect_vec();
 
     // iterate over all trees


### PR DESCRIPTION
Addresses #45

* Fixes clippy warnings about unnecessary vec![] and Arc<RefCell<..>>
* Applies cargo fmt

With this patch applied, both these commands run cleanly:

```
$ cargo clippy --all-features --all-targets
$ cargo fmt --check
```

Notes:
* running cargo version `1.72.0 (103a7ff2e 2023-08-15)`
* Changed all occurences of Arc<RefCell<..>> to Arc<Mutex<..>>.  These were only in the Dashboard.

Testing:
* Verified that Dashboard runs and navigated all screens
* ran `cargo test` without error