### PR TITLE
add a page with link to UML diagrams.

### DIFF
--- a/developer_docs/uml_diagrams.md
+++ b/developer_docs/uml_diagrams.md
@@ -1,0 +1,1 @@
+Some UML diagrams of neptune-core and related crates are available at [tinyurl.com/neptune-diagrams](https://tinyurl.com/neptune-diagrams).


### PR DESCRIPTION
Hi, as an aid to learning the code/data layout I generated some UML diagrams for neptune-core and related crates.  

The diagrams can be viewed at [tinyurl.com/neptune-diagrams](https://tinyurl.com/neptune-diagrams).

I thought they might be useful for other developers onboarding, hence this PR.

------------

**Notes**
This PR add a 1 line markdown file with a link to the UML diagrams.

The diagrams are being auto-generated and pushed to github nightly in a repo of mine.

If there are any other related/relevant crates you think I should add, please let me know.
The present list is neptune-core, twenty-first, tasm-lib, tasm-lang, triton-vm.

If you should wish to have the diagrams under the Neptune-Crypto account, you could fork my neptune-diagrams repo and either grant me push access, or run the generator yourself from cron.   The cron command looks like:

```
0 2 * * * /path/to/ml/contrib/autogen/gen_and_push_to_github.php git@github.com:dan-da/neptune-diagrams.git  /path/to/neptune_diagrams/neptune-crates.json 2>&1 > /tmp/neptune-diagrams.log```
```

Please note the diagrams tend to be more readable with smaller crates.   The 'bare' diagrams are easiest for seeing relations between entities while 'compact' and 'full' are useful for seeing data fields and member functions respectively.

