### PR TITLE
Listen to IPv4 and IPv6 ports as default

### DIFF
--- a/src/config_models/cli_args.rs
+++ b/src/config_models/cli_args.rs
@@ -89,7 +89,7 @@ pub struct Args {
     pub rpc_port: u16,
 
     /// IP on which to listen for peer connections. Will default to all network interfaces.
-    #[clap(short, long, default_value = "0.0.0.0")]
+    #[clap(short, long, default_value = "::")]
     pub listen_addr: IpAddr,
 
     /// Max number of blocks that the client can catch up to before going into syncing mode.


### PR DESCRIPTION
This should add IPv6 support. That works, but I haven't tested that IPv4 still works, as I haven't had the chance to run it on a machine with a static IP address which is the only way to connect via IPv4.