### PR TITLE
feat: global state lock, async leveldb, etc.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -205,7 +205,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -217,7 +217,7 @@ dependencies = [
  "attribute-derive-macro",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -233,7 +233,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "quote-use",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -304,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.5"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bech32"
@@ -322,7 +322,7 @@ checksum = "9cb236fab4b97d1b1329308831c14bb9a439216c15492e16b9190a3f7ff56342"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -505,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.12"
+version = "4.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfab8ba68f3668e89f6ff60f5b205cea56aa7b769451a59f34b8682f51c056d"
+checksum = "c12ed66a79a555082f595f7eb980d08669de95009dd4b3d61168c573ebe38fc9"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -515,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.12"
+version = "4.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb7fb5e4e979aec3be7791562fcba452f94ad85e954da024396433e0e25a79e9"
+checksum = "0f4645eab3431e5a8403a96bea02506a8b35d28cd0f0330977dd5d22f9c84f43"
 dependencies = [
  "anstream",
  "anstyle",
@@ -544,7 +544,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -641,9 +641,9 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
@@ -695,44 +695,37 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a9b73a36529d9c47029b9fb3a6f0ea3cc916a261195352ba19e770fc1748b2"
+checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
 dependencies = [
- "cfg-if",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca89a0e215bab21874660c67903c5f143333cab1da83d041c7ded6053774751"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
 dependencies = [
- "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.17"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e3681d554572a651dda4186cd47240627c3d0114d45a95f6ad27f2f22e7548d"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
- "autocfg",
- "cfg-if",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a430a770ebd84726f584a90ee7f020d28db52c6d02138900f22341f866d39c"
-dependencies = [
- "cfg-if",
-]
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crossterm"
@@ -796,7 +789,7 @@ checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -807,7 +800,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -816,7 +809,7 @@ version = "0.1.0"
 source = "git+https://github.com/TritonVM/tasm-lib.git?rev=6c11a2db#6c11a2dbd604c3d4f002dd2ca7fd771d51ed2dcc"
 dependencies = [
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -882,7 +875,7 @@ checksum = "510ef69263e119c8ec0213761e397d26a3f6d35e13a454549508446d3578ddc0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -922,7 +915,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1073,7 +1066,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1142,14 +1135,14 @@ checksum = "13a1bcfb855c1f340d5913ab542e36f25a1c56f57de79022928297632435dec2"
 dependencies = [
  "attribute-derive",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1174,9 +1167,9 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "h2"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+checksum = "b553656127a00601c8ae5590fcfdc118e4083a7924b6cf4ffc1ea4b99dc429d7"
 dependencies = [
  "bytes",
  "fnv",
@@ -1500,9 +1493,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.151"
+version = "0.2.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "libm"
@@ -1676,7 +1669,6 @@ dependencies = [
  "priority-queue",
  "rand",
  "ratatui",
- "rs-leveldb",
  "semver",
  "serde",
  "serde_derive",
@@ -1995,7 +1987,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2024,7 +2016,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2144,9 +2136,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.74"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2de98502f212cfcea8d0bb305bd0f49d7ebdd75b64ba0a68f937d888f4e0d6db"
+checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
 dependencies = [
  "unicode-ident",
 ]
@@ -2171,7 +2163,7 @@ dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2200,7 +2192,7 @@ checksum = "a7b5abe3fe82fdeeb93f44d66a7b444dedf2e4827defb0a8e69c437b2de2ef94"
 dependencies = [
  "quote",
  "quote-use-macros",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2212,7 +2204,7 @@ dependencies = [
  "derive-where",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2438,9 +2430,9 @@ checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 
 [[package]]
 name = "serde"
-version = "1.0.194"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b114498256798c94a0689e1a15fec6005dee8ac1f41de56404b67afc2a4b773"
+checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
 dependencies = [
  "serde_derive",
 ]
@@ -2456,20 +2448,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.194"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3385e45322e8f9931410f01b3031ec534c3947d0e94c18049af4d9f9907d4e0"
+checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.110"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fbd975230bada99c8bb618e0c365c2eefa219158d5c6c29610fd09ff1833257"
+checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
 dependencies = [
  "itoa",
  "ryu",
@@ -2600,7 +2592,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2622,9 +2614,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.46"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89456b690ff72fddcecf231caedbe615c59480c93358a93dfae7fc29e3ebbf0e"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2680,7 +2672,7 @@ dependencies = [
  "anyhow",
  "derive_tasm_object",
  "hex",
- "itertools 0.10.5",
+ "itertools 0.12.0",
  "num",
  "num-traits",
  "rand",
@@ -2718,7 +2710,7 @@ checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2842,7 +2834,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2979,7 +2971,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3096,8 +3088,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "twenty-first"
 version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3f639a7068bac2e4023b7c5a0a02d19637b2b77670087440ae42659c833553a"
+source = "git+https://github.com/Neptune-Crypto/twenty-first.git?rev=d4ee75bf0b1f7f0ae2b04968b15638899e6f36d4#d4ee75bf0b1f7f0ae2b04968b15638899e6f36d4"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -3233,7 +3224,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
  "wasm-bindgen-shared",
 ]
 
@@ -3255,7 +3246,7 @@ checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3465,7 +3456,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3485,5 +3476,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ num-traits = "0"
 priority-queue = "1"
 rand = "0.8"
 ratatui = "0.23"
-rs-leveldb = "0.1.5"
 semver = "^1.0.21"
 serde = { version = "1", features = ["derive"] }
 serde_derive = "1"
@@ -87,3 +86,7 @@ opt-level = 0
 # incremental = true
 # codegen-units = 256
 # rpath = false
+
+[patch.crates-io]
+# needed for now.
+twenty-first = { git = "https://github.com/Neptune-Crypto/twenty-first.git", rev = "d4ee75bf0b1f7f0ae2b04968b15638899e6f36d4" }

--- a/src/bin/dashboard_src/history_screen.rs
+++ b/src/bin/dashboard_src/history_screen.rs
@@ -1,11 +1,10 @@
 use std::{
     cmp::{max, min},
     sync::{Arc, Mutex},
-    time::{Duration, UNIX_EPOCH},
+    time::Duration,
 };
 
 use super::{dashboard_app::DashboardEvent, screen::Screen};
-use chrono::{DateTime, Utc};
 use crossterm::event::{Event, KeyCode, KeyEventKind};
 use itertools::Itertools;
 use neptune_core::{
@@ -265,10 +264,10 @@ impl Widget for HistoryScreen {
             .iter()
             .rev()
             .map(|bu| {
-                let (height, duration, amount, sign, balance) = *bu;
+                let (height, timestamp, amount, sign, balance) = *bu;
                 vec![
                     height.to_string(),
-                    DateTime::<Utc>::from(UNIX_EPOCH + duration).to_string(),
+                    neptune_core::utc_timestamp_to_localtime(timestamp.as_millis()).to_string(),
                     if sign == Sign::NonNegative {
                         "↘".to_string()
                     } else {

--- a/src/bin/dashboard_src/peers_screen.rs
+++ b/src/bin/dashboard_src/peers_screen.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use super::{dashboard_app::DashboardEvent, screen::Screen};
-use chrono::{DateTime, Utc};
 use itertools::Itertools;
 use neptune_core::{models::peer::PeerInfo, rpc_server::RPCClient};
 use ratatui::{
@@ -177,12 +176,12 @@ impl Widget for PeersScreen {
             .map(|pi| {
                 let latest_violation: Option<String> =
                     pi.standing.latest_sanction.map(|x| x.to_string());
-                let formatted_datetime = DateTime::<Utc>::from(pi.last_seen)
-                    .format("%Y-%m-%d %H:%M")
-                    .to_string();
+                let last_seen_timestamp =
+                    pi.last_seen.duration_since(std::time::UNIX_EPOCH).unwrap();
                 vec![
                     pi.connected_address.to_string(),
-                    formatted_datetime,
+                    neptune_core::utc_timestamp_to_localtime(last_seen_timestamp.as_millis())
+                        .to_string(),
                     pi.standing.standing.to_string(),
                     if pi.is_archival_node {
                         "✓".to_string()

--- a/src/config_models/cli_args.rs
+++ b/src/config_models/cli_args.rs
@@ -35,7 +35,7 @@ pub struct Args {
     ///
     /// This sets the threshold for when a peer should be automatically refused.
     ///
-    /// For a list of reasons that cause bad standing, see <MISSING>.
+    /// For a list of reasons that cause bad standing, see [PeerSanctionReason](crate::models::peer::PeerSanctionReason).
     #[clap(long, default_value = "100", value_name = "VALUE")]
     pub peer_tolerance: u16,
 

--- a/src/connect_to_peers.rs
+++ b/src/connect_to_peers.rs
@@ -18,7 +18,7 @@ use crate::{
         peer::{
             ConnectionRefusedReason, ConnectionStatus, HandshakeData, PeerMessage, PeerStanding,
         },
-        state::GlobalState,
+        state::GlobalStateLock,
     },
     peer_loop::PeerLoopHandler,
     MAGIC_STRING_REQUEST, MAGIC_STRING_RESPONSE,
@@ -37,12 +37,16 @@ fn get_codec_rules() -> LengthDelimitedCodec {
 }
 
 /// Check if connection is allowed. Used for both ingoing and outgoing connections.
+///
+/// Locking:
+///   * acquires `global_state_lock` for read
 async fn check_if_connection_is_allowed(
-    state: &GlobalState,
+    global_state_lock: GlobalStateLock,
     own_handshake: &HandshakeData,
     other_handshake: &HandshakeData,
     peer_address: &SocketAddr,
 ) -> ConnectionStatus {
+    let global_state = global_state_lock.lock_guard().await;
     fn versions_are_compatible(own_version: &str, other_version: &str) -> bool {
         let own_version = semver::Version::parse(own_version)
             .expect("Must be able to parse own version string. Got: {own_version}");
@@ -66,7 +70,7 @@ async fn check_if_connection_is_allowed(
     }
 
     // Disallow connection if peer is banned via CLI arguments
-    if state.cli.ban.contains(&peer_address.ip()) {
+    if global_state.cli.ban.contains(&peer_address.ip()) {
         warn!(
             "Banned peer {} attempted to connect. Disallowing.",
             peer_address.ip()
@@ -75,27 +79,36 @@ async fn check_if_connection_is_allowed(
     }
 
     // Disallow connection if peer is in bad standing
-    let standing = state
+    let standing = global_state
         .net
         .get_peer_standing_from_database(peer_address.ip())
         .await;
 
-    if standing.is_some() && standing.unwrap().standing < -(state.cli.peer_tolerance as i32) {
+    if standing.is_some() && standing.unwrap().standing < -(global_state.cli.peer_tolerance as i32)
+    {
         return ConnectionStatus::Refused(ConnectionRefusedReason::BadStanding);
     }
 
-    let pm = state.net.peer_map.lock().unwrap();
-
-    // Disallow connection if max number of &peers has been attained
-    if (state.cli.max_peers as usize) <= pm.len() {
-        return ConnectionStatus::Refused(ConnectionRefusedReason::MaxPeerNumberExceeded);
-    }
-
-    // Disallow connection to already connected peer.
-    if pm.values().any(|peer| {
-        peer.instance_id == other_handshake.instance_id || *peer_address == peer.connected_address
-    }) {
-        return ConnectionStatus::Refused(ConnectionRefusedReason::AlreadyConnected);
+    if let Some(status) = {
+        // Disallow connection if max number of &peers has been attained
+        if (global_state.cli.max_peers as usize) <= global_state.net.peer_map.len() {
+            Some(ConnectionStatus::Refused(
+                ConnectionRefusedReason::MaxPeerNumberExceeded,
+            ))
+        }
+        // Disallow connection to already connected peer.
+        else if global_state.net.peer_map.values().any(|peer| {
+            peer.instance_id == other_handshake.instance_id
+                || *peer_address == peer.connected_address
+        }) {
+            Some(ConnectionStatus::Refused(
+                ConnectionRefusedReason::AlreadyConnected,
+            ))
+        } else {
+            None
+        }
+    } {
+        return status;
     }
 
     // Disallow connection to self
@@ -118,7 +131,7 @@ async fn check_if_connection_is_allowed(
 
 pub async fn answer_peer_wrapper<S>(
     stream: S,
-    state: GlobalState,
+    state_lock: GlobalStateLock,
     peer_address: std::net::SocketAddr,
     main_to_peer_thread_rx: broadcast::Receiver<MainToPeerThread>,
     peer_thread_to_main_tx: mpsc::Sender<PeerThreadToMain>,
@@ -127,14 +140,14 @@ pub async fn answer_peer_wrapper<S>(
 where
     S: AsyncRead + AsyncWrite + std::fmt::Debug + std::marker::Unpin,
 {
-    let state_clone = state.clone();
+    let state_lock_clone = state_lock.clone();
     let peer_thread_to_main_tx_clone = peer_thread_to_main_tx.clone();
     let mut inner_ret: anyhow::Result<()> = Ok(());
 
     let panic_result = std::panic::AssertUnwindSafe(async {
         inner_ret = answer_peer(
             stream,
-            state,
+            state_lock_clone,
             peer_address,
             main_to_peer_thread_rx,
             peer_thread_to_main_tx,
@@ -150,7 +163,7 @@ where
         Err(_err) => {
             error!("Peer thread (incoming) for {peer_address} panicked. Invoking close connection callback");
             let _ret = close_peer_connected_callback(
-                &state_clone,
+                state_lock.clone(),
                 peer_address,
                 &peer_thread_to_main_tx_clone,
             )
@@ -163,7 +176,7 @@ where
 
 async fn answer_peer<S>(
     stream: S,
-    state: GlobalState,
+    state: GlobalStateLock,
     peer_address: std::net::SocketAddr,
     main_to_peer_thread_rx: broadcast::Receiver<MainToPeerThread>,
     peer_thread_to_main_tx: mpsc::Sender<PeerThreadToMain>,
@@ -208,9 +221,13 @@ where
             }
 
             // Check if incoming connection is allowed
-            let connection_status =
-                check_if_connection_is_allowed(&state, &own_handshake_data, &hsd, &peer_address)
-                    .await;
+            let connection_status = check_if_connection_is_allowed(
+                state.clone(),
+                &own_handshake_data,
+                &hsd,
+                &peer_address,
+            )
+            .await;
 
             peer.send(PeerMessage::ConnectionStatus(connection_status))
                 .await?;
@@ -250,7 +267,7 @@ where
 /// thread gracefully.
 pub async fn call_peer_wrapper(
     peer_address: std::net::SocketAddr,
-    state: GlobalState,
+    state: GlobalStateLock,
     main_to_peer_thread_rx: broadcast::Receiver<MainToPeerThread>,
     peer_thread_to_main_tx: mpsc::Sender<PeerThreadToMain>,
     own_handshake_data: HandshakeData,
@@ -292,7 +309,7 @@ pub async fn call_peer_wrapper(
         Err(_) => {
             error!("Peer thread (outgoing) for {peer_address} panicked. Invoking close connection callback");
             let _ret = close_peer_connected_callback(
-                &state_clone,
+                state_clone,
                 peer_address,
                 &peer_thread_to_main_tx_clone,
             )
@@ -303,7 +320,7 @@ pub async fn call_peer_wrapper(
 
 async fn call_peer<S>(
     stream: S,
-    state: GlobalState,
+    state: GlobalStateLock,
     peer_address: std::net::SocketAddr,
     main_to_peer_thread_rx: broadcast::Receiver<MainToPeerThread>,
     peer_thread_to_main_tx: mpsc::Sender<PeerThreadToMain>,
@@ -369,9 +386,13 @@ where
     // Peer accepted us. Check if we accept the peer. Note that the protocol does not stipulate
     // that we answer with a connection status here, so if the connection is *not* accepted, we
     // simply hang up but log the reason for the refusal.
-    let connection_status =
-        check_if_connection_is_allowed(&state, own_handshake, &other_handshake, &peer_address)
-            .await;
+    let connection_status = check_if_connection_is_allowed(
+        state.clone(),
+        own_handshake,
+        &other_handshake,
+        &peer_address,
+    )
+    .await;
     if let ConnectionStatus::Refused(refused_reason) = connection_status {
         warn!(
             "Outgoing connection refused. Reason: {:?}\nNow hanging up.",
@@ -399,18 +420,17 @@ where
 /// Remove peer from state. This function must be called every time
 /// a peer is disconnected. Whether this happens through a panic
 /// in the peer thread or through a regular disconnect.
+///
+/// Locking:
+///   * acquires `global_state_lock` for write
 pub async fn close_peer_connected_callback(
-    global_state: &GlobalState,
+    global_state_lock: GlobalStateLock,
     peer_address: SocketAddr,
     to_main_tx: &mpsc::Sender<PeerThreadToMain>,
 ) -> Result<()> {
+    let mut global_state_mut = global_state_lock.lock_guard_mut().await;
     // Store any new peer-standing to database
-    let peer_info_writeback = global_state
-        .net
-        .peer_map
-        .lock()
-        .unwrap_or_else(|e| panic!("Failed to lock peer map: {}", e))
-        .remove(&peer_address);
+    let peer_info_writeback = global_state_mut.net.peer_map.remove(&peer_address);
 
     let new_standing = match peer_info_writeback {
         Some(new) => new.standing,
@@ -420,7 +440,7 @@ pub async fn close_peer_connected_callback(
         }
     };
     debug!("Fetched peer info standing for {}", peer_address);
-    global_state
+    global_state_mut
         .net
         .write_peer_standing_on_decrease(peer_address.ip(), new_standing)
         .await;
@@ -491,7 +511,7 @@ mod connect_tests {
         .await?;
 
         // Verify that peer map is empty after connection has been closed
-        match state.net.peer_map.lock().unwrap().keys().len() {
+        match state.lock(|s| s.net.peer_map.keys().len()).await {
             0 => (),
             _ => bail!("Incorrect number of maps in peer map"),
         };
@@ -503,49 +523,58 @@ mod connect_tests {
     #[tokio::test]
     async fn test_get_connection_status() -> Result<()> {
         let network = Network::Alpha;
-        let (_peer_broadcast_tx, _from_main_rx_clone, _to_main_tx, _to_main_rx1, mut state, _hsd) =
+        let (_peer_broadcast_tx, _from_main_rx_clone, _to_main_tx, _to_main_rx1, state_lock, _hsd) =
             get_test_genesis_setup(network, 1).await?;
 
         // Get an address for a peer that's not already connected
         let (other_handshake, peer_sa) = get_dummy_peer_connection_data_genesis(network, 1);
         let own_handshake = get_dummy_handshake_data_for_genesis(network);
 
-        let mut status =
-            check_if_connection_is_allowed(&state, &own_handshake, &other_handshake, &peer_sa)
-                .await;
+        let mut status = check_if_connection_is_allowed(
+            state_lock.clone(),
+            &own_handshake,
+            &other_handshake,
+            &peer_sa,
+        )
+        .await;
         if status != ConnectionStatus::Accepted {
             bail!("Must return ConnectionStatus::Accepted");
         }
 
-        status =
-            check_if_connection_is_allowed(&state, &own_handshake, &own_handshake, &peer_sa).await;
+        status = check_if_connection_is_allowed(
+            state_lock.clone(),
+            &own_handshake,
+            &own_handshake,
+            &peer_sa,
+        )
+        .await;
         if status != ConnectionStatus::Refused(ConnectionRefusedReason::SelfConnect) {
             bail!("Must return ConnectionStatus::Refused(ConnectionRefusedReason::SelfConnect))");
         }
 
-        state.cli.max_peers = 1;
-        status = check_if_connection_is_allowed(&state, &own_handshake, &other_handshake, &peer_sa)
-            .await;
+        state_lock.lock_mut(|s| s.cli.max_peers = 1).await;
+        status = check_if_connection_is_allowed(
+            state_lock.clone(),
+            &own_handshake,
+            &other_handshake,
+            &peer_sa,
+        )
+        .await;
         if status != ConnectionStatus::Refused(ConnectionRefusedReason::MaxPeerNumberExceeded) {
             bail!(
-            "Must return ConnectionStatus::Refused(ConnectionRefusedReason::MaxPeerNumberExceeded))"
-        );
+                "Must return ConnectionStatus::Refused(ConnectionRefusedReason::MaxPeerNumberExceeded))"
+            );
         }
-        state.cli.max_peers = 100;
+        state_lock.lock_mut(|s| s.cli.max_peers = 100).await;
 
         // Attempt to connect to already connected peer
-        let connected_peer: PeerInfo = state
-            .net
-            .peer_map
-            .lock()
-            .unwrap()
-            .values()
-            .collect::<Vec<_>>()[0]
-            .clone();
+        let connected_peer: PeerInfo = state_lock
+            .lock(|s| s.net.peer_map.values().collect::<Vec<_>>()[0].clone())
+            .await;
         let mut mutated_other_handshake = other_handshake.clone();
         mutated_other_handshake.instance_id = connected_peer.instance_id;
         status = check_if_connection_is_allowed(
-            &state,
+            state_lock.clone(),
             &own_handshake,
             &mutated_other_handshake,
             &peer_sa,
@@ -559,16 +588,26 @@ mod connect_tests {
 
         // Verify that banned peers are rejected by this check
         // First check that peers can be banned by command-line arguments
-        state.cli.ban.push(peer_sa.ip());
-        status = check_if_connection_is_allowed(&state, &own_handshake, &other_handshake, &peer_sa)
-            .await;
+        state_lock.lock_mut(|s| s.cli.ban.push(peer_sa.ip())).await;
+        status = check_if_connection_is_allowed(
+            state_lock.clone(),
+            &own_handshake,
+            &other_handshake,
+            &peer_sa,
+        )
+        .await;
         if status != ConnectionStatus::Refused(ConnectionRefusedReason::BadStanding) {
             bail!("Must return ConnectionStatus::Refused(ConnectionRefusedReason::BadStanding)) on CLI-ban");
         }
 
-        state.cli.ban.pop();
-        status = check_if_connection_is_allowed(&state, &own_handshake, &other_handshake, &peer_sa)
-            .await;
+        state_lock.lock_mut(|s| s.cli.ban.pop()).await;
+        status = check_if_connection_is_allowed(
+            state_lock.clone(),
+            &own_handshake,
+            &other_handshake,
+            &peer_sa,
+        )
+        .await;
         if status != ConnectionStatus::Accepted {
             bail!("Must return ConnectionStatus::Accepted after unban");
         }
@@ -582,12 +621,21 @@ mod connect_tests {
             ))),
             timestamp_of_latest_sanction: Some(SystemTime::now()),
         };
-        state
+
+        state_lock
+            .lock_guard()
+            .await
             .net
             .write_peer_standing_on_decrease(peer_sa.ip(), bad_standing)
             .await;
-        status = check_if_connection_is_allowed(&state, &own_handshake, &other_handshake, &peer_sa)
-            .await;
+
+        status = check_if_connection_is_allowed(
+            state_lock.clone(),
+            &own_handshake,
+            &other_handshake,
+            &peer_sa,
+        )
+        .await;
         if status != ConnectionStatus::Refused(ConnectionRefusedReason::BadStanding) {
             bail!("Must return ConnectionStatus::Refused(ConnectionRefusedReason::BadStanding)) on db-ban");
         }
@@ -623,11 +671,11 @@ mod connect_tests {
             ))?)
             .read(&to_bytes(&PeerMessage::Bye)?)
             .build();
-        let (_peer_broadcast_tx, from_main_rx_clone, to_main_tx, _to_main_rx1, state, _hsd) =
+        let (_peer_broadcast_tx, from_main_rx_clone, to_main_tx, _to_main_rx1, state_lock, _hsd) =
             get_test_genesis_setup(network, 0).await?;
         answer_peer(
             mock,
-            state.clone(),
+            state_lock.clone(),
             get_dummy_socket_address(0),
             from_main_rx_clone,
             to_main_tx,
@@ -636,7 +684,7 @@ mod connect_tests {
         .await?;
 
         // Verify that peer map is empty after connection has been closed
-        match state.net.peer_map.lock().unwrap().keys().len() {
+        match state_lock.lock(|s| s.net.peer_map.keys().len()).await {
             0 => (),
             _ => bail!("Incorrect number of maps in peer map"),
         };
@@ -711,9 +759,10 @@ mod connect_tests {
     #[tokio::test]
     async fn test_incoming_connection_fail_bad_version() {
         let mut other_handshake = get_dummy_handshake_data_for_genesis(Network::Testnet);
-        let (_peer_broadcast_tx, from_main_rx_clone, to_main_tx, _to_main_rx1, own_state, _hsd) =
+        let (_peer_broadcast_tx, from_main_rx_clone, to_main_tx, _to_main_rx1, state_lock, _hsd) =
             get_test_genesis_setup(Network::Alpha, 0).await.unwrap();
-        let mut own_handshake = own_state.get_own_handshakedata().await;
+        let state = state_lock.lock_guard().await;
+        let mut own_handshake = state.get_own_handshakedata().await;
 
         // Set reported versions to something incompatible
         own_handshake.version = "0.0.3".to_owned();
@@ -721,7 +770,7 @@ mod connect_tests {
 
         let peer_address = get_dummy_socket_address(55);
         let connection_status = check_if_connection_is_allowed(
-            &own_state,
+            state_lock.clone(),
             &own_handshake,
             &other_handshake,
             &peer_address,
@@ -753,7 +802,7 @@ mod connect_tests {
 
         let answer = answer_peer(
             mock,
-            own_state,
+            state_lock.clone(),
             get_dummy_socket_address(0),
             from_main_rx_clone,
             to_main_tx,
@@ -788,16 +837,16 @@ mod connect_tests {
             ))?)
             .build();
 
-        let (_peer_broadcast_tx, from_main_rx_clone, to_main_tx, _to_main_rx1, mut state, _hsd) =
+        let (_peer_broadcast_tx, from_main_rx_clone, to_main_tx, _to_main_rx1, state_lock, _hsd) =
             get_test_genesis_setup(Network::Alpha, 2).await?;
 
         // set max_peers to 2 to ensure failure on next connection attempt
-        state.cli.max_peers = 2;
+        state_lock.lock_mut(|s| s.cli.max_peers = 2).await;
 
         let (_, _, _latest_block_header) = get_dummy_latest_block(None);
         let answer = answer_peer(
             mock,
-            state,
+            state_lock.clone(),
             get_dummy_socket_address(2),
             from_main_rx_clone,
             to_main_tx,
@@ -832,7 +881,7 @@ mod connect_tests {
             .build();
 
         let peer_count_before_incoming_connection_request = 3;
-        let (_peer_broadcast_tx, from_main_rx_clone, to_main_tx, _to_main_rx1, state, _hsd) =
+        let (_peer_broadcast_tx, from_main_rx_clone, to_main_tx, _to_main_rx1, state_lock, _hsd) =
             get_test_genesis_setup(
                 Network::Alpha,
                 peer_count_before_incoming_connection_request,
@@ -847,14 +896,17 @@ mod connect_tests {
             timestamp_of_latest_sanction: Some(SystemTime::now()),
         };
         let peer_address = get_dummy_socket_address(3);
-        state
+
+        state_lock
+            .lock_guard_mut()
+            .await
             .net
             .write_peer_standing_on_decrease(peer_address.ip(), bad_standing)
             .await;
 
         let answer = answer_peer(
             mock,
-            state.clone(),
+            state_lock.clone(),
             peer_address,
             from_main_rx_clone,
             to_main_tx,
@@ -867,7 +919,7 @@ mod connect_tests {
         );
 
         // Verify that peer map is empty after connection has been refused
-        match state.net.peer_map.lock().unwrap().keys().len() {
+        match state_lock.lock(|s| s.net.peer_map.keys().len()).await {
             3 => (),
             _ => bail!("Incorrect number of maps in peer map"),
         };

--- a/src/database/leveldb.rs
+++ b/src/database/leveldb.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use serde::{de::DeserializeOwned, Serialize};
 use std::path::Path;
+use twenty_first::leveldb::options::Options;
 
 /// The interface we want for any LevelDB crate we may use.
 pub trait LevelDB<Key, Value>
@@ -8,11 +9,11 @@ where
     Key: Serialize + DeserializeOwned,
     Value: Serialize + DeserializeOwned,
 {
-    fn new(db_path: &Path, options: &leveldb::options::Options) -> Result<Self>
+    fn new(db_path: &Path, options: &Options) -> Result<Self>
     where
         Self: Sized;
-    fn batch_write(&mut self, entries: &[(Key, Value)]);
-    fn get(&mut self, key: Key) -> Option<Value>;
-    fn put(&mut self, key: Key, value: Value);
-    fn delete(&mut self, key: Key) -> Option<Value>;
+    fn batch_write(&self, entries: impl IntoIterator<Item = (Key, Value)>);
+    fn get(&self, key: Key) -> Option<Value>;
+    fn put(&self, key: Key, value: Value);
+    fn delete(&self, key: Key) -> Option<Value>;
 }

--- a/src/database/leveldb.rs
+++ b/src/database/leveldb.rs
@@ -16,4 +16,5 @@ where
     fn get(&self, key: Key) -> Option<Value>;
     fn put(&self, key: Key, value: Value);
     fn delete(&self, key: Key) -> Option<Value>;
+    fn flush(&self);
 }

--- a/src/database/rusty.rs
+++ b/src/database/rusty.rs
@@ -103,6 +103,12 @@ where
             Err(err) => panic!("database failure: {}", err),
         }
     }
+
+    fn flush(&self) {
+        self.database
+            .write(&WriteBatch::new(), true)
+            .expect("Database flushing to disk must succeed");
+    }
 }
 
 /// `RustyLevelDbAsync` provides an async-friendly and clone-friendly wrapper
@@ -213,6 +219,12 @@ where
         task::spawn_blocking(move || inner.delete(key))
             .await
             .unwrap()
+    }
+
+    /// Delete database value asynchronously
+    pub async fn flush(&self) {
+        let inner = self.0.clone();
+        task::spawn_blocking(move || inner.flush()).await.unwrap()
     }
 }
 

--- a/src/database/rusty.rs
+++ b/src/database/rusty.rs
@@ -1,12 +1,17 @@
 use super::leveldb::LevelDB;
 use anyhow::Result;
-use leveldb::batch::WriteBatch;
-use leveldb::iterator::Iterable;
-use leveldb::options::ReadOptions;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::marker::PhantomData;
 use std::path::Path;
+use std::sync::Arc;
+use tokio::task;
+use twenty_first::leveldb::{
+    batch::WriteBatch,
+    iterator::Iterable,
+    options::{Options, ReadOptions},
+};
+use twenty_first::leveldb_sys::Compression;
 use twenty_first::storage::level_db::DB;
 
 pub struct RustyLevelDB<Key, Value>
@@ -35,8 +40,8 @@ where
     }
 }
 
-pub fn create_db_if_missing() -> leveldb::options::Options {
-    let mut opts = leveldb::options::Options::new();
+pub fn create_db_if_missing() -> Options {
+    let mut opts = Options::new();
     opts.create_if_missing = true;
     opts
 }
@@ -47,7 +52,7 @@ where
     Value: Serialize + DeserializeOwned,
 {
     /// Open or create a new or existing database
-    fn new(db_path: &Path, options: &leveldb::options::Options) -> Result<Self> {
+    fn new(db_path: &Path, options: &Options) -> Result<Self> {
         let database = DB::open(db_path, options)?;
         let database = Self {
             database,
@@ -57,30 +62,30 @@ where
         Ok(database)
     }
 
-    fn get(&mut self, key: Key) -> Option<Value> {
+    fn get(&self, key: Key) -> Option<Value> {
         let key_bytes: Vec<u8> = bincode::serialize(&key).unwrap();
         let value_bytes: Option<Vec<u8>> = self.database.get(&key_bytes).unwrap();
         value_bytes.map(|bytes| bincode::deserialize(&bytes).unwrap())
     }
 
-    fn put(&mut self, key: Key, value: Value) {
+    fn put(&self, key: Key, value: Value) {
         let key_bytes: Vec<u8> = bincode::serialize(&key).unwrap();
         let value_bytes: Vec<u8> = bincode::serialize(&value).unwrap();
         self.database.put(&key_bytes, &value_bytes).unwrap();
     }
 
-    fn batch_write(&mut self, entries: &[(Key, Value)]) {
+    fn batch_write(&self, entries: impl IntoIterator<Item = (Key, Value)>) {
         let batch = WriteBatch::new();
-        for (key, value) in entries.iter() {
-            let key_bytes: Vec<u8> = bincode::serialize(key).unwrap();
-            let value_bytes: Vec<u8> = bincode::serialize(value).unwrap();
+        for (key, value) in entries.into_iter() {
+            let key_bytes: Vec<u8> = bincode::serialize(&key).unwrap();
+            let value_bytes: Vec<u8> = bincode::serialize(&value).unwrap();
             batch.put(&key_bytes, &value_bytes);
         }
 
         self.database.write(&batch, true).unwrap();
     }
 
-    fn delete(&mut self, key: Key) -> Option<Value> {
+    fn delete(&self, key: Key) -> Option<Value> {
         let key_bytes: Vec<u8> = bincode::serialize(&key).unwrap(); // add safety
         let value_bytes: Option<Vec<u8>> = self.database.get(&key_bytes).unwrap();
         let value_object = value_bytes.map(|bytes| bincode::deserialize(&bytes).unwrap());
@@ -93,54 +98,174 @@ where
     }
 }
 
-impl<Key: Serialize + DeserializeOwned, Value: Serialize + DeserializeOwned>
-    RustyLevelDB<Key, Value>
-{
-    pub fn new_iter(&self) -> RustyLevelDBIterator<Key, Value> {
-        RustyLevelDBIterator::new(self)
-    }
+/// `RustyLevelDbAsync` provides an async-friendly and clone-friendly wrapper
+/// around [`RustyLevelDB`].
+///
+/// Methods in the underlying struct `LevelDB` from `rs-leveldb` crate are all sync
+/// and they sometimes perfom blocking file IO.  It is discouraged to
+/// call blocking IO from async code as it can lead to concurrency problems,
+/// usually hidden until a certain level of load is reached.
+///
+/// The tokio page for spawn_blocking says:
+///     In general, issuing a blocking call or performing a lot of compute in a
+///     future without yielding is problematic, as it may prevent the executor from
+///     driving other futures forward.
+///
+/// See:
+///  * <https://github.com/Neptune-Crypto/neptune-core/issues/74>
+///  * <https://internals.rust-lang.org/t/warning-when-calling-a-blocking-function-in-an-async-context/11440/5>
+///  * <https://docs.rs/tokio/latest/tokio/task/fn.spawn_blocking.html>
+///
+/// Therefore `RustyLevelDbAsync` wraps the sync methods with `spawn_blocking()`
+/// so that the tokio runtime can run the blocking IO on a thread where blocking
+/// is acceptable
+#[derive(Clone)]
+pub struct RustyLevelDbAsync<Key, Value>(Arc<RustyLevelDB<Key, Value>>)
+where
+    Key: Serialize + DeserializeOwned,
+    Value: Serialize + DeserializeOwned;
 
-    pub fn flush(&mut self) {
-        self.database
-            .write(&WriteBatch::new(), true)
-            .expect("Database flushing to disk must succeed");
-    }
-}
-
-pub struct RustyLevelDBIterator<
-    'a,
+impl<Key, Value> core::fmt::Debug for RustyLevelDbAsync<Key, Value>
+where
     Key: Serialize + DeserializeOwned,
     Value: Serialize + DeserializeOwned,
-> {
-    iterator: leveldb::iterator::Iterator<'a>,
-    _key: PhantomData<Key>,
-    _value: PhantomData<Value>,
-}
-
-impl<'a, Key: Serialize + DeserializeOwned, Value: Serialize + DeserializeOwned> Iterator
-    for RustyLevelDBIterator<'a, Key, Value>
 {
-    type Item = (Key, Value);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.iterator.next().map(|(sk, sv)| {
-            (
-                bincode::deserialize(&sk).unwrap(),
-                bincode::deserialize(&sv).unwrap(),
-            )
-        })
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RustyLevelDBAsync").finish()
     }
 }
 
-impl<'a, Key: Serialize + DeserializeOwned, Value: Serialize + DeserializeOwned>
-    RustyLevelDBIterator<'a, Key, Value>
+impl<Key, Value> RustyLevelDbAsync<Key, Value>
+where
+    Key: Serialize + DeserializeOwned + Send + Sync + 'static,
+    Value: Serialize + DeserializeOwned + Send + Sync + 'static,
 {
-    fn new(database: &'a RustyLevelDB<Key, Value>) -> Self {
-        let iterator = database.database.iter(&ReadOptions::new());
-        Self {
-            iterator,
-            _key: PhantomData,
-            _value: PhantomData,
+    /// Open or create a new or existing database asynchronously
+    pub async fn new(db_path: &Path, options: &Options) -> Result<Self> {
+        let options_async = OptionsAsync::from(options);
+        let path = db_path.to_path_buf();
+
+        let db =
+            task::spawn_blocking(move || RustyLevelDB::new(&path, &options_async.into())).await??;
+
+        Ok(Self(Arc::new(db)))
+    }
+
+    /// IMPORTANT:  the returne iterator is NOT async.  The database is queried
+    /// synchrously so the caller will block.  Consider using
+    /// `spawn_blocking()` task when using this iterator in async code.
+    ///
+    /// ALSO: this calls allocates all DB keys.  For large databases
+    /// this could be problematic and is best to avoid.
+    ///
+    // todo: can we avoid allocating keys with collect()?
+    // todo: can we create a true async iterator?
+    // todo: perhaps refactor neptune, so it does not need/use a level-db iterator.
+    pub fn iter(&self) -> Box<dyn Iterator<Item = (Key, Value)> + '_> {
+        let inner = self.0.clone();
+        let keys: Vec<_> = inner.database.keys_iter(&ReadOptions::new()).collect();
+
+        Box::new(keys.into_iter().map(move |k| {
+            let v = inner.database.get_u8(&k).unwrap().unwrap();
+
+            (
+                bincode::deserialize(&k).unwrap(),
+                bincode::deserialize(&v).unwrap(),
+            )
+        }))
+    }
+
+    /// Get database value asynchronously
+    pub async fn get(&self, key: Key) -> Option<Value> {
+        let inner = self.0.clone();
+        task::spawn_blocking(move || inner.get(key)).await.unwrap()
+    }
+
+    /// Set database value asynchronously
+    pub async fn put(&self, key: Key, value: Value) {
+        let inner = self.0.clone();
+        task::spawn_blocking(move || inner.put(key, value))
+            .await
+            .unwrap()
+    }
+
+    /// Write database values as a batch asynchronously
+    pub async fn batch_write(
+        &self,
+        entries: impl IntoIterator<Item = (Key, Value)> + Send + Sync + 'static,
+    ) {
+        let inner = self.0.clone();
+        task::spawn_blocking(move || inner.batch_write(entries))
+            .await
+            .unwrap()
+    }
+
+    /// Delete database value asynchronously
+    pub async fn delete(&self, key: Key) -> Option<Value> {
+        let inner = self.0.clone();
+        task::spawn_blocking(move || inner.delete(key))
+            .await
+            .unwrap()
+    }
+}
+
+// We made this OptionsAsync struct because leveldb::options::Options cannot be
+// passed between threads because it contains the `cache: Option<Cache>` field
+// and Cache is not `Send`.  We can't do anything about that, so instead we
+// send this OptionsAsync between threads, which does not have a Cache field.
+//
+// todo:  add a cache_size option specified in bytes.
+struct OptionsAsync {
+    pub create_if_missing: bool,
+    pub error_if_exists: bool,
+    pub paranoid_checks: bool,
+    pub write_buffer_size: Option<usize>,
+    pub max_open_files: Option<i32>,
+    pub block_size: Option<usize>,
+    pub block_restart_interval: Option<i32>,
+    pub compression: Compression,
+}
+impl From<&Options> for OptionsAsync {
+    fn from(o: &Options) -> Self {
+        if o.cache.is_some() {
+            panic!("cache option not supported for RustyLevelDbAsync");
         }
+
+        Self {
+            create_if_missing: o.create_if_missing,
+            error_if_exists: o.error_if_exists,
+            paranoid_checks: o.paranoid_checks,
+            write_buffer_size: o.write_buffer_size,
+            max_open_files: o.max_open_files,
+            block_size: o.block_size,
+            block_restart_interval: o.block_restart_interval,
+            compression: o.compression,
+        }
+    }
+}
+impl From<Options> for OptionsAsync {
+    fn from(o: Options) -> Self {
+        Self::from(&o)
+    }
+}
+
+impl From<&OptionsAsync> for Options {
+    fn from(o: &OptionsAsync) -> Self {
+        Self {
+            create_if_missing: o.create_if_missing,
+            error_if_exists: o.error_if_exists,
+            paranoid_checks: o.paranoid_checks,
+            write_buffer_size: o.write_buffer_size,
+            max_open_files: o.max_open_files,
+            block_size: o.block_size,
+            block_restart_interval: o.block_restart_interval,
+            compression: o.compression,
+            cache: None,
+        }
+    }
+}
+impl From<OptionsAsync> for Options {
+    fn from(o: OptionsAsync) -> Self {
+        Self::from(&o)
     }
 }

--- a/src/database/rusty.rs
+++ b/src/database/rusty.rs
@@ -9,7 +9,7 @@ use tokio::task;
 use twenty_first::leveldb::{
     batch::WriteBatch,
     iterator::Iterable,
-    options::{Options, ReadOptions},
+    options::{Options, ReadOptions, WriteOptions},
 };
 use twenty_first::leveldb_sys::Compression;
 use twenty_first::storage::level_db::DB;
@@ -53,7 +53,14 @@ where
 {
     /// Open or create a new or existing database
     fn new(db_path: &Path, options: &Options) -> Result<Self> {
-        let database = DB::open(db_path, options)?;
+        let mut write_options = WriteOptions::new();
+        write_options.sync = true;
+
+        let mut read_options = ReadOptions::new();
+        read_options.verify_checksums = true;
+        read_options.fill_cache = true;
+
+        let database = DB::open_with_options(db_path, options, read_options, write_options)?;
         let database = Self {
             database,
             _key: PhantomData,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,16 @@
 // recursion limit for macros (e.g. triton_asm!)
 #![recursion_limit = "2048"]
 #![deny(clippy::shadow_unrelated)]
+
+// danda: making all of these pub for now, so docs are generated.
+// later maybe we ought to split some stuff out into re-usable crate(s)...?
 pub mod config_models;
-mod connect_to_peers;
-mod database;
-mod main_loop;
-mod mine_loop;
+pub mod connect_to_peers;
+pub mod database;
+pub mod main_loop;
+pub mod mine_loop;
 pub mod models;
-mod peer_loop;
+pub mod peer_loop;
 pub mod rpc_server;
 pub mod util_types;
 
@@ -18,31 +21,30 @@ use crate::config_models::data_directory::DataDirectory;
 use crate::connect_to_peers::call_peer_wrapper;
 use crate::main_loop::MainLoopHandler;
 use crate::models::channel::RPCServerToMain;
-use crate::models::database::BlockIndexKey;
-use crate::models::database::BlockIndexValue;
+
 use crate::models::state::archival_state::ArchivalState;
-use crate::models::state::blockchain_state::BlockchainState;
+use crate::models::state::blockchain_state::{BlockchainArchivalState, BlockchainState};
 use crate::models::state::light_state::LightState;
 use crate::models::state::mempool::Mempool;
 use crate::models::state::networking_state::NetworkingState;
 use crate::models::state::wallet::wallet_state::WalletState;
 use crate::models::state::wallet::WalletSecret;
-use crate::models::state::GlobalState;
+use crate::models::state::GlobalStateLock;
 use crate::rpc_server::RPC;
 use anyhow::{Context, Result};
 use config_models::cli_args;
-use database::rusty::RustyLevelDB;
+
+use crate::util_types::sync::tokio as sync_tokio;
+use chrono::{DateTime, Local, NaiveDateTime, Utc};
 use futures::future;
 use futures::Future;
 use futures::StreamExt;
 use models::blockchain::block::Block;
 use models::blockchain::shared::Hash;
-use models::database::PeerDatabases;
 use models::peer::PeerInfo;
 use std::collections::HashMap;
 use std::env;
 use std::net::SocketAddr;
-use std::sync::{Arc, Mutex};
 use tarpc::server;
 use tarpc::server::incoming::Incoming;
 use tarpc::server::Channel;
@@ -50,7 +52,8 @@ use tokio::net::TcpListener;
 use tokio::sync::{broadcast, mpsc, watch};
 use tokio::time::Instant;
 use tokio_serde::formats::*;
-use tracing::info;
+use tracing::{info, trace};
+use twenty_first::sync::{LockCallbackFn, LockEvent};
 
 use crate::models::channel::{MainToMiner, MainToPeerThread, MinerToMain, PeerThreadToMain};
 use crate::models::peer::HandshakeData;
@@ -80,18 +83,13 @@ pub async fn initialize(cli_args: cli_args::Args) -> Result<()> {
     info!("Got wallet state.");
 
     // Connect to or create databases for block index, peers, mutator set, block sync
-    let block_index_db = ArchivalState::initialize_block_index_database(&data_dir)?;
-    let block_index_db: Arc<tokio::sync::Mutex<RustyLevelDB<BlockIndexKey, BlockIndexValue>>> =
-        Arc::new(tokio::sync::Mutex::new(block_index_db));
+    let block_index_db = ArchivalState::initialize_block_index_database(&data_dir).await?;
     info!("Got block index database");
 
-    let peer_databases = NetworkingState::initialize_peer_databases(&data_dir)?;
-    let peer_databases: Arc<tokio::sync::Mutex<PeerDatabases>> =
-        Arc::new(tokio::sync::Mutex::new(peer_databases));
+    let peer_databases = NetworkingState::initialize_peer_databases(&data_dir).await?;
     info!("Got peer database");
 
-    let archival_mutator_set = ArchivalState::initialize_mutator_set(&data_dir)?;
-    let archival_mutator_set = Arc::new(tokio::sync::Mutex::new(archival_mutator_set));
+    let archival_mutator_set = ArchivalState::initialize_mutator_set(&data_dir).await?;
     info!("Got archival mutator set");
 
     let archival_state = ArchivalState::new(data_dir, block_index_db, archival_mutator_set).await;
@@ -105,8 +103,7 @@ pub async fn initialize(cli_args: cli_args::Args) -> Result<()> {
     .with_context(|| format!("Failed to bind to local TCP port {}:{}. Is an instance of this program already running?", cli_args.listen_addr, cli_args.peer_port))?;
     info!("Now listening for incoming transactions");
 
-    let peer_map: Arc<Mutex<HashMap<SocketAddr, PeerInfo>>> =
-        Arc::new(std::sync::Mutex::new(HashMap::new()));
+    let peer_map: HashMap<SocketAddr, PeerInfo> = HashMap::new();
 
     // Construct the broadcast channel to communicate from the main thread to peer threads
     let (main_to_peer_broadcast_tx, _main_to_peer_broadcast_rx) =
@@ -118,24 +115,29 @@ pub async fn initialize(cli_args: cli_args::Args) -> Result<()> {
 
     // Create handshake data which is used when connecting to outgoing peers specified in the
     // CLI arguments
-    let syncing = Arc::new(std::sync::RwLock::new(false));
+    let syncing = false;
     let networking_state = NetworkingState::new(peer_map, peer_databases, syncing);
 
-    let light_state: LightState = LightState::new(latest_block.clone());
-    let blockchain_state = BlockchainState {
+    let light_state: LightState = LightState::from(latest_block.clone());
+    let blockchain_archival_state = BlockchainArchivalState {
         light_state,
-        archival_state: Some(archival_state),
+        archival_state,
     };
+    let blockchain_state = BlockchainState::Archival(blockchain_archival_state);
     let mempool = Mempool::new(cli_args.max_mempool_size);
-    let state = GlobalState {
-        chain: blockchain_state,
-        cli: cli_args,
-        net: networking_state,
+    let global_state_lock = GlobalStateLock::new(
         wallet_state,
+        blockchain_state,
+        networking_state,
+        cli_args,
         mempool,
-        mining: Arc::new(std::sync::RwLock::new(false)),
-    };
-    let own_handshake_data: HandshakeData = state.get_own_handshakedata().await;
+        false,
+    );
+    let own_handshake_data: HandshakeData = global_state_lock
+        .lock_guard()
+        .await
+        .get_own_handshakedata()
+        .await;
     info!(
         "Most known canonical block has height {}",
         own_handshake_data.tip_header.height
@@ -143,29 +145,37 @@ pub async fn initialize(cli_args: cli_args::Args) -> Result<()> {
 
     // Check if we need to restore the wallet database, and if so, do it.
     info!("Checking if we need to restore UTXOs");
-    state.restore_monitored_utxos_from_recovery_data().await?;
+    global_state_lock
+        .lock_guard_mut()
+        .await
+        .restore_monitored_utxos_from_recovery_data()
+        .await?;
     info!("UTXO restoration check complete");
+
+    let global_state = global_state_lock.lock_guard().await;
 
     // Connect to peers, and provide each peer thread with a thread-safe copy of the state
     let mut thread_join_handles = vec![];
-    for peer_address in state.cli.peers.clone() {
-        let peer_state_var = state.clone();
+    for peer_address in global_state.cli.peers.clone() {
+        let peer_state_var = global_state_lock.clone(); // bump arc refcount
         let main_to_peer_broadcast_rx_clone: broadcast::Receiver<MainToPeerThread> =
             main_to_peer_broadcast_tx.subscribe();
         let peer_thread_to_main_tx_clone: mpsc::Sender<PeerThreadToMain> =
             peer_thread_to_main_tx.clone();
         let own_handshake_data_clone = own_handshake_data.clone();
-        let peer_join_handle = tokio::spawn(async move {
-            call_peer_wrapper(
-                peer_address,
-                peer_state_var.clone(),
-                main_to_peer_broadcast_rx_clone,
-                peer_thread_to_main_tx_clone,
-                own_handshake_data_clone,
-                1, // All outgoing connections have distance 1
-            )
-            .await;
-        });
+        let peer_join_handle = tokio::task::Builder::new()
+            .name("call_peer_wrapper_3")
+            .spawn(async move {
+                call_peer_wrapper(
+                    peer_address,
+                    peer_state_var.clone(),
+                    main_to_peer_broadcast_rx_clone,
+                    peer_thread_to_main_tx_clone,
+                    own_handshake_data_clone,
+                    1, // All outgoing connections have distance 1
+                )
+                .await;
+            })?;
         thread_join_handles.push(peer_join_handle);
     }
     info!("Made outgoing connections to peers");
@@ -173,18 +183,20 @@ pub async fn initialize(cli_args: cli_args::Args) -> Result<()> {
     // Start mining threads if requested
     let (miner_to_main_tx, miner_to_main_rx) = mpsc::channel::<MinerToMain>(MINER_CHANNEL_CAPACITY);
     let (main_to_miner_tx, main_to_miner_rx) = watch::channel::<MainToMiner>(MainToMiner::Empty);
-    let state_clone_for_miner = state.clone();
-    if state.cli.mine {
-        let miner_join_handle = tokio::spawn(async move {
-            mine_loop::mine(
-                main_to_miner_rx,
-                miner_to_main_tx,
-                latest_block,
-                state_clone_for_miner,
-            )
-            .await
-            .expect("Error in mining thread");
-        });
+    let miner_state_lock = global_state_lock.clone(); // bump arc refcount.
+    if global_state.cli.mine {
+        let miner_join_handle = tokio::task::Builder::new()
+            .name("miner")
+            .spawn(async move {
+                mine_loop::mine(
+                    main_to_miner_rx,
+                    miner_to_main_tx,
+                    latest_block,
+                    miner_state_lock,
+                )
+                .await
+                .expect("Error in mining thread");
+            })?;
         thread_join_handles.push(miner_join_handle);
         info!("Started mining thread");
     }
@@ -194,16 +206,20 @@ pub async fn initialize(cli_args: cli_args::Args) -> Result<()> {
     let (rpc_server_to_main_tx, rpc_server_to_main_rx) =
         mpsc::channel::<RPCServerToMain>(RPC_CHANNEL_CAPACITY);
     let mut rpc_listener = tarpc::serde_transport::tcp::listen(
-        format!("127.0.0.1:{}", state.cli.rpc_port),
+        format!("127.0.0.1:{}", global_state.cli.rpc_port),
         Json::default,
     )
     .await?;
     rpc_listener.config_mut().max_frame_length(usize::MAX);
-    let rpc_listener_state: GlobalState = state.clone();
+
+    drop(global_state);
+
+    let rpc_state_lock = global_state_lock.clone();
 
     async fn spawn(fut: impl Future<Output = ()> + Send + 'static) {
         tokio::spawn(fut);
     }
+
     let rpc_join_handle = tokio::spawn(async move {
         rpc_listener
             // Ignore accept errors.
@@ -213,10 +229,10 @@ pub async fn initialize(cli_args: cli_args::Args) -> Result<()> {
             .max_channels_per_key(5, |t| t.transport().peer_addr().unwrap().ip())
             // serve is generated by the service attribute. It takes as input any type implementing
             // the generated RPC trait.
-            .map(|channel| {
+            .map(move |channel| {
                 let server = rpc_server::NeptuneRPCServer {
                     socket_address: channel.transport().peer_addr().unwrap(),
-                    state: rpc_listener_state.clone(),
+                    state: rpc_state_lock.clone(),
                     rpc_server_to_main_tx: rpc_server_to_main_tx.clone(),
                 };
                 channel.execute(server.serve()).for_each(spawn)
@@ -233,7 +249,7 @@ pub async fn initialize(cli_args: cli_args::Args) -> Result<()> {
     info!("Starting main loop");
     let main_loop_handler = MainLoopHandler::new(
         incoming_peer_listener,
-        state,
+        global_state_lock,
         main_to_peer_broadcast_tx,
         peer_thread_to_main_tx,
         main_to_miner_tx,
@@ -268,3 +284,114 @@ where
     let total_time = elapsed.as_secs() as f64 + elapsed.subsec_nanos() as f64 / 1e9;
     (output, total_time)
 }
+
+/// Converts a UTC timestamp (seconds since 1970 UTC) into
+/// a `DateTime<Local>`, ie local-time.
+pub fn utc_timestamp_to_localtime<T>(timestamp: T) -> DateTime<Local>
+where
+    T: TryInto<i64>,
+    <T as TryInto<i64>>::Error: std::fmt::Debug,
+{
+    // We just want to convert a UTC timestamp to a
+    // local time string.  I've never seen this be so
+    // unintuitive in any other language or library.
+    // Why on earth is chrono popular?!!
+    let naive = NaiveDateTime::from_timestamp_millis(timestamp.try_into().unwrap()).unwrap();
+    let utc: DateTime<Utc> = DateTime::from_naive_utc_and_offset(naive, *Utc::now().offset());
+    DateTime::from(utc)
+}
+
+// This is a callback fn passed to AtomicRw, AtomicMutex
+// and called when a lock event occurs.  This way
+// we can track which threads+tasks are acquiring
+// which locks for reads and/or mutations.
+pub(crate) fn log_lock_event(lock_event: LockEvent) {
+    let tokio_id = match tokio::task::try_id() {
+        Some(id) => format!("{}", id),
+        None => "?".to_string(),
+    };
+
+    let (event_type, info, acquisition) = match lock_event {
+        LockEvent::TryAcquire {
+            ref info,
+            acquisition,
+        } => ("TryAcquire", info, acquisition),
+        LockEvent::Acquire {
+            ref info,
+            acquisition,
+        } => ("Acquire", info, acquisition),
+        LockEvent::Release {
+            ref info,
+            acquisition,
+        } => ("Release", info, acquisition),
+    };
+    trace!(
+            ?lock_event,
+            "{} lock `{}` of type `{}` for `{}` by\n\t|-- thread {}, (`{}`)\n\t|-- tokio task {}\n\t|--",
+            event_type,
+            info.name().unwrap_or("?"),
+            info.lock_type(),
+            acquisition,
+            current_thread_id(),
+            std::thread::current().name().unwrap_or("?"),
+            tokio_id,
+    );
+}
+const LOG_LOCK_EVENT_CB: LockCallbackFn = log_lock_event;
+
+pub(crate) fn current_thread_id() -> u64 {
+    // workaround: parse thread_id debug output into a u64.
+    // (because ThreadId::as_u64() is unstable)
+    let thread_id_dbg: String = format!("{:?}", std::thread::current().id());
+    let nums_u8 = &thread_id_dbg
+        .chars()
+        .filter_map(|c| {
+            if c.is_ascii_digit() {
+                Some(c as u8)
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<u8>>();
+    let nums = String::from_utf8_lossy(nums_u8).to_string();
+
+    nums.parse::<u64>().unwrap()
+}
+
+// This is a callback fn passed to AtomicRw, AtomicMutex
+// and called when a lock event occurs.  This way
+// we can track which threads+tasks are acquiring
+// which locks for reads and/or mutations.
+pub(crate) fn log_tokio_lock_event(lock_event: sync_tokio::LockEvent) {
+    let tokio_id = match tokio::task::try_id() {
+        Some(id) => format!("{}", id),
+        None => "?".to_string(),
+    };
+
+    let (event_type, info, acquisition) = match lock_event {
+        sync_tokio::LockEvent::TryAcquire {
+            ref info,
+            acquisition,
+        } => ("TryAcquire", info, acquisition),
+        sync_tokio::LockEvent::Acquire {
+            ref info,
+            acquisition,
+        } => ("Acquire", info, acquisition),
+        sync_tokio::LockEvent::Release {
+            ref info,
+            acquisition,
+        } => ("Release", info, acquisition),
+    };
+    trace!(
+            ?lock_event,
+            "{} tokio lock `{}` of type `{}` for `{}` by\n\t|-- thread {}, (`{}`)\n\t|-- tokio task {}\n\t|--",
+            event_type,
+            info.name().unwrap_or("?"),
+            info.lock_type(),
+            acquisition,
+            current_thread_id(),
+            std::thread::current().name().unwrap_or("?"),
+            tokio_id,
+    );
+}
+const LOG_TOKIO_LOCK_EVENT_CB: sync_tokio::LockCallbackFn = log_tokio_lock_event;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,7 +285,7 @@ where
     (output, total_time)
 }
 
-/// Converts a UTC timestamp (seconds since 1970 UTC) into
+/// Converts a UTC millisecond timestamp (millis since 1970 UTC) into
 /// a `DateTime<Local>`, ie local-time.
 pub fn utc_timestamp_to_localtime<T>(timestamp: T) -> DateTime<Local>
 where

--- a/src/models/database.rs
+++ b/src/models/database.rs
@@ -6,7 +6,7 @@ use twenty_first::shared_math::digest::Digest;
 use super::blockchain::block::block_header::BlockHeader;
 use super::blockchain::block::block_height::BlockHeight;
 use super::peer::PeerStanding;
-use crate::database::rusty::RustyLevelDB;
+use crate::database::rusty::RustyLevelDbAsync;
 
 pub const DATABASE_DIRECTORY_ROOT_NAME: &str = "databases";
 
@@ -131,8 +131,9 @@ impl BlockIndexValue {
     }
 }
 
+#[derive(Clone)]
 pub struct PeerDatabases {
-    pub peer_standings: RustyLevelDB<IpAddr, PeerStanding>,
+    pub peer_standings: RustyLevelDbAsync<IpAddr, PeerStanding>,
 }
 
 impl fmt::Debug for PeerDatabases {

--- a/src/models/state/blockchain_state.rs
+++ b/src/models/state/blockchain_state.rs
@@ -1,17 +1,82 @@
 use super::{archival_state::ArchivalState, light_state::LightState};
 
-/// The `BlockchainState` contains database access to block headers.
+/// `BlockChainState` provides an `Archival` variant
+/// for full nodes and a `Light` variant for light nodes.
+///
+/// It provides a bit of abstraction over the chain state.
+/// In particular, one can call `light_state()` and get
+/// the current tip for either variant.
+///
+/// It is intended to be forward thinking for when we
+/// actually implement a light node.
+///
+// silence possible clippy bug / false positive.
+// see: https://github.com/rust-lang/rust-clippy/issues/9798
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug)]
+pub enum BlockchainState {
+    /// represents a Archival blockchain state
+    Archival(BlockchainArchivalState),
+    /// represents Light node blockchain state (ie the current tip)
+    Light(LightState),
+}
+
+impl BlockchainState {
+    /// check if this is an archival node/state
+    #[inline]
+    pub fn is_archival_node(&self) -> bool {
+        matches!(self, Self::Archival(_))
+    }
+
+    /// retrieve archival state.
+    ///
+    /// panics if called by a light node.
+    #[inline]
+    pub fn archival_state(&self) -> &ArchivalState {
+        match self {
+            Self::Archival(bac) => &bac.archival_state,
+            Self::Light(_) => panic!("archival_state not available in LightState mode"),
+        }
+    }
+
+    /// retrieve mutable archival state.
+    ///
+    /// panics if called by a light node.
+    #[inline]
+    pub fn archival_state_mut(&mut self) -> &mut ArchivalState {
+        match self {
+            Self::Archival(bac) => &mut bac.archival_state,
+            Self::Light(_) => panic!("archival_state not available in LightState mode"),
+        }
+    }
+
+    /// retrieve light state, ie the current tip.
+    #[inline]
+    pub fn light_state(&self) -> &LightState {
+        match self {
+            Self::Archival(bac) => &bac.light_state,
+            Self::Light(light_state) => light_state,
+        }
+    }
+
+    /// retrieve mutable light state, ie the current tip.
+    #[inline]
+    pub fn light_state_mut(&mut self) -> &mut LightState {
+        match self {
+            Self::Archival(bac) => &mut bac.light_state,
+            Self::Light(light_state) => light_state,
+        }
+    }
+}
+
+/// The `BlockchainArchivalState` contains database access to block headers.
 ///
 /// It is divided into `ArchivalState` and `LightState`.
-#[derive(Debug, Clone)]
-pub struct BlockchainState {
-    /// The `archival_state` locks require an await to be taken, so archival_state
-    /// locks must always be taken before light state locks. Due to the policy of
-    /// taking locks in the order they are defined in terms of fields, archival_state
-    /// must be listed before `light_state`.
-    pub archival_state: Option<ArchivalState>,
+#[derive(Debug)]
+pub struct BlockchainArchivalState {
+    /// Historical blockchain data, persisted
+    pub archival_state: ArchivalState,
 
-    /// The `LightState` contains a lock from std::sync which may not be held
-    /// across an await.
+    /// The present tip.
     pub light_state: LightState,
 }

--- a/src/models/state/light_state.rs
+++ b/src/models/state/light_state.rs
@@ -1,30 +1,5 @@
-use std::sync::Arc;
-
-use crate::models::blockchain::block::block_header::BlockHeader;
 use crate::models::blockchain::block::Block;
 
-#[derive(Debug, Clone)]
-pub struct LightState {
-    // The documentation recommends using `std::sync::Mutex` for data that lives in memory,
-    // but the `stad::sync::Mutex` cannot be held across `await` and that is too restrictive
-    // at the moment, since we often want to hold multiple locks at the same time, and some
-    // of these require calls to await.
-    pub latest_block: Arc<tokio::sync::Mutex<Block>>,
-}
-
-impl LightState {
-    // TODO: Consider renaming to `new_threadsafe()` to reflect it does not return a `Self`.
-    pub fn new(initial_latest_block: Block) -> Self {
-        Self {
-            latest_block: Arc::new(tokio::sync::Mutex::new(initial_latest_block)),
-        }
-    }
-
-    pub async fn get_latest_block(&self) -> Block {
-        self.latest_block.lock().await.clone()
-    }
-
-    pub async fn get_latest_block_header(&self) -> BlockHeader {
-        self.latest_block.lock().await.header.clone()
-    }
-}
+/// LightState is just a thread-safe Block.
+/// (always representing the latest block)
+pub type LightState = Block;

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -826,19 +826,25 @@ impl GlobalState {
         // flush wallet databases
         self.wallet_state.wallet_db.persist();
 
-        let hash = self.chain.archival_state().get_latest_block().await.hash;
+        // flush block_index database
+        self.chain.archival_state().block_index_db.flush().await;
 
         // persist archival_mutator_set, with sync label
+        let hash = self.chain.archival_state().get_latest_block().await.hash;
         self.chain
             .archival_state_mut()
             .archival_mutator_set
             .set_sync_label(hash);
+
         self.chain
             .archival_state_mut()
             .archival_mutator_set
             .persist();
 
-        debug!("Persisted all databases");
+        // flush peer_standings
+        self.net.peer_databases.peer_standings.flush().await;
+
+        debug!("Flushed all databases");
 
         Ok(())
     }

--- a/src/models/state/networking_state.rs
+++ b/src/models/state/networking_state.rs
@@ -1,13 +1,10 @@
 use crate::config_models::data_directory::DataDirectory;
-use crate::database::leveldb::LevelDB;
-use crate::database::rusty::{create_db_if_missing, RustyLevelDB};
+use crate::database::rusty::{create_db_if_missing, RustyLevelDbAsync};
 use crate::models::database::PeerDatabases;
 use crate::models::peer::{self, PeerStanding};
 use anyhow::Result;
 use std::net::IpAddr;
-use std::sync::Mutex as StdMutex;
-use std::{collections::HashMap, net::SocketAddr, sync::Arc};
-use tokio::sync::Mutex as TokioMutex;
+use std::{collections::HashMap, net::SocketAddr};
 
 pub const BANNED_IPS_DB_NAME: &str = "banned_ips";
 
@@ -19,28 +16,23 @@ type PeerMap = HashMap<SocketAddr, peer::PeerInfo>;
 pub struct NetworkingState {
     // Stores info about the peers that the client is connected to
     // Peer threads may update their own entries into this map.
-    pub peer_map: Arc<StdMutex<PeerMap>>,
+    pub peer_map: PeerMap,
 
-    // Since this is a database, we use the tokio Mutex here.
     // `peer_databases` are used to persist IPs with their standing.
     // The peer threads may update their own entries into this map.
-    pub peer_databases: Arc<TokioMutex<PeerDatabases>>,
+    pub peer_databases: PeerDatabases,
 
     // This value is only true if instance is running an archival node
     // that is currently downloading blocks to catch up.
     // Only the main thread may update this flag
-    pub syncing: Arc<std::sync::RwLock<bool>>,
+    pub syncing: bool,
 
     // Read-only value set during startup
     pub instance_id: u128,
 }
 
 impl NetworkingState {
-    pub fn new(
-        peer_map: Arc<StdMutex<PeerMap>>,
-        peer_databases: Arc<TokioMutex<PeerDatabases>>,
-        syncing: Arc<std::sync::RwLock<bool>>,
-    ) -> Self {
+    pub fn new(peer_map: PeerMap, peer_databases: PeerDatabases, syncing: bool) -> Self {
         Self {
             peer_map,
             peer_databases,
@@ -50,14 +42,15 @@ impl NetworkingState {
     }
 
     /// Create databases for peer standings
-    pub fn initialize_peer_databases(data_dir: &DataDirectory) -> Result<PeerDatabases> {
+    pub async fn initialize_peer_databases(data_dir: &DataDirectory) -> Result<PeerDatabases> {
         let database_dir_path = data_dir.database_dir_path();
         DataDirectory::create_dir_if_not_exists(&database_dir_path)?;
 
-        let peer_standings = RustyLevelDB::<IpAddr, PeerStanding>::new(
+        let peer_standings = RustyLevelDbAsync::<IpAddr, PeerStanding>::new(
             &data_dir.banned_ips_database_dir_path(),
             &create_db_if_missing(),
-        )?;
+        )
+        .await?;
 
         Ok(PeerDatabases { peer_standings })
     }
@@ -66,8 +59,7 @@ impl NetworkingState {
     pub async fn all_peer_sanctions_in_database(&self) -> HashMap<IpAddr, PeerStanding> {
         let mut sanctions = HashMap::default();
 
-        let peer_databases = self.peer_databases.lock().await;
-        let mut dbiterator = peer_databases.peer_standings.new_iter();
+        let mut dbiterator = self.peer_databases.peer_standings.iter();
         for (ip, standing) in dbiterator.by_ref() {
             if standing.is_negative() {
                 sanctions.insert(ip, standing);
@@ -78,33 +70,32 @@ impl NetworkingState {
     }
 
     pub async fn get_peer_standing_from_database(&self, ip: IpAddr) -> Option<PeerStanding> {
-        let mut peer_databases = self.peer_databases.lock().await;
-        peer_databases.peer_standings.get(ip)
+        self.peer_databases.peer_standings.get(ip).await
     }
 
     pub async fn clear_ip_standing_in_database(&self, ip: IpAddr) {
-        let mut peer_databases = self.peer_databases.lock().await;
-
-        let old_standing = peer_databases.peer_standings.get(ip);
+        let old_standing = self.peer_databases.peer_standings.get(ip).await;
 
         if old_standing.is_some() {
-            peer_databases
+            self.peer_databases
                 .peer_standings
                 .put(ip, PeerStanding::default())
+                .await
         }
     }
 
     pub async fn clear_all_standings_in_database(&self) {
-        let mut peer_databases = self.peer_databases.lock().await;
+        let new_entries: Vec<_> = self
+            .peer_databases
+            .peer_standings
+            .iter()
+            .map(|(ip, _old_standing)| (ip, PeerStanding::default()))
+            .collect();
 
-        let mut dbiterator = peer_databases.peer_standings.new_iter();
-
-        let mut new_entries = vec![];
-        for (ip, _old_standing) in dbiterator.by_ref() {
-            new_entries.push((ip, PeerStanding::default()));
-        }
-
-        peer_databases.peer_standings.batch_write(&new_entries);
+        self.peer_databases
+            .peer_standings
+            .batch_write(new_entries)
+            .await
     }
 
     // Storing IP addresses is, according to this answer, not a violation of GDPR:
@@ -115,11 +106,13 @@ impl NetworkingState {
         ip: IpAddr,
         current_standing: PeerStanding,
     ) {
-        let mut peer_databases = self.peer_databases.lock().await;
-        let old_standing = peer_databases.peer_standings.get(ip);
+        let old_standing = self.peer_databases.peer_standings.get(ip).await;
 
         if old_standing.is_none() || old_standing.unwrap().standing > current_standing.standing {
-            peer_databases.peer_standings.put(ip, current_standing)
+            self.peer_databases
+                .peer_standings
+                .put(ip, current_standing)
+                .await
         }
     }
 }

--- a/src/util_types/sync/tokio/atomic_mutex.rs
+++ b/src/util_types/sync/tokio/atomic_mutex.rs
@@ -143,7 +143,7 @@ impl<T> From<Mutex<T>> for AtomicMutex<T> {
     }
 }
 impl<T> From<(Mutex<T>, Option<String>, Option<LockCallbackFn>)> for AtomicMutex<T> {
-    /// Create from an Mutex<T> plus an optional name
+    /// Create from a `Mutex<T>` plus an optional name
     /// and an optional callback function, which is called
     /// when a lock event occurs.
     #[inline]
@@ -194,7 +194,7 @@ impl<T> From<AtomicMutex<T>> for Arc<Mutex<T>> {
 // note: we impl the Atomic trait methods here also so they
 // can be used without caller having to use the trait.
 impl<T> AtomicMutex<T> {
-    /// Acquire lock and return a `MutexGuard`
+    /// Acquire read lock and return an `AtomicMutexGuard`
     ///
     /// # Examples
     /// ```

--- a/src/util_types/sync/tokio/atomic_rw.rs
+++ b/src/util_types/sync/tokio/atomic_rw.rs
@@ -19,8 +19,7 @@ use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 /// # })
 /// ```
 ///
-/// It is also possible to provide a name and callback fn
-/// during instantiation.  In this way, the application
+/// It is also possible to provide a name and callback fn/// during instantiation.  In this way, the application
 /// can easily trace lock acquisitions.
 ///
 /// # Examples
@@ -143,7 +142,7 @@ impl<T> From<RwLock<T>> for AtomicRw<T> {
     }
 }
 impl<T> From<(RwLock<T>, Option<String>, Option<LockCallbackFn>)> for AtomicRw<T> {
-    /// Create from an RwLock<T> plus an optional name
+    /// Create from a `RwLock<T>` plus an optional name
     /// and an optional callback function, which is called
     /// when a lock event occurs.
     #[inline]

--- a/src/util_types/sync/tokio/mod.rs
+++ b/src/util_types/sync/tokio/mod.rs
@@ -4,15 +4,16 @@
 //       It would make sense to put these tokio wrappers there also except
 //       that twenty-first presently has no tokio dependency and I didn't
 //       really want to introduce one just for this.  So that's why they are
-//       here instead.  We may wish to revisit in the future.
+//       here instead.  We may wish to revisit in the future, and maybe
+//       put all the sync types in their own crate.
 
 mod atomic_mutex;
 mod atomic_rw;
 mod shared;
 pub mod traits;
 
-pub use atomic_mutex::AtomicMutex;
-pub use atomic_rw::AtomicRw;
+pub use atomic_mutex::{AtomicMutex, AtomicMutexGuard};
+pub use atomic_rw::{AtomicRw, AtomicRwReadGuard, AtomicRwWriteGuard};
 pub use shared::{LockAcquisition, LockCallbackFn, LockEvent, LockInfo, LockType};
 
 use shared::LockCallbackInfo;


### PR DESCRIPTION
First off, I apologize for the size of this PR.   I normally keep PRs as small/focused as I can.

I started a branch while working on twenty_first storage in order to test those changes in neptune.   As I iterated on storage that led to the AtomicRw lock in twenty-first, which led to tokio AtomicRw in neptune.  At first I was replacing and refactoring (encapsulating) the existing locks and I wanted to be able to log/trace their activity, so I added a facility for that.   As I dug deeper I found that we still couldn't really guarantee concurrent write serialization at the highest level ie across Blockchain, Mempool, Wallet state.  So I experimented with a lock around GlobalState, and it appears to work well and also simplify code in the other State types as well.  Most other changes were sort of incidental along the way, as I was deep into refactoring.

Here are the high level changes:

 * create `GlobalStateLock` and use it for all state locking.
 * remove other locks (except those in storage layer, still a todo)
 * add tokio `AtomicRw` and `AtomicMutex` async lock types.
 * trace (log) all lock events (TryAcquire, Acquire, Release)
 * use tokio Builder when spawning tasks to provide a task name for tracing.
 * add `RustyLevelDbAsync` async-friendly DB wrapper
 * simplify `LightState`, now just a type alias for Block
 * add enum `BlockChainState` to distinguish Archival vs Light mode
 * use twenty_first storage iterators where appropriate
 * improve some doc-comments, `cargo doc` runs without warnings
 * general cleanups and refactors
 * log timestamp of each mined block, converted to localtime
 * display date fields using user's localtime in `neptune-dashboard` 

Many of these changes are inter-related.  However, if requested I could pull out some things into smaller, easier to review PRs.

The GlobalState lock is the most significant architectural change and so may need the most justification.  Here's a comment from the code that describes and makes a case for it:

```
`GlobalStateLock` holds a [`tokio::AtomicRw`] ([`RwLock`]) over [`GlobalState`].

Conceptually** all reads and writes of application state
require acuiring this lock.

Having a single lock is useful for a few reasons:
 1. Enables write serialization over all application state.
    (blockchain, mempool, wallet, global flags)
 2. Readers see a consistent view of data.
 3. makes it easy to reason about locking.
 4. simplifies the codebase.

The primary drawback is that long write operations can
block readers.  As such, every effort should be made to keep
write operations as short as possible, though
correctness/atomicity have first priority.

Using an `RwLock` is beneficial for concurrency vs using a `Mutex`.
Readers do not block eachother.  Only a writer blocks readers.
See [`RwLock`](std::sync::RwLock) docs for details.

** At the present time, storage types in twenty_first::storage
implement their own locking, which means they can be mutated
without acquiring the `GlobalStateLock`.  This may change in
the future.

Usage conventions:

// property naming:
struct Foo {
    global_state_lock: GlobalStateLock
}

// read guard naming:
let global_state = foo.global_state_lock.lock_guard().await;

// write guard naming:
let global_state_mut = foo.global_state_lock.lock_guard_mut().await;

These conventions make it easy to distinguish read access from write
access when reading and reviewing code.

When using a read-guard or write-guard, always drop it as soon as possible.
Failure to do so can result in poor concurrency or deadlock.

Deadlocks are generally not hard to track down.  Lock events are traced.
The app log records each `TryAcquire`, `Acquire` and `Release` event
when run with `RUST_LOG='info,neptune_core=trace'`.

If a deadlock has occurred, the log will end with a `TryAcquire` event
(read or write) and just scroll up to find the previous `Acquire` for
write event to see which thread is holding the lock.
```

So yeah I think the GlobalStateLock is a good change.  If nothing else, it makes a lot of code easier to read/maintain without all the interior locks.   But if others don't agree, I am willing to do some more work to inform and hopefully justify it, such as creating/running some perf benchmarks... (though that would take time that could be spent on other things).     Alternatively, some of the other changes could be split out into separate PRs.   I also have some older code from the branch that encapsulates existing locks rather than using `GlobalStateLock`.


Notes:

* I have squashed the 70+ original commits since early December into a single commit because rebasing all of those onto present tip would have taken ages.
* I had some twenty-first dep difficulties:
    * This relies on some twenty-first changes made after 0.36.0.   So there is a Cargo.toml patch section.   The patches are in branch `0_36_backports` in twenty-first repo.
   * I couldn't just use twenty-first master because it appears to contain some changes that are incompatible with triton-vm and/or tasm.
   * triton-vm now exports twenty_first (yay!) but tasm does not yet export triton-vm.   If/when that happens, we could/should change all use statements in neptune-core, and that would enable mixed versions of twenty-first for times like this.    But for now the 0_36_backports branch is a workaround.
   * If twenty-first::storage and twenty-first::sync were in their own crates, that would have solved this issue also.  Perhaps eventually.

Testing:

* ran two nodes on local subnet overnight, each starting with no wallet or blockchain, connected only to eachother, with dashboard running.   Both found blocks and reported no significant errors.
* synced with alphanet-v5 peers.
* passes all unit tests and doc tests
* cargo doc generates docs without warnings.
* fmt and cargo are clean, including tests
