### PR TITLE
fix: reduce dashboard CPU usage via fewer draws

### DIFF
--- a/src/bin/dashboard_src/history_screen.rs
+++ b/src/bin/dashboard_src/history_screen.rs
@@ -124,7 +124,7 @@ impl HistoryScreen {
     async fn run_polling_loop(
         rpc_client: Arc<RPCClient>,
         balance_updates: BalanceUpdateArc,
-        _escalatable_event_arc: DashboardEventArc,
+        escalatable_event: DashboardEventArc,
     ) -> ! {
         // use macros to reduce boilerplate
         macro_rules! setup_poller {
@@ -161,6 +161,9 @@ impl HistoryScreen {
                         history_builder.push((*block_height, *timestamp, *amount, *sign, balance));
                     }
                     *balance_updates.lock().unwrap() = history_builder;
+
+                    *escalatable_event.lock().unwrap() = Some(DashboardEvent::RefreshScreen);
+
                     reset_poller!(balance_history, Duration::from_secs(10));
                 },
             }

--- a/src/bin/dashboard_src/overview_screen.rs
+++ b/src/bin/dashboard_src/overview_screen.rs
@@ -203,6 +203,8 @@ impl OverviewScreen {
                                 own_overview_data.confirmations = resp.confirmations;
                             }
 
+                            *escalatable_event.lock().unwrap() = Some(DashboardEvent::RefreshScreen);
+
                             reset_poller!(dashboard_overview_data, Duration::from_secs(3));
                         },
                         Err(e) => *escalatable_event.lock().unwrap() = Some(DashboardEvent::Shutdown(e.to_string())),

--- a/src/bin/dashboard_src/peers_screen.rs
+++ b/src/bin/dashboard_src/peers_screen.rs
@@ -93,6 +93,8 @@ impl PeersScreen {
                     match rpc_client.peer_info(context::current()).await {
                         Ok(pi) => {
                             *peer_info.lock().unwrap() = pi;
+
+                            *escalatable_event_arc.lock().unwrap() = Some(DashboardEvent::RefreshScreen);
                             reset_poller!(balance, Duration::from_secs(10));
                         },
                         Err(e) => {

--- a/src/bin/dashboard_src/send_screen.rs
+++ b/src/bin/dashboard_src/send_screen.rs
@@ -179,7 +179,7 @@ impl SendScreen {
                                     }
                                     SendScreenWidget::Amount => {
                                         *own_focus = SendScreenWidget::Ok;
-                                        escalate_event = None;
+                                        escalate_event = Some(DashboardEvent::RefreshScreen);
                                     }
                                     SendScreenWidget::Ok => {
                                         // clone outside of async section
@@ -198,7 +198,7 @@ impl SendScreen {
                                             )
                                             .await;
                                         });
-                                        escalate_event = None;
+                                        escalate_event = Some(DashboardEvent::RefreshScreen);
                                     }
                                     _ => {
                                         escalate_event = None;
@@ -214,7 +214,7 @@ impl SendScreen {
                                     SendScreenWidget::Ok => SendScreenWidget::Amount,
                                     SendScreenWidget::Notice => SendScreenWidget::Notice,
                                 };
-                                escalate_event = None;
+                                escalate_event = Some(DashboardEvent::RefreshScreen);
                             } else {
                                 escalate_event = Some(event);
                             }
@@ -227,7 +227,7 @@ impl SendScreen {
                                     SendScreenWidget::Ok => SendScreenWidget::Address,
                                     SendScreenWidget::Notice => SendScreenWidget::Notice,
                                 };
-                                escalate_event = None;
+                                escalate_event = Some(DashboardEvent::RefreshScreen);
                             } else {
                                 escalate_event = Some(event);
                             }
@@ -236,7 +236,7 @@ impl SendScreen {
                             if let Ok(own_focus) = self.focus.try_lock() {
                                 if own_focus.to_owned() == SendScreenWidget::Amount {
                                     self.amount = format!("{}{}", self.amount, c);
-                                    escalate_event = None;
+                                    escalate_event = Some(DashboardEvent::RefreshScreen);
                                 } else {
                                     escalate_event = Some(event);
                                 }
@@ -250,7 +250,7 @@ impl SendScreen {
                                     if !self.amount.is_empty() {
                                         self.amount.drain(self.amount.len() - 1..);
                                     }
-                                    escalate_event = None;
+                                    escalate_event = Some(DashboardEvent::RefreshScreen);
                                 }
                             } else {
                                 escalate_event = Some(event);
@@ -265,7 +265,7 @@ impl SendScreen {
                     if let Ok(mut own_focus) = self.focus.try_lock() {
                         self.address = string.trim().to_owned();
                         *own_focus = SendScreenWidget::Amount;
-                        escalate_event = None;
+                        escalate_event = Some(DashboardEvent::RefreshScreen);
                     } else {
                         escalate_event = Some(DashboardEvent::ConsoleMode(
                             ConsoleIO::InputSupplied(string),


### PR DESCRIPTION
The dashboard was constantly using around 15% CPU on my system while doing basically nothing.  This drops usage to under 1% for all screens.

The high usage was caused by constantly re-drawing the screen in the main loop.

The implemented fix is to add a `RefreshScreen` event which is sent by sub-screens when data or key events occur that require a redraw.

In this way, redraws only occur when required.

----

I am not certain this is the best or most elegant way to fix it, but it seems to works well on my system.

Testing: I tested functionality in all screens and compared with a dashboard instance running the previous code, and they appear to function identically, including the send screen which has some tricky stuff grabbing user input and moving control focus.