### PR TITLE
Height in history pr

### DIFF
--- a/src/bin/dashboard_src/history_screen.rs
+++ b/src/bin/dashboard_src/history_screen.rs
@@ -149,7 +149,7 @@ impl HistoryScreen {
                     let bh = rpc_client.get_history(context::current()).await.unwrap();
                     let mut history_builder = Vec::with_capacity(bh.len());
                     let mut balance = Amount::zero();
-                    for (block_height, timestamp, amount, sign) in bh.iter() {
+                    for (_, block_height, timestamp, amount, sign) in bh.iter() {
                         match sign {
                             Sign::NonNegative => { balance = balance + *amount; }
                             Sign::Negative => {

--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -79,7 +79,7 @@ pub trait RPC {
     // Get sum of unspent UTXOs.
     async fn get_synced_balance() -> Amount;
 
-    async fn get_history() -> Vec<(Duration, Amount, Sign)>;
+    async fn get_history() -> Vec<(BlockHeight, Duration, Amount, Sign)>;
 
     async fn get_wallet_status() -> WalletStatus;
 
@@ -161,7 +161,7 @@ impl RPC for NeptuneRPCServer {
     type GetReceivingAddressFut = Ready<generation_address::ReceivingAddress>;
     type GetMempoolTxCountFut = Ready<usize>;
     type GetMempoolSizeFut = Ready<usize>;
-    type GetHistoryFut = Ready<Vec<(Duration, Amount, Sign)>>;
+    type GetHistoryFut = Ready<Vec<(BlockHeight, Duration, Amount, Sign)>>;
     type GetDashboardOverviewDataFut = Ready<DashBoardOverviewDataFromClient>;
     type PauseMinerFut = Ready<()>;
     type RestartMinerFut = Ready<()>;
@@ -346,9 +346,9 @@ impl RPC for NeptuneRPCServer {
         let history = executor::block_on(self.state.get_balance_history());
 
         // sort
-        let mut display_history: Vec<(Duration, Amount, Sign)> = history
+        let mut display_history: Vec<(BlockHeight, Duration, Amount, Sign)> = history
             .iter()
-            .map(|(_h, t, _bh, a, s)| (*t, *a, *s))
+            .map(|(_h, t, bh, a, s)| (*bh, *t, *a, *s))
             .collect::<Vec<_>>();
         display_history.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
 

--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -79,7 +79,7 @@ pub trait RPC {
     // Get sum of unspent UTXOs.
     async fn get_synced_balance() -> Amount;
 
-    async fn get_history() -> Vec<(BlockHeight, Duration, Amount, Sign)>;
+    async fn get_history() -> Vec<(Digest, BlockHeight, Duration, Amount, Sign)>;
 
     async fn get_wallet_status() -> WalletStatus;
 
@@ -161,7 +161,7 @@ impl RPC for NeptuneRPCServer {
     type GetReceivingAddressFut = Ready<generation_address::ReceivingAddress>;
     type GetMempoolTxCountFut = Ready<usize>;
     type GetMempoolSizeFut = Ready<usize>;
-    type GetHistoryFut = Ready<Vec<(BlockHeight, Duration, Amount, Sign)>>;
+    type GetHistoryFut = Ready<Vec<(Digest, BlockHeight, Duration, Amount, Sign)>>;
     type GetDashboardOverviewDataFut = Ready<DashBoardOverviewDataFromClient>;
     type PauseMinerFut = Ready<()>;
     type RestartMinerFut = Ready<()>;
@@ -346,11 +346,11 @@ impl RPC for NeptuneRPCServer {
         let history = executor::block_on(self.state.get_balance_history());
 
         // sort
-        let mut display_history: Vec<(BlockHeight, Duration, Amount, Sign)> = history
+        let mut display_history: Vec<(Digest, BlockHeight, Duration, Amount, Sign)> = history
             .iter()
-            .map(|(_h, t, bh, a, s)| (*bh, *t, *a, *s))
+            .map(|(h, t, bh, a, s)| (*h, *bh, *t, *a, *s))
             .collect::<Vec<_>>();
-        display_history.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+        display_history.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
 
         // return
         future::ready(display_history)


### PR DESCRIPTION
This is a draft PR as a starting point for discussion of the changes mentioned below.

There is no existing issue for this, just a small change I thought would be useful.

This builds on #56 (not yet merged) and adds a height field to data returned from get_history() rpc.  This field is then displayed in the dashboard history screen.   Example:

![Screenshot_2023-10-07_13-51-34](https://github.com/Neptune-Crypto/neptune-core/assets/5110592/5e8c9bbd-1967-4ac0-82b0-02938f995b78)

It can be argued that height is not necessary to the wallet end-user and thus need not be displayed in dashboard history, but I would counter that:
* a CLI wallet like the dashboard will be used by devs and power users
* the height is a useful display field for me and probably others.

The position of the height column could be changed if desired.   I'm open to suggestions.  Also it could be called "block", "block height", or "height".  I chose the latter for now.

Even if we decide not to display height in the dashboard history screen, I think it is still useful to return it from the get_history() rpc, for future callers.

The block hash/digest is also available (returned from `get_balance_history()` and perhaps should be returned from `get_history()` as well.  I think it might be useful for wallets, for example so they can create a URL to a block explorer for each block.

Even more useful would be a TX id/hash, which is typically displayed/used in history of  cryptocurrency wallets.  That is presently *not* returned from `get_balance_history()`.  I'm not yet certain how to do that, as `get_balance_history()` iterates over `monitored_utxos` and I don't immediately see how to find the `Transaction` that a `Utxo` or `MonitoredUtxo` is part of.

So concretely then, before finalizing this PR, I would like to add fields for `transaction_hash` and `block_hash` to `get_history()` RPC.  These would not be displayed in the dashboard history.  I need some guidance how to get transaction_hash.
