### PR TITLE
fix hard-coded "regtest" in log output

### DIFF
--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -358,7 +358,7 @@ pub async fn mine(
                             mt.abort();
                         }
                         latest_block = *block;
-                        info!("Miner thread received regtest block height {}", latest_block.header.height);
+                        info!("Miner thread received {} block height {}", state.cli.network, latest_block.header.height);
                     }
                     MainToMiner::Empty => (),
                     MainToMiner::ReadyToMineNextBlock => {
@@ -402,7 +402,7 @@ pub async fn mine(
                 // if it is not.
                 assert!(new_block_info.block.is_valid(&latest_block), "Own mined block must be valid. Failed validity check after successful PoW check.");
 
-                info!("Found new regtest block with block height {}. Hash: {}", new_block_info.block.header.height, new_block_info.block.hash.emojihash());
+                info!("Found new {} block with block height {}. Hash: {}", state.cli.network, new_block_info.block.header.height, new_block_info.block.hash.emojihash());
 
                 latest_block = *new_block_info.block.to_owned();
                 to_main.send(MinerToMain::NewBlockFound(new_block_info)).await?;

--- a/src/models/blockchain/transaction/amount.rs
+++ b/src/models/blockchain/transaction/amount.rs
@@ -150,7 +150,7 @@ impl PartialEq for Amount {
 
 impl PartialOrd for Amount {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.0.partial_cmp(&other.0)
+        Some(self.cmp(other))
     }
 }
 

--- a/src/util_types/mutator_set/ms_membership_proof.rs
+++ b/src/util_types/mutator_set/ms_membership_proof.rs
@@ -140,10 +140,7 @@ impl<H: AlgebraicHasher + BFieldCodec> MsMembershipProof<H> {
                     .map(|x| (x / CHUNK_SIZE as u128) as u64)
                     .collect();
                 chunks_set.iter().for_each(|chnkidx| {
-                    chunk_index_to_mp_index
-                        .entry(*chnkidx)
-                        .or_insert_with(Vec::new)
-                        .push(i)
+                    chunk_index_to_mp_index.entry(*chnkidx).or_default().push(i)
                 });
             });
 

--- a/src/util_types/mutator_set/removal_record.rs
+++ b/src/util_types/mutator_set/removal_record.rs
@@ -165,12 +165,9 @@ impl<H: AlgebraicHasher + BFieldCodec> RemovalRecord<H> {
                 .iter()
                 .map(|x| (x / CHUNK_SIZE as u128) as u64)
                 .collect();
-            chunks_set.iter().for_each(|chnkidx| {
-                chunk_index_to_mp_index
-                    .entry(*chnkidx)
-                    .or_insert_with(Vec::new)
-                    .push(i)
-            });
+            chunks_set
+                .iter()
+                .for_each(|chnkidx| chunk_index_to_mp_index.entry(*chnkidx).or_default().push(i));
         });
 
         // Find the removal records that need a new dictionary entry for the chunk that's being

--- a/src/util_types/mutator_set/shared.rs
+++ b/src/util_types/mutator_set/shared.rs
@@ -21,7 +21,7 @@ pub fn indices_to_hash_map(all_indices: &[u128; NUM_TRIALS as usize]) -> HashMap
         .for_each(|(chunk_index, index)| {
             chunkidx_to_indices_dict
                 .entry(chunk_index)
-                .or_insert_with(Vec::new)
+                .or_default()
                 .push(*index);
         });
 


### PR DESCRIPTION
Addresses #57

Now uses state.cli.network instead of hard-coded string for the two occurrences previously identified in #57.

New (tested) log output:

```
2023-10-10T03:44:50.540462149Z  INFO ThreadId(05) neptune_core::mine_loop: Miner thread received alpha block height 00000000000000005102

```