### PR TITLE
update derive-where dep to v1.2.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,9 +683,9 @@ checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
 
 [[package]]
 name = "derive-where"
-version = "1.2.3"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875a0460143f2dbcc71fd8a63f34b7c83ac66f14bead94054e7cd619c57bbb27"
+checksum = "146398d62142a0f35248a608f17edf0dde57338354966d6e41d0eb2d16980ccb"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
Addresses #50.

Cargo.lock was referencing yanked derive-where v1.2.3.

ran `cargo update -p derive-where` to update lock file.

Testing:

1. `cargo audit` no longer reports any warning for derive-where
2. `cargo test` passes tests.