### PR TITLE
Change tui dep to ratatui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,11 +632,27 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
 dependencies = [
  "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags 2.4.0",
  "crossterm_winapi",
  "libc",
  "mio",
@@ -1313,7 +1329,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
- "crossterm",
+ "crossterm 0.27.0",
  "directories",
  "field_count",
  "futures",
@@ -1326,6 +1342,7 @@ dependencies = [
  "pin-project-lite",
  "priority-queue",
  "rand 0.8.5",
+ "ratatui",
  "rusty-leveldb",
  "semver",
  "serde",
@@ -1343,7 +1360,6 @@ dependencies = [
  "tracing-subscriber",
  "tracing-test",
  "triton-vm",
- "tui",
  "twenty-first",
  "unicode-width",
 ]
@@ -1847,6 +1863,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcc0d032bccba900ee32151ec0265667535c230169f5a011154cdcd984e16829"
+dependencies = [
+ "bitflags 1.3.2",
+ "cassowary",
+ "crossterm 0.26.1",
+ "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]
@@ -2548,19 +2577,6 @@ dependencies = [
  "strum",
  "strum_macros",
  "twenty-first",
- "unicode-width",
-]
-
-[[package]]
-name = "tui"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccdd26cbd674007e649a272da4475fb666d3aa0ad0531da7136db6fab0e5bad1"
-dependencies = [
- "bitflags 1.3.2",
- "cassowary",
- "crossterm",
- "unicode-segmentation",
  "unicode-width",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ bytes = "1"
 bytesize = "1"
 chrono = "^0.4.26"
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4.4.1"
 crossterm = "0"
 directories = "5"
 field_count = "0.1.1"
@@ -33,6 +34,7 @@ num-traits = "0"
 num-rational = "0"
 priority-queue = "1"
 rand = "0.8"
+ratatui = "0.20.0"
 rusty-leveldb = "2"
 semver = "^1.0.18"
 serde = { version = "1", features = ["derive"] }
@@ -55,9 +57,7 @@ tracing-subscriber = { version = "0", features = [
 tracing-test = "0"
 triton-vm = "0.33.0"
 twenty-first = "0.32.1"
-tui = "0"
 unicode-width = "0"
-clap_complete = "4.4.1"
 
 [dev-dependencies]
 pin-project-lite = "0.2.12"

--- a/src/bin/dashboard_src/dashboard_app.rs
+++ b/src/bin/dashboard_src/dashboard_app.rs
@@ -5,6 +5,14 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use neptune_core::{config_models::network::Network, rpc_server::RPCClient};
+use ratatui::{
+    backend::{Backend, CrosstermBackend},
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Modifier, Style},
+    text::{Span, Spans, Text},
+    widgets::{Block, Borders, List, ListItem, Paragraph},
+    Frame, Terminal,
+};
 use std::{
     cell::{RefCell, RefMut},
     collections::HashMap,
@@ -18,14 +26,6 @@ use std::{
 use strum::{EnumCount, IntoEnumIterator};
 use strum_macros::{EnumCount, EnumIter};
 use tokio::{sync::Mutex, time::sleep};
-use tui::{
-    backend::{Backend, CrosstermBackend},
-    layout::{Constraint, Direction, Layout},
-    style::{Color, Modifier, Style},
-    text::{Span, Spans, Text},
-    widgets::{Block, Borders, List, ListItem, Paragraph},
-    Frame, Terminal,
-};
 
 use super::{
     history_screen::HistoryScreen, overview_screen::OverviewScreen, peers_screen::PeersScreen,

--- a/src/bin/dashboard_src/history_screen.rs
+++ b/src/bin/dashboard_src/history_screen.rs
@@ -12,14 +12,14 @@ use neptune_core::{
     rpc_server::RPCClient,
 };
 use num_traits::{CheckedSub, Zero};
-use tarpc::context;
-use tokio::time::sleep;
-use tokio::{select, task::JoinHandle};
-use tui::{
+use ratatui::{
     layout::{Constraint, Margin},
     style::{Color, Style},
     widgets::{Block, Borders, Cell, Row, Table, Widget},
 };
+use tarpc::context;
+use tokio::time::sleep;
+use tokio::{select, task::JoinHandle};
 use unicode_width::UnicodeWidthStr;
 
 type BalanceUpdate = (Duration, Amount, Sign, Amount);
@@ -131,7 +131,7 @@ impl Screen for HistoryScreen {
 }
 
 impl Widget for HistoryScreen {
-    fn render(self, area: tui::layout::Rect, buf: &mut tui::buffer::Buffer) {
+    fn render(self, area: ratatui::layout::Rect, buf: &mut ratatui::buffer::Buffer) {
         // history box
         let style: Style = if self.in_focus {
             Style::default().fg(Color::LightCyan).bg(self.bg)

--- a/src/bin/dashboard_src/overview_screen.rs
+++ b/src/bin/dashboard_src/overview_screen.rs
@@ -15,13 +15,13 @@ use neptune_core::models::blockchain::shared::Hash;
 use neptune_core::models::blockchain::transaction::amount::Amount;
 use neptune_core::rpc_server::RPCClient;
 use num_traits::Zero;
-use tarpc::context;
-use tokio::{select, task::JoinHandle, time};
-use tui::{
+use ratatui::{
     layout::{Margin, Rect},
     style::{Color, Style},
     widgets::{Block, Borders, List, ListItem, Widget},
 };
+use tarpc::context;
+use tokio::{select, task::JoinHandle, time};
 use twenty_first::util_types::algebraic_hasher::AlgebraicHasher;
 use twenty_first::util_types::emojihash_trait::Emojihash;
 
@@ -314,7 +314,7 @@ impl VerticalRectifier {
 }
 
 impl Widget for OverviewScreen {
-    fn render(self, area: tui::layout::Rect, buf: &mut tui::buffer::Buffer) {
+    fn render(self, area: ratatui::layout::Rect, buf: &mut ratatui::buffer::Buffer) {
         // overview box
         let style: Style = if self.in_focus {
             Style::default().fg(Color::LightCyan).bg(self.bg)

--- a/src/bin/dashboard_src/peers_screen.rs
+++ b/src/bin/dashboard_src/peers_screen.rs
@@ -8,14 +8,14 @@ use super::{dashboard_app::DashboardEvent, screen::Screen};
 use chrono::{DateTime, Utc};
 use itertools::Itertools;
 use neptune_core::{models::peer::PeerInfo, rpc_server::RPCClient};
-use tarpc::context;
-use tokio::time::sleep;
-use tokio::{select, task::JoinHandle};
-use tui::{
+use ratatui::{
     layout::{Constraint, Margin},
     style::{Color, Style},
     widgets::{Block, Borders, Cell, Row, Table, Widget},
 };
+use tarpc::context;
+use tokio::time::sleep;
+use tokio::{select, task::JoinHandle};
 use unicode_width::UnicodeWidthStr;
 
 #[derive(Debug, Clone)]
@@ -140,7 +140,7 @@ impl Screen for PeersScreen {
 }
 
 impl Widget for PeersScreen {
-    fn render(self, area: tui::layout::Rect, buf: &mut tui::buffer::Buffer) {
+    fn render(self, area: ratatui::layout::Rect, buf: &mut ratatui::buffer::Buffer) {
         // overview box
         let style: Style = if self.in_focus {
             Style::default().fg(Color::LightCyan).bg(self.bg)

--- a/src/bin/dashboard_src/receive_screen.rs
+++ b/src/bin/dashboard_src/receive_screen.rs
@@ -11,13 +11,13 @@ use super::{
 };
 use crossterm::event::{Event, KeyCode};
 use neptune_core::{config_models::network::Network, rpc_server::RPCClient};
-use tarpc::context;
-use tui::{
+use ratatui::{
     layout::{Alignment, Margin},
     style::{Color, Style},
     text::{Span, Spans, Text},
     widgets::{Block, Borders, Paragraph, Widget},
 };
+use tarpc::context;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum Sign {
@@ -150,7 +150,7 @@ impl Screen for ReceiveScreen {
 }
 
 impl Widget for ReceiveScreen {
-    fn render(self, area: tui::layout::Rect, buf: &mut tui::buffer::Buffer) {
+    fn render(self, area: ratatui::layout::Rect, buf: &mut ratatui::buffer::Buffer) {
         // receive box
         let style: Style = if self.in_focus {
             Style::default().fg(Color::LightCyan).bg(self.bg)

--- a/src/bin/dashboard_src/send_screen.rs
+++ b/src/bin/dashboard_src/send_screen.rs
@@ -18,14 +18,14 @@ use neptune_core::{
 };
 
 use num_traits::Zero;
-use tarpc::context;
-use tokio::{sync::Mutex, time::sleep};
-use tui::{
+use ratatui::{
     layout::{Alignment, Margin},
     style::{Color, Modifier, Style},
     text::{Span, Spans, Text},
     widgets::{Block, Borders, Paragraph, Widget},
 };
+use tarpc::context;
+use tokio::{sync::Mutex, time::sleep};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SendScreenWidget {
@@ -302,7 +302,7 @@ impl Screen for SendScreen {
 }
 
 impl Widget for SendScreen {
-    fn render(self, area: tui::layout::Rect, buf: &mut tui::buffer::Buffer) {
+    fn render(self, area: ratatui::layout::Rect, buf: &mut ratatui::buffer::Buffer) {
         let own_focus = if let Ok(of) = self.focus.try_lock() {
             of.to_owned()
         } else {


### PR DESCRIPTION
Addresses #52

Cargo.toml:

* removes tui dep
* adds ratatui 0.20.0 dep

Also updates dashboard src files to use ratatui instead of tui.

Testing:

Ran neptune-dashboard and verified that all screen/tabs load and appear to look correct.

Notes:
* tui is [unmaintained](https://github.com/fdehau/tui-rs/issues/654).
* ratatui v0.20.0 appears to be drop-in replacement for tui 0.19.0.   It builds and runs without error.
* ratatui v.0.21.0 and above deprecate some things and do not compile cleanly for the dashboard, so minor work will be required should we wish to use a later version.  For now though I prefer to keep the PR small so its easier to review.
* I opted to change `tui` references in code rather than aliasing `ratatui` to `tui` in Cargo.toml.
