### PR TITLE
feat: sanction/reward peer for connect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1687,6 +1687,7 @@ dependencies = [
  "strum",
  "tarpc",
  "tasm-lib",
+ "thiserror",
  "tiny-bip39",
  "tokio",
  "tokio-serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ tracing-subscriber = { version = "0", features = [
 tracing-test = "0"
 unicode-width = "0"
 zeroize = "1.7.0"
+thiserror = "1.0.56"
 
 [dev-dependencies]
 pin-project-lite = "0.2.13"

--- a/src/bin/dashboard_src/peers_screen.rs
+++ b/src/bin/dashboard_src/peers_screen.rs
@@ -184,7 +184,7 @@ impl Widget for PeersScreen {
                     pi.connected_address.to_string(),
                     neptune_core::utc_timestamp_to_localtime(last_seen_timestamp.as_millis())
                         .to_string(),
-                    pi.standing.standing.to_string(),
+                    pi.standing.score.to_string(),
                     if pi.is_archival_node {
                         "✓".to_string()
                     } else {

--- a/src/database/neptune_leveldb.rs
+++ b/src/database/neptune_leveldb.rs
@@ -125,7 +125,7 @@ where
 }
 
 /// `NeptuneLevelDb` provides an async-friendly and clone-friendly wrapper
-/// around [`NeptuneLevelDbInternal`].
+/// around `NeptuneLevelDbInternal`.
 ///
 /// Methods in the underlying struct `LevelDB` from `rs-leveldb` crate are all sync
 /// and they sometimes perfom blocking file IO.  It is discouraged to

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,12 @@ pub async fn initialize(cli_args: cli_args::Args) -> Result<()> {
     // Create handshake data which is used when connecting to outgoing peers specified in the
     // CLI arguments
     let syncing = false;
-    let networking_state = NetworkingState::new(peer_map, peer_databases, syncing);
+    let networking_state = NetworkingState::new(
+        peer_map,
+        peer_databases,
+        syncing,
+        cli_args.peer_tolerance as i32,
+    );
 
     let light_state: LightState = LightState::from(latest_block.clone());
     let blockchain_archival_state = BlockchainArchivalState {

--- a/src/models/database.rs
+++ b/src/models/database.rs
@@ -1,7 +1,7 @@
 use crate::prelude::twenty_first;
 
 use serde::{Deserialize, Serialize};
-use std::{fmt, net::IpAddr};
+use std::{fmt, net::SocketAddr};
 use twenty_first::shared_math::b_field_element::BFieldElement;
 use twenty_first::shared_math::digest::Digest;
 
@@ -135,7 +135,7 @@ impl BlockIndexValue {
 
 #[derive(Clone)]
 pub struct PeerDatabases {
-    pub peer_standings: NeptuneLevelDb<IpAddr, PeerStanding>,
+    pub peer_standings: NeptuneLevelDb<SocketAddr, PeerStanding>,
 }
 
 impl fmt::Debug for PeerDatabases {

--- a/src/models/state/networking_state.rs
+++ b/src/models/state/networking_state.rs
@@ -1,12 +1,22 @@
 use crate::config_models::data_directory::DataDirectory;
 use crate::database::{create_db_if_missing, NeptuneLevelDb};
 use crate::models::database::PeerDatabases;
-use crate::models::peer::{self, PeerStanding};
+use crate::models::peer::{
+    self, ConnectionRefusedReason, ConnectionStatus, HandshakeData, PeerSanctionReason,
+    PeerStanding, PeerUnsanctionReason,
+};
 use anyhow::Result;
-use std::net::IpAddr;
-use std::{collections::HashMap, net::SocketAddr};
+use std::collections::HashMap;
+use std::net::{IpAddr, SocketAddr};
+use tracing::{debug, info, warn};
 
 pub const BANNED_IPS_DB_NAME: &str = "banned_ips";
+
+// When a potential peer is banned because of PeerSanctionReason::ConnectFailed,
+// our node will wait this many seconds until trying to connect to that peer again.
+//
+// For now we arbitrarily set it to 5 minutes.
+pub const CONNECT_FAILED_TIMEOUT_SECS: u16 = 60 * 5;
 
 type PeerMap = HashMap<SocketAddr, peer::PeerInfo>;
 
@@ -18,7 +28,7 @@ pub struct NetworkingState {
     // Peer threads may update their own entries into this map.
     pub peer_map: PeerMap,
 
-    // `peer_databases` are used to persist IPs with their standing.
+    // `peer_databases` are used to persist SocketAddrs with their standing.
     // The peer threads may update their own entries into this map.
     pub peer_databases: PeerDatabases,
 
@@ -29,15 +39,24 @@ pub struct NetworkingState {
 
     // Read-only value set during startup
     pub instance_id: u128,
+
+    // Read-only value from cli args. set during startup
+    pub peer_tolerance: i32,
 }
 
 impl NetworkingState {
-    pub fn new(peer_map: PeerMap, peer_databases: PeerDatabases, syncing: bool) -> Self {
+    pub fn new(
+        peer_map: PeerMap,
+        peer_databases: PeerDatabases,
+        syncing: bool,
+        peer_tolerance: i32,
+    ) -> Self {
         Self {
             peer_map,
             peer_databases,
             syncing,
             instance_id: rand::random(),
+            peer_tolerance,
         }
     }
 
@@ -46,7 +65,7 @@ impl NetworkingState {
         let database_dir_path = data_dir.database_dir_path();
         DataDirectory::create_dir_if_not_exists(&database_dir_path)?;
 
-        let peer_standings = NeptuneLevelDb::<IpAddr, PeerStanding>::new(
+        let peer_standings = NeptuneLevelDb::<SocketAddr, PeerStanding>::new(
             &data_dir.banned_ips_database_dir_path(),
             &create_db_if_missing(),
         )
@@ -56,30 +75,37 @@ impl NetworkingState {
     }
 
     /// Return a list of peer sanctions stored in the database.
-    pub async fn all_peer_sanctions_in_database(&self) -> HashMap<IpAddr, PeerStanding> {
-        let mut sanctions = HashMap::default();
-
-        let mut dbiterator = self.peer_databases.peer_standings.iter();
-        for (ip, standing) in dbiterator.by_ref() {
-            if standing.is_negative() {
-                sanctions.insert(ip, standing);
-            }
-        }
-
-        sanctions
+    ///
+    /// Finds all [PeerStanding] with a standing score in the negative.
+    ///
+    /// note:
+    ///   The DB iterator used performs blocking I/O, so we wrap it
+    ///   with [tokio::task::block_in_place()] to make this method async-friendly.
+    ///
+    ///   This requires tokio feature `rt-multi-thread`, and any
+    ///   test that calls this method must use:
+    ///     `#[tokio::test(flavor = "multi_thread")]`
+    pub async fn all_peer_sanctions_in_database(&self) -> HashMap<SocketAddr, PeerStanding> {
+        tokio::task::block_in_place(|| {
+            self.peer_databases
+                .peer_standings
+                .iter()
+                .filter(|(_addr, standing)| standing.is_negative())
+                .collect()
+        })
     }
 
-    pub async fn get_peer_standing_from_database(&self, ip: IpAddr) -> Option<PeerStanding> {
-        self.peer_databases.peer_standings.get(ip).await
+    pub async fn get_peer_standing_from_database(&self, addr: SocketAddr) -> Option<PeerStanding> {
+        self.peer_databases.peer_standings.get(addr).await
     }
 
-    pub async fn clear_ip_standing_in_database(&mut self, ip: IpAddr) {
-        let old_standing = self.peer_databases.peer_standings.get(ip).await;
+    pub async fn clear_peer_standing_in_database(&mut self, addr: SocketAddr) {
+        let old_standing = self.peer_databases.peer_standings.get(addr).await;
 
         if old_standing.is_some() {
             self.peer_databases
                 .peer_standings
-                .put(ip, PeerStanding::default())
+                .put(addr, PeerStanding::default())
                 .await
         }
     }
@@ -89,7 +115,7 @@ impl NetworkingState {
             .peer_databases
             .peer_standings
             .iter()
-            .map(|(ip, _old_standing)| (ip, PeerStanding::default()))
+            .map(|(addr, _old_standing)| (addr, PeerStanding::default()))
             .collect();
 
         self.peer_databases
@@ -103,16 +129,437 @@ impl NetworkingState {
     // Wayback machine: https://web.archive.org/web/20220708143841/https://law.stackexchange.com/questions/28603/how-to-satisfy-gdprs-consent-requirement-for-ip-logging/28609
     pub async fn write_peer_standing_on_decrease(
         &mut self,
-        ip: IpAddr,
+        addr: SocketAddr,
         current_standing: PeerStanding,
     ) {
-        let old_standing = self.peer_databases.peer_standings.get(ip).await;
+        let old_standing = self.peer_databases.peer_standings.get(addr).await;
 
-        if old_standing.is_none() || old_standing.unwrap().standing > current_standing.standing {
+        if old_standing.is_none() || old_standing.unwrap().score > current_standing.score {
             self.peer_databases
                 .peer_standings
-                .put(ip, current_standing)
+                .put(addr, current_standing)
                 .await
         }
     }
+
+    pub async fn write_peer_standing(&mut self, addr: SocketAddr, current_standing: PeerStanding) {
+        self.peer_databases
+            .peer_standings
+            .put(addr, current_standing)
+            .await
+    }
+
+    /// Sanctions a peer by lowering its standing score.
+    ///
+    /// Each peer is identified by a [SocketAddr].
+    ///
+    /// The standing score can be lowered to a minimum of
+    /// `0 - NetworkingState::peer_tolerance - 1`.
+    ///
+    /// When the minimum score is reached, this results in a ban.
+    /// Further calls do not lower the score, but do record the
+    /// [PeerSanctionReason] and a timestamp.
+    ///
+    /// If a ban occurs, a log warning is issued.
+    ///
+    /// This method will sanction a peer even if it not currently connected
+    /// and thus not in [peer_map](Self::peer_map).
+    ///
+    /// This method writes to the peer database and will also update the
+    /// `peer_map` entry if the peer is presently connected.
+    ///
+    /// The returned [PeerStanding] represents the new standing after sanctioning.
+    pub async fn sanction_peer(
+        &mut self,
+        peer_address: SocketAddr,
+        reason: PeerSanctionReason,
+    ) -> Result<PeerStanding> {
+        let mut peer_standing = match self.peer_map.get_mut(&peer_address).map(|p| p.standing) {
+            Some(ps) => ps,
+            None => self
+                .get_peer_standing_from_database(peer_address)
+                .await
+                .unwrap_or_default(),
+        };
+
+        warn!(
+            "Sanctioning peer {}:{} for {:?}",
+            peer_address.ip(),
+            peer_address.port(),
+            reason
+        );
+
+        debug!(
+            "Old Standing for Peer {}:{} was {:?}",
+            peer_address.ip(),
+            peer_address.port(),
+            peer_standing,
+        );
+
+        let banned_before = self.peer_standing_is_banned(&peer_standing);
+        peer_standing.sanction(reason, self.peer_standing_banned_score());
+        let banned_now = self.peer_standing_is_banned(&peer_standing);
+
+        debug!(
+            "New Standing for Peer {}:{} is {:?}",
+            peer_address.ip(),
+            peer_address.port(),
+            peer_standing,
+        );
+
+        self.peer_map
+            .entry(peer_address)
+            .and_modify(|ps| ps.standing = peer_standing);
+
+        self.write_peer_standing(peer_address, peer_standing).await;
+
+        // warn if peer was in good standing and now is in bad standing
+        if !banned_before && banned_now {
+            warn!("Banning peer {}:{}", peer_address.ip(), peer_address.port());
+        }
+
+        Ok(peer_standing)
+    }
+
+    /// Unsanctions (rewards) a peer by increasing its standing score.
+    ///
+    /// Each peer is identified by a [SocketAddr].
+    ///
+    /// The standing score can be raised to a maximum of
+    /// `NetworkingState::peer_tolerance + 1`.
+    ///
+    /// When the maximum score is reached, subsequent
+    /// calls do not increase the score, but do record the
+    /// [PeerUnsanctionReason] and a timestamp.
+    ///
+    /// If the peer was previously banned via [sanction_peer()](Self::sanction_peer()) then
+    /// this call will result in the peer being unbanned provided the
+    /// [PeerUnsanctionReason] has a non-zero effect on the score.
+    ///
+    /// This method will reward a peer even if it not currently connected
+    /// and thus not in [peer_map](Self::peer_map).
+    ///
+    /// This method writes to the peer database and will also update the
+    /// `peer_map` entry if the peer is presently connected.
+    ///
+    /// The returned [PeerStanding] represents the new standing after unsanctioning.
+    pub async fn unsanction_peer(
+        &mut self,
+        peer_address: SocketAddr,
+        reason: PeerUnsanctionReason,
+    ) -> Result<PeerStanding> {
+        info!(
+            "rewarding peer {}:{} for {:?}",
+            peer_address.ip(),
+            peer_address.port(),
+            reason
+        );
+
+        let mut peer_standing = match self.peer_map.get_mut(&peer_address).map(|p| p.standing) {
+            Some(ps) => ps,
+            None => self
+                .get_peer_standing_from_database(peer_address)
+                .await
+                .unwrap_or_default(),
+        };
+
+        debug!(
+            "Old Standing for Peer {}:{} was {:?}",
+            peer_address.ip(),
+            peer_address.port(),
+            peer_standing,
+        );
+
+        let banned_before = self.peer_standing_is_banned(&peer_standing);
+
+        peer_standing.unsanction(reason, self.peer_tolerance + 1);
+        let banned_now = self.peer_standing_is_banned(&peer_standing);
+
+        debug!(
+            "New Standing for Peer {}:{} is {:?}",
+            peer_address.ip(),
+            peer_address.port(),
+            peer_standing,
+        );
+
+        self.peer_map
+            .entry(peer_address)
+            .and_modify(|ps| ps.standing = peer_standing);
+
+        self.write_peer_standing(peer_address, peer_standing).await;
+
+        // if peer was banned and now is not, log the change.
+        if banned_before && !banned_now {
+            info!(
+                "Unbanning peer {}:{}",
+                peer_address.ip(),
+                peer_address.port()
+            );
+        }
+
+        Ok(peer_standing)
+    }
+
+    /// Looks up peer by [SocketAddr] and returns true if peer is banned, false if not, and None if record not found in DB.
+    ///
+    /// A peer is considered Banned if the peer's standing score is less than
+    /// (0 - peer_tolerance), which is a config option.
+    #[inline]
+    pub(crate) async fn peer_is_banned(&self, peer_addr: SocketAddr) -> Option<bool> {
+        self.get_peer_standing_from_database(peer_addr)
+            .await
+            .map(|ps| self.peer_standing_is_banned(&ps))
+    }
+
+    /// returns false if [PeerStanding] is in a banned state, else true
+    ///
+    /// A peer is considered Banned if the peer's standing score is less than
+    /// (0 - peer_tolerance), which is a config option.
+    #[inline]
+    fn peer_standing_is_banned(&self, peer_standing: &PeerStanding) -> bool {
+        peer_standing.score <= self.peer_standing_banned_score()
+    }
+
+    #[inline]
+    pub(crate) fn peer_standing_banned_score(&self) -> i32 {
+        PeerStanding::default_score() - self.peer_tolerance
+    }
+
+    /// Indicates if we can connect to the peer identified by [SocketAddr]
+    ///
+    /// Connect may proceed if `Ok` is returned.
+    ///
+    /// We can connect to a peer unless:
+    ///   + The peer's IP is banned by config.
+    ///   + we have reached max number of peers
+    ///   + we are already connected to this peer.
+    ///   + not allowed due to peer standing.
+    ///     see [standing_permits_connect_to_peer()](Self::standing_permits_connect_to_peer())
+    ///
+    /// This method emits debug log entries for all conditions to aid with diagnosis.
+    pub async fn allow_connect_to_peer(
+        &self,
+        socket_addr: SocketAddr,
+        banned_ip_list: &[IpAddr],
+        max_peers: usize,
+    ) -> Result<(), AllowConnectToPeerError> {
+        // Disallow connection if peer's IP is banned (via CLI/config)
+        if banned_ip_list.contains(&socket_addr.ip()) {
+            warn!(
+                "allow_connect_to_peer: {}. peer's IP is BANNED by config.  allow: false",
+                socket_addr
+            );
+            return Err(AllowConnectToPeerError::IpBannedByConfig);
+        }
+
+        // Disallow connection if max number of peers has been attained
+        if max_peers <= self.peer_map.len() {
+            debug!(
+                "allow_connect_to_peer: {:?}. max peers limit of {} reached.  allow: false",
+                socket_addr, max_peers
+            );
+            return Err(AllowConnectToPeerError::MaxPeersExceeded);
+        }
+
+        // Disallow connection to already connected peer.
+        if self.peer_map.contains_key(&socket_addr) {
+            debug!(
+                "allow_connect_to_peer: {:?}. already connected to this peer. allow: false",
+                socket_addr
+            );
+            return Err(AllowConnectToPeerError::AlreadyConnected);
+        }
+
+        self.standing_permits_connect_to_peer(socket_addr).await
+    }
+
+    /// Indicates if peer's [PeerStanding] permits connecting to them.
+    ///
+    /// With regard to PeerStanding, we can connect to a peer unless:
+    ///   1. Peer has been banned.  (bad standing)  *and*
+    ///   2. The peer's latest [PeerSanctionReason] was NOT a `ConnectFailed`  *or*
+    ///   3. The peer's latest [PeerSanctionReason] was a `ConnectFailed` *and*
+    ///      more than [CONNECT_FAILED_TIMEOUT_SECS] seconds have elapsed.
+    ///
+    /// This method emits debug log entries for all conditions to aid with diagnosis.
+    pub async fn standing_permits_connect_to_peer(
+        &self,
+        socket_addr: SocketAddr,
+    ) -> Result<(), AllowConnectToPeerError> {
+        let standing_opt = self.get_peer_standing_from_database(socket_addr).await;
+
+        match standing_opt {
+            Some(standing) => {
+                if !self.peer_standing_is_banned(&standing) {
+                    debug!(
+                        "standing_permits_connect_to_peer: {:?}.  peer NOT banned. score: {}. allow: true",
+                        socket_addr, standing.score
+                    );
+                    Ok(())
+                } else {
+                    // we still allow connect if the last_sanction was a ConnectFailed and the
+                    // elapsed time since last sanction is greater than sanction_retry_connect timeout
+                    match (
+                        standing.latest_sanction,
+                        standing.timestamp_of_latest_sanction,
+                    ) {
+                        (Some(latest_sanction), Some(timestamp)) => {
+                            let sanction_duration = CONNECT_FAILED_TIMEOUT_SECS as i128;
+                            let sanction_remaining_secs =
+                                sanction_duration - timestamp.elapsed().unwrap().as_secs() as i128;
+
+                            match latest_sanction {
+                                PeerSanctionReason::ConnectFailed => {
+                                    let allow = sanction_remaining_secs <= 0;
+
+                                    match allow {
+                                        true => {
+                                            debug!("standing_permits_connect_to_peer: {:?}. peer is BANNED but timeout expired since ConnectFailed sanction. score: {}. allow: true", socket_addr, standing.score);
+                                            Ok(())
+                                        }
+                                        false => {
+                                            debug!("standing_permits_connect_to_peer: {:?}. peer remains BANNED since last ConnectFailed.  Can try again in {} seconds.  score: {}. allow: false", socket_addr, sanction_remaining_secs, standing.score);
+                                            Err(AllowConnectToPeerError::BannedForConnectFailed(
+                                                sanction_remaining_secs as u64, // must be positive here; cast is safe.
+                                            ))
+                                        }
+                                    }
+                                }
+                                _ => {
+                                    debug!("standing_permits_connect_to_peer: {:?}. Peer remains BANNED. latest sanction: {:?}. score: {}. allow: false", socket_addr, latest_sanction, standing.score);
+                                    Err(AllowConnectToPeerError::Banned(standing))
+                                }
+                            }
+                        }
+                        _ => {
+                            debug!("standing_permits_connect_to_peer: {:?}. latest sanction not found.  allow: true", socket_addr);
+                            Ok(())
+                        }
+                    }
+                }
+            }
+            None => {
+                debug!(
+                    "standing_permits_connect_to_peer: {:?}.  peer standing not found. allow: true",
+                    socket_addr
+                );
+                Ok(())
+            }
+        }
+    }
+
+    /// Check if an established connection is allowed to proceed.
+    ///
+    /// Intended for both incoming and outgoing connections.
+    ///
+    /// checks for:
+    ///  + peer's IP is banned by config
+    ///  + peer is banned due to past sanctions
+    ///  + we reached our max number of peers
+    ///  + we already have a connection to this peer
+    ///  + we connected to ourself
+    ///  + peer version number is incompatible with ours.
+    pub async fn check_if_connection_is_allowed(
+        &self,
+        banned_ip_list: &[IpAddr],
+        max_peers: usize,
+        own_handshake: &HandshakeData,
+        other_handshake: &HandshakeData,
+        peer_address: SocketAddr,
+    ) -> ConnectionStatus {
+        fn versions_are_compatible(own_version: &str, other_version: &str) -> bool {
+            let own_version = semver::Version::parse(own_version)
+                .expect("Must be able to parse own version string. Got: {own_version}");
+            let other_version = match semver::Version::parse(other_version) {
+                Ok(version) => version,
+                Err(err) => {
+                    warn!("Peer version is not a valid semver version. Got error: {err}",);
+                    return false;
+                }
+            };
+
+            // All alphanet versions are incompatible with each other. Alphanet has versions
+            // "0.0.n". Alphanet is also incompatible with mainnet or any other versions.
+            if own_version.major == 0 && own_version.minor == 0
+                || other_version.major == 0 && other_version.minor == 0
+            {
+                return own_version == other_version;
+            }
+
+            true
+        }
+
+        // Disallow connection if peer's IP is banned (via CLI arguments)
+        if banned_ip_list.contains(&peer_address.ip()) {
+            warn!(
+                "Banned peer {} attempted to connect. Disallowing.",
+                peer_address.ip()
+            );
+            return ConnectionStatus::Refused(ConnectionRefusedReason::BadStanding);
+        }
+
+        // Disallow connection if peer is banned.
+        if let Some(banned) = self.peer_is_banned(peer_address).await {
+            if banned {
+                return ConnectionStatus::Refused(ConnectionRefusedReason::BadStanding);
+            }
+        }
+
+        if let Some(status) = {
+            // Disallow connection if max number of &peers has been attained
+            if max_peers <= self.peer_map.len() {
+                Some(ConnectionStatus::Refused(
+                    ConnectionRefusedReason::MaxPeerNumberExceeded,
+                ))
+            }
+            // Disallow connection to already connected peer.
+            else if self.peer_map.values().any(|peer| {
+                peer.instance_id == other_handshake.instance_id
+                    || peer_address == peer.connected_address
+            }) {
+                Some(ConnectionStatus::Refused(
+                    ConnectionRefusedReason::AlreadyConnected,
+                ))
+            } else {
+                None
+            }
+        } {
+            return status;
+        }
+
+        // Disallow connection to self
+        if own_handshake.instance_id == other_handshake.instance_id {
+            return ConnectionStatus::Refused(ConnectionRefusedReason::SelfConnect);
+        }
+
+        // Disallow connection if versions are incompatible
+        if !versions_are_compatible(&own_handshake.version, &other_handshake.version) {
+            warn!(
+                "Attempting to connect to incompatible version. You might have to upgrade, or the other node does. Own version: {}, other version: {}",
+                own_handshake.version,
+                other_handshake.version);
+            return ConnectionStatus::Refused(ConnectionRefusedReason::IncompatibleVersion);
+        }
+
+        info!("ConnectionStatus::Accepted");
+        ConnectionStatus::Accepted
+    }
+}
+
+#[derive(thiserror::Error, Debug, Clone, PartialEq)]
+pub enum AllowConnectToPeerError {
+    #[error("the IP is banned by configuration")]
+    IpBannedByConfig,
+
+    #[error("max peers limit exceeded")]
+    MaxPeersExceeded,
+
+    #[error("already connected to peer")]
+    AlreadyConnected,
+
+    #[error("peer is still banned since last ConnectFailed. Can retry in {0} seconds")]
+    BannedForConnectFailed(u64),
+
+    #[error("peer is banned.  standing: {0:?}")]
+    Banned(PeerStanding),
 }

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -204,7 +204,12 @@ pub async fn get_mock_global_state(
             std::net::SocketAddr::from_str(&format!("123.123.123.{}:8080", i)).unwrap();
         peer_map.insert(peer_address, get_dummy_peer(peer_address));
     }
-    let networking_state = NetworkingState::new(peer_map, peer_db, syncing);
+    let cli_args = cli_args::Args {
+        network,
+        ..Default::default()
+    };
+    let networking_state =
+        NetworkingState::new(peer_map, peer_db, syncing, cli_args.peer_tolerance as i32);
     let (block, _, _) = get_dummy_latest_block(None);
     let light_state: LightState = LightState::from(block);
     let blockchain_state = BlockchainState::Archival(BlockchainArchivalState {
@@ -212,10 +217,6 @@ pub async fn get_mock_global_state(
         archival_state,
     });
     let mempool = Mempool::new(ByteSize::gb(1));
-    let cli_args = cli_args::Args {
-        network,
-        ..Default::default()
-    };
 
     GlobalStateLock::new(
         get_mock_wallet_state(wallet, network).await,

--- a/src/util_types/mutator_set/removal_record.rs
+++ b/src/util_types/mutator_set/removal_record.rs
@@ -81,7 +81,7 @@ impl serde::Serialize for AbsoluteIndexSet {
 
 /// ArrayVisitor
 /// Used for deserializing large arrays, with size known at compile time.
-/// Credit: MikailBag https://github.com/serde-rs/serde/issues/1937
+/// Credit: MikailBag <https://github.com/serde-rs/serde/issues/1937>
 struct ArrayVisitor<T, const N: usize>(PhantomData<T>);
 
 impl<'de, T, const N: usize> Visitor<'de> for ArrayVisitor<T, N>

--- a/src/util_types/sync/tokio/atomic_mutex.rs
+++ b/src/util_types/sync/tokio/atomic_mutex.rs
@@ -361,7 +361,7 @@ impl<T> AtomicMutex<T> {
     }
 }
 
-/// A wrapper for [MutexGuard](tokio::sync::MutexGuard) that
+/// A wrapper for [MutexGuard] that
 /// can optionally call a callback to notify when the
 /// lock event occurs.
 pub struct AtomicMutexGuard<'a, T> {

--- a/src/util_types/sync/tokio/atomic_rw.rs
+++ b/src/util_types/sync/tokio/atomic_rw.rs
@@ -350,7 +350,7 @@ impl<T> AtomicRw<T> {
     }
 }
 
-/// A wrapper for [RwLockReadGuard](tokio::sync::RwLockReadGuard) that
+/// A wrapper for [RwLockReadGuard] that
 /// can optionally call a callback to notify when the
 /// lock event occurs.
 pub struct AtomicRwReadGuard<'a, T> {
@@ -392,7 +392,7 @@ impl<'a, T> Deref for AtomicRwReadGuard<'a, T> {
     }
 }
 
-/// A wrapper for [RwLockWriteGuard](tokio::sync::RwLockWriteGuard) that
+/// A wrapper for [RwLockWriteGuard] that
 /// can optionally call a callback to notify when the
 /// lock event occurs.
 pub struct AtomicRwWriteGuard<'a, T> {


### PR DESCRIPTION
**The big picture**

At a high-level this PR enables the following scenario:

1. We successfully connect to new peer `A` and `A`'s standing score improves
2. Later `A` goes offline and our connect attempts fail.  Each failed attempt worsens `A` standing score until it reaches the minimum score, `0 - cli.peer_tolerance` and is banned.
3. Every 5 minutes (TBD?) we attempt to connect again.  Eventually a successful connect occurs, and `A`'s standing improves, resulting in `A` becoming unbanned, but still with a low score.  A single failed connect at this point would get `A` banned again.
4. Each time we connect to `A` again in the future, `A`'s standing score improves.  Eventually `A`'s score reaches the maximum  `0 + cli.peer_tolerance` and is capped. 

To achieve this, some changes were made to the existing Peer Standing/Sanction system:

1. cli.peer_tolerance is now used to define both a min and max for peer standing score, which was previously unlimited.   Note that these limits are dynamic and at the control of the node operator.  (though static/immutable for each execution of neptune-core).
2. A peer is considered banned when the standing score is exactly the minimum score.  Any improvement in the score results in being unbanned.   But still the peer can easily be banned if sanctioned again, whereas if they achieve higher scores, they can then tolerate more sanctions.
3. There is now a mechanism to unsanction (reward) a peer.   For now, it is only used for ConnectSuccess, but we can extend it for other things as well.

-----

**Uniquely Identifying Peers**

An issue arose early in dev/testing with multiple peers on the same machine, invoked with the `run-multiple-instances.sh` script.  Sanctions for all 3 peers were being stored in the same DB record, identified only by IP, which in this case is `127.0.0.1`.   The Database type was defined as:

```
pub struct PeerDatabases {
    pub peer_standings: NeptuneLevelDb<IpAddr, PeerStanding>,
}
```

This equates an IP with a peer, however that doesn't reflect reality, where it is clearly possible to run nodes on different ports, and those nodes could be running different code, different network configs, etc.

As such, I modified to:

```
    pub peer_standings: NeptuneLevelDb<SocketAddr, PeerStanding>,
```

and adapted APIs to match.  So `PeerStanding` are identified by `SocketAddr,` ie `IP`+`port`.

I added a test case `can_track_peer_standing_by_port` that verifies `PeerStanding` can be independently tracked for Peers on the same IP.    This test would fail on the older code, if ever adapted for it.

note: the node operator can still use the cli `--ban` arg to ban entire IP(s) without specifying ports.

I realize this change *might* be controversial.  It can be reverted if necessary, but I feel it is "more correct" and has great utility in enabling PeerStanding to be correctly tracked for multiple nodes running on localhost with different ports.

----
**Open Qs:**

1. How long should we wait after a peer is banned before we can attempt to connect again?   Presently it is set to 5 minutes, which may be too short, since our check-for-peers interval is 2 minutes.   Perhaps 1 hour?    But the other consideration, is that when a node goes offline, it will shortly become banned for ConnectFailed, and when it comes back online, we'd like to connect to it without too much delay.   There's kind of a tension.   So maybe 10 mins, with that in mind?

2. If a peer is banned and the LatestSanction is *NOT* a ConnectFailed, then we never try to connect again.   This node is effectively perma-banned with no chance to improve.  I did this because it seems to mirror existing behavior.   However, maybe we should give every banned node an opportunity to redeem itself once in a while.

We don't have to resolve these q's now.  Both could easily be addressed in a future PR.

----
**Commit Msg**


closes #35

High Level Changes:
* add doc-comments describing how sanctioning system works
* Identify `PeerStanding` by `SocketAddr` instead of `IpAddr` because peer's can share IP (not a unique ID)
* Add Unsanction (reward) capability
* Sanction peer for connect failure
* Unsanction peer for connect success
* Establish min peer_standing score equal to 0 - cli.peer_tolerance A peer is banned when the min score is reached.
* Establish max peer_standing score equal to cli.peer_tolerance
* A peer can become banned for ConnectFail but after a 5 minute period is eligible to attempt connect again and becomes unbanned if successful. see: networking_state::CONNECT_FAILED_TIMEOUT_SECS

Cleanups/Tweaks:
* rename punish_peer to sanction_peer
* rename PeerStanding::standing to score
* impl strum::Display for PeerSanctionReason
* move some existing methods into GlobalState, NetworkingState
* wrap db iterator with block_in_place() to make it async-friendly

Dependencies:
* adds direct dep on thiserror; it already existed in our dep-tree

New Tests:
* can_track_peer_standing_by_port
* ban_peer_connect_fail_and_unban_connect_success

-----

**Testing Performed**

1. Implemented test `ban_peer_connect_fail_and_unban_connect_success` which simulates a full sequence of sanctioning, banning, unsanctioning, unbanning and verifies details at each point.

2. ran 3 localhost nodes.   procedure:

    * temporarily adjusted CONNECT_FAILED_TIMEOUT_SECS from 5 mins to 40 secs.
    * temporarily adjusted PEER_DISCOVERY_INTERVAL_IN_SECONDS from 2 mins to 20 secs.
    * ran 3 regtest nodes on 3 localhost ports using the `run-multiple-instances.sh` script. 
    * Waited until each node has 3 peers, then shutdown the 3rd node. 
    * Verified in node 1 and 2's logs that node 3 gets repeatedly sanctioned, until banned.
    * Verified that nodes 1 and 2 attempt to connect to node 3 after CONNECT_FAILED_TIMEOUT_SECS and peer remains banned.
    * restarted node 3
    * Verified that nodes 1 and 2 attempt to connect to node 3 after CONNECT_FAILED_TIMEOUT_SECS and peer is unsanctioned and unbanned after successful connect.   Each node again shows 2 peers in dashboard.

Here is an edited-for-readability log from node 0, that demonstrates the detailed logging:

```
2024-02-09T23:05:19 DEBUG standing_permits_connect_to_peer: [127.0.0.1]:29792.  peer standing not found. allow: true
2024-02-09T23:05:19  INFO Connecting to peer [127.0.0.1]:29792 with distance 2
2024-02-09T23:05:19  INFO rewarding peer 127.0.0.1:29792 for ConnectSuccess
2024-02-09T23:05:19 DEBUG Old Standing for Peer 127.0.0.1:29792 was PeerStanding { score: 0, latest_sanction: None, timestamp_of_latest_sanction: None }
2024-02-09T23:05:19 DEBUG New Standing for Peer 127.0.0.1:29792 is PeerStanding { score: 25, latest_sanction: None, timestamp_of_latest_sanction: None }

2024-02-09T23:05:31 DEBUG Removing max block height from sync data structure for peer [127.0.0.1]:29792

2024-02-09T23:05:39 DEBUG standing_permits_connect_to_peer: [127.0.0.1]:29792.  peer NOT banned. score: 25. allow: true
2024-02-09T23:05:39  INFO Connecting to peer [127.0.0.1]:29792 with distance 2
2024-02-09T23:05:39  WARN Sanctioning peer 127.0.0.1:29792 for ConnectFailed
2024-02-09T23:05:39 DEBUG Old Standing for Peer 127.0.0.1:29792 was PeerStanding { score: 25, latest_sanction: None, timestamp_of_latest_sanction: None }
2024-02-09T23:05:39 DEBUG New Standing for Peer 127.0.0.1:29792 is PeerStanding { score: 0, latest_sanction: Some(ConnectFailed), timestamp_of_latest_sanction: Some(SystemTime { tv_sec: 1707519939, tv_nsec: 883171674 }) }

2024-02-09T23:05:59 DEBUG standing_permits_connect_to_peer: [127.0.0.1]:29792.  peer NOT banned. score: 0. allow: true
2024-02-09T23:05:59  INFO Connecting to peer [127.0.0.1]:29792 with distance 2
2024-02-09T23:05:59  WARN Sanctioning peer 127.0.0.1:29792 for ConnectFailed
2024-02-09T23:05:59 DEBUG Old Standing for Peer 127.0.0.1:29792 was PeerStanding { score: 0, latest_sanction: Some(ConnectFailed), timestamp_of_latest_sanction: Some(SystemTime { tv_sec: 1707519939, tv_nsec: 883171674 }) }
2024-02-09T23:05:59 DEBUG New Standing for Peer 127.0.0.1:29792 is PeerStanding { score: -25, latest_sanction: Some(ConnectFailed), timestamp_of_latest_sanction: Some(SystemTime { tv_sec: 1707519959, tv_nsec: 887529758 }) }

2024-02-09T23:06:19 DEBUG standing_permits_connect_to_peer: [127.0.0.1]:29792.  peer NOT banned. score: -25. allow: true
2024-02-09T23:06:19  INFO Connecting to peer [127.0.0.1]:29792 with distance 2
2024-02-09T23:06:19  WARN Sanctioning peer 127.0.0.1:29792 for ConnectFailed
2024-02-09T23:06:19 DEBUG Old Standing for Peer 127.0.0.1:29792 was PeerStanding { score: -25, latest_sanction: Some(ConnectFailed), timestamp_of_latest_sanction: Some(SystemTime { tv_sec: 1707519959, tv_nsec: 887529758 }) }
2024-02-09T23:06:19 DEBUG New Standing for Peer 127.0.0.1:29792 is PeerStanding { score: -50, latest_sanction: Some(ConnectFailed), timestamp_of_latest_sanction: Some(SystemTime { tv_sec: 1707519979, tv_nsec: 889638190 }) }

2024-02-09T23:06:39 DEBUG standing_permits_connect_to_peer: [127.0.0.1]:29792.  peer NOT banned. score: -50. allow: true
2024-02-09T23:06:39  INFO Connecting to peer [127.0.0.1]:29792 with distance 2
2024-02-09T23:06:39  WARN Sanctioning peer 127.0.0.1:29792 for ConnectFailed
2024-02-09T23:06:39 DEBUG Old Standing for Peer 127.0.0.1:29792 was PeerStanding { score: -50, latest_sanction: Some(ConnectFailed), timestamp_of_latest_sanction: Some(SystemTime { tv_sec: 1707519979, tv_nsec: 889638190 }) }
2024-02-09T23:06:39 DEBUG New Standing for Peer 127.0.0.1:29792 is PeerStanding { score: -75, latest_sanction: Some(ConnectFailed), timestamp_of_latest_sanction: Some(SystemTime { tv_sec: 1707519999, tv_nsec: 891635518 }) }

2024-02-09T23:06:59 DEBUG standing_permits_connect_to_peer: [127.0.0.1]:29792.  peer NOT banned. score: -75. allow: true
2024-02-09T23:06:59  INFO Connecting to peer [127.0.0.1]:29792 with distance 2
2024-02-09T23:06:59  WARN Sanctioning peer 127.0.0.1:29792 for ConnectFailed
2024-02-09T23:06:59 DEBUG Old Standing for Peer 127.0.0.1:29792 was PeerStanding { score: -75, latest_sanction: Some(ConnectFailed), timestamp_of_latest_sanction: Some(SystemTime { tv_sec: 1707519999, tv_nsec: 891635518 }) }
2024-02-09T23:06:59 DEBUG New Standing for Peer 127.0.0.1:29792 is PeerStanding { score: -100, latest_sanction: Some(ConnectFailed), timestamp_of_latest_sanction: Some(SystemTime { tv_sec: 1707520019, tv_nsec: 895418539 }) }
2024-02-09T23:06:59  WARN Banning peer 127.0.0.1:29792

2024-02-09T23:07:19 DEBUG standing_permits_connect_to_peer: [127.0.0.1]:29792. peer remains BANNED since last ConnectFailed.  Can try again in 20 seconds.  score: -100. allow: false

2024-02-09T23:07:39 DEBUG standing_permits_connect_to_peer: [127.0.0.1]:29792. peer is BANNED but timeout expired since ConnectFailed sanction. score: -100. allow: true
2024-02-09T23:07:39  INFO Connecting to peer [127.0.0.1]:29792 with distance 2
2024-02-09T23:07:39  WARN Sanctioning peer 127.0.0.1:29792 for ConnectFailed
2024-02-09T23:07:39 DEBUG Old Standing for Peer 127.0.0.1:29792 was PeerStanding { score: -100, latest_sanction: Some(ConnectFailed), timestamp_of_latest_sanction: Some(SystemTime { tv_sec: 1707520019, tv_nsec: 895418539 }) }
2024-02-09T23:07:39 DEBUG New Standing for Peer 127.0.0.1:29792 is PeerStanding { score: -100, latest_sanction: Some(ConnectFailed), timestamp_of_latest_sanction: Some(SystemTime { tv_sec: 1707520059, tv_nsec: 902585255 }) }

2024-02-09T23:07:59 DEBUG standing_permits_connect_to_peer: [127.0.0.1]:29792. peer remains BANNED since last ConnectFailed.  Can try again in 20 seconds.  score: -100. allow: false

2024-02-09T23:08:19 DEBUG standing_permits_connect_to_peer: [127.0.0.1]:29792. peer is BANNED but timeout expired since ConnectFailed sanction. score: -100. allow: true
2024-02-09T23:08:19  INFO Connecting to peer [127.0.0.1]:29792 with distance 2
2024-02-09T23:08:19  INFO rewarding peer 127.0.0.1:29792 for ConnectSuccess
2024-02-09T23:08:19 DEBUG Old Standing for Peer 127.0.0.1:29792 was PeerStanding { score: -100, latest_sanction: Some(ConnectFailed), timestamp_of_latest_sanction: Some(SystemTime { tv_sec: 1707520059, tv_nsec: 902585255 }) }
2024-02-09T23:08:19 DEBUG New Standing for Peer 127.0.0.1:29792 is PeerStanding { score: -75, latest_sanction: Some(ConnectFailed), timestamp_of_latest_sanction: Some(SystemTime { tv_sec: 1707520059, tv_nsec: 902585255 }) }
2024-02-09T23:08:19  INFO Unbanning peer 127.0.0.1:29792

```

[peer2-readable.log](https://github.com/Neptune-Crypto/neptune-core/files/14230995/peer2-readable.log)

----
**Problems after rebase to master**

The above testing was performed on my branch created from master at 0d414d98 on Jan 25.  Today I rebased it to master @ 9fb265c24 Feb 5.   I again attempted to run 3 nodes with `run-multiple-instances.sh` but now the peers are unable to pass eachother blocks and disconnect from eachother.   I get a log error "In order to be transferred, a Block must have a non-None proof field".   Here's an example:

```
2024-02-11T02:03:11.68229879Z  INFO ThreadId(02) neptune_core::connect_to_peers: Connection accepted from [::ffff:127.0.0.1]:47096
2024-02-11T02:03:11.682693047Z DEBUG ThreadId(01) neptune_core::main_loop: Received message sent to main thread.
2024-02-11T02:03:11.682784953Z DEBUG ThreadId(01) neptune_core::main_loop: Received add peer max block height from a peer thread
2024-02-11T02:03:11.683502005Z DEBUG ThreadId(05) neptune_core::peer_loop: Received block notification request from peer [::ffff:127.0.0.1]:47096
2024-02-11T02:03:11.683632119Z DEBUG ThreadId(05) neptune_core::peer_loop: Got BlockNotificationRequest
2024-02-11T02:03:11.684171193Z DEBUG ThreadId(05) neptune_core::peer_loop: Received peer list req from peer [::ffff:127.0.0.1]:47096
2024-02-11T02:03:11.684250284Z DEBUG ThreadId(05) neptune_core::peer_loop: Responding with: [([::ffff:127.0.0.1]:29791, 125719324242919459118982459613409448902)]
2024-02-11T02:03:11.68462132Z DEBUG ThreadId(05) neptune_core::peer_loop: Received block req by height from peer [::ffff:127.0.0.1]:47096
2024-02-11T02:03:11.684657636Z DEBUG ThreadId(05) neptune_core::peer_loop: Got BlockRequestByHeight of height 14
2024-02-11T02:03:11.685041049Z DEBUG ThreadId(05) neptune_core::peer_loop: Found 1 blocks
2024-02-11T02:03:11.685521208Z ERROR ThreadId(05) neptune_core::models::blockchain::block: In order to be transferred, a Block must have a non-None proof field.
thread 'tokio-runtime-worker' panicked at src/models/blockchain/block/mod.rs:80:17:
explicit panic
```

This appears to be caused by the intervening changes to master, unrelated to this PR.


