### PR TITLE
History table scroll pr

### DIFF
--- a/src/bin/dashboard_src/dashboard_app.rs
+++ b/src/bin/dashboard_src/dashboard_app.rs
@@ -358,7 +358,10 @@ impl DashboardApp {
             let escalated: Option<DashboardEvent> = match self.current_menu_item {
                 // MenuItem::Overview => todo!(),
                 // MenuItem::Peers => todo!(),
-                // MenuItem::History => todo!(),
+                MenuItem::History => {
+                    let mut history_screen = self.history_screen.as_ref().borrow_mut();
+                    history_screen.handle(event)?
+                }
                 MenuItem::Receive => {
                     let mut receive_screen = self.receive_screen.as_ref().borrow_mut();
                     receive_screen.handle(event)?

--- a/src/bin/dashboard_src/history_screen.rs
+++ b/src/bin/dashboard_src/history_screen.rs
@@ -6,6 +6,7 @@ use std::{
 
 use super::{dashboard_app::DashboardEvent, screen::Screen};
 use chrono::{DateTime, Utc};
+use crossterm::event::{Event, KeyCode, KeyEventKind};
 use itertools::Itertools;
 use neptune_core::{
     models::blockchain::transaction::amount::{Amount, Sign},
@@ -14,8 +15,8 @@ use neptune_core::{
 use num_traits::{CheckedSub, Zero};
 use ratatui::{
     layout::{Constraint, Margin},
-    style::{Color, Style},
-    widgets::{Block, Borders, Cell, Row, Table, Widget},
+    style::{Color, Modifier, Style},
+    widgets::{Block, Borders, Cell, Row, StatefulWidget, Table, TableState, Widget},
 };
 use tarpc::context;
 use tokio::time::sleep;
@@ -23,6 +24,73 @@ use tokio::{select, task::JoinHandle};
 use unicode_width::UnicodeWidthStr;
 
 type BalanceUpdate = (Duration, Amount, Sign, Amount);
+type BalanceUpdateArc = Arc<std::sync::Mutex<Vec<BalanceUpdate>>>;
+type DashboardEventArc = Arc<std::sync::Mutex<Option<DashboardEvent>>>;
+type JoinHandleArc = Arc<Mutex<JoinHandle<()>>>;
+
+// Define some events to display.
+// note: based on ratatui scrollable table example at:
+//   https://github.com/ratatui-org/ratatui/blob/main/examples/table.rs
+#[derive(Debug, Clone)]
+struct Events {
+    // `items` is the state managed by the application.
+    items: BalanceUpdateArc,
+    // `state` is the state that can be modified by the UI. It stores the index of the selected
+    // item as well as the offset computed during the previous draw call (used to implement
+    // natural scrolling).
+    state: TableState,
+}
+
+impl From<BalanceUpdateArc> for Events {
+    fn from(items: BalanceUpdateArc) -> Self {
+        Events {
+            items,
+            state: Default::default(),
+        }
+    }
+}
+
+impl Events {
+    // # of rows in table header (1 text row, 2 border rows).
+    // this is used to avoid selecting the header rows.
+    // kind of a hack, but appears to be necessary for now.
+    // ratatui seems to be redesigning scrollable widgets at present.
+    const TABLE_HEADER_ROWS: usize = 3;
+
+    // Select the next item. This will not be reflected until the widget is drawn
+    // with `Frame::render_stateful_widget`.
+    pub fn next(&mut self) {
+        let offset = Self::TABLE_HEADER_ROWS;
+        let i = match self.state.selected() {
+            Some(i) => {
+                if i >= self.items.lock().unwrap().len() + offset - 1 {
+                    i // end on last entry.  (no wrap to start)
+                } else {
+                    i + 1
+                }
+            }
+            None => offset,
+        };
+        self.state.select(Some(i));
+    }
+
+    // Select the previous item. This will not be reflected until the widget is drawn
+    // with `Frame::render_stateful_widget`.
+    pub fn previous(&mut self) {
+        let offset = Self::TABLE_HEADER_ROWS;
+        let i = match self.state.selected() {
+            Some(i) => {
+                if i == offset {
+                    i // stay at first entry.  (no wrap to end.)
+                } else {
+                    i - 1
+                }
+            }
+            None => offset,
+        };
+        self.state.select(Some(i));
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct HistoryScreen {
@@ -30,30 +98,33 @@ pub struct HistoryScreen {
     fg: Color,
     bg: Color,
     in_focus: bool,
-    data: Arc<std::sync::Mutex<Vec<BalanceUpdate>>>,
+    data: BalanceUpdateArc,
     server: Arc<RPCClient>,
-    poll_thread: Option<Arc<Mutex<JoinHandle<()>>>>,
-    escalatable_event: Arc<std::sync::Mutex<Option<DashboardEvent>>>,
+    poll_thread: Option<JoinHandleArc>,
+    escalatable_event: DashboardEventArc,
+    events: Events,
 }
 
 impl HistoryScreen {
     pub fn new(rpc_server: Arc<RPCClient>) -> Self {
+        let data = Arc::new(Mutex::new(vec![]));
         HistoryScreen {
             active: false,
             fg: Color::Gray,
             bg: Color::Black,
             in_focus: false,
-            data: Arc::new(Mutex::new(vec![])),
+            data: data.clone(),
             server: rpc_server,
             poll_thread: None,
             escalatable_event: Arc::new(std::sync::Mutex::new(None)),
+            events: data.into(),
         }
     }
 
     async fn run_polling_loop(
         rpc_client: Arc<RPCClient>,
-        balance_updates: Arc<std::sync::Mutex<Vec<BalanceUpdate>>>,
-        _escalatable_event_arc: Arc<std::sync::Mutex<Option<DashboardEvent>>>,
+        balance_updates: BalanceUpdateArc,
+        _escalatable_event_arc: DashboardEventArc,
     ) -> ! {
         // use macros to reduce boilerplate
         macro_rules! setup_poller {
@@ -91,9 +162,36 @@ impl HistoryScreen {
                     }
                     *balance_updates.lock().unwrap() = history_builder;
                     reset_poller!(balance_history, Duration::from_secs(10));
+                },
+            }
+        }
+    }
+
+    /// handle a DashboardEvent
+    ///
+    /// In particular we handle Up/Down keypress for scrolling
+    /// the history table.
+    pub fn handle(
+        &mut self,
+        event: DashboardEvent,
+    ) -> Result<Option<DashboardEvent>, Box<dyn std::error::Error>> {
+        let mut escalate_event = None;
+
+        if self.in_focus {
+            if let DashboardEvent::ConsoleEvent(Event::Key(key)) = event {
+                if key.kind == KeyEventKind::Press {
+                    match key.code {
+                        KeyCode::Down => self.events.next(),
+                        KeyCode::Up => self.events.previous(),
+                        // todo: PgUp,PgDn.  (but how to determine page size?  fixed n?)
+                        _ => {
+                            escalate_event = Some(event);
+                        }
+                    }
                 }
             }
         }
+        Ok(escalate_event)
     }
 }
 
@@ -125,13 +223,13 @@ impl Screen for HistoryScreen {
         self.in_focus = false;
     }
 
-    fn escalatable_event(&self) -> Arc<std::sync::Mutex<Option<DashboardEvent>>> {
+    fn escalatable_event(&self) -> DashboardEventArc {
         self.escalatable_event.clone()
     }
 }
 
 impl Widget for HistoryScreen {
-    fn render(self, area: ratatui::layout::Rect, buf: &mut ratatui::buffer::Buffer) {
+    fn render(mut self, area: ratatui::layout::Rect, buf: &mut ratatui::buffer::Buffer) {
         // history box
         let style: Style = if self.in_focus {
             Style::default().fg(Color::LightCyan).bg(self.bg)
@@ -156,6 +254,7 @@ impl Widget for HistoryScreen {
 
         // table
         let style = Style::default().fg(self.fg).bg(self.bg);
+        let selected_style = style.add_modifier(Modifier::REVERSED);
         let header = vec!["date", " ", "amount", "balance after"];
         let matrix = self
             .data
@@ -275,11 +374,14 @@ impl Widget for HistoryScreen {
             .iter()
             .map(|w| Constraint::Length(*w as u16))
             .collect_vec();
-        let table = Table::new(rows).widths(&width_constraints).style(style);
+        let table = Table::new(rows)
+            .widths(&width_constraints)
+            .style(style)
+            .highlight_style(selected_style);
         table_canvas.width = min(
             table_canvas.width,
             widths.iter().sum::<usize>() as u16 + 3 * widths.len() as u16 + 1,
         );
-        table.render(table_canvas, buf);
+        StatefulWidget::render(table, table_canvas, buf, &mut self.events.state);
     }
 }

--- a/src/models/blockchain/transaction/amount.rs
+++ b/src/models/blockchain/transaction/amount.rs
@@ -150,7 +150,7 @@ impl PartialEq for Amount {
 
 impl PartialOrd for Amount {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.0.partial_cmp(&other.0)
+        Some(self.cmp(other))
     }
 }
 

--- a/src/util_types/mutator_set/ms_membership_proof.rs
+++ b/src/util_types/mutator_set/ms_membership_proof.rs
@@ -140,10 +140,7 @@ impl<H: AlgebraicHasher + BFieldCodec> MsMembershipProof<H> {
                     .map(|x| (x / CHUNK_SIZE as u128) as u64)
                     .collect();
                 chunks_set.iter().for_each(|chnkidx| {
-                    chunk_index_to_mp_index
-                        .entry(*chnkidx)
-                        .or_insert_with(Vec::new)
-                        .push(i)
+                    chunk_index_to_mp_index.entry(*chnkidx).or_default().push(i)
                 });
             });
 

--- a/src/util_types/mutator_set/removal_record.rs
+++ b/src/util_types/mutator_set/removal_record.rs
@@ -165,12 +165,9 @@ impl<H: AlgebraicHasher + BFieldCodec> RemovalRecord<H> {
                 .iter()
                 .map(|x| (x / CHUNK_SIZE as u128) as u64)
                 .collect();
-            chunks_set.iter().for_each(|chnkidx| {
-                chunk_index_to_mp_index
-                    .entry(*chnkidx)
-                    .or_insert_with(Vec::new)
-                    .push(i)
-            });
+            chunks_set
+                .iter()
+                .for_each(|chnkidx| chunk_index_to_mp_index.entry(*chnkidx).or_default().push(i));
         });
 
         // Find the removal records that need a new dictionary entry for the chunk that's being

--- a/src/util_types/mutator_set/shared.rs
+++ b/src/util_types/mutator_set/shared.rs
@@ -21,7 +21,7 @@ pub fn indices_to_hash_map(all_indices: &[u128; NUM_TRIALS as usize]) -> HashMap
         .for_each(|(chunk_index, index)| {
             chunkidx_to_indices_dict
                 .entry(chunk_index)
-                .or_insert_with(Vec::new)
+                .or_default()
                 .push(*index);
         });
 


### PR DESCRIPTION
It was annoying me that the wallet history in the Dashboard exceeded the screen length and I could not scroll down to see the older entries.

This fixes that.    Up/Down arrows now work to move a selected row and it scrolls to end of list and back.   The impl is surprisingly manual.... I was expecting something like a `set scrollable=true` property on the widget, but no such luck.   Anyway, I based it on a [ratatui example](https://github.com/ratatui-org/ratatui/blob/main/examples/table.rs).

I originally had it wrapping around as per the example, but it was kind of surprising behavior, so now I made it stop at first entry when scrolling up and last entry when down. 

I wanted to add PgUp/PgDn support, but I couldn't find a way to get the number of visible rows in the table given that terminal height is variable.  

From a bit of digging on ratatui github I see that there are several issues open about scrolling and they are discussing new design(s), so hopefully the new design will enable easy PgUp/PgDn handling.    see:  [draft PR](https://github.com/ratatui-org/ratatui/pull/4), [rfc](https://github.com/ratatui-org/ratatui/issues/174).