### PR TITLE
make completions command work without server connection

### DIFF
--- a/scripts/install-bash-completions.sh
+++ b/scripts/install-bash-completions.sh
@@ -1,9 +1,11 @@
+set -e
+
 SCRIPT="$HOME/.bash_neptune_cli"
 LINE="source $SCRIPT"
 FILE="$HOME/.bashrc"
 
-cargo run --bin neptune-cli -- completions > $SCRIPT && \
-grep -qF -- "$LINE" "$FILE" || echo "$LINE" >> "$FILE" && \
-source $SCRIPT && \
+cargo run --bin neptune-cli -- completions > $SCRIPT
+grep -qF -- "$LINE" "$FILE" || echo "$LINE" >> "$FILE"
+source $SCRIPT
 echo "completions installed to $SCRIPT and added to $FILE"
 


### PR DESCRIPTION
Addresses https://github.com/Neptune-Crypto/neptune-core/pull/44#issuecomment-1732285455

In neptune-cli:

  * process completions command before connecting to server.

In install-bash-completions.sh:

  * modify error handling so error on any line will abort script.