### PR TITLE
add get_confirmations() RPC and add to dashboard

### DIFF
--- a/src/bin/dashboard_src/overview_screen.rs
+++ b/src/bin/dashboard_src/overview_screen.rs
@@ -31,7 +31,7 @@ use super::screen::Screen;
 #[derive(Debug, Clone)]
 pub struct OverviewData {
     synced_balance: Option<Amount>,
-    confirmations: Option<usize>,
+    confirmations: Option<u64>,
     synchronization_percentage: Option<f64>,
 
     network: Network,
@@ -199,6 +199,7 @@ impl OverviewScreen {
                                 own_overview_data.syncing=resp.syncing;
                                 own_overview_data.synced_balance = Some(resp.synced_balance);
                                 own_overview_data.is_mining = resp.is_mining;
+                                own_overview_data.confirmations = resp.confirmations;
                             }
 
                             reset_poller!(dashboard_overview_data, Duration::from_secs(3));

--- a/src/bin/dashboard_src/overview_screen.rs
+++ b/src/bin/dashboard_src/overview_screen.rs
@@ -11,6 +11,7 @@ use chrono::DateTime;
 use itertools::Itertools;
 use neptune_core::config_models::network::Network;
 use neptune_core::models::blockchain::block::block_header::BlockHeader;
+use neptune_core::models::blockchain::block::block_height::BlockHeight;
 use neptune_core::models::blockchain::shared::Hash;
 use neptune_core::models::blockchain::transaction::amount::Amount;
 use neptune_core::rpc_server::RPCClient;
@@ -31,7 +32,7 @@ use super::screen::Screen;
 #[derive(Debug, Clone)]
 pub struct OverviewData {
     synced_balance: Option<Amount>,
-    confirmations: Option<u64>,
+    confirmations: Option<BlockHeight>,
     synchronization_percentage: Option<f64>,
 
     network: Network,
@@ -91,7 +92,7 @@ impl OverviewData {
     pub fn test() -> Self {
         OverviewData {
             synced_balance: Some(Amount::zero()),
-            confirmations: Some(17),
+            confirmations: Some(17.into()),
             synchronization_percentage: Some(99.5),
 
             listen_address: None,

--- a/src/models/blockchain/block/block_height.rs
+++ b/src/models/blockchain/block/block_height.rs
@@ -90,7 +90,7 @@ impl PartialOrd for BlockHeight {
 
 impl Display for BlockHeight {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
+        write!(f, "{}", u64::from(self.0))
     }
 }
 

--- a/src/models/blockchain/transaction/amount.rs
+++ b/src/models/blockchain/transaction/amount.rs
@@ -160,7 +160,7 @@ impl PartialEq for Amount {
 
 impl PartialOrd for Amount {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.0.partial_cmp(&other.0)
+        Some(self.cmp(other))
     }
 }
 

--- a/src/models/blockchain/transaction/amount.rs
+++ b/src/models/blockchain/transaction/amount.rs
@@ -43,6 +43,16 @@ pub enum Sign {
     Negative,
 }
 
+impl Display for Sign {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match *self {
+            Self::NonNegative => "",
+            Self::Negative => "-",
+        };
+        write!(f, "{}", s)
+    }
+}
+
 pub const AMOUNT_SIZE_FOR_U32: usize = 4;
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, BFieldCodec)]

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -175,9 +175,6 @@ impl GlobalState {
     }
 
     /// Retrieve wallet balance history
-    ///
-    /// todo: ignore abandoned/unsynced utxo.
-    /// see: https://github.com/Neptune-Crypto/neptune-core/issues/28
     pub async fn get_balance_history(&self) -> Vec<(Digest, Duration, BlockHeight, Amount, Sign)> {
         let current_tip_digest = self.chain.light_state.get_latest_block().await.hash;
 

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -98,11 +98,7 @@ impl GlobalState {
         let (height, time_secs) =
             time_fn_call_async(self.get_latest_balance_height_internal()).await;
 
-        #[cfg(not(test))]
         debug!("call to get_latest_balance_height() took {time_secs} seconds");
-
-        #[cfg(test)]
-        println!("call to get_latest_balance_height() took {time_secs} seconds");
 
         height
     }

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -860,22 +860,59 @@ impl WalletState {
 
     /// Retrieve block height of last change to wallet balance.
     ///
+    /// note: this fn could be implemented as:
+    ///   1. get_balance_history()
+    ///   2. sort by height
+    ///   3. return height of last entry.
+    ///
+    /// this implementation is a bit more efficient as it avoids
+    ///   the sort and some minor work looking up amount and confirmation
+    ///   height of each utxo.
+    ///
+    /// Presently this is o(n) with the number of monitored utxos.
+    /// if storage could keep track of latest spend utxo, then this could
+    /// be o(1).
+    ///
     /// todo: ignore abandoned/unsynced utxo.  
     ///       also an issue for get_balance_history().
     /// see: https://github.com/Neptune-Crypto/neptune-core/issues/28
     pub async fn get_latest_balance_height(&self) -> Option<BlockHeight> {
-        let db_lock = self.wallet_db.lock().await;
-        let len = db_lock.monitored_utxos.len();
+        let monitored_utxos = self.wallet_db.lock().await.monitored_utxos.clone();
+        let len = monitored_utxos.len();
+
         if len > 0 {
-            let utxo = db_lock.monitored_utxos.get(len - 1);
-            if let Some((.., confirmation_height)) = utxo.confirmed_in_block {
+            let mut latest: BlockHeight = 0.into();
+
+            // note: would be nicer to use an iterator to find max spending_height.
+            // perhaps someday: https://github.com/Neptune-Crypto/twenty-first/issues/139
+            for i in 0..len {
+                // latest change to balance could be a spend utxo, and it could be anywhere
+                // in the monitored_utxos list, so we must check each entry in list.
+                let utxo = monitored_utxos.get(i);
                 if let Some((.., spending_height)) = utxo.spent_in_block {
-                    return Some(spending_height);
+                    if spending_height > latest {
+                        latest = spending_height;
+                    }
                 }
-                return Some(confirmation_height);
+
+                // if latest change is an incoming utxo, we can save some work by checking only
+                // the last entry because monitored_utxos is already ordered by
+                // confirmation_height ascending
+                if i == len - 1 {
+                    if let Some((.., confirmation_height)) = utxo.confirmed_in_block {
+                        if confirmation_height > latest {
+                            latest = confirmation_height;
+                        }
+                    }
+                }
             }
+            assert!(
+                latest > 0.into() || (len == 1 && monitored_utxos.get(0).spent_in_block.is_none())
+            );
+            Some(latest)
+        } else {
+            None
         }
-        None
     }
 }
 

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -823,6 +823,7 @@ impl WalletState {
 #[cfg(test)]
 mod tests {
     use num_traits::One;
+    use tracing_test::traced_test;
 
     use crate::{
         config_models::network::Network,
@@ -833,6 +834,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
+    #[traced_test]
     async fn wallet_state_prune_abandoned_mutxos() {
         // Get genesis block. Verify wallet is empty
         // Add two blocks to state containing no UTXOs for own wallet

--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -191,7 +191,7 @@ impl RPC for NeptuneRPCServer {
     }
 
     fn get_confirmations(self, _: context::Context) -> Self::GetConfirmationsFut {
-        match executor::block_on(self.state.wallet_state.get_latest_balance_height()) {
+        match executor::block_on(self.state.get_latest_balance_height()) {
             Some(latest_balance_height) => {
                 let tip_block_header =
                     executor::block_on(self.state.chain.light_state.get_latest_block_header());

--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -343,7 +343,7 @@ impl RPC for NeptuneRPCServer {
     }
 
     fn get_history(self, _context: tarpc::context::Context) -> Self::GetHistoryFut {
-        let history = executor::block_on(self.state.wallet_state.get_balance_history());
+        let history = executor::block_on(self.state.get_balance_history());
 
         // sort
         let mut display_history: Vec<(Duration, Amount, Sign)> = history

--- a/src/util_types/mutator_set/ms_membership_proof.rs
+++ b/src/util_types/mutator_set/ms_membership_proof.rs
@@ -140,10 +140,7 @@ impl<H: AlgebraicHasher + BFieldCodec> MsMembershipProof<H> {
                     .map(|x| (x / CHUNK_SIZE as u128) as u64)
                     .collect();
                 chunks_set.iter().for_each(|chnkidx| {
-                    chunk_index_to_mp_index
-                        .entry(*chnkidx)
-                        .or_insert_with(Vec::new)
-                        .push(i)
+                    chunk_index_to_mp_index.entry(*chnkidx).or_default().push(i)
                 });
             });
 

--- a/src/util_types/mutator_set/removal_record.rs
+++ b/src/util_types/mutator_set/removal_record.rs
@@ -165,12 +165,9 @@ impl<H: AlgebraicHasher + BFieldCodec> RemovalRecord<H> {
                 .iter()
                 .map(|x| (x / CHUNK_SIZE as u128) as u64)
                 .collect();
-            chunks_set.iter().for_each(|chnkidx| {
-                chunk_index_to_mp_index
-                    .entry(*chnkidx)
-                    .or_insert_with(Vec::new)
-                    .push(i)
-            });
+            chunks_set
+                .iter()
+                .for_each(|chnkidx| chunk_index_to_mp_index.entry(*chnkidx).or_default().push(i));
         });
 
         // Find the removal records that need a new dictionary entry for the chunk that's being

--- a/src/util_types/mutator_set/shared.rs
+++ b/src/util_types/mutator_set/shared.rs
@@ -21,7 +21,7 @@ pub fn indices_to_hash_map(all_indices: &[u128; NUM_TRIALS as usize]) -> HashMap
         .for_each(|(chunk_index, index)| {
             chunkidx_to_indices_dict
                 .entry(chunk_index)
-                .or_insert_with(Vec::new)
+                .or_default()
                 .push(*index);
         });
 


### PR DESCRIPTION
Addresses #6.  (partial)

The major objective of this PR is adding the `get_confirmations` RPC.   A secondary objective is displaying the confirmations field in overview screen of the Dashboard.   Other changes are ancillary.

Server:
* `implement get_confirmations` RPC
* return confirmations field in `get_dashboard_overview_data` RPC
* add `wallet_state::get_latest_balance_height()`
* add `block_height` to tuple returned from `wallet_state::get_balance_history`

Dashboard:
* display confirmations in overview screens
* change confirmations field from `usize` to `u64`

Notes:

* The `get_confirmations()` RPC function has been simplified and made more efficient than the prototype [here](https://github.com/Neptune-Crypto/neptune-core/issues/6#issuecomment-1732668472).
* `get_latest_balance_height()` will need to be modified to take into account unsynced/abandoned utxo.  There is already #28 for this, so I think it is best to do in a follow-up PR.  Also, I'm not yet certain of the correct fix, as I did try to simply filter out by `utxo.is_abandoned` in `get_balance_history()` and that did not solve the balance/history sync issue.   suggestions welcome.
* I considered returning additional fields from `get_latest_balance_height()` and just calling it `get_latest_balance()`.  However the amount field requires an additional call+loop and since there is no present need, I decided to keep it as simple/fast as possible.
* As a first pass at optimizing I had added `block_height` field to values returned from `wallet_state::get_balance_history()`.  That fn is no longer called from `get_confirmations()` however I left the `block_height` field in place because I think it would be useful to callers of the `get_history()` RPC.  I think it would be useful to display the height in Dashboard history, but decided to leave that change for a follow-up PR.  Anyway, this note explains that diff.
* I'm a bit uncertain yet about the correct type(s) for block heights (and counts).   There is the `BlockHeight` type which the compiler treats as `i128`.  But it doesn't really make sense for a height to be signed.  Also, `i128` and `u128` both seem like overkill... how many blocks are we anticipating?    Is `u64` not enough?    The dashboard was previously using `usize` for `confirmations` field, which seems a bit loose as it could be `u32` on some platform, so I changed it to `u64` and also my reasoning is less data over the wire vs `u128`.  But I would rather just be consistent with a single type (based on `u64`?) used everywhere to represent block heights.  Perhaps the RPC and Dashboard should all be using the `BlockHeight` for `confirmations` field rather than a primitive type.  thoughts?

Testing:

* Restarted server and Dashboard, then verified that confirmations are displayed in the overview screen to the right of `synced balance`
* Verified that confirmations field is zero when a new block is mined to my wallet, and increases by 1 for each subsequent block.
* Compared the `synced balance` with top-most balance in `History` screen.  The history screen balance is higher than `synced balance`.  This is wrong but expected until #28 is fixed.

I wanted to create a unit test for `get_confirmations` RPC however it is unclear to me how to do so.  There are a few unit tests in rpc_server.rs, but afaict none of them setup a wallet with a non-zero balance which would be a requirement for my test(s).  If someone could provide such a setup fn, I would happily make use of it.