### PR TITLE
add git branch guidelines,  update build instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Neptune-core is the reference implementation for the [Neptune](https://neptune.c
 
 ## Installing
 
+note: We recommend installing the latest release unless you are a developer intending to contribute code.
+
 ### Compile from Source -- Linux Debian/Ubuntu
 
  - Open a terminal to run the following commands.
@@ -13,6 +15,9 @@ Neptune-core is the reference implementation for the [Neptune](https://neptune.c
  - Install LebelDB: `sudo apt install libleveldb-dev libsnappy-dev cmake`
  - Download the repository: `git clone https://github.com/Neptune-Crypto/neptune-core.git`
  - Enter the repository: `cd neptune-core`
+ * for dev(unstable) skip this step.
+ else for latest release: `git checkout v0.0.5`.
+
  - Build for release and put the binaries in your local path (`~/.cargo/bin/`): `cargo install --path .` (needs at least 3 GB of RAM and a few minutes)
 
 ### Windows
@@ -24,6 +29,8 @@ With a functioning version of cargo, compilation on Windows should just work out
 - Open PowerShell to run the following commands.
 - Download the repository: `git clone https://github.com/Neptune-Crypto/neptune-core.git`
 - Enter the repository: `cd neptune-core`
+- for dev(unstable) skip this step. else for latest release: `git checkout v0.0.5`.
+
 - Run `cargo install --path .`
 
 
@@ -34,7 +41,7 @@ With a functioning version of cargo, compilation on Windows should just work out
    - `--peers [ip_address:port]` to connect to a given peer, for instance `--peers [2001:bc8:611:1c72::1]:9798` or `--peers 139.162.193.206:9798` or both
    - `--mine` to mine — if you want to generate testnet coins to test sending and receiving
    - `--help` to get a list of available command-line arguments
-  
+
 If you don't have a static IPv4, then try connecting to other nodes with IPv6. It's our experience that you will then be able to open and receive connections to other nodes through Nepture Core's built-in peer-discovery process.
 
 ## Dashboard
@@ -62,6 +69,10 @@ If you set up `neptune-core` on a different address or port from the default (12
  - in `vscode` install the plugin `rust-analyzer`
  - in `vscode` activate format-on-save via `File` > `Preferences` > `Settings` then check the box for "Format on Save"
  - install `cpulimit` for nicer, and more quiet integration tests: `apt install cpulimit`
+
+## Branches and Pull Requests
+
+Please see this [this document](./developer_docs/git_branches.md) for documentation of our branching methodology and how to submit a pull request.
 
 ## Logging
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ note: We recommend installing the latest release unless you are a developer inte
  - Download the repository: `git clone https://github.com/Neptune-Crypto/neptune-core.git`
  - Enter the repository: `cd neptune-core`
  * for dev(unstable) skip this step.
- else for latest release: `git checkout v0.0.5`.
 
  - Build for release and put the binaries in your local path (`~/.cargo/bin/`): `cargo install --path .` (needs at least 3 GB of RAM and a few minutes)
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ note: We recommend installing the latest release unless you are a developer inte
  - Install LebelDB: `sudo apt install libleveldb-dev libsnappy-dev cmake`
  - Download the repository: `git clone https://github.com/Neptune-Crypto/neptune-core.git`
  - Enter the repository: `cd neptune-core`
- * for dev(unstable) skip this step.
+ - for dev(unstable) skip this step. else for latest release: `git checkout v0.0.5`.
 
  - Build for release and put the binaries in your local path (`~/.cargo/bin/`): `cargo install --path .` (needs at least 3 GB of RAM and a few minutes)
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ Neptune-core is the reference implementation for the [Neptune](https://neptune.c
 
 ## Installing
 
-note: We recommend installing the latest release unless you are a developer intending to contribute code.
-
 ### Compile from Source -- Linux Debian/Ubuntu
 
  - Open a terminal to run the following commands.
@@ -15,7 +13,7 @@ note: We recommend installing the latest release unless you are a developer inte
  - Install LebelDB: `sudo apt install libleveldb-dev libsnappy-dev cmake`
  - Download the repository: `git clone https://github.com/Neptune-Crypto/neptune-core.git`
  - Enter the repository: `cd neptune-core`
- - for dev(unstable) skip this step. else for latest release: `git checkout v0.0.5`.
+ - Checkout the release branch `git checkout release`. (Alternatively, for the *unstable development* branch, skip this step.)
 
  - Build for release and put the binaries in your local path (`~/.cargo/bin/`): `cargo install --path .` (needs at least 3 GB of RAM and a few minutes)
 
@@ -28,7 +26,7 @@ With a functioning version of cargo, compilation on Windows should just work out
 - Open PowerShell to run the following commands.
 - Download the repository: `git clone https://github.com/Neptune-Crypto/neptune-core.git`
 - Enter the repository: `cd neptune-core`
-- for dev(unstable) skip this step. else for latest release: `git checkout v0.0.5`.
+- Checkout the release branch `git checkout release`. (Alternatively, for the *unstable development* branch, skip this step.)
 
 - Run `cargo install --path .`
 

--- a/developer_docs/.gitmessage
+++ b/developer_docs/.gitmessage
@@ -1,0 +1,31 @@
+# Title: Summary, imperative, start upper case, don't end with a period
+# use convential commit format. http://conventionalcommits.org
+#   <type>[optional scope]: <description>
+#   scope is in parens, eg: feat(lang): added polish language
+#   types: build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test 
+# No more than 60 chars. #### 60 chars is here: #
+
+# Body: Explain *what* and *why* (not *how*). Include task ID (Jira issue).
+# BREAKING CHANGE: a commit that has the text BREAKING CHANGE: at the
+#   beginning of its optional body or footer section introduces a breaking
+#   API change (correlating with MAJOR in semantic versioning). 
+# Wrap at 72 chars. ################################## which is here: #
+
+
+# At the end: Include Co-authored-by for all contributors. 
+# Include at least one empty line before it. Format: 
+# Co-authored-by: name <user@users.noreply.github.com>
+#
+# How to Write a Git Commit Message:
+# https://chris.beams.io/posts/git-commit/
+#
+# 1.Separate subject from body with a blank line
+# 2. Limit the subject line to 50 characters
+# 3. Capitalize the subject line
+# 4. Do not end the subject line with a period
+# 5. Use the imperative mood in the subject line
+# 6. Wrap the body at 72 characters
+# 7. Use the body to explain what and why vs. how
+
+# Instructions to use this as a template. see
+# https://gist.github.com/lisawolderiksen/a7b99d94c92c6671181611be1641c733

--- a/developer_docs/git_branches.md
+++ b/developer_docs/git_branches.md
@@ -7,13 +7,15 @@ We follow a standard [GitHub Flow](https://docs.github.com/en/get-started/using-
 It can be visualized like this:
 
 ```
-          --------
-master   / topic  \
----*----------------------*--------------->
-    \ release              \ release
-     ------------------>    --------->
-      \ hotfix /
-       --------
+master
+-------*----------------------*>
+ \             --------
+  \  dev      / topic  \
+   ----*----------------------*--------------->
+        \ release              \ release
+        ------------------>    --------->
+        \ hotfix /
+        --------
 ```
 
 ### master branch (aka trunk)
@@ -40,6 +42,32 @@ Third party contributors without repo write access must create a *topic* branch 
 4. make your changes and commit them.
 5. push your topic branch to your forked repo
 6. submit the pull request.
+
+#### Topic Branch Naming
+
+When working on an open github issue, it is recommended to prefix the topic branch with the issue identifier.
+
+When the branch is intended to become a pull request, it is recommended to add the suffix `_pr`.
+
+If the branch exists in a triton/neptune official repo, (as opposed to a personal fork), then it is recommended to prefix with your github username follwed by `/`.
+
+So if working on issue `#232` and adding feature *walk_and_chew_gum* one might name the branch `myuser/232_walk_and_chew_gum_pr`.
+
+# Conventional Commits
+
+It is preferred/requested that commit messages use the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) format.
+
+This aids readability of commit messages and facilitates automated generation of the ChangeLog.
+
+For all but the most trivial changes, please provide some additional lines with a basic summary of the changes and also the _reason/rationale_ for the changes.
+
+A git template for assisting with creation of conventional commit messages can be found in [.gitmessage](.gitmessage). This template can be added globally to git with this command:
+
+```
+git config --global commit.template /path/to/neptune-core/developer_docs/.gitmessage
+```
+
+It can also be added on a per-repository basis by omitting the `--global` flag.
 
 ### Release tagging
 

--- a/developer_docs/git_branches.md
+++ b/developer_docs/git_branches.md
@@ -1,0 +1,111 @@
+# How branches are used in neptune-core and related neptune/triton crates.
+
+## Github Flow
+
+We follow a standard [GitHub Flow](https://docs.github.com/en/get-started/using-github/github-flow) methodology with additional [release branches](https://blog.bitsrc.io/git-branching-strategies-made-simple-af135de57000#c7ea).
+
+It can be visualized like this:
+
+```
+          --------
+master   / topic  \
+---*----------------------*--------------->
+    \ release              \ release
+     ------------------>    --------->
+      \ hotfix /
+       --------
+```
+
+### master branch (aka trunk)
+
+The `master` branch represents the tip of current development. It is an _integration_ branch, in the sense that developer changes from smaller _topic_ branches get merged and integrated into `master` and github's CI performs testing for every pull-request.
+
+The master branch of each crate should always build and should always pass all tests.
+
+At present, any team member with repo write access may directly commit to the `master` branch. However, as we get closer to a mainnet launch, `master` should/will become locked so that all changes must go through the pull-request process and be peer reviewed.
+
+### topic branches
+
+Even now, team members are encouraged to create a *topic* branch and pull-request for larger changes or anything that might be considered non-obvious or controversial.
+
+tip: *topic* branches are sometimes called *feature* branches.
+
+A *topic* branch typically branches off of `master` or another *topic* branch.  It is intended for an individual
+feature or bug-fix.  We should strive to keep each *topic* branch focused on a single change/feature and as short-lived as possible.
+
+Third party contributors without repo write access must create a *topic* branch and submit a pull request for each change.  This is accomplished by:
+1. fork the repo
+2. checkout and build the desired branch (usually master or a release branch)
+3. create a topic branch
+4. make your changes and commit them.
+5. push your topic branch to your forked repo
+6. submit the pull request.
+
+### Release tagging
+
+Every published release of a crate is tagged with the [semver](https://semver.org) version eg `v0.0.5`. Some releases of neptune-core may create a new testnet in which case the testnet identifier is also tagged, eg: `(tag: v0.0.5, tag: alphanet-v5)`.
+
+### Release branch(es)
+
+If any changes/fixes are needed for a published release, then a branch can be created based on the release tag
+for any affected crate(s), and the fix should be placed on that branch. Normally a `hotfix` branch should be created based on the release branch with a corresponding pull-request.
+
+As long as the fix does not require an API change, the crate(s) can be published to crates.io with only a bump to the semver PATCH version.
+
+A neptune-core release branch should be created for each
+release, even if it has no further commits.
+
+The neptune-core `README.md` should likewise be updated with each release to provide instructions for
+checking out and building from the release
+branch.
+
+Additionally a warning shall be placed in the
+README.md that the tip of `master` branch is
+for development and should be considered unstable, along with a link to this document.
+
+
+## Cargo dependencies
+
+### For published crate releases
+
+When publishing a crate, and/or when making a release of `neptune-core`, all dependencies should/must reference a version published to [crates.io](https://crates.io).
+
+In particular, git repo references must not be used.
+
+### For development between crate releases.
+
+Often parallel development will be occurring in
+multiple triton/neptune crates.  In such cases
+there may be API or functionality changes that necessitate temporarily specifying a git dependency reference instead of a published crates.io version.
+
+For this, we keep the original dependency line unchanged, and add a crates.io patch at the bottom of Cargo.toml.
+
+Example:
+
+```
+[dependencies]
+tasm-lib = "0.2.1"
+
+[patch.crates-io]
+# revision  "f711ae27" is tip of tasm-lib master as of 2024-01-25
+tasm-lib = { git = "https://github.com/TritonVM/tasm-lib.git", rev = "f711ae27" }
+```
+
+Note that:
+1. `tasm-lib = "0.2.1"`.  We do not use `{git = "..."}` here.
+2. We specify a specific revision, rather than a branch name.
+2. We place a comment indicating the branch on which the
+revision resides, as of placement date.
+
+A branch name is a moving target.  So if we were to specify a branch, then our build might compile fine today
+and tomorrow it no longer does.
+
+The [patch section docs](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section) have more detail.  In particular take note that:
+
+1. Cargo only looks at the patch settings in the Cargo.toml manifest at the root of the workspace.
+2. Patch settings defined in dependencies will be ignored.
+
+This [blog article](https://gatowololo.github.io/blog/cargo-patch/) is also helpful.
+
+
+Finally, all such temporary patches must be removed before publishing a crate!

--- a/developer_docs/git_branches.md
+++ b/developer_docs/git_branches.md
@@ -53,6 +53,27 @@ If the branch exists in a triton/neptune official repo, (as opposed to a persona
 
 So if working on issue `#232` and adding feature *walk_and_chew_gum* one might name the branch `myuser/232_walk_and_chew_gum_pr`.
 
+### release branch
+
+The `master` branch can contain changes that are not compatible with whatever network is currently live. Beta-testers looking for the branch that will synchronize with the network that is currently live need branch `release`. This branch may cherry-pick commits that are meant for `master` so long as they are backwards-compatible. However, when this task is too cumbersome, branch `release` will become effectively abandoned -- until the next network version is released.
+
+#### TestNet Release Protocol
+
+ - Ensure that master builds against crates that live on [crates.io](https://crates.io). In particular, no dependencies on github repositories or revisions.
+ - Update `README.md` in case to make sure the installation instructions are up-to-date.
+ - Ensure that all tests pass.
+ - Bump the version in `Cargo.toml`
+ - Create a commit with the subject line `v0.0.6` (or watever the new version number is) and in the body list all the changes.
+ - Push to `master` on github.
+ - Add a tag marking the current commit with the version:
+   - `git tag v0.0.6` (or whatever the next version is)
+   - `git push --tags`.
+ - Set branch `release` to point to `master`:
+   - `git checkout release`
+   - `git reset master`
+   - `git push`
+ - Consider making an announcement.
+
 # Conventional Commits
 
 It is preferred/requested that commit messages use the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) format.
@@ -68,29 +89,6 @@ git config --global commit.template /path/to/neptune-core/developer_docs/.gitmes
 ```
 
 It can also be added on a per-repository basis by omitting the `--global` flag.
-
-### Release tagging
-
-Every published release of a crate is tagged with the [semver](https://semver.org) version eg `v0.0.5`. Some releases of neptune-core may create a new testnet in which case the testnet identifier is also tagged, eg: `(tag: v0.0.5, tag: alphanet-v5)`.
-
-### Release branch(es)
-
-If any changes/fixes are needed for a published release, then a branch can be created based on the release tag
-for any affected crate(s), and the fix should be placed on that branch. Normally a `hotfix` branch should be created based on the release branch with a corresponding pull-request.
-
-As long as the fix does not require an API change, the crate(s) can be published to crates.io with only a bump to the semver PATCH version.
-
-A neptune-core release branch should be created for each
-release, even if it has no further commits.
-
-The neptune-core `README.md` should likewise be updated with each release to provide instructions for
-checking out and building from the release
-branch.
-
-Additionally a warning shall be placed in the
-README.md that the tip of `master` branch is
-for development and should be considered unstable, along with a link to this document.
-
 
 ## Cargo dependencies
 
@@ -136,4 +134,4 @@ The [patch section docs](https://doc.rust-lang.org/cargo/reference/overriding-de
 This [blog article](https://gatowololo.github.io/blog/cargo-patch/) is also helpful.
 
 
-Finally, all such temporary patches must be removed before publishing a crate!
+Finally, all such temporary patches must be removed before publishing a crate or issuing a new release!


### PR DESCRIPTION
For consideration:

Let's consider this a first draft/proposal, and iterate from there.   The goal is to reach a written policy every team member can agree with and be happy with.

------

Adds written policy/guidelines for branch usage and updates the README to provide instructions for building the latest release branch or the tip.

The branch guidelines are an attempt to balance/integrate/codify several things:

1. standard `github flow` branching and PRs that most github devs are familiar with.
2. simplicity for devs, ie no need to commit changes to multiple branches in normal flow and also for now we allow direct commits to master by team members without review.
3. CI to ensure development tip of all triton/neptune crates always builds and passes tests.
4. specifies release branches for incorporating hotfixes to past releases if necessary/desired.
5. guidelines for keeping crate tips building against each other in between crates.io releases.
6. provide simple instructions for end users to install the latest tagged release and thereby participate in the latest testnet/alphanet (without being too verbose).

I also threw in some recommendations for using conventional commit style and for naming topic branches.  As with everything, this is a proposal, so let me know if anyone is not happy with it.

Read the file git_branches.md for details.

I tried to take all the feedback I received into account, but please let me know of any concerns or omissions.