### PR TITLE
fix: Flaky mutator set bug

### DIFF
--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -50,7 +50,7 @@ fn make_block_template(
 ) -> (BlockHeader, BlockBody) {
     let additions = transaction.kernel.outputs.clone();
     let removals = transaction.kernel.inputs.clone();
-    let mut next_mutator_set_accumulator: MutatorSetAccumulator<Hash> =
+    let mut next_mutator_set_accumulator: MutatorSetAccumulator =
         previous_block.kernel.body.mutator_set_accumulator.clone();
 
     // Apply the mutator set update to the mutator set accumulator
@@ -176,7 +176,7 @@ fn make_coinbase_transaction(
     receiver_digest: Digest,
     wallet_secret: &WalletSecret,
     block_height: BlockHeight,
-    mutator_set_accumulator: MutatorSetAccumulator<Hash>,
+    mutator_set_accumulator: MutatorSetAccumulator,
 ) -> (Transaction, Digest) {
     let sender_randomness: Digest =
         wallet_secret.generate_sender_randomness(block_height, receiver_digest);
@@ -190,7 +190,7 @@ fn make_coinbase_transaction(
                 .expect("Make coinbase transaction: failed to parse coin state as amount.")
         })
         .sum();
-    let coinbase_addition_record = commit::<Hash>(
+    let coinbase_addition_record = commit(
         Hash::hash(coinbase_utxo),
         sender_randomness,
         receiver_digest,

--- a/src/models/blockchain/block/block_body.rs
+++ b/src/models/blockchain/block/block_body.rs
@@ -37,7 +37,7 @@ pub struct BlockBody {
     /// The mutator set accumulator represents the UTXO set. It is simultaneously an
     /// accumulator (=> compact representation and membership proofs) and an anonymity
     /// construction (=> outputs from one transaction do not look like inputs to another).
-    pub mutator_set_accumulator: MutatorSetAccumulator<Hash>,
+    pub mutator_set_accumulator: MutatorSetAccumulator,
 
     /// Lock-free UTXOs do not come with lock scripts and do not live in the mutator set.
     pub lock_free_mmr_accumulator: MmrAccumulator<Hash>,

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -121,7 +121,7 @@ impl Block {
     }
 
     pub fn genesis_block() -> Self {
-        let mut genesis_mutator_set = MutatorSetAccumulator::<Hash>::default();
+        let mut genesis_mutator_set = MutatorSetAccumulator::default();
         let mut ms_update = MutatorSetUpdate::default();
 
         let premine_distribution = Self::premine_distribution();
@@ -141,7 +141,7 @@ impl Block {
                 timestamp,
                 public_announcements: vec![],
                 coinbase: Some(total_premine_amount),
-                mutator_set_hash: MutatorSetAccumulator::<Hash>::new().hash(),
+                mutator_set_hash: MutatorSetAccumulator::new().hash(),
             },
             witness: Witness::Faith,
         };
@@ -157,7 +157,7 @@ impl Block {
             let receiver_digest = receiving_address.privacy_digest;
 
             // Add pre-mine UTXO to MutatorSet
-            let addition_record = commit::<Hash>(utxo_digest, bad_randomness, receiver_digest);
+            let addition_record = commit(utxo_digest, bad_randomness, receiver_digest);
             ms_update.additions.push(addition_record);
             genesis_mutator_set.add(&addition_record);
 
@@ -218,7 +218,7 @@ impl Block {
     pub fn accumulate_transaction(
         &mut self,
         transaction: Transaction,
-        old_mutator_set_accumulator: &MutatorSetAccumulator<Hash>,
+        old_mutator_set_accumulator: &MutatorSetAccumulator,
     ) {
         // merge transactions
         let merged_timestamp = BFieldElement::new(max(

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -215,8 +215,12 @@ impl Block {
 
     /// Merge a transaction into this block's transaction.
     /// The mutator set data must be valid in all inputs.
-    pub fn accumulate_transaction(&mut self, transaction: Transaction) {
-        // merge
+    pub fn accumulate_transaction(
+        &mut self,
+        transaction: Transaction,
+        old_mutator_set_accumulator: &MutatorSetAccumulator<Hash>,
+    ) {
+        // merge transactions
         let merged_timestamp = BFieldElement::new(max(
             self.kernel.header.timestamp.value(),
             max(
@@ -224,24 +228,37 @@ impl Block {
                 transaction.kernel.timestamp.value(),
             ),
         ));
+        let new_transaction = self
+            .kernel
+            .body
+            .transaction
+            .clone()
+            .merge_with(transaction.clone());
 
-        // accumulate
-        let mut next_mutator_set_accumulator = self.kernel.body.mutator_set_accumulator.clone();
-
+        // accumulate mutator set updates
+        // Can't use the current mutator sat accumulator because it is in an in-between state.
+        let mut new_mutator_set_accumulator = old_mutator_set_accumulator.clone();
         let mutator_set_update = MutatorSetUpdate::new(
-            transaction.kernel.inputs.clone(),
-            transaction.kernel.outputs.clone(),
+            [
+                self.kernel.body.transaction.kernel.inputs.clone(),
+                transaction.kernel.inputs,
+            ]
+            .concat(),
+            [
+                self.kernel.body.transaction.kernel.outputs.clone(),
+                transaction.kernel.outputs.clone(),
+            ]
+            .concat(),
         );
 
-        let new_transaction = self.kernel.body.transaction.clone().merge_with(transaction);
         // Apply the mutator set update to get the `next_mutator_set_accumulator`
         mutator_set_update
-            .apply(&mut next_mutator_set_accumulator)
+            .apply(&mut new_mutator_set_accumulator)
             .expect("Mutator set mutation must work");
 
         let block_body: BlockBody = BlockBody {
             transaction: new_transaction,
-            mutator_set_accumulator: next_mutator_set_accumulator.clone(),
+            mutator_set_accumulator: new_mutator_set_accumulator.clone(),
             lock_free_mmr_accumulator: self.kernel.body.lock_free_mmr_accumulator.clone(),
             block_mmr_accumulator: self.kernel.body.block_mmr_accumulator.clone(),
             uncle_blocks: self.kernel.body.uncle_blocks.clone(),
@@ -560,7 +577,7 @@ mod block_tests {
             .unwrap();
         assert!(new_tx.is_valid(), "Created tx must be valid");
 
-        block_1.accumulate_transaction(new_tx);
+        block_1.accumulate_transaction(new_tx, &genesis_block.kernel.body.mutator_set_accumulator);
         assert!(
             block_1.is_valid(&genesis_block),
             "Block 1 must be valid after adding a transaction; previous mutator set hash: {} and next mutator set hash: {}",

--- a/src/models/blockchain/block/mutator_set_update.rs
+++ b/src/models/blockchain/block/mutator_set_update.rs
@@ -1,25 +1,22 @@
-use anyhow::{bail, Result};
+use anyhow::Result;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    models::blockchain::shared::Hash,
-    util_types::mutator_set::{
-        addition_record::AdditionRecord, mutator_set_accumulator::MutatorSetAccumulator,
-        mutator_set_trait::MutatorSet, removal_record::RemovalRecord,
-    },
+use crate::util_types::mutator_set::{
+    addition_record::AdditionRecord, mutator_set_accumulator::MutatorSetAccumulator,
+    mutator_set_trait::MutatorSet, removal_record::RemovalRecord,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct MutatorSetUpdate {
     // The ordering of the removal/addition records must match that of
     // the block.
-    pub removals: Vec<RemovalRecord<Hash>>,
+    pub removals: Vec<RemovalRecord>,
     pub additions: Vec<AdditionRecord>,
 }
 
 impl MutatorSetUpdate {
-    pub fn new(removals: Vec<RemovalRecord<Hash>>, additions: Vec<AdditionRecord>) -> Self {
+    pub fn new(removals: Vec<RemovalRecord>, additions: Vec<AdditionRecord>) -> Self {
         Self {
             additions,
             removals,
@@ -28,12 +25,12 @@ impl MutatorSetUpdate {
 
     /// Apply a mutator set update to a mutator set accumulator. Changes the input mutator set
     /// accumulator according to the provided additions and removals.
-    pub fn apply(&self, ms_accumulator: &mut MutatorSetAccumulator<Hash>) -> Result<()> {
+    pub fn apply(&self, ms_accumulator: &mut MutatorSetAccumulator) -> Result<()> {
         let mut addition_records: Vec<AdditionRecord> = self.additions.clone();
         addition_records.reverse();
         let mut removal_records = self.removals.clone();
         removal_records.reverse();
-        let mut removal_records: Vec<&mut RemovalRecord<Hash>> =
+        let mut removal_records: Vec<&mut RemovalRecord> =
             removal_records.iter_mut().collect::<Vec<_>>();
         while let Some(addition_record) = addition_records.pop() {
             RemovalRecord::batch_update_from_addition(
@@ -45,12 +42,7 @@ impl MutatorSetUpdate {
         }
 
         while let Some(removal_record) = removal_records.pop() {
-            let update_res =
-                RemovalRecord::batch_update_from_remove(&mut removal_records, removal_record);
-
-            if update_res.is_err() {
-                bail!("Failed to update removal records with addition record");
-            }
+            RemovalRecord::batch_update_from_remove(&mut removal_records, removal_record);
 
             ms_accumulator.remove(removal_record);
         }

--- a/src/models/blockchain/block/mutator_set_update.rs
+++ b/src/models/blockchain/block/mutator_set_update.rs
@@ -36,14 +36,10 @@ impl MutatorSetUpdate {
         let mut removal_records: Vec<&mut RemovalRecord<Hash>> =
             removal_records.iter_mut().collect::<Vec<_>>();
         while let Some(addition_record) = addition_records.pop() {
-            let update_res = RemovalRecord::batch_update_from_addition(
+            RemovalRecord::batch_update_from_addition(
                 &mut removal_records,
                 &mut ms_accumulator.kernel,
             );
-
-            if update_res.is_err() {
-                bail!("Failed to update removal records with addition record");
-            }
 
             ms_accumulator.add(&addition_record);
         }

--- a/src/models/blockchain/block/validity/correct_mutator_set_update.rs
+++ b/src/models/blockchain/block/validity/correct_mutator_set_update.rs
@@ -6,16 +6,13 @@ use tasm_lib::{
 };
 
 use crate::{
-    models::{
-        blockchain::shared::Hash,
-        consensus::{SecretWitness, SupportedClaim},
-    },
+    models::consensus::{SecretWitness, SupportedClaim},
     util_types::mutator_set::mutator_set_accumulator::MutatorSetAccumulator,
 };
 
 #[derive(Debug, Clone, BFieldCodec, GetSize, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CorrectMutatorSetUpdateWitness {
-    previous_mutator_set_accumulator: MutatorSetAccumulator<Hash>,
+    previous_mutator_set_accumulator: MutatorSetAccumulator,
 }
 
 impl SecretWitness for CorrectMutatorSetUpdateWitness {

--- a/src/models/blockchain/transaction/mod.rs
+++ b/src/models/blockchain/transaction/mod.rs
@@ -109,15 +109,13 @@ impl Transaction {
             RemovalRecord::batch_update_from_addition(
                 &mut block_removal_records,
                 &mut msa_state.kernel,
-            )
-            .expect("MS removal record update from add must succeed in wallet handler");
+            );
 
             // Batch update transaction's removal records
             RemovalRecord::batch_update_from_addition(
                 &mut transaction_removal_records,
                 &mut msa_state.kernel,
-            )
-            .expect("MS removal record update from add must succeed in wallet handler");
+            );
 
             // Batch update primitive witness membership proofs
             if let Witness::Primitive(witness) = &mut self.witness {

--- a/src/models/blockchain/transaction/mod.rs
+++ b/src/models/blockchain/transaction/mod.rs
@@ -58,10 +58,10 @@ pub struct TransactionPrimitiveWitness {
     pub input_lock_scripts: Vec<LockScript>,
     pub type_scripts: Vec<TypeScript>,
     pub lock_script_witnesses: Vec<Vec<BFieldElement>>,
-    pub input_membership_proofs: Vec<MsMembershipProof<Hash>>,
+    pub input_membership_proofs: Vec<MsMembershipProof>,
     pub output_utxos: Vec<Utxo>,
     pub public_announcements: Vec<PublicAnnouncement>,
-    pub mutator_set_accumulator: MutatorSetAccumulator<Hash>,
+    pub mutator_set_accumulator: MutatorSetAccumulator,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, GetSize, BFieldCodec)]
@@ -89,18 +89,18 @@ impl Transaction {
     /// witnesses the witness data can be and is updated.
     pub fn update_mutator_set_records(
         &mut self,
-        previous_mutator_set_accumulator: &MutatorSetAccumulator<Hash>,
+        previous_mutator_set_accumulator: &MutatorSetAccumulator,
         block: &Block,
     ) -> Result<()> {
-        let mut msa_state: MutatorSetAccumulator<Hash> = previous_mutator_set_accumulator.clone();
+        let mut msa_state: MutatorSetAccumulator = previous_mutator_set_accumulator.clone();
         let block_addition_records: Vec<AdditionRecord> =
             block.kernel.body.transaction.kernel.outputs.clone();
-        let mut transaction_removal_records: Vec<RemovalRecord<Hash>> = self.kernel.inputs.clone();
-        let mut transaction_removal_records: Vec<&mut RemovalRecord<Hash>> =
+        let mut transaction_removal_records: Vec<RemovalRecord> = self.kernel.inputs.clone();
+        let mut transaction_removal_records: Vec<&mut RemovalRecord> =
             transaction_removal_records.iter_mut().collect();
         let mut block_removal_records = block.kernel.body.transaction.kernel.inputs.clone();
         block_removal_records.reverse();
-        let mut block_removal_records: Vec<&mut RemovalRecord<Hash>> =
+        let mut block_removal_records: Vec<&mut RemovalRecord> =
             block_removal_records.iter_mut().collect::<Vec<_>>();
 
         // Apply all addition records in the block
@@ -136,16 +136,14 @@ impl Transaction {
 
         while let Some(removal_record) = block_removal_records.pop() {
             // Batch update block's removal records to keep them valid after next removal
-            RemovalRecord::batch_update_from_remove(&mut block_removal_records, removal_record)
-                .expect("MS removal record update from remove must succeed in wallet handler");
+            RemovalRecord::batch_update_from_remove(&mut block_removal_records, removal_record);
 
             // batch update transaction's removal records
             // Batch update block's removal records to keep them valid after next removal
             RemovalRecord::batch_update_from_remove(
                 &mut transaction_removal_records,
                 removal_record,
-            )
-            .expect("MS removal record update from remove must succeed in wallet handler");
+            );
 
             // Batch update primitive witness membership proofs
             if let Witness::Primitive(witness) = &mut self.witness {
@@ -320,7 +318,7 @@ impl Transaction {
     /// window Bloom filter, and whether the MMR membership proofs are valid.
     pub fn is_confirmable_relative_to(
         &self,
-        mutator_set_accumulator: &MutatorSetAccumulator<Hash>,
+        mutator_set_accumulator: &MutatorSetAccumulator,
     ) -> bool {
         self.kernel
             .inputs
@@ -530,7 +528,7 @@ mod transaction_tests {
             coins: NeptuneCoins::new(42).to_native_coins(),
             lock_script_hash: LockScript::anyone_can_spend().hash(),
         };
-        let ar = commit::<Hash>(Hash::hash(&output_1), random(), random());
+        let ar = commit(Hash::hash(&output_1), random(), random());
 
         // Verify that a sane timestamp is returned. `make_mock_transaction` must follow
         // the correct time convention for this test to work.

--- a/src/models/blockchain/transaction/transaction_kernel.rs
+++ b/src/models/blockchain/transaction/transaction_kernel.rs
@@ -13,12 +13,9 @@ use twenty_first::shared_math::{
 };
 
 use super::{neptune_coins::pseudorandom_amount, NeptuneCoins, PublicAnnouncement};
-use crate::{
-    util_types::mutator_set::{
-        addition_record::{pseudorandom_addition_record, AdditionRecord},
-        removal_record::{pseudorandom_removal_record, RemovalRecord},
-    },
-    Hash,
+use crate::util_types::mutator_set::{
+    addition_record::{pseudorandom_addition_record, AdditionRecord},
+    removal_record::{pseudorandom_removal_record, RemovalRecord},
 };
 
 pub fn pseudorandom_public_announcement(seed: [u8; 32]) -> PublicAnnouncement {
@@ -30,7 +27,7 @@ pub fn pseudorandom_public_announcement(seed: [u8; 32]) -> PublicAnnouncement {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, GetSize, BFieldCodec, TasmObject)]
 pub struct TransactionKernel {
-    pub inputs: Vec<RemovalRecord<Hash>>,
+    pub inputs: Vec<RemovalRecord>,
 
     // `outputs` contains the commitments (addition records) that go into the AOCL
     pub outputs: Vec<AdditionRecord>,

--- a/src/models/blockchain/transaction/validity/removal_records_integrity.rs
+++ b/src/models/blockchain/transaction/validity/removal_records_integrity.rs
@@ -40,7 +40,7 @@ use crate::{
 )]
 pub struct RemovalRecordsIntegrityWitness {
     pub input_utxos: Vec<Utxo>,
-    pub membership_proofs: Vec<MsMembershipProof<Hash>>,
+    pub membership_proofs: Vec<MsMembershipProof>,
     pub aocl: MmrAccumulator<Hash>,
     pub swbfi: MmrAccumulator<Hash>,
     pub swbfa_hash: Digest,

--- a/src/models/blockchain/transaction/validity/tasm/compute_canonical_commitment.rs
+++ b/src/models/blockchain/transaction/validity/tasm/compute_canonical_commitment.rs
@@ -45,7 +45,7 @@ impl BasicSnippet for ComputeCanonicalCommitment {
     }
 
     fn code(&self, library: &mut Library) -> Vec<triton_vm::instruction::LabelledInstruction> {
-        type MsMpH = MsMembershipProof<Hash>;
+        type MsMpH = MsMembershipProof;
         let mp_to_sr = tasm_lib::field!(MsMpH::sender_randomness);
         let mp_to_rp = tasm_lib::field!(MsMpH::receiver_preimage);
         let commit = library.import(Box::new(Commit));
@@ -135,7 +135,7 @@ impl Function for ComputeCanonicalCommitment {
         }
 
         // decode object
-        let membership_proof = *MsMembershipProof::<Hash>::decode(&encoding).unwrap();
+        let membership_proof = *MsMembershipProof::decode(&encoding).unwrap();
 
         // compute commitment
         println!("receiver_preimage: {}", membership_proof.receiver_preimage);
@@ -146,7 +146,7 @@ impl Function for ComputeCanonicalCommitment {
             membership_proof.sender_randomness
         );
         println!("\nitem:\n{}", item);
-        let c = commit::<Hash>(item, membership_proof.sender_randomness, receiver_digest);
+        let c = commit(item, membership_proof.sender_randomness, receiver_digest);
 
         // push onto stack
         stack.push(mp_pointer);
@@ -165,7 +165,7 @@ impl Function for ComputeCanonicalCommitment {
         let mut rng: StdRng = SeedableRng::from_seed(seed);
 
         // generate random ms membership proof object
-        let membership_proof = pseudorandom_mutator_set_membership_proof::<Hash>(rng.gen());
+        let membership_proof = pseudorandom_mutator_set_membership_proof(rng.gen());
 
         // populate memory, with the size of the encoding prepended
         let address = BFieldElement::new(rng.next_u64() % (1 << 20));

--- a/src/models/blockchain/transaction/validity/tasm/compute_indices.rs
+++ b/src/models/blockchain/transaction/validity/tasm/compute_indices.rs
@@ -46,7 +46,7 @@ impl BasicSnippet for ComputeIndices {
     }
 
     fn code(&self, library: &mut Library) -> Vec<triton_vm::instruction::LabelledInstruction> {
-        type MsMpH = MsMembershipProof<Hash>;
+        type MsMpH = MsMembershipProof;
         let mp_to_sr = tasm_lib::field!(MsMpH::sender_randomness);
         let mp_to_rp = tasm_lib::field!(MsMpH::receiver_preimage);
         let mp_to_ap = tasm_lib::field!(MsMpH::auth_path_aocl);
@@ -159,7 +159,7 @@ impl Function for ComputeIndices {
         for i in 0..size {
             sequence.push(*memory.get(&BFieldElement::new(2u64 + i)).unwrap());
         }
-        let msmp = *MsMembershipProof::<Hash>::decode(&sequence).unwrap();
+        let msmp = *MsMembershipProof::decode(&sequence).unwrap();
         let leaf_index = msmp.auth_path_aocl.leaf_index;
         let leaf_index_hi = leaf_index >> 32;
         let leaf_index_lo = leaf_index & (u32::MAX as u64);
@@ -218,8 +218,7 @@ impl Function for ComputeIndices {
 
         let mut rng: StdRng = SeedableRng::from_seed(seed);
 
-        let mut msmp =
-            pseudorandom_mutator_set_membership_proof::<crate::Hash>(rand::Rng::gen(&mut rng));
+        let mut msmp = pseudorandom_mutator_set_membership_proof(rand::Rng::gen(&mut rng));
         msmp.auth_path_aocl.leaf_index = rng.next_u32() as u64;
 
         let msmp_encoded = twenty_first::shared_math::bfield_codec::BFieldCodec::encode(&msmp);
@@ -271,7 +270,6 @@ mod tests {
     use triton_vm::prelude::NonDeterminism;
     use twenty_first::shared_math::bfield_codec::BFieldCodec;
 
-    use crate::models::blockchain::shared::Hash;
     use crate::util_types::mutator_set::mutator_set_kernel::get_swbf_indices;
 
     use super::*;
@@ -292,7 +290,7 @@ mod tests {
 
         // sample membership proofs
         let membership_proofs = (0..num_items)
-            .map(|_| pseudorandom_mutator_set_membership_proof::<Hash>(rng.gen()))
+            .map(|_| pseudorandom_mutator_set_membership_proof(rng.gen()))
             .collect_vec();
 
         // sample items
@@ -400,7 +398,7 @@ mod tests {
             .into_iter()
             .zip(membership_proofs)
             .map(|(item, mp)| {
-                get_swbf_indices::<Hash>(
+                get_swbf_indices(
                     item,
                     mp.sender_randomness,
                     mp.receiver_preimage,

--- a/src/models/blockchain/transaction/validity/tasm/removal_records_integrity.rs
+++ b/src/models/blockchain/transaction/validity/tasm/removal_records_integrity.rs
@@ -129,7 +129,7 @@ impl CompiledProgram for RemovalRecordsIntegrity {
             .iter()
             .zip(removal_record_integrity_witness.membership_proofs.iter())
             .map(|(&item, msmp)| {
-                AbsoluteIndexSet::new(&get_swbf_indices::<Hash>(
+                AbsoluteIndexSet::new(&get_swbf_indices(
                     item,
                     msmp.sender_randomness,
                     msmp.receiver_preimage,
@@ -157,7 +157,7 @@ impl CompiledProgram for RemovalRecordsIntegrity {
             .zip(removal_record_integrity_witness.membership_proofs.iter())
             .map(|(item, msmp)| {
                 (
-                    commit::<Hash>(
+                    commit(
                         item,
                         msmp.sender_randomness,
                         msmp.receiver_preimage.hash::<Hash>(),

--- a/src/models/blockchain/transaction/validity/tasm/verify_aocl_membership.rs
+++ b/src/models/blockchain/transaction/validity/tasm/verify_aocl_membership.rs
@@ -57,7 +57,7 @@ impl BasicSnippet for VerifyAoclMembership {
         // We do not need to use get field for MmrMembershipProof because
         // it has a custom implementation of BFieldCodec. However, we do
         // need it for MsMembershipProof.
-        type MsMpH = MsMembershipProof<Hash>;
+        type MsMpH = MsMembershipProof;
         type MmrMpH = MmrMembershipProof<Hash>;
         let msmp_to_mmrmp = tasm_lib::field!(MsMpH::auth_path_aocl);
         let mmr_mp_to_li = tasm_lib::field!(MmrMpH::leaf_index);
@@ -164,7 +164,7 @@ impl Function for VerifyAoclMembership {
         for i in 0..mp_size {
             mp_encoding.push(*memory.get(&(mp_ptr + BFieldElement::new(i))).unwrap());
         }
-        let memproof = *MsMembershipProof::<Hash>::decode(&mp_encoding).unwrap();
+        let memproof = *MsMembershipProof::decode(&mp_encoding).unwrap();
         println!("memproof li: {}", memproof.auth_path_aocl.leaf_index);
         println!(
             "memproof ap: {}",
@@ -199,7 +199,7 @@ impl Function for VerifyAoclMembership {
         let leaf_index = rng.next_u64() % num_leafs;
         let leaf = mmr.get_leaf(leaf_index);
         let (mmr_mp, peaks) = mmr.prove_membership(leaf_index);
-        let mut msmp = pseudorandom_mutator_set_membership_proof::<Hash>(rng.gen());
+        let mut msmp = pseudorandom_mutator_set_membership_proof(rng.gen());
         msmp.auth_path_aocl = mmr_mp;
 
         // populate memory

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -641,7 +641,8 @@ mod tests {
 
         // Create next block which includes preminer's transaction
         let (mut block_2, _, _) = make_mock_block(&block_1, None, premine_receiver_address);
-        block_2.accumulate_transaction(tx_by_preminer);
+        block_2
+            .accumulate_transaction(tx_by_preminer, &block_1.kernel.body.mutator_set_accumulator);
 
         // Update the mempool with block 2 and verify that the mempool now only contains one tx
         assert_eq!(2, mempool.len());
@@ -680,7 +681,10 @@ mod tests {
             "tx_by_other_updated has mutator set hash: {}",
             tx_by_other_updated.kernel.mutator_set_hash.emojihash()
         );
-        block_3_with_updated_tx.accumulate_transaction(tx_by_other_updated.clone());
+        block_3_with_updated_tx.accumulate_transaction(
+            tx_by_other_updated.clone(),
+            &block_2.kernel.body.mutator_set_accumulator,
+        );
         assert!(
             block_3_with_updated_tx.is_valid(&block_2),
             "Block with tx with updated mutator set data must be valid"
@@ -702,7 +706,10 @@ mod tests {
         let (mut block_14, _, _) = make_mock_block(&previous_block, None, other_receiver_address);
         assert_eq!(Into::<BlockHeight>::into(14), block_14.kernel.header.height);
         tx_by_other_updated = mempool.get_transactions_for_block(usize::MAX)[0].clone();
-        block_14.accumulate_transaction(tx_by_other_updated);
+        block_14.accumulate_transaction(
+            tx_by_other_updated,
+            &previous_block.kernel.body.mutator_set_accumulator,
+        );
         assert!(
             block_14.is_valid(&previous_block),
             "Block with tx with updated mutator set data must be valid after 10 blocks have been mined"

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -294,7 +294,7 @@ impl Mempool {
     /// transactions that were not removed due to being included in the block.
     pub fn update_with_block(
         &mut self,
-        previous_mutator_set_accumulator: MutatorSetAccumulator<Hash>,
+        previous_mutator_set_accumulator: MutatorSetAccumulator,
         block: &Block,
     ) {
         // Check if the sets of inserted indices in the block transaction

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -383,14 +383,14 @@ impl GlobalState {
             + fee;
 
         // todo: accomodate a future change whereby this function also returns the matching spending keys
-        let spendable_utxos_and_mps: Vec<(Utxo, LockScript, MsMembershipProof<Hash>)> = self
+        let spendable_utxos_and_mps: Vec<(Utxo, LockScript, MsMembershipProof)> = self
             .wallet_state
             .allocate_sufficient_input_funds_from_lock(total_spend, bc_tip.hash())
             .await?;
 
         // Create all removal records. These must be relative to the block tip.
         let msa_tip = &bc_tip.kernel.body.mutator_set_accumulator;
-        let mut inputs: Vec<RemovalRecord<Hash>> = vec![];
+        let mut inputs: Vec<RemovalRecord> = vec![];
         let mut input_amount: NeptuneCoins = NeptuneCoins::zero();
         for (spendable_utxo, _lock_script, mp) in spendable_utxos_and_mps.iter() {
             let removal_record = msa_tip.kernel.drop(Hash::hash(spendable_utxo), mp);
@@ -402,7 +402,7 @@ impl GlobalState {
         let mut transaction_outputs: Vec<AdditionRecord> = vec![];
         let mut output_utxos: Vec<Utxo> = vec![];
         for rd in receiver_data.iter() {
-            let addition_record = commit::<Hash>(
+            let addition_record = commit(
                 Hash::hash(&rd.utxo),
                 rd.sender_randomness,
                 rd.receiver_privacy_digest,
@@ -437,7 +437,7 @@ impl GlobalState {
                 .wallet_state
                 .wallet_secret
                 .generate_sender_randomness(bc_tip.kernel.header.height, receiver_digest);
-            let change_addition_record = commit::<Hash>(
+            let change_addition_record = commit(
                 Hash::hash(&change_utxo),
                 change_sender_randomness,
                 receiver_digest,
@@ -772,7 +772,7 @@ impl GlobalState {
                     .await?;
                 let previous_mutator_set = match maybe_revert_block_predecessor {
                     Some(block) => block.kernel.body.mutator_set_accumulator,
-                    None => MutatorSetAccumulator::<Hash>::default(),
+                    None => MutatorSetAccumulator::default(),
                 };
 
                 debug!("MUTXO confirmed at height {confirming_block_height}, reverting for height {} on abandoned chain", revert_block.kernel.header.height);
@@ -824,7 +824,7 @@ impl GlobalState {
                     .await?;
                 let mut block_msa = match maybe_apply_block_predecessor {
                     Some(block) => block.kernel.body.mutator_set_accumulator,
-                    None => MutatorSetAccumulator::<Hash>::default(),
+                    None => MutatorSetAccumulator::default(),
                 };
                 let addition_records = apply_block.kernel.body.transaction.kernel.outputs;
                 let removal_records = apply_block.kernel.body.transaction.kernel.inputs;

--- a/src/models/state/wallet/address/generation_address.rs
+++ b/src/models/state/wallet/address/generation_address.rs
@@ -196,8 +196,7 @@ impl SpendingKey {
             // Note: the commitment is computed in the same way as in the mutator set.
             let receiver_preimage = self.privacy_preimage;
             let receiver_digest = receiver_preimage.hash::<Hash>();
-            let addition_record =
-                commit::<Hash>(Hash::hash(&utxo), sender_randomness, receiver_digest);
+            let addition_record = commit(Hash::hash(&utxo), sender_randomness, receiver_digest);
 
             // push to list
             received_utxos_with_randomnesses.push((
@@ -592,7 +591,7 @@ mod test_generation_addresses {
             announced_txs[0].clone();
         assert_eq!(utxo, read_utxo);
 
-        let expected_addition_record = commit::<Hash>(
+        let expected_addition_record = commit(
             Hash::hash(&utxo),
             sender_randomness,
             receiving_address.privacy_digest,

--- a/src/models/state/wallet/mod.rs
+++ b/src/models/state/wallet/mod.rs
@@ -757,7 +757,7 @@ mod wallet_tests {
             NeptuneCoins::zero(),
             msa_tip_previous.clone(),
         );
-        next_block.accumulate_transaction(tx);
+        next_block.accumulate_transaction(tx, &msa_tip_previous);
 
         own_wallet_state
             .update_wallet_state_with_new_block(&msa_tip_previous.clone(), &next_block)
@@ -848,7 +848,7 @@ mod wallet_tests {
             .await
             .unwrap();
 
-        block_1.accumulate_transaction(valid_tx);
+        block_1.accumulate_transaction(valid_tx, &previous_msa);
 
         // Verify the validity of the merged transaction and block
         assert!(block_1.is_valid(&genesis_block));
@@ -1099,7 +1099,10 @@ mod wallet_tests {
             .create_transaction(vec![receiver_data_six.clone()], NeptuneCoins::new(4))
             .await
             .unwrap();
-        block_3_b.accumulate_transaction(tx_from_preminer);
+        block_3_b.accumulate_transaction(
+            tx_from_preminer,
+            &block_2_b.kernel.body.mutator_set_accumulator,
+        );
         assert!(
             block_3_b.is_valid(&block_2_b),
             "Block must be valid after accumulating txs"

--- a/src/models/state/wallet/mod.rs
+++ b/src/models/state/wallet/mod.rs
@@ -11,7 +11,8 @@ use anyhow::{bail, Context, Result};
 use bip39::Mnemonic;
 use itertools::Itertools;
 use num_traits::Zero;
-use rand::{thread_rng, Rng};
+use rand::rngs::StdRng;
+use rand::{thread_rng, Rng, SeedableRng};
 use serde::{Deserialize, Serialize};
 use std::fs::{self};
 use std::path::{Path, PathBuf};
@@ -91,9 +92,15 @@ impl WalletSecret {
     /// Create a new `Wallet` and populate it with a new secret seed, with entropy
     /// obtained via `thread_rng()` from the operating system.
     pub fn new_random() -> Self {
+        Self::new_pseudorandom(thread_rng().gen())
+    }
+
+    /// Create a new `Wallet` and populate it by expanding a given seed.
+    pub fn new_pseudorandom(seed: [u8; 32]) -> Self {
+        let mut rng: StdRng = SeedableRng::from_seed(seed);
         Self {
             name: STANDARD_WALLET_NAME.to_string(),
-            secret_seed: SecretKeyMaterial(thread_rng().gen()),
+            secret_seed: SecretKeyMaterial(rng.gen()),
             version: STANDARD_WALLET_VERSION,
         }
     }

--- a/src/models/state/wallet/monitored_utxo.rs
+++ b/src/models/state/wallet/monitored_utxo.rs
@@ -5,7 +5,6 @@ use std::{collections::VecDeque, time::Duration};
 use crate::{
     models::{blockchain::block::block_height::BlockHeight, state::archival_state::ArchivalState},
     util_types::mutator_set::ms_membership_proof::MsMembershipProof,
-    Hash,
 };
 use serde::{Deserialize, Serialize};
 use twenty_first::shared_math::tip5::Digest;
@@ -17,7 +16,7 @@ pub struct MonitoredUtxo {
     pub utxo: Utxo,
 
     // Mapping from block digest to membership proof
-    pub blockhash_to_membership_proof: VecDeque<(Digest, MsMembershipProof<Hash>)>,
+    pub blockhash_to_membership_proof: VecDeque<(Digest, MsMembershipProof)>,
 
     pub number_of_mps_per_utxo: usize,
 
@@ -52,7 +51,7 @@ impl MonitoredUtxo {
     pub fn add_membership_proof_for_tip(
         &mut self,
         block_digest: Digest,
-        updated_membership_proof: MsMembershipProof<Hash>,
+        updated_membership_proof: MsMembershipProof,
     ) {
         while self.blockhash_to_membership_proof.len() >= self.number_of_mps_per_utxo {
             self.blockhash_to_membership_proof.pop_back();
@@ -65,14 +64,14 @@ impl MonitoredUtxo {
     pub fn get_membership_proof_for_block(
         &self,
         block_digest: Digest,
-    ) -> Option<MsMembershipProof<Hash>> {
+    ) -> Option<MsMembershipProof> {
         self.blockhash_to_membership_proof
             .iter()
             .find(|x| x.0 == block_digest)
             .map(|x| x.1.clone())
     }
 
-    pub fn get_latest_membership_proof_entry(&self) -> Option<(Digest, MsMembershipProof<Hash>)> {
+    pub fn get_latest_membership_proof_entry(&self) -> Option<(Digest, MsMembershipProof)> {
         self.blockhash_to_membership_proof.iter().next().cloned()
     }
 

--- a/src/models/state/wallet/utxo_notification_pool.rs
+++ b/src/models/state/wallet/utxo_notification_pool.rs
@@ -49,7 +49,7 @@ impl ExpectedUtxo {
         received_from: UtxoNotifier,
     ) -> Self {
         Self {
-            addition_record: commit::<Hash>(
+            addition_record: commit(
                 Hash::hash(&utxo),
                 sender_randomness,
                 receiver_preimage.hash::<Hash>(),
@@ -228,7 +228,7 @@ impl UtxoNotificationPool {
         // TODO: Add check that we can actually unlock the UTXO's lock script.
         // Also check that receiver preimage belongs to us etc.
         // Or should this be the caller's responsibility?
-        let addition_record = commit::<Hash>(
+        let addition_record = commit(
             Hash::hash(&utxo),
             sender_randomness,
             receiver_preimage.hash::<Hash>(),
@@ -377,7 +377,7 @@ mod wallet_state_tests {
         let sender_randomness: Digest = random();
         let receiver_preimage: Digest = random();
         let peer_instance_id: InstanceId = random();
-        let expected_addition_record = commit::<Hash>(
+        let expected_addition_record = commit(
             Hash::hash(&mock_utxo),
             sender_randomness,
             receiver_preimage.hash::<Hash>(),
@@ -405,7 +405,7 @@ mod wallet_state_tests {
         assert_eq!(1, ret_with_tx_containing_utxo.len());
 
         // Call scan but with another input. Verify that it returns the empty list
-        let another_addition_record = commit::<Hash>(
+        let another_addition_record = commit(
             Hash::hash(&mock_utxo),
             random(),
             receiver_preimage.hash::<Hash>(),
@@ -501,7 +501,7 @@ mod wallet_state_tests {
         // notification can be stored.
         notification_pool
             .mark_as_received(
-                commit::<Hash>(
+                commit(
                     Hash::hash(&mock_utxo),
                     first_sender_randomness,
                     receiver_preimage.hash::<Hash>(),

--- a/src/models/state/wallet/wallet_status.rs
+++ b/src/models/state/wallet/wallet_status.rs
@@ -5,7 +5,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::models::blockchain::transaction::{neptune_coins::NeptuneCoins, utxo::Utxo};
 use crate::util_types::mutator_set::ms_membership_proof::MsMembershipProof;
-use crate::Hash;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct WalletStatusElement(pub u64, pub Utxo);
@@ -20,7 +19,7 @@ impl Display for WalletStatusElement {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct WalletStatus {
     pub synced_unspent_amount: NeptuneCoins,
-    pub synced_unspent: Vec<(WalletStatusElement, MsMembershipProof<Hash>)>,
+    pub synced_unspent: Vec<(WalletStatusElement, MsMembershipProof)>,
     pub unsynced_unspent_amount: NeptuneCoins,
     pub unsynced_unspent: Vec<WalletStatusElement>,
     pub synced_spent_amount: NeptuneCoins,

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -452,7 +452,7 @@ pub fn pseudorandom_removal_record_integrity_witness(
         .iter()
         .zip(membership_proofs.iter())
         .map(|(utxo, msmp)| {
-            commit::<Hash>(
+            commit(
                 Hash::hash(utxo),
                 msmp.sender_randomness,
                 msmp.receiver_preimage.hash::<Hash>(),
@@ -496,7 +496,7 @@ pub fn pseudorandom_removal_record_integrity_witness(
                 msmp.auth_path_aocl.leaf_index,
             )
         })
-        .map(|(item, sr, rp, li)| get_swbf_indices::<Hash>(item, sr, rp, li))
+        .map(|(item, sr, rp, li)| get_swbf_indices(item, sr, rp, li))
         .map(|ais| RemovalRecord {
             absolute_indices: AbsoluteIndexSet::new(&ais),
             target_chunks: pseudorandom_chunk_dictionary(rng.gen()),
@@ -732,14 +732,10 @@ pub fn random_option<T>(thing: T) -> Option<T> {
 // TODO: Consider moving this to to the appropriate place in global state,
 // keep fn interface. Can be helper function to `create_transaction`.
 pub fn make_mock_transaction_with_generation_key(
-    input_utxos_mps_keys: Vec<(
-        Utxo,
-        MsMembershipProof<Hash>,
-        generation_address::SpendingKey,
-    )>,
+    input_utxos_mps_keys: Vec<(Utxo, MsMembershipProof, generation_address::SpendingKey)>,
     receiver_data: Vec<UtxoReceiverData>,
     fee: NeptuneCoins,
-    tip_msa: MutatorSetAccumulator<Hash>,
+    tip_msa: MutatorSetAccumulator,
 ) -> Transaction {
     // Generate removal records
     let mut inputs = vec![];
@@ -750,7 +746,7 @@ pub fn make_mock_transaction_with_generation_key(
 
     let mut outputs = vec![];
     for rd in receiver_data.iter() {
-        let addition_record = commit::<Hash>(
+        let addition_record = commit(
             Hash::hash(&rd.utxo),
             rd.sender_randomness,
             rd.receiver_privacy_digest,
@@ -825,7 +821,7 @@ pub fn make_mock_transaction_with_generation_key(
 // `make_mock_transaction`, in contrast to `make_mock_transaction2`, assumes you
 // already have created `DevNetInput`s.
 pub fn make_mock_transaction(
-    inputs: Vec<RemovalRecord<Hash>>,
+    inputs: Vec<RemovalRecord>,
     outputs: Vec<AdditionRecord>,
 ) -> Transaction {
     let timestamp: BFieldElement = BFieldElement::new(
@@ -853,7 +849,7 @@ pub fn make_mock_transaction(
 
 // TODO: Change this function into something more meaningful!
 pub fn make_mock_transaction_with_wallet(
-    inputs: Vec<RemovalRecord<Hash>>,
+    inputs: Vec<RemovalRecord>,
     outputs: Vec<AdditionRecord>,
     fee: NeptuneCoins,
     _wallet_state: &WalletState,
@@ -912,7 +908,7 @@ pub fn make_mock_block(
     let coinbase_digest: Digest = Hash::hash(&coinbase_utxo);
 
     let coinbase_addition_record: AdditionRecord =
-        commit::<Hash>(coinbase_digest, coinbase_output_randomness, receiver_digest);
+        commit(coinbase_digest, coinbase_output_randomness, receiver_digest);
     next_mutator_set.add(&coinbase_addition_record);
 
     let block_timestamp = match block_timestamp {

--- a/src/util_types/mutator_set/addition_record.rs
+++ b/src/util_types/mutator_set/addition_record.rs
@@ -30,59 +30,65 @@ pub fn pseudorandom_addition_record(seed: [u8; 32]) -> AdditionRecord {
 
 #[cfg(test)]
 mod addition_record_tests {
+    use crate::models::blockchain::shared::Hash;
     use crate::util_types::mutator_set::mutator_set_trait::commit;
 
     use rand::random;
-    use twenty_first::shared_math::tip5::Tip5;
     use twenty_first::util_types::algebraic_hasher::AlgebraicHasher;
 
     use super::*;
 
     #[test]
     fn get_size_test() {
-        type H = Tip5;
-
-        let addition_record_0: AdditionRecord =
-            commit::<H>(H::hash(&1492u128), H::hash(&1522u128), H::hash(&1521u128));
+        let addition_record_0: AdditionRecord = commit(
+            Hash::hash(&1492u128),
+            Hash::hash(&1522u128),
+            Hash::hash(&1521u128),
+        );
 
         assert_eq!(std::mem::size_of::<Digest>(), addition_record_0.get_size());
     }
 
     #[test]
     fn hash_identity_test() {
-        type H = Tip5;
+        let addition_record_0: AdditionRecord = commit(
+            Hash::hash(&1492u128),
+            Hash::hash(&1522u128),
+            Hash::hash(&1521u128),
+        );
 
-        let addition_record_0: AdditionRecord =
-            commit::<H>(H::hash(&1492u128), H::hash(&1522u128), H::hash(&1521u128));
-
-        let addition_record_1: AdditionRecord =
-            commit::<H>(H::hash(&1492u128), H::hash(&1522u128), H::hash(&1521u128));
+        let addition_record_1: AdditionRecord = commit(
+            Hash::hash(&1492u128),
+            Hash::hash(&1522u128),
+            Hash::hash(&1521u128),
+        );
 
         assert_eq!(
-            H::hash(&addition_record_0),
-            H::hash(&addition_record_1),
+            Hash::hash(&addition_record_0),
+            Hash::hash(&addition_record_1),
             "Two addition records with same commitments and same MMR AOCLs must agree."
         );
 
-        let addition_record_2: AdditionRecord =
-            commit::<H>(H::hash(&1451u128), H::hash(&1480u128), H::hash(&1481u128));
+        let addition_record_2: AdditionRecord = commit(
+            Hash::hash(&1451u128),
+            Hash::hash(&1480u128),
+            Hash::hash(&1481u128),
+        );
 
         // Verify behavior with empty mutator sets. All empty MS' are the same.
         assert_ne!(
-            H::hash(&addition_record_0),
-            H::hash(&addition_record_2),
+            Hash::hash(&addition_record_0),
+            Hash::hash(&addition_record_2),
             "Two addition records with differing commitments but same MMR AOCLs must differ."
         );
     }
 
     #[test]
     fn serialization_test() {
-        type H = Tip5;
-
-        let item = H::hash(&1492u128);
-        let sender_randomness = H::hash(&1522u128);
-        let receiver_digest = H::hash(&1583u128);
-        let addition_record: AdditionRecord = commit::<H>(item, sender_randomness, receiver_digest);
+        let item = Hash::hash(&1492u128);
+        let sender_randomness = Hash::hash(&1522u128);
+        let receiver_digest = Hash::hash(&1583u128);
+        let addition_record: AdditionRecord = commit(item, sender_randomness, receiver_digest);
         let json = serde_json::to_string(&addition_record).unwrap();
         let s_back = serde_json::from_str::<AdditionRecord>(&json).unwrap();
         assert_eq!(

--- a/src/util_types/mutator_set/ms_membership_proof.rs
+++ b/src/util_types/mutator_set/ms_membership_proof.rs
@@ -1,3 +1,4 @@
+use crate::models::blockchain::shared::Hash;
 use crate::prelude::twenty_first;
 
 use get_size::GetSize;
@@ -47,17 +48,17 @@ pub enum MembershipProofError {
 
 // In order to store this structure in the database, it needs to be serializable.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, GetSize, BFieldCodec, TasmObject)]
-pub struct MsMembershipProof<H: AlgebraicHasher> {
+pub struct MsMembershipProof {
     pub sender_randomness: Digest,
     pub receiver_preimage: Digest,
-    pub auth_path_aocl: MmrMembershipProof<H>,
-    pub target_chunks: ChunkDictionary<H>,
+    pub auth_path_aocl: MmrMembershipProof<Hash>,
+    pub target_chunks: ChunkDictionary,
 }
 
-impl<H: AlgebraicHasher + BFieldCodec> MsMembershipProof<H> {
+impl MsMembershipProof {
     /// Compute the indices that will be added to the SWBF if this item is removed.
     pub fn compute_indices(&self, item: Digest) -> AbsoluteIndexSet {
-        AbsoluteIndexSet::new(&get_swbf_indices::<H>(
+        AbsoluteIndexSet::new(&get_swbf_indices(
             item,
             self.sender_randomness,
             self.receiver_preimage,
@@ -67,10 +68,10 @@ impl<H: AlgebraicHasher + BFieldCodec> MsMembershipProof<H> {
 
     /// Update a list of membership proofs in anticipation of an addition. If successful,
     /// return (wrapped in an Ok) a vector of all indices of updated membership proofs.
-    pub fn batch_update_from_addition<MMR: Mmr<H>>(
+    pub fn batch_update_from_addition<MMR: Mmr<Hash>>(
         membership_proofs: &mut [&mut Self],
         own_items: &[Digest],
-        mutator_set: &MutatorSetKernel<H, MMR>,
+        mutator_set: &MutatorSetKernel<MMR>,
         addition_record: &AdditionRecord,
     ) -> Result<Vec<usize>, Box<dyn Error>> {
         assert!(
@@ -101,7 +102,7 @@ impl<H: AlgebraicHasher + BFieldCodec> MsMembershipProof<H> {
         );
 
         // if window does not slide, we are done
-        if !MutatorSetKernel::<H, MMR>::window_slides(new_item_index) {
+        if !MutatorSetKernel::<MMR>::window_slides(new_item_index) {
             return Ok(indices_for_updated_mps);
         }
 
@@ -109,7 +110,7 @@ impl<H: AlgebraicHasher + BFieldCodec> MsMembershipProof<H> {
         let batch_index = new_item_index / BATCH_SIZE as u64;
         let old_window_start_batch_index = batch_index - 1;
         let new_chunk = mutator_set.swbf_active.slid_chunk();
-        let new_chunk_digest: Digest = H::hash(&new_chunk);
+        let new_chunk_digest: Digest = Hash::hash(&new_chunk);
 
         // Insert the new chunk digest into the accumulator-version of the
         // SWBF MMR to get its authentication path. It's important to convert the MMR
@@ -117,8 +118,8 @@ impl<H: AlgebraicHasher + BFieldCodec> MsMembershipProof<H> {
         // a whole archival MMR for this operation, as the archival MMR can be in the
         // size of gigabytes, whereas the MMR accumulator should be in the size of
         // kilobytes.
-        let mut mmra: MmrAccumulator<H> = mutator_set.swbf_inactive.to_accumulator();
-        let new_swbf_auth_path: MmrMembershipProof<H> = mmra.append(new_chunk_digest);
+        let mut mmra: MmrAccumulator<Hash> = mutator_set.swbf_inactive.to_accumulator();
+        let new_swbf_auth_path: MmrMembershipProof<Hash> = mmra.append(new_chunk_digest);
 
         // Collect all indices for all membership proofs that are being updated
         // Notice that this is a *very* expensive operation if the indices are
@@ -129,7 +130,7 @@ impl<H: AlgebraicHasher + BFieldCodec> MsMembershipProof<H> {
             .zip(own_items.iter())
             .enumerate()
             .for_each(|(i, (mp, &item))| {
-                let indices = AbsoluteIndexSet::new(&get_swbf_indices::<H>(
+                let indices = AbsoluteIndexSet::new(&get_swbf_indices(
                     item,
                     mp.sender_randomness,
                     mp.receiver_preimage,
@@ -190,7 +191,7 @@ impl<H: AlgebraicHasher + BFieldCodec> MsMembershipProof<H> {
         // So relegating that bookkeeping to this function instead would not be more
         // efficient.
         let mut mmr_membership_proofs_for_append: Vec<
-            &mut mmr::mmr_membership_proof::MmrMembershipProof<H>,
+            &mut mmr::mmr_membership_proof::MmrMembershipProof<Hash>,
         > = vec![];
 
         // The `mmr_membership_proof_index_to_membership_proof_index` variable is to remember
@@ -208,7 +209,7 @@ impl<H: AlgebraicHasher + BFieldCodec> MsMembershipProof<H> {
         }
 
         let indices_for_mutated_values =
-            mmr::mmr_membership_proof::MmrMembershipProof::<H>::batch_update_from_append(
+            mmr::mmr_membership_proof::MmrMembershipProof::<Hash>::batch_update_from_append(
                 &mut mmr_membership_proofs_for_append,
                 mutator_set.swbf_inactive.count_leaves(),
                 new_chunk_digest,
@@ -240,7 +241,7 @@ impl<H: AlgebraicHasher + BFieldCodec> MsMembershipProof<H> {
     pub fn update_from_addition(
         &mut self,
         own_item: Digest,
-        mutator_set: &MutatorSetAccumulator<H>,
+        mutator_set: &MutatorSetAccumulator,
         addition_record: &AdditionRecord,
     ) -> Result<bool, Box<dyn Error>> {
         assert!(self.auth_path_aocl.leaf_index < mutator_set.kernel.aocl.count_leaves());
@@ -254,16 +255,16 @@ impl<H: AlgebraicHasher + BFieldCodec> MsMembershipProof<H> {
         );
 
         // if window does not slide, we are done
-        if !MutatorSetKernel::<H, MmrAccumulator<H>>::window_slides(new_item_index) {
+        if !MutatorSetKernel::<MmrAccumulator<Hash>>::window_slides(new_item_index) {
             return Ok(aocl_mp_updated);
         }
 
         // window does slide
         let new_chunk = mutator_set.kernel.swbf_active.slid_chunk();
-        let new_chunk_digest: Digest = H::hash(&new_chunk);
+        let new_chunk_digest: Digest = Hash::hash(&new_chunk);
 
         // Get indices by recalculating them. (We do not cache indices any more.)
-        let all_indices = get_swbf_indices::<H>(
+        let all_indices = get_swbf_indices(
             own_item,
             self.sender_randomness,
             self.receiver_preimage,
@@ -281,8 +282,8 @@ impl<H: AlgebraicHasher + BFieldCodec> MsMembershipProof<H> {
         // a whole archival MMR for this operation, as the archival MMR can be in the
         // size of gigabytes, whereas the MMR accumulator should be in the size of
         // kilobytes.
-        let mut mmra: MmrAccumulator<H> = mutator_set.kernel.swbf_inactive.to_accumulator();
-        let new_auth_path: mmr::mmr_membership_proof::MmrMembershipProof<H> =
+        let mut mmra: MmrAccumulator<Hash> = mutator_set.kernel.swbf_inactive.to_accumulator();
+        let new_auth_path: mmr::mmr_membership_proof::MmrMembershipProof<Hash> =
             mmra.append(new_chunk_digest);
 
         let mut swbf_chunk_dictionary_updated = false;
@@ -344,7 +345,7 @@ impl<H: AlgebraicHasher + BFieldCodec> MsMembershipProof<H> {
     /// the state of the mutator set kernel prior to adding them.
     pub fn revert_update_from_batch_addition(
         &mut self,
-        previous_mutator_set: &MutatorSetAccumulator<H>,
+        previous_mutator_set: &MutatorSetAccumulator,
     ) {
         // calculate AOCL MMR MP length
         let previous_leaf_count = previous_mutator_set.kernel.aocl.count_leaves();
@@ -383,11 +384,11 @@ impl<H: AlgebraicHasher + BFieldCodec> MsMembershipProof<H> {
     /// that have been mutated.
     pub fn batch_update_from_remove(
         membership_proofs: &mut [&mut Self],
-        removal_record: &RemovalRecord<H>,
+        removal_record: &RemovalRecord,
     ) -> Result<Vec<usize>, Box<dyn Error>> {
         // Set all chunk values to the new values and calculate the mutation argument
         // for the batch updating of the MMR membership proofs.
-        let mut chunk_dictionaries: Vec<&mut ChunkDictionary<H>> = membership_proofs
+        let mut chunk_dictionaries: Vec<&mut ChunkDictionary> = membership_proofs
             .iter_mut()
             .map(|mp| &mut mp.target_chunks)
             .collect();
@@ -400,7 +401,7 @@ impl<H: AlgebraicHasher + BFieldCodec> MsMembershipProof<H> {
         // mutated.
         // The chunk values contained in the MS membership proof's chunk dictionary has already
         // been updated by the `get_batch_mutation_argument_for_removal_record` function.
-        let mut own_mmr_mps: Vec<&mut mmr::mmr_membership_proof::MmrMembershipProof<H>> = vec![];
+        let mut own_mmr_mps: Vec<&mut mmr::mmr_membership_proof::MmrMembershipProof<Hash>> = vec![];
         let mut mmr_mp_index_to_input_index: Vec<usize> = vec![];
         for (i, chunk_dict) in chunk_dictionaries.iter_mut().enumerate() {
             for (_, (mp, _)) in chunk_dict.dictionary.iter_mut() {
@@ -430,7 +431,7 @@ impl<H: AlgebraicHasher + BFieldCodec> MsMembershipProof<H> {
 
     pub fn update_from_remove(
         &mut self,
-        removal_record: &RemovalRecord<H>,
+        removal_record: &RemovalRecord,
     ) -> Result<bool, Box<dyn Error>> {
         // Removing items does not slide the active window. We only
         // need to take into account new indices in the sparse Bloom
@@ -450,7 +451,7 @@ impl<H: AlgebraicHasher + BFieldCodec> MsMembershipProof<H> {
         // It would be sufficient to only update the membership proofs that live in the Merkle
         // trees that have been updated, but it probably will not give a measureable speedup
         // since this change would not reduce the amount of hashing needed
-        let mut chunk_mmr_mps: Vec<&mut mmr::mmr_membership_proof::MmrMembershipProof<H>> = self
+        let mut chunk_mmr_mps: Vec<&mut mmr::mmr_membership_proof::MmrMembershipProof<Hash>> = self
             .target_chunks
             .dictionary
             .iter_mut()
@@ -470,7 +471,7 @@ impl<H: AlgebraicHasher + BFieldCodec> MsMembershipProof<H> {
     /// with a removal record.
     pub fn revert_update_from_remove(
         &mut self,
-        removal_record: &RemovalRecord<H>,
+        removal_record: &RemovalRecord,
     ) -> Result<bool, Box<dyn Error>> {
         // The logic here is essentially the same as in
         // `update_from_remove` but with the new and old chunks
@@ -489,7 +490,7 @@ impl<H: AlgebraicHasher + BFieldCodec> MsMembershipProof<H> {
         // Note that *all* MMR membership proofs must be updated. It's not sufficient to update
         // those whose leaf has changed, since an authentication path changes if *any* leaf
         // in the same Merkle tree (under the same MMR peak) changes.
-        let mut chunk_mmr_mps: Vec<&mut mmr::mmr_membership_proof::MmrMembershipProof<H>> = self
+        let mut chunk_mmr_mps: Vec<&mut mmr::mmr_membership_proof::MmrMembershipProof<Hash>> = self
             .target_chunks
             .dictionary
             .iter_mut()
@@ -508,14 +509,12 @@ impl<H: AlgebraicHasher + BFieldCodec> MsMembershipProof<H> {
 
 /// Generate a pseudorandom mutator set membership proof from the given seed, for testing
 /// purposes.
-pub fn pseudorandom_mutator_set_membership_proof<H: AlgebraicHasher>(
-    seed: [u8; 32],
-) -> MsMembershipProof<H> {
+pub fn pseudorandom_mutator_set_membership_proof(seed: [u8; 32]) -> MsMembershipProof {
     let mut rng: StdRng = SeedableRng::from_seed(seed);
     let sender_randomness: Digest = rng.gen();
     let receiver_preimage: Digest = rng.gen();
-    let auth_path_aocl: MmrMembershipProof<H> = pseudorandom_mmr_membership_proof::<H>(rng.gen());
-    let target_chunks: ChunkDictionary<H> = pseudorandom_chunk_dictionary(rng.gen());
+    let auth_path_aocl: MmrMembershipProof<Hash> = pseudorandom_mmr_membership_proof(rng.gen());
+    let target_chunks: ChunkDictionary = pseudorandom_chunk_dictionary(rng.gen());
     MsMembershipProof {
         sender_randomness,
         receiver_preimage,
@@ -554,41 +553,39 @@ mod ms_proof_tests {
     use rand::rngs::StdRng;
     use rand::{random, thread_rng, Rng, RngCore, SeedableRng};
     use twenty_first::shared_math::other::random_elements;
-    use twenty_first::shared_math::tip5::Tip5;
     use twenty_first::util_types::mmr::mmr_membership_proof::MmrMembershipProof;
 
     #[test]
     fn mp_equality_test() {
-        type H = Tip5;
         let mut rng = thread_rng();
 
         let (_item, sender_randomness, receiver_preimage) = make_item_and_randomnesses();
 
-        let base_mp = MsMembershipProof::<H> {
+        let base_mp = MsMembershipProof {
             sender_randomness,
             receiver_preimage,
-            auth_path_aocl: MmrMembershipProof::<H>::new(0, vec![]),
+            auth_path_aocl: MmrMembershipProof::<Hash>::new(0, vec![]),
             target_chunks: ChunkDictionary::default(),
         };
 
-        let mp_with_different_leaf_index = MsMembershipProof::<H> {
+        let mp_with_different_leaf_index = MsMembershipProof {
             sender_randomness,
             receiver_preimage,
-            auth_path_aocl: MmrMembershipProof::<H>::new(100073, vec![]),
+            auth_path_aocl: MmrMembershipProof::<Hash>::new(100073, vec![]),
             target_chunks: ChunkDictionary::default(),
         };
 
-        let mp_with_different_sender_randomness = MsMembershipProof::<H> {
+        let mp_with_different_sender_randomness = MsMembershipProof {
             sender_randomness: rng.gen(),
             receiver_preimage,
-            auth_path_aocl: MmrMembershipProof::<H>::new(0, vec![]),
+            auth_path_aocl: MmrMembershipProof::<Hash>::new(0, vec![]),
             target_chunks: ChunkDictionary::default(),
         };
 
-        let mp_with_different_receiver_preimage = MsMembershipProof::<H> {
+        let mp_with_different_receiver_preimage = MsMembershipProof {
             receiver_preimage: rng.gen(),
             sender_randomness,
-            auth_path_aocl: MmrMembershipProof::<H>::new(0, vec![]),
+            auth_path_aocl: MmrMembershipProof::<Hash>::new(0, vec![]),
             target_chunks: ChunkDictionary::default(),
         };
 
@@ -606,18 +603,18 @@ mod ms_proof_tests {
 
         // Construct an MMR with 7 leafs
         let mmr_digests = random_elements::<Digest>(7);
-        let mut mmra: MmrAccumulator<H> = MmrAccumulator::new(mmr_digests);
+        let mut mmra: MmrAccumulator<Hash> = MmrAccumulator::new(mmr_digests);
 
         // Get an MMR membership proof by adding the 8th leaf
         let zero_chunk = Chunk::empty_chunk();
-        let mmr_mp = mmra.append(H::hash(&zero_chunk));
+        let mmr_mp = mmra.append(Hash::hash(&zero_chunk));
 
         // Verify that the MMR membership proof has the expected length of 3 (sanity check)
         assert_eq!(3, mmr_mp.authentication_path.len());
 
         // Create a new mutator set membership proof with a non-empty chunk dictionary
         // and verify that it is considered a different membership proof
-        let mut mp_mutated: MsMembershipProof<H> = base_mp.clone();
+        let mut mp_mutated: MsMembershipProof = base_mp.clone();
         mp_mutated
             .target_chunks
             .dictionary
@@ -629,8 +626,7 @@ mod ms_proof_tests {
     fn serialization_test() {
         // This test belongs here since the serialization for `Option<[T; $len]>` is implemented
         // in this code base as a macro. So this is basically a test of that macro.
-        type H = Tip5;
-        let accumulator: MutatorSetAccumulator<H> = MutatorSetAccumulator::default();
+        let accumulator: MutatorSetAccumulator = MutatorSetAccumulator::default();
         for _ in 0..10 {
             let (item, sender_randomness, receiver_preimage) = make_item_and_randomnesses();
 
@@ -639,7 +635,7 @@ mod ms_proof_tests {
                 .prove(item, sender_randomness, receiver_preimage);
 
             let json: String = serde_json::to_string(&mp).unwrap();
-            let mp_again = serde_json::from_str::<MsMembershipProof<H>>(&json).unwrap();
+            let mp_again = serde_json::from_str::<MsMembershipProof>(&json).unwrap();
 
             assert_eq!(mp_again.target_chunks, mp.target_chunks);
             assert_eq!(mp_again, mp);
@@ -648,7 +644,6 @@ mod ms_proof_tests {
 
     #[test]
     fn revert_update_from_remove_test() {
-        type H = Tip5;
         let n = 100;
         let mut rng = thread_rng();
 
@@ -657,17 +652,16 @@ mod ms_proof_tests {
         let mut own_item = None;
 
         // set up mutator set
-        let mut rms = empty_rusty_mutator_set::<H>();
+        let mut rms = empty_rusty_mutator_set();
         let archival_mutator_set = rms.ams_mut();
-        let mut membership_proofs: Vec<(Digest, MsMembershipProof<Tip5>)> = vec![];
+        let mut membership_proofs: Vec<(Digest, MsMembershipProof)> = vec![];
 
         // add items
         for i in 0..n {
             let item: Digest = random();
             let sender_randomness: Digest = random();
             let receiver_preimage: Digest = random();
-            let addition_record =
-                commit::<H>(item, sender_randomness, receiver_preimage.hash::<H>());
+            let addition_record = commit(item, sender_randomness, receiver_preimage.hash::<Hash>());
 
             for (oi, mp) in membership_proofs.iter_mut() {
                 mp.update_from_addition(*oi, &archival_mutator_set.accumulator(), &addition_record)
@@ -726,8 +720,7 @@ mod ms_proof_tests {
             RemovalRecord::batch_update_from_remove(
                 &mut mutable_records.iter_mut().collect::<Vec<_>>(),
                 applied_removal_record,
-            )
-            .expect("Could not apply removal record.");
+            );
 
             own_membership_proof
                 .as_mut()
@@ -777,8 +770,7 @@ mod ms_proof_tests {
 
     #[test]
     fn revert_update_single_remove_test() {
-        type H = Tip5;
-        let mut rms = empty_rusty_mutator_set::<H>();
+        let mut rms = empty_rusty_mutator_set();
         let ams = rms.ams_mut();
         let mut mps = vec![];
         let mut items = vec![];
@@ -788,8 +780,7 @@ mod ms_proof_tests {
             let item: Digest = random();
             let sender_randomness: Digest = random();
             let receiver_preimage: Digest = random();
-            let addition_record =
-                commit::<H>(item, sender_randomness, receiver_preimage.hash::<H>());
+            let addition_record = commit(item, sender_randomness, receiver_preimage.hash::<Hash>());
             MsMembershipProof::batch_update_from_addition(
                 &mut mps.iter_mut().collect_vec(),
                 &items,
@@ -858,10 +849,8 @@ mod ms_proof_tests {
 
     #[test]
     fn revert_update_single_addition_test() {
-        type H = Tip5;
-
         for j in 2..30 {
-            let mut rms = empty_rusty_mutator_set::<H>();
+            let mut rms = empty_rusty_mutator_set();
             let ams = rms.ams_mut();
 
             // Add `j` items to MSA
@@ -873,7 +862,7 @@ mod ms_proof_tests {
                 let sender_randomness: Digest = random();
                 let receiver_preimage: Digest = random();
                 let addition_record =
-                    commit::<H>(item, sender_randomness, receiver_preimage.hash::<H>());
+                    commit(item, sender_randomness, receiver_preimage.hash::<Hash>());
                 MsMembershipProof::batch_update_from_addition(
                     &mut mps.iter_mut().collect_vec(),
                     &items,
@@ -909,9 +898,7 @@ mod ms_proof_tests {
 
     #[test]
     fn revert_update_from_addition_batches_test() {
-        type H = Tip5;
-
-        let mut msa: MutatorSetAccumulator<H> = MutatorSetAccumulator::new();
+        let mut msa: MutatorSetAccumulator = MutatorSetAccumulator::new();
 
         let mut rng = thread_rng();
         for _ in 0..10 {
@@ -925,7 +912,7 @@ mod ms_proof_tests {
                 let sender_randomness: Digest = random();
                 let receiver_preimage: Digest = random();
                 let addition_record =
-                    commit::<H>(item, sender_randomness, receiver_preimage.hash::<H>());
+                    commit(item, sender_randomness, receiver_preimage.hash::<Hash>());
                 msa.add(&addition_record);
             }
 
@@ -933,10 +920,10 @@ mod ms_proof_tests {
             let own_item: Digest = random();
             let own_sender_randomness: Digest = random();
             let own_receiver_preimage: Digest = random();
-            let own_addition_record = commit::<H>(
+            let own_addition_record = commit(
                 own_item,
                 own_sender_randomness,
-                own_receiver_preimage.hash::<H>(),
+                own_receiver_preimage.hash::<Hash>(),
             );
             let mut own_mp = msa.prove(own_item, own_sender_randomness, own_receiver_preimage);
             msa.add(&own_addition_record);
@@ -948,7 +935,7 @@ mod ms_proof_tests {
                 let sender_randomness: Digest = random();
                 let receiver_preimage: Digest = random();
                 let addition_record =
-                    commit::<H>(item, sender_randomness, receiver_preimage.hash::<H>());
+                    commit(item, sender_randomness, receiver_preimage.hash::<Hash>());
                 own_mp
                     .update_from_addition(own_item, &msa, &addition_record)
                     .unwrap();
@@ -967,7 +954,7 @@ mod ms_proof_tests {
                 let sender_randomness: Digest = random();
                 let receiver_preimage: Digest = random();
                 let addition_record =
-                    commit::<H>(item, sender_randomness, receiver_preimage.hash::<H>());
+                    commit(item, sender_randomness, receiver_preimage.hash::<Hash>());
                 own_mp
                     .update_from_addition(own_item, &msa, &addition_record)
                     .unwrap();
@@ -990,7 +977,6 @@ mod ms_proof_tests {
 
     #[test]
     fn revert_update_from_addition_test() {
-        type H = Tip5;
         let mut rng = thread_rng();
         let n = rng.next_u32() as usize % 100 + 1;
         // let n = 55;
@@ -1001,7 +987,7 @@ mod ms_proof_tests {
         let mut own_item = None;
 
         // set up mutator set
-        let mut rms = empty_rusty_mutator_set::<H>();
+        let mut rms = empty_rusty_mutator_set();
         let archival_mutator_set = rms.ams_mut();
 
         // add items
@@ -1010,8 +996,7 @@ mod ms_proof_tests {
             let item: Digest = random();
             let sender_randomness: Digest = random();
             let receiver_preimage: Digest = random();
-            let addition_record =
-                commit::<H>(item, sender_randomness, receiver_preimage.hash::<H>());
+            let addition_record = commit(item, sender_randomness, receiver_preimage.hash::<Hash>());
             addition_records.push(addition_record);
 
             let membership_proof =
@@ -1076,7 +1061,6 @@ mod ms_proof_tests {
 
     #[test]
     fn revert_updates_mixed_test() {
-        type H = Tip5;
         let mut rng_seeder = thread_rng();
         // let seed_integer = rng.next_u32();
         let error_tuple: (usize, u32) = (
@@ -1095,7 +1079,7 @@ mod ms_proof_tests {
 
         let mut rng = StdRng::from_seed(seed_as_bytes);
 
-        let mut rms = empty_rusty_mutator_set::<H>();
+        let mut rms = empty_rusty_mutator_set();
         let archival_mutator_set = rms.ams_mut();
 
         let own_index = rng.next_u32() as usize % 10;
@@ -1106,10 +1090,10 @@ mod ms_proof_tests {
         rates.insert("additions".to_owned(), 0.7);
         rates.insert("removals".to_owned(), 0.95);
 
-        let mut tracked_items_and_membership_proofs: Vec<(Digest, MsMembershipProof<H>)> = vec![];
-        let mut removed_items_and_membership_proofs: Vec<(Digest, MsMembershipProof<H>, usize)> =
+        let mut tracked_items_and_membership_proofs: Vec<(Digest, MsMembershipProof)> = vec![];
+        let mut removed_items_and_membership_proofs: Vec<(Digest, MsMembershipProof, usize)> =
             vec![];
-        let mut records: Vec<Either<AdditionRecord, RemovalRecord<H>>> = vec![];
+        let mut records: Vec<Either<AdditionRecord, RemovalRecord>> = vec![];
 
         for i in 0..2000 {
             let sample: f64 = rng.gen();
@@ -1128,7 +1112,7 @@ mod ms_proof_tests {
 
                 // generate addition record
                 let addition_record =
-                    commit::<H>(item, sender_randomness, receiver_preimage.hash::<H>());
+                    commit(item, sender_randomness, receiver_preimage.hash::<Hash>());
 
                 // record membership proof
                 let membership_proof =
@@ -1335,11 +1319,10 @@ mod ms_proof_tests {
 
     #[test]
     fn test_decode_mutator_set_membership_proof() {
-        type H = Tip5;
         for _ in 0..100 {
-            let msmp = random_mutator_set_membership_proof::<H>();
+            let msmp = random_mutator_set_membership_proof();
             let encoded = msmp.encode();
-            let decoded: MsMembershipProof<H> = *MsMembershipProof::decode(&encoded).unwrap();
+            let decoded: MsMembershipProof = *MsMembershipProof::decode(&encoded).unwrap();
             assert_eq!(msmp, decoded);
         }
     }

--- a/src/util_types/mutator_set/ms_membership_proof.rs
+++ b/src/util_types/mutator_set/ms_membership_proof.rs
@@ -65,7 +65,8 @@ impl<H: AlgebraicHasher + BFieldCodec> MsMembershipProof<H> {
         ))
     }
 
-    /// Update a list of membership proofs in anticipation of an addition
+    /// Update a list of membership proofs in anticipation of an addition. If successful,
+    /// return (wrapped in an Ok) a vector of all indices of updated membership proofs.
     pub fn batch_update_from_addition<MMR: Mmr<H>>(
         membership_proofs: &mut [&mut Self],
         own_items: &[Digest],
@@ -695,7 +696,6 @@ mod ms_proof_tests {
 
             archival_mutator_set.add(&addition_record);
         }
-        println!("Added {n} items.");
 
         // assert that own mp is valid
         assert!(
@@ -742,8 +742,6 @@ mod ms_proof_tests {
             }
         }
 
-        println!("Removed {} items.", removal_records.len());
-
         // assert valid
         assert!(
             archival_mutator_set.verify(own_item.unwrap(), own_membership_proof.as_ref().unwrap())
@@ -764,8 +762,6 @@ mod ms_proof_tests {
             // keep other removal records up-to-date?
             // - nah, we don't need them for anything anymore
         }
-
-        println!("Reverted {} removals.", reversions.len());
 
         // assert valid
         assert!(
@@ -1063,7 +1059,6 @@ mod ms_proof_tests {
                 // assert!(previous_mutator_set.set_commitment.verify(own_item, self));
             }
         }
-        println!("Added {n} items.");
 
         // revert additions
         let (_petrified, revertible) = addition_records.split_at(own_index + 1);

--- a/src/util_types/mutator_set/mutator_set_kernel.rs
+++ b/src/util_types/mutator_set/mutator_set_kernel.rs
@@ -1,3 +1,4 @@
+use crate::models::blockchain::shared::Hash;
 use crate::prelude::twenty_first;
 
 use get_size::GetSize;
@@ -39,14 +40,14 @@ pub enum MutatorSetKernelError {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, GetSize)]
-pub struct MutatorSetKernel<H: AlgebraicHasher + BFieldCodec, MMR: Mmr<H>> {
+pub struct MutatorSetKernel<MMR: Mmr<Hash>> {
     pub aocl: MMR,
     pub swbf_inactive: MMR,
-    pub swbf_active: ActiveWindow<H>,
+    pub swbf_active: ActiveWindow,
 }
 
-// FIXME: Apply over-sampling to circumvent risk of duplicates.
-pub fn get_swbf_indices<H: AlgebraicHasher>(
+/// Get the (absolute) indices for removing this item from the mutator set.
+pub fn get_swbf_indices(
     item: Digest,
     sender_randomness: Digest,
     receiver_preimage: Digest,
@@ -74,9 +75,9 @@ pub fn get_swbf_indices<H: AlgebraicHasher>(
         "Input to sponge must be a multiple digest length"
     );
 
-    let mut sponge = <H as SpongeHasher>::init();
-    H::absorb_repeatedly(&mut sponge, input.iter());
-    H::sample_indices(&mut sponge, WINDOW_SIZE, NUM_TRIALS as usize)
+    let mut sponge = <Hash as SpongeHasher>::init();
+    Hash::absorb_repeatedly(&mut sponge, input.iter());
+    Hash::sample_indices(&mut sponge, WINDOW_SIZE, NUM_TRIALS as usize)
         .into_iter()
         .map(|sample_index| sample_index as u128 + batch_offset)
         .collect_vec()
@@ -84,10 +85,10 @@ pub fn get_swbf_indices<H: AlgebraicHasher>(
         .unwrap()
 }
 
-impl<H: AlgebraicHasher + BFieldCodec, M: Mmr<H>> MutatorSetKernel<H, M> {
+impl<M: Mmr<Hash>> MutatorSetKernel<M> {
     /// Generates a removal record with which to update the set commitment.
-    pub fn drop(&self, item: Digest, membership_proof: &MsMembershipProof<H>) -> RemovalRecord<H> {
-        let indices: AbsoluteIndexSet = AbsoluteIndexSet::new(&get_swbf_indices::<H>(
+    pub fn drop(&self, item: Digest, membership_proof: &MsMembershipProof) -> RemovalRecord {
+        let indices: AbsoluteIndexSet = AbsoluteIndexSet::new(&get_swbf_indices(
             item,
             membership_proof.sender_randomness,
             membership_proof.receiver_preimage,
@@ -145,7 +146,7 @@ impl<H: AlgebraicHasher + BFieldCodec, M: Mmr<H>> MutatorSetKernel<H, M> {
         // if window slides, update filter
         // First update the inactive part of the SWBF, the SWBF MMR
         let new_chunk: Chunk = self.swbf_active.slid_chunk();
-        let chunk_digest: Digest = H::hash(&new_chunk);
+        let chunk_digest: Digest = Hash::hash(&new_chunk);
         let new_chunk_index = self.swbf_inactive.count_leaves();
         self.swbf_inactive.append(chunk_digest); // ignore auth path
 
@@ -161,12 +162,12 @@ impl<H: AlgebraicHasher + BFieldCodec, M: Mmr<H>> MutatorSetKernel<H, M> {
 
     /// Remove a record and return the chunks that have been updated in this process,
     /// after applying the update. Does not mutate the removal record.
-    pub fn remove_helper(&mut self, removal_record: &RemovalRecord<H>) -> HashMap<u64, Chunk> {
+    pub fn remove_helper(&mut self, removal_record: &RemovalRecord) -> HashMap<u64, Chunk> {
         let batch_index = self.get_batch_index();
         let active_window_start = batch_index as u128 * CHUNK_SIZE as u128;
 
         // insert all indices
-        let mut new_target_chunks: ChunkDictionary<H> = removal_record.target_chunks.clone();
+        let mut new_target_chunks: ChunkDictionary = removal_record.target_chunks.clone();
         let chunkindices_to_indices_dict: HashMap<u64, Vec<u128>> =
             removal_record.get_chunkidx_to_indices_dict();
 
@@ -209,8 +210,8 @@ impl<H: AlgebraicHasher + BFieldCodec, M: Mmr<H>> MutatorSetKernel<H, M> {
         let all_leafs = new_target_chunks
             .dictionary
             .values()
-            .map(|(_p, chunk)| H::hash(chunk));
-        let mutation_data: Vec<(MmrMembershipProof<H>, Digest)> =
+            .map(|(_p, chunk)| Hash::hash(chunk));
+        let mutation_data: Vec<(MmrMembershipProof<Hash>, Digest)> =
             all_mmr_membership_proofs.zip(all_leafs).collect();
 
         // If we want to update the membership proof with this removal, we
@@ -232,13 +233,13 @@ impl<H: AlgebraicHasher + BFieldCodec, M: Mmr<H>> MutatorSetKernel<H, M> {
         item: Digest,
         sender_randomness: Digest,
         receiver_preimage: Digest,
-    ) -> MsMembershipProof<H> {
+    ) -> MsMembershipProof {
         // compute commitment
-        let item_commitment = H::hash_pair(item, sender_randomness);
+        let item_commitment = Hash::hash_pair(item, sender_randomness);
 
         // simulate adding to commitment list
         let auth_path_aocl = self.aocl.to_accumulator().append(item_commitment);
-        let target_chunks: ChunkDictionary<H> = ChunkDictionary::default();
+        let target_chunks: ChunkDictionary = ChunkDictionary::default();
 
         // return membership proof
         MsMembershipProof {
@@ -249,7 +250,7 @@ impl<H: AlgebraicHasher + BFieldCodec, M: Mmr<H>> MutatorSetKernel<H, M> {
         }
     }
 
-    pub fn verify(&self, item: Digest, membership_proof: &MsMembershipProof<H>) -> bool {
+    pub fn verify(&self, item: Digest, membership_proof: &MsMembershipProof) -> bool {
         // If data index does not exist in AOCL, return false
         // This also ensures that no "future" indices will be
         // returned from `get_indices`, so we don't have to check for
@@ -259,9 +260,9 @@ impl<H: AlgebraicHasher + BFieldCodec, M: Mmr<H>> MutatorSetKernel<H, M> {
         }
 
         // verify that a commitment to the item lives in the aocl mmr
-        let leaf = H::hash_pair(
-            H::hash_pair(item, membership_proof.sender_randomness),
-            H::hash_pair(
+        let leaf = Hash::hash_pair(
+            Hash::hash_pair(item, membership_proof.sender_randomness),
+            Hash::hash_pair(
                 membership_proof.receiver_preimage,
                 Digest::new([BFieldElement::zero(); DIGEST_LENGTH]),
             ),
@@ -285,7 +286,7 @@ impl<H: AlgebraicHasher + BFieldCodec, M: Mmr<H>> MutatorSetKernel<H, M> {
         let window_start = current_batch_index as u128 * CHUNK_SIZE as u128;
 
         // Get all bloom filter indices
-        let all_indices = AbsoluteIndexSet::new(&get_swbf_indices::<H>(
+        let all_indices = AbsoluteIndexSet::new(&get_swbf_indices(
             item,
             membership_proof.sender_randomness,
             membership_proof.receiver_preimage,
@@ -305,7 +306,7 @@ impl<H: AlgebraicHasher + BFieldCodec, M: Mmr<H>> MutatorSetKernel<H, M> {
                     break 'outer;
                 }
 
-                let mp_and_chunk: &(mmr::mmr_membership_proof::MmrMembershipProof<H>, Chunk) =
+                let mp_and_chunk: &(mmr::mmr_membership_proof::MmrMembershipProof<Hash>, Chunk) =
                     membership_proof
                         .target_chunks
                         .dictionary
@@ -313,7 +314,7 @@ impl<H: AlgebraicHasher + BFieldCodec, M: Mmr<H>> MutatorSetKernel<H, M> {
                         .unwrap();
                 let (valid_auth_path, _) = mp_and_chunk.0.verify(
                     &self.swbf_inactive.get_peaks(),
-                    H::hash(&mp_and_chunk.1),
+                    Hash::hash(&mp_and_chunk.1),
                     self.swbf_inactive.count_leaves(),
                 );
 
@@ -346,8 +347,8 @@ impl<H: AlgebraicHasher + BFieldCodec, M: Mmr<H>> MutatorSetKernel<H, M> {
     /// { chunk index => updated_chunk }.
     pub fn batch_remove(
         &mut self,
-        mut removal_records: Vec<RemovalRecord<H>>,
-        preserved_membership_proofs: &mut [&mut MsMembershipProof<H>],
+        mut removal_records: Vec<RemovalRecord>,
+        preserved_membership_proofs: &mut [&mut MsMembershipProof],
     ) -> HashMap<u64, Chunk> {
         let batch_index = self.get_batch_index();
         let active_window_start = batch_index as u128 * CHUNK_SIZE as u128;
@@ -377,19 +378,19 @@ impl<H: AlgebraicHasher + BFieldCodec, M: Mmr<H>> MutatorSetKernel<H, M> {
 
         // Collect all affected chunks as they look before these removal records are applied
         // These chunks are part of the removal records, so we fetch them there.
-        let mut mutation_data_preimage: HashMap<u64, (&mut Chunk, MmrMembershipProof<H>)> =
+        let mut mutation_data_preimage: HashMap<u64, (&mut Chunk, MmrMembershipProof<Hash>)> =
             HashMap::new();
         for removal_record in removal_records.iter_mut() {
             for (chunk_index, (mmr_mp, chunk)) in removal_record.target_chunks.dictionary.iter_mut()
             {
-                let chunk_hash = H::hash(chunk);
+                let chunk_hash = Hash::hash(chunk);
                 let prev_val =
                     mutation_data_preimage.insert(*chunk_index, (chunk, mmr_mp.to_owned()));
 
                 // Sanity check that all removal records agree on both chunks and MMR membership
                 // proofs.
                 if let Some((chnk, mm)) = prev_val {
-                    assert!(mm == *mmr_mp && chunk_hash == H::hash(chnk))
+                    assert!(mm == *mmr_mp && chunk_hash == Hash::hash(chnk))
                 }
             }
         }
@@ -417,16 +418,16 @@ impl<H: AlgebraicHasher + BFieldCodec, M: Mmr<H>> MutatorSetKernel<H, M> {
         // Calculate the digests of the affected leafs in the inactive part of the sliding-window
         // Bloom filter such that we can apply a batch-update operation to the MMR through which
         // this part of the Bloom filter is represented.
-        let swbf_inactive_mutation_data: Vec<(MmrMembershipProof<H>, Digest)> =
+        let swbf_inactive_mutation_data: Vec<(MmrMembershipProof<Hash>, Digest)> =
             mutation_data_preimage
                 .into_values()
-                .map(|x| (x.1, H::hash(x.0)))
+                .map(|x| (x.1, Hash::hash(x.0)))
                 .collect();
 
         // Create a vector of pointers to the MMR-membership part of the mutator set membership
         // proofs that we want to preserve. This is used as input to a batch-call to the
         // underlying MMR.
-        let mut preseved_mmr_membership_proofs: Vec<&mut MmrMembershipProof<H>> =
+        let mut preseved_mmr_membership_proofs: Vec<&mut MmrMembershipProof<Hash>> =
             preserved_membership_proofs
                 .iter_mut()
                 .flat_map(|x| {
@@ -450,7 +451,7 @@ impl<H: AlgebraicHasher + BFieldCodec, M: Mmr<H>> MutatorSetKernel<H, M> {
 
     /// Check if a removal record can be applied to a mutator set. Returns false if either
     /// the MMR membership proofs are unsynced, or if all its indices are already set.
-    pub fn can_remove(&self, removal_record: &RemovalRecord<H>) -> bool {
+    pub fn can_remove(&self, removal_record: &RemovalRecord) -> bool {
         let mut have_absent_index = false;
         if !removal_record.validate(self) {
             return false;
@@ -486,9 +487,7 @@ impl<H: AlgebraicHasher + BFieldCodec, M: Mmr<H>> MutatorSetKernel<H, M> {
     }
 }
 
-impl<H: AlgebraicHasher + BFieldCodec, MMR: Mmr<H> + BFieldCodec> BFieldCodec
-    for MutatorSetKernel<H, MMR>
-{
+impl<MMR: Mmr<Hash> + BFieldCodec> BFieldCodec for MutatorSetKernel<MMR> {
     type Error = anyhow::Error;
     fn decode(sequence: &[BFieldElement]) -> anyhow::Result<Box<Self>> {
         let mut index = 0;
@@ -564,7 +563,6 @@ mod accumulation_scheme_tests {
     use rand::Rng;
 
     use tasm_lib::twenty_first::util_types::storage_vec::StorageVec;
-    use twenty_first::shared_math::tip5::Tip5;
     use twenty_first::util_types::mmr::mmr_accumulator::MmrAccumulator;
 
     use crate::config_models::network::Network;
@@ -589,8 +587,8 @@ mod accumulation_scheme_tests {
     #[test]
     fn get_batch_index_test() {
         // Verify that the method to get batch index returns sane results
-        type H = Tip5;
-        let mut mutator_set = MutatorSetAccumulator::<H>::default();
+
+        let mut mutator_set = MutatorSetAccumulator::default();
         assert_eq!(
             0,
             mutator_set.kernel.get_batch_index(),
@@ -599,8 +597,7 @@ mod accumulation_scheme_tests {
 
         for i in 0..BATCH_SIZE {
             let (item, sender_randomness, receiver_preimage) = make_item_and_randomnesses();
-            let addition_record =
-                commit::<H>(item, sender_randomness, receiver_preimage.hash::<H>());
+            let addition_record = commit(item, sender_randomness, receiver_preimage.hash::<Hash>());
             mutator_set.add(&addition_record);
             assert_eq!(
                 0,
@@ -611,7 +608,7 @@ mod accumulation_scheme_tests {
         }
 
         let (item, sender_randomness, receiver_preimage) = make_item_and_randomnesses();
-        let addition_record = commit::<H>(item, sender_randomness, receiver_preimage.hash::<H>());
+        let addition_record = commit(item, sender_randomness, receiver_preimage.hash::<Hash>());
         mutator_set.add(&addition_record);
         assert_eq!(
             1,
@@ -622,13 +619,11 @@ mod accumulation_scheme_tests {
 
     #[test]
     fn mutator_set_hash_test() {
-        type H = Tip5;
-
-        let empty_set = MutatorSetAccumulator::<H>::default();
+        let empty_set = MutatorSetAccumulator::default();
         let empty_hash = empty_set.hash();
 
         // Add one element to append-only commitment list
-        let mut set_with_aocl_append = MutatorSetAccumulator::<H>::default();
+        let mut set_with_aocl_append = MutatorSetAccumulator::default();
 
         let (item0, _sender_randomness, _receiver_preimage) = make_item_and_randomnesses();
 
@@ -641,7 +636,7 @@ mod accumulation_scheme_tests {
         );
 
         // Manipulate inactive SWBF
-        let mut set_with_swbf_inactive_append = MutatorSetAccumulator::<H>::default();
+        let mut set_with_swbf_inactive_append = MutatorSetAccumulator::default();
         set_with_swbf_inactive_append
             .kernel
             .swbf_inactive
@@ -679,11 +674,10 @@ mod accumulation_scheme_tests {
         // Test that `get_indices` behaves as expected, i.e.
         // that it always returns something of length `NUM_TRIALS`, and that the
         // returned values are in the expected range.
-        type H = Tip5;
 
         let (item, sender_randomness, receiver_preimage) = make_item_and_randomnesses();
         let ret: [u128; NUM_TRIALS as usize] =
-            get_swbf_indices::<H>(item, sender_randomness, receiver_preimage, 0);
+            get_swbf_indices(item, sender_randomness, receiver_preimage, 0);
         assert_eq!(NUM_TRIALS as usize, ret.len());
         assert!(ret.iter().all(|&x| x < WINDOW_SIZE as u128));
     }
@@ -692,18 +686,18 @@ mod accumulation_scheme_tests {
     fn ms_get_indices_test_big() {
         // Test that `get_indices` behaves as expected. I.e. that it returns indices in the correct range,
         // and always returns something of length `NUM_TRIALS`.
-        type H = Tip5;
+
         for _ in 0..1000 {
             let (item, sender_randomness, receiver_preimage) = make_item_and_randomnesses();
             let ret: [u128; NUM_TRIALS as usize] =
-                get_swbf_indices::<H>(item, sender_randomness, receiver_preimage, 0);
+                get_swbf_indices(item, sender_randomness, receiver_preimage, 0);
             assert_eq!(NUM_TRIALS as usize, ret.len());
             assert!(ret.iter().all(|&x| x < WINDOW_SIZE as u128));
         }
 
         for _ in 0..1000 {
             let (item, sender_randomness, receiver_preimage) = make_item_and_randomnesses();
-            let ret: [u128; NUM_TRIALS as usize] = get_swbf_indices::<H>(
+            let ret: [u128; NUM_TRIALS as usize] = get_swbf_indices(
                 item,
                 sender_randomness,
                 receiver_preimage,
@@ -719,10 +713,8 @@ mod accumulation_scheme_tests {
 
     #[test]
     fn init_test() {
-        type H = Tip5;
-
-        let accumulator = MutatorSetAccumulator::<H>::default();
-        let mut rms = empty_rusty_mutator_set::<H>();
+        let accumulator = MutatorSetAccumulator::default();
+        let mut rms = empty_rusty_mutator_set();
         let archival = rms.ams_mut();
 
         // Verify that function to get batch index does not overflow for the empty MS
@@ -742,16 +734,16 @@ mod accumulation_scheme_tests {
     fn verify_future_indices_test() {
         // Ensure that `verify` does not crash when given a membership proof
         // that represents a future addition to the AOCL.
-        type H = Tip5;
-        let mut mutator_set = MutatorSetAccumulator::<H>::default().kernel;
-        let empty_mutator_set = MutatorSetAccumulator::<H>::default().kernel;
+
+        let mut mutator_set = MutatorSetAccumulator::default().kernel;
+        let empty_mutator_set = MutatorSetAccumulator::default().kernel;
 
         for _ in 0..2 * BATCH_SIZE + 2 {
             let (item, sender_randomness, receiver_preimage) = make_item_and_randomnesses();
 
             let addition_record: AdditionRecord =
-                commit::<H>(item, sender_randomness, receiver_preimage.hash::<H>());
-            let membership_proof: MsMembershipProof<H> =
+                commit(item, sender_randomness, receiver_preimage.hash::<Hash>());
+            let membership_proof: MsMembershipProof =
                 mutator_set.prove(item, sender_randomness, receiver_preimage);
             mutator_set.add_helper(&addition_record);
             assert!(mutator_set.verify(item, &membership_proof));
@@ -763,23 +755,24 @@ mod accumulation_scheme_tests {
 
     #[test]
     fn test_membership_proof_update_from_add() {
-        type H = Tip5;
-
-        let mut mutator_set = MutatorSetAccumulator::<H>::default();
+        let mut mutator_set = MutatorSetAccumulator::default();
         let (own_item, sender_randomness, receiver_preimage) = make_item_and_randomnesses();
 
-        let addition_record =
-            commit::<H>(own_item, sender_randomness, receiver_preimage.hash::<H>());
+        let addition_record = commit(
+            own_item,
+            sender_randomness,
+            receiver_preimage.hash::<Hash>(),
+        );
         let mut membership_proof =
             mutator_set.prove(own_item, sender_randomness, receiver_preimage);
         mutator_set.kernel.add_helper(&addition_record);
 
         // Update membership proof with add operation. Verify that it has changed, and that it now fails to verify.
         let (new_item, new_sender_randomness, new_receiver_preimage) = make_item_and_randomnesses();
-        let new_addition_record = commit::<H>(
+        let new_addition_record = commit(
             new_item,
             new_sender_randomness,
-            new_receiver_preimage.hash::<H>(),
+            new_receiver_preimage.hash::<Hash>(),
         );
         let original_membership_proof = membership_proof.clone();
         let changed_mp = match membership_proof.update_from_addition(
@@ -822,10 +815,9 @@ mod accumulation_scheme_tests {
 
     #[test]
     fn membership_proof_updating_from_add_pbt() {
-        type H = Tip5;
         let mut rng = thread_rng();
 
-        let mut mutator_set = MutatorSetAccumulator::<H>::default();
+        let mut mutator_set = MutatorSetAccumulator::default();
 
         let num_additions = rng.gen_range(0..=100i32);
         println!(
@@ -833,14 +825,13 @@ mod accumulation_scheme_tests {
             num_additions
         );
 
-        let mut membership_proofs_and_items: Vec<(MsMembershipProof<H>, Digest)> = vec![];
+        let mut membership_proofs_and_items: Vec<(MsMembershipProof, Digest)> = vec![];
         for i in 0..num_additions {
             println!("loop iteration {}", i);
 
             let (item, sender_randomness, receiver_preimage) = make_item_and_randomnesses();
 
-            let addition_record =
-                commit::<H>(item, sender_randomness, receiver_preimage.hash::<H>());
+            let addition_record = commit(item, sender_randomness, receiver_preimage.hash::<Hash>());
             let membership_proof = mutator_set.prove(item, sender_randomness, receiver_preimage);
 
             // Update all membership proofs
@@ -869,13 +860,10 @@ mod accumulation_scheme_tests {
 
     #[test]
     fn test_add_and_prove() {
-        type H = Tip5;
-
-        let mut mutator_set = MutatorSetAccumulator::<H>::default();
+        let mut mutator_set = MutatorSetAccumulator::default();
         let (item0, sender_randomness0, receiver_preimage0) = make_item_and_randomnesses();
 
-        let addition_record =
-            commit::<H>(item0, sender_randomness0, receiver_preimage0.hash::<H>());
+        let addition_record = commit(item0, sender_randomness0, receiver_preimage0.hash::<Hash>());
         let membership_proof = mutator_set.prove(item0, sender_randomness0, receiver_preimage0);
 
         assert!(!mutator_set.verify(item0, &membership_proof));
@@ -886,7 +874,7 @@ mod accumulation_scheme_tests {
 
         // Insert a new item and verify that this still works
         let (item1, sender_randomness1, receiver_preimage1) = make_item_and_randomnesses();
-        let new_ar = commit::<H>(item1, sender_randomness1, receiver_preimage1.hash::<H>());
+        let new_ar = commit(item1, sender_randomness1, receiver_preimage1.hash::<Hash>());
         let new_mp = mutator_set.prove(item1, sender_randomness1, receiver_preimage1);
         assert!(!mutator_set.verify(item1, &new_mp));
 
@@ -899,7 +887,7 @@ mod accumulation_scheme_tests {
         // position.
         for _ in 0..2 * BATCH_SIZE + 4 {
             let (item, sender_randomness, receiver_preimage) = make_item_and_randomnesses();
-            let other_ar = commit::<H>(item, sender_randomness, receiver_preimage.hash::<H>());
+            let other_ar = commit(item, sender_randomness, receiver_preimage.hash::<Hash>());
             let other_mp = mutator_set.prove(item, sender_randomness, receiver_preimage);
             assert!(!mutator_set.verify(item, &other_mp));
 
@@ -910,8 +898,7 @@ mod accumulation_scheme_tests {
 
     #[test]
     fn batch_update_from_addition_and_removal_test() {
-        type H = Tip5;
-        let mut mutator_set = MutatorSetAccumulator::<H>::default();
+        let mut mutator_set = MutatorSetAccumulator::default();
 
         // It's important to test number of additions around the shifting of the window,
         // i.e. around batch size.
@@ -926,20 +913,23 @@ mod accumulation_scheme_tests {
             6 * BATCH_SIZE + 1,
         ];
 
-        let mut membership_proofs: Vec<MsMembershipProof<H>> = vec![];
+        let mut membership_proofs: Vec<MsMembershipProof> = vec![];
         let mut items = vec![];
 
         for num_additions in num_additions_list {
             for _ in 0..num_additions {
                 let (new_item, sender_randomness, receiver_preimage) = make_item_and_randomnesses();
 
-                let addition_record =
-                    commit::<H>(new_item, sender_randomness, receiver_preimage.hash::<H>());
+                let addition_record = commit(
+                    new_item,
+                    sender_randomness,
+                    receiver_preimage.hash::<Hash>(),
+                );
                 let membership_proof =
                     mutator_set.prove(new_item, sender_randomness, receiver_preimage);
 
                 // Update *all* membership proofs with newly added item
-                let batch_update_res = MsMembershipProof::<H>::batch_update_from_addition(
+                let batch_update_res = MsMembershipProof::batch_update_from_addition(
                     &mut membership_proofs.iter_mut().collect::<Vec<_>>(),
                     &items,
                     &mutator_set.kernel,
@@ -965,7 +955,7 @@ mod accumulation_scheme_tests {
                 assert!(mutator_set.verify(item, &mp));
 
                 // generate removal record
-                let removal_record: RemovalRecord<H> = mutator_set.drop(item, &mp);
+                let removal_record: RemovalRecord = mutator_set.drop(item, &mp);
                 assert!(removal_record.validate(&mutator_set.kernel));
                 assert!(mutator_set.kernel.can_remove(&removal_record));
 
@@ -989,19 +979,20 @@ mod accumulation_scheme_tests {
 
     #[test]
     fn test_multiple_adds() {
-        type H = Tip5;
-
-        let mut mutator_set = MutatorSetAccumulator::<H>::default();
+        let mut mutator_set = MutatorSetAccumulator::default();
 
         let num_additions = 65;
 
-        let mut items_and_membership_proofs: Vec<(Digest, MsMembershipProof<H>)> = vec![];
+        let mut items_and_membership_proofs: Vec<(Digest, MsMembershipProof)> = vec![];
 
         for _ in 0..num_additions {
             let (new_item, sender_randomness, receiver_preimage) = make_item_and_randomnesses();
 
-            let addition_record =
-                commit::<H>(new_item, sender_randomness, receiver_preimage.hash::<H>());
+            let addition_record = commit(
+                new_item,
+                sender_randomness,
+                receiver_preimage.hash::<Hash>(),
+            );
             let membership_proof =
                 mutator_set.prove(new_item, sender_randomness, receiver_preimage);
 
@@ -1049,7 +1040,7 @@ mod accumulation_scheme_tests {
             assert!(mutator_set.verify(item, &mp));
 
             // generate removal record
-            let removal_record: RemovalRecord<H> = mutator_set.drop(item, &mp);
+            let removal_record: RemovalRecord = mutator_set.drop(item, &mp);
             assert!(removal_record.validate(&mutator_set.kernel));
             assert!(mutator_set.kernel.can_remove(&removal_record));
             (i..items_and_membership_proofs.len()).for_each(|k| {
@@ -1092,10 +1083,9 @@ mod accumulation_scheme_tests {
         // in the runtime. This test is to verify that that does not happen.
         // Cf. https://stackoverflow.com/questions/72618777/how-to-deserialize-a-nested-big-array
         // and https://stackoverflow.com/questions/72621410/how-do-i-use-serde-stacker-in-my-deserialize-implementation
-        type H = Tip5;
-        type Mmr = MmrAccumulator<H>;
-        type Ms = MutatorSetKernel<H, Mmr>;
-        let mut mutator_set: Ms = MutatorSetAccumulator::<H>::default().kernel;
+        type Mmr = MmrAccumulator<Hash>;
+        type Ms = MutatorSetKernel<Mmr>;
+        let mut mutator_set: Ms = MutatorSetAccumulator::default().kernel;
 
         let json_empty = serde_json::to_string(&mutator_set).unwrap();
         println!("json = \n{}", json_empty);

--- a/src/util_types/mutator_set/mutator_set_trait.rs
+++ b/src/util_types/mutator_set/mutator_set_trait.rs
@@ -1,3 +1,4 @@
+use crate::models::blockchain::shared::Hash;
 use crate::prelude::twenty_first;
 
 use twenty_first::shared_math::tip5::Digest;
@@ -9,17 +10,14 @@ use super::removal_record::RemovalRecord;
 
 /// Generates an addition record from an item and explicit random-
 /// ness. The addition record is itself a commitment to the item.
-pub fn commit<H: AlgebraicHasher>(
-    item: Digest,
-    sender_randomness: Digest,
-    receiver_digest: Digest,
-) -> AdditionRecord {
-    let canonical_commitment = H::hash_pair(H::hash_pair(item, sender_randomness), receiver_digest);
+pub fn commit(item: Digest, sender_randomness: Digest, receiver_digest: Digest) -> AdditionRecord {
+    let canonical_commitment =
+        Hash::hash_pair(Hash::hash_pair(item, sender_randomness), receiver_digest);
 
     AdditionRecord::new(canonical_commitment)
 }
 
-pub trait MutatorSet<H: AlgebraicHasher> {
+pub trait MutatorSet {
     /// Generates a membership proof that will be valid when the item
     /// is added to the mutator set.
     fn prove(
@@ -27,27 +25,27 @@ pub trait MutatorSet<H: AlgebraicHasher> {
         item: Digest,
         sender_randomness: Digest,
         receiver_preimage: Digest,
-    ) -> MsMembershipProof<H>;
+    ) -> MsMembershipProof;
 
-    fn verify(&self, item: Digest, membership_proof: &MsMembershipProof<H>) -> bool;
+    fn verify(&self, item: Digest, membership_proof: &MsMembershipProof) -> bool;
 
     /// Generates a removal record with which to update the set commitment.
-    fn drop(&self, item: Digest, membership_proof: &MsMembershipProof<H>) -> RemovalRecord<H>;
+    fn drop(&self, item: Digest, membership_proof: &MsMembershipProof) -> RemovalRecord;
 
     /// Updates the set-commitment with an addition record.
     fn add(&mut self, addition_record: &AdditionRecord);
 
     /// Updates the mutator set so as to remove the item determined by
     /// its removal record.
-    fn remove(&mut self, removal_record: &RemovalRecord<H>);
+    fn remove(&mut self, removal_record: &RemovalRecord);
 
     /// batch_remove
     /// Apply multiple removal records, and update a list of membership proofs to
     /// be valid after the application of these removal records.
     fn batch_remove(
         &mut self,
-        removal_records: Vec<RemovalRecord<H>>,
-        preserved_membership_proofs: &mut [&mut MsMembershipProof<H>],
+        removal_records: Vec<RemovalRecord>,
+        preserved_membership_proofs: &mut [&mut MsMembershipProof],
     );
 
     /// hash

--- a/src/util_types/mutator_set/removal_record.rs
+++ b/src/util_types/mutator_set/removal_record.rs
@@ -1,3 +1,4 @@
+use crate::models::blockchain::shared::Hash;
 use crate::prelude::twenty_first;
 
 use get_size::GetSize;
@@ -9,7 +10,6 @@ use serde::ser::SerializeTuple;
 use serde::Deserialize;
 use serde_derive::Serialize;
 use std::collections::{HashMap, HashSet};
-use std::error::Error;
 use std::marker::PhantomData;
 use std::ops::IndexMut;
 use tasm_lib::structure::tasm_object::TasmObject;
@@ -127,29 +127,29 @@ impl<'de> Deserialize<'de> for AbsoluteIndexSet {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, GetSize, BFieldCodec, TasmObject)]
-pub struct RemovalRecord<H: AlgebraicHasher> {
+pub struct RemovalRecord {
     pub absolute_indices: AbsoluteIndexSet,
-    pub target_chunks: ChunkDictionary<H>,
+    pub target_chunks: ChunkDictionary,
 }
 
-impl<H: AlgebraicHasher + BFieldCodec> RemovalRecord<H> {
+impl RemovalRecord {
     /// Update a batch of removal records that are synced to a given mutator set, given
     /// that that mutator set will be updated with an addition. (The addition record
     /// does not matter; all necessary information is in the mutator set.)
-    pub fn batch_update_from_addition<MMR: Mmr<H>>(
+    pub fn batch_update_from_addition<MMR: Mmr<Hash>>(
         removal_records: &mut [&mut Self],
-        mutator_set: &mut MutatorSetKernel<H, MMR>,
+        mutator_set: &mut MutatorSetKernel<MMR>,
     ) {
         let new_item_index = mutator_set.aocl.count_leaves();
 
         // if window does not slide, do nothing
-        if !MutatorSetKernel::<H, MMR>::window_slides(new_item_index) {
+        if !MutatorSetKernel::<MMR>::window_slides(new_item_index) {
             return;
         }
 
         // window does slide
         let new_chunk = mutator_set.swbf_active.slid_chunk();
-        let new_chunk_digest: Digest = H::hash(&new_chunk);
+        let new_chunk_digest: Digest = Hash::hash(&new_chunk);
 
         // Insert the new chunk digest into the accumulator-version of the
         // SWBF MMR to get its authentication path. It's important to convert the MMR
@@ -157,8 +157,8 @@ impl<H: AlgebraicHasher + BFieldCodec> RemovalRecord<H> {
         // a whole archival MMR for this operation, as the archival MMR can be in the
         // size of gigabytes, whereas the MMR accumulator should be in the size of
         // kilobytes.
-        let mut mmra: MmrAccumulator<H> = mutator_set.swbf_inactive.to_accumulator();
-        let new_swbf_auth_path: mmr::mmr_membership_proof::MmrMembershipProof<H> =
+        let mut mmra: MmrAccumulator<Hash> = mutator_set.swbf_inactive.to_accumulator();
+        let new_swbf_auth_path: mmr::mmr_membership_proof::MmrMembershipProof<Hash> =
             mmra.append(new_chunk_digest);
 
         // Collect all indices for all removal records that are being updated
@@ -222,7 +222,7 @@ impl<H: AlgebraicHasher + BFieldCodec> RemovalRecord<H> {
         // So relegating that bookkeeping to this function instead would not be more
         // efficient.
         let mut mmr_membership_proofs_for_append: Vec<
-            &mut mmr::mmr_membership_proof::MmrMembershipProof<H>,
+            &mut mmr::mmr_membership_proof::MmrMembershipProof<Hash>,
         > = vec![];
         for (i, rr) in removal_records.iter_mut().enumerate() {
             if rrs_for_batch_append.contains(&i) {
@@ -233,7 +233,7 @@ impl<H: AlgebraicHasher + BFieldCodec> RemovalRecord<H> {
         }
 
         // Perform the update of all the MMR membership proofs contained in the removal records
-        mmr::mmr_membership_proof::MmrMembershipProof::<H>::batch_update_from_append(
+        mmr::mmr_membership_proof::MmrMembershipProof::<Hash>::batch_update_from_append(
             &mut mmr_membership_proofs_for_append,
             mutator_set.swbf_inactive.count_leaves(),
             new_chunk_digest,
@@ -243,11 +243,11 @@ impl<H: AlgebraicHasher + BFieldCodec> RemovalRecord<H> {
 
     pub fn batch_update_from_remove(
         removal_records: &mut [&mut Self],
-        applied_removal_record: &RemovalRecord<H>,
-    ) -> Result<(), Box<dyn Error>> {
+        applied_removal_record: &RemovalRecord,
+    ) {
         // Set all chunk values to the new values and calculate the mutation argument
         // for the batch updating of the MMR membership proofs.
-        let mut chunk_dictionaries: Vec<&mut ChunkDictionary<H>> = removal_records
+        let mut chunk_dictionaries: Vec<&mut ChunkDictionary> = removal_records
             .iter_mut()
             .map(|mp| &mut mp.target_chunks)
             .collect();
@@ -258,7 +258,7 @@ impl<H: AlgebraicHasher + BFieldCodec> RemovalRecord<H> {
             );
 
         // Collect all the MMR membership proofs from the chunk dictionaries.
-        let mut own_mmr_mps: Vec<&mut mmr::mmr_membership_proof::MmrMembershipProof<H>> = vec![];
+        let mut own_mmr_mps: Vec<&mut mmr::mmr_membership_proof::MmrMembershipProof<Hash>> = vec![];
         for chunk_dict in chunk_dictionaries.iter_mut() {
             for (_, (mp, _)) in chunk_dict.dictionary.iter_mut() {
                 own_mmr_mps.push(mp);
@@ -270,21 +270,19 @@ impl<H: AlgebraicHasher + BFieldCodec> RemovalRecord<H> {
             &mut own_mmr_mps,
             mutation_argument,
         );
-
-        Ok(())
     }
 
     /// Validates that a removal record is synchronized against the inactive part of the SWBF
-    pub fn validate<M>(&self, mutator_set: &MutatorSetKernel<H, M>) -> bool
+    pub fn validate<M>(&self, mutator_set: &MutatorSetKernel<M>) -> bool
     where
-        M: Mmr<H>,
+        M: Mmr<Hash>,
     {
         let peaks = mutator_set.swbf_inactive.get_peaks();
         self.target_chunks
             .dictionary
             .iter()
             .all(|(_i, (proof, chunk))| {
-                let leaf_digest = H::hash(chunk);
+                let leaf_digest = Hash::hash(chunk);
                 let leaf_count = mutator_set.swbf_inactive.count_leaves();
                 let (verified, _final_state) = proof.verify(&peaks, leaf_digest, leaf_count);
 
@@ -299,7 +297,7 @@ impl<H: AlgebraicHasher + BFieldCodec> RemovalRecord<H> {
 }
 
 /// Generate a pseudorandom removal record from the given seed, for testing purposes.
-pub fn pseudorandom_removal_record<H: AlgebraicHasher>(seed: [u8; 32]) -> RemovalRecord<H> {
+pub fn pseudorandom_removal_record(seed: [u8; 32]) -> RemovalRecord {
     let mut rng: StdRng = SeedableRng::from_seed(seed);
     let absolute_indices = AbsoluteIndexSet::new(
         &(0..NUM_TRIALS as usize)
@@ -321,7 +319,6 @@ mod removal_record_tests {
     use itertools::Itertools;
     use rand::seq::SliceRandom;
     use rand::{thread_rng, Rng, RngCore};
-    use twenty_first::shared_math::tip5::Tip5;
 
     use crate::util_types::mutator_set::addition_record::AdditionRecord;
     use crate::util_types::mutator_set::ms_membership_proof::MsMembershipProof;
@@ -332,13 +329,11 @@ mod removal_record_tests {
 
     use super::*;
 
-    fn get_item_mp_and_removal_record() -> (Digest, MsMembershipProof<Tip5>, RemovalRecord<Tip5>) {
-        type H = Tip5;
-        let mut accumulator: MutatorSetAccumulator<H> = MutatorSetAccumulator::default();
+    fn get_item_mp_and_removal_record() -> (Digest, MsMembershipProof, RemovalRecord) {
+        let mut accumulator: MutatorSetAccumulator = MutatorSetAccumulator::default();
         let (item, sender_randomness, receiver_preimage) = make_item_and_randomnesses();
-        let mp: MsMembershipProof<H> =
-            accumulator.prove(item, sender_randomness, receiver_preimage);
-        let removal_record: RemovalRecord<H> = accumulator.drop(item, &mp);
+        let mp: MsMembershipProof = accumulator.prove(item, sender_randomness, receiver_preimage);
+        let removal_record: RemovalRecord = accumulator.drop(item, &mp);
         (item, mp, removal_record)
     }
 
@@ -372,22 +367,20 @@ mod removal_record_tests {
 
     #[test]
     fn hash_test() {
-        type H = Tip5;
-
         let (_item, _mp, removal_record) = get_item_mp_and_removal_record();
 
-        let mut removal_record_alt: RemovalRecord<H> = removal_record.clone();
+        let mut removal_record_alt: RemovalRecord = removal_record.clone();
         assert_eq!(
-            H::hash(&removal_record),
-            H::hash(&removal_record_alt),
+            Hash::hash(&removal_record),
+            Hash::hash(&removal_record_alt),
             "Same removal record must hash to same value"
         );
 
         // Verify that changing the absolute indices, changes the hash value
         removal_record_alt.absolute_indices.to_array_mut()[NUM_TRIALS as usize / 4] += 1;
         assert_ne!(
-            H::hash(&removal_record),
-            H::hash(&removal_record_alt),
+            Hash::hash(&removal_record),
+            Hash::hash(&removal_record_alt),
             "Changing an index must produce a new hash"
         );
     }
@@ -419,12 +412,11 @@ mod removal_record_tests {
         // TODO: You could argue that this test doesn't belong here, as it tests the behavior of
         // an imported library. I included it here, though, because the setup seems a bit clumsy
         // to me so far.
-        type H = Tip5;
 
         let (_item, _mp, removal_record) = get_item_mp_and_removal_record();
 
         let json: String = serde_json::to_string(&removal_record).unwrap();
-        let s_back = serde_json::from_str::<RemovalRecord<H>>(&json).unwrap();
+        let s_back = serde_json::from_str::<RemovalRecord>(&json).unwrap();
         assert_eq!(s_back.absolute_indices, removal_record.absolute_indices);
         assert_eq!(s_back.target_chunks, removal_record.target_chunks);
     }
@@ -432,11 +424,10 @@ mod removal_record_tests {
     #[test]
     fn simple_remove_test() {
         // Verify that a single element can be added to and removed from the mutator set
-        type H = Tip5;
-        let mut accumulator: MutatorSetAccumulator<H> = MutatorSetAccumulator::default();
+        let mut accumulator: MutatorSetAccumulator = MutatorSetAccumulator::default();
         let (item, sender_randomness, receiver_preimage) = make_item_and_randomnesses();
         let addition_record: AdditionRecord =
-            commit::<H>(item, sender_randomness, receiver_preimage.hash::<H>());
+            commit(item, sender_randomness, receiver_preimage.hash::<Hash>());
         let mp = accumulator.prove(item, sender_randomness, receiver_preimage);
 
         assert!(
@@ -459,19 +450,18 @@ mod removal_record_tests {
     #[test]
     fn batch_update_from_addition_pbt() {
         // Verify that a single element can be added to and removed from the mutator set
-        type H = Tip5;
 
         let test_iterations = 10;
         for _ in 0..test_iterations {
-            let mut accumulator: MutatorSetAccumulator<H> = MutatorSetAccumulator::default();
-            let mut removal_records: Vec<(usize, RemovalRecord<H>)> = vec![];
+            let mut accumulator: MutatorSetAccumulator = MutatorSetAccumulator::default();
+            let mut removal_records: Vec<(usize, RemovalRecord)> = vec![];
             let mut items = vec![];
             let mut mps = vec![];
             for i in 0..2 * BATCH_SIZE + 4 {
                 let (item, sender_randomness, receiver_preimage) = make_item_and_randomnesses();
 
                 let addition_record: AdditionRecord =
-                    commit::<H>(item, sender_randomness, receiver_preimage.hash::<H>());
+                    commit(item, sender_randomness, receiver_preimage.hash::<Hash>());
                 let mp = accumulator.prove(item, sender_randomness, receiver_preimage);
 
                 // Update all removal records from addition, then add the element
@@ -544,10 +534,10 @@ mod removal_record_tests {
     #[test]
     fn batch_update_from_addition_and_remove_pbt() {
         // Verify that a single element can be added to and removed from the mutator set
-        type H = Tip5;
-        let mut accumulator: MutatorSetAccumulator<H> = MutatorSetAccumulator::default();
 
-        let mut removal_records: Vec<(usize, RemovalRecord<H>)> = vec![];
+        let mut accumulator: MutatorSetAccumulator = MutatorSetAccumulator::default();
+
+        let mut removal_records: Vec<(usize, RemovalRecord)> = vec![];
         let mut original_first_removal_record = None;
         let mut items = vec![];
         let mut mps = vec![];
@@ -555,7 +545,7 @@ mod removal_record_tests {
             let (item, sender_randomness, receiver_preimage) = make_item_and_randomnesses();
 
             let addition_record: AdditionRecord =
-                commit::<H>(item, sender_randomness, receiver_preimage.hash::<H>());
+                commit(item, sender_randomness, receiver_preimage.hash::<Hash>());
             let mp = accumulator.prove(item, sender_randomness, receiver_preimage);
 
             // Update all removal records from addition, then add the element
@@ -606,17 +596,12 @@ mod removal_record_tests {
         for i in 0..12 * BATCH_SIZE + 4 {
             let remove_idx = rand::thread_rng().gen_range(0..removal_records.len());
             let random_removal_record = removal_records.remove(remove_idx).1;
-            let update_res_rr = RemovalRecord::batch_update_from_remove(
+            RemovalRecord::batch_update_from_remove(
                 &mut removal_records
                     .iter_mut()
                     .map(|x| &mut x.1)
                     .collect::<Vec<_>>(),
                 &random_removal_record,
-            );
-            assert!(
-                update_res_rr.is_ok(),
-                "batch update must return OK, i = {}",
-                i
             );
 
             accumulator.remove(&random_removal_record);
@@ -661,9 +646,8 @@ mod removal_record_tests {
 
     #[test]
     fn test_removal_record_decode() {
-        type H = Tip5;
         for _ in 0..10 {
-            let removal_record = random_removal_record::<H>();
+            let removal_record = random_removal_record();
             let encoded = removal_record.encode();
             let decoded = *RemovalRecord::decode(&encoded).unwrap();
             assert_eq!(removal_record, decoded);
@@ -672,22 +656,20 @@ mod removal_record_tests {
 
     #[test]
     fn test_removal_record_vec_decode() {
-        type H = Tip5;
         let mut rng = thread_rng();
         for _ in 0..10 {
             let length = rng.gen_range(0..10);
-            let removal_records = vec![random_removal_record::<H>(); length];
+            let removal_records = vec![random_removal_record(); length];
             let encoded = removal_records.encode();
-            let decoded = *Vec::<RemovalRecord<H>>::decode(&encoded).unwrap();
+            let decoded = *Vec::<RemovalRecord>::decode(&encoded).unwrap();
             assert_eq!(removal_records, decoded);
         }
     }
 
     #[test]
     fn test_absindexset_record_decode() {
-        type H = Tip5;
         for _ in 0..100 {
-            let removal_record = random_removal_record::<H>();
+            let removal_record = random_removal_record();
             let encoded_absindexset = removal_record.absolute_indices.encode();
             let decoded_absindexset = *AbsoluteIndexSet::decode(&encoded_absindexset).unwrap();
             assert_eq!(removal_record.absolute_indices, decoded_absindexset);

--- a/src/util_types/mutator_set/shared.rs
+++ b/src/util_types/mutator_set/shared.rs
@@ -1,9 +1,9 @@
+use crate::models::blockchain::shared::Hash;
 use crate::prelude::twenty_first;
 
 use std::collections::{HashMap, HashSet};
 
-use twenty_first::shared_math::bfield_codec::BFieldCodec;
-use twenty_first::shared_math::tip5::Digest;
+use tasm_lib::Digest;
 use twenty_first::util_types::algebraic_hasher::AlgebraicHasher;
 use twenty_first::util_types::mmr::mmr_membership_proof::MmrMembershipProof;
 
@@ -54,12 +54,12 @@ pub fn indices_to_hash_map(all_indices: &[u128; NUM_TRIALS as usize]) -> HashMap
 /// This function is factored out because it is shared by `update_from_remove`
 /// and `batch_update_from_remove`.
 #[allow(clippy::type_complexity)]
-pub fn get_batch_mutation_argument_for_removal_record<H: AlgebraicHasher + BFieldCodec>(
-    removal_record: &RemovalRecord<H>,
-    chunk_dictionaries: &mut [&mut ChunkDictionary<H>],
-) -> (HashSet<usize>, Vec<(MmrMembershipProof<H>, Digest)>) {
+pub fn get_batch_mutation_argument_for_removal_record(
+    removal_record: &RemovalRecord,
+    chunk_dictionaries: &mut [&mut ChunkDictionary],
+) -> (HashSet<usize>, Vec<(MmrMembershipProof<Hash>, Digest)>) {
     // chunk index -> (mmr mp, chunk hash)
-    let mut batch_modification_hash_map: HashMap<u64, (MmrMembershipProof<H>, Digest)> =
+    let mut batch_modification_hash_map: HashMap<u64, (MmrMembershipProof<Hash>, Digest)> =
         HashMap::new();
     // `mutated_chunk_dictionaries` records the indices into the
     // input `chunk_dictionaries` slice that shows which elements
@@ -85,7 +85,7 @@ pub fn get_batch_mutation_argument_for_removal_record<H: AlgebraicHasher + BFiel
                     // *old* (non-updated) MMR membership proof.
                     if !batch_modification_hash_map.contains_key(chunk_index) {
                         batch_modification_hash_map
-                            .insert(*chunk_index, (mmr_mp.to_owned(), H::hash(chunk)));
+                            .insert(*chunk_index, (mmr_mp.to_owned(), Hash::hash(chunk)));
                     }
                 }
 
@@ -110,8 +110,10 @@ pub fn get_batch_mutation_argument_for_removal_record<H: AlgebraicHasher + BFiel
 
                                 // Since all indices have been applied to the chunk in the above
                                 // for-loop, we can calculate the hash of the updated chunk now.
-                                batch_modification_hash_map
-                                    .insert(*chunk_index, (mp.to_owned(), H::hash(&target_chunk)));
+                                batch_modification_hash_map.insert(
+                                    *chunk_index,
+                                    (mp.to_owned(), Hash::hash(&target_chunk)),
+                                );
                             }
                         }
                     };
@@ -151,14 +153,12 @@ pub fn get_batch_mutation_argument_for_removal_record<H: AlgebraicHasher + BFiel
 /// This function is factored out because it is shared by
 /// `revert_update_from_remove` and `batch_revert_update_from_remove`.
 #[allow(clippy::type_complexity)]
-pub fn prepare_authenticated_batch_modification_for_removal_record_reversion<
-    H: AlgebraicHasher + BFieldCodec,
->(
-    removal_record: &RemovalRecord<H>,
-    chunk_dictionaries: &mut [&mut ChunkDictionary<H>],
-) -> (HashSet<usize>, Vec<(MmrMembershipProof<H>, Digest)>) {
+pub fn prepare_authenticated_batch_modification_for_removal_record_reversion(
+    removal_record: &RemovalRecord,
+    chunk_dictionaries: &mut [&mut ChunkDictionary],
+) -> (HashSet<usize>, Vec<(MmrMembershipProof<Hash>, Digest)>) {
     // chunk index -> (mmr mp, chunk hash)
-    let mut batch_modification_hash_map: HashMap<u64, (MmrMembershipProof<H>, Digest)> =
+    let mut batch_modification_hash_map: HashMap<u64, (MmrMembershipProof<Hash>, Digest)> =
         HashMap::new();
 
     // `mutated_chunk_dictionaries` records the indices in `chunk_dictionaries`
@@ -180,7 +180,7 @@ pub fn prepare_authenticated_batch_modification_for_removal_record_reversion<
                     // *old* (before reversion) MMR membership proof.
                     if !batch_modification_hash_map.contains_key(chunk_index) {
                         batch_modification_hash_map
-                            .insert(*chunk_index, (mmr_mp.to_owned(), H::hash(chunk)));
+                            .insert(*chunk_index, (mmr_mp.to_owned(), Hash::hash(chunk)));
                     }
                 }
 
@@ -209,8 +209,10 @@ pub fn prepare_authenticated_batch_modification_for_removal_record_reversion<
 
                                 // Since all indices have been applied to the chunk in the above
                                 // for-loop, we can calculate the hash of the updated chunk now.
-                                batch_modification_hash_map
-                                    .insert(*chunk_index, (mp.to_owned(), H::hash(&target_chunk)));
+                                batch_modification_hash_map.insert(
+                                    *chunk_index,
+                                    (mp.to_owned(), Hash::hash(&target_chunk)),
+                                );
                             }
                         }
                     };


### PR DESCRIPTION
The problem was located in `Block::accumulate_transaction`, which is invoked repeatedly by a miner as he selects which mempool transactions to include in his block. Recall that the block has only one transaction, which represents the merger of all transactions of the miner's choice.

The problem is that the block-in-preparation contains the updated mutator set accumulator. When a new transaction is aggregated, the mutator set accumulator is updated *from this intermediate state, with the new transaction's addition and removal records*. It is not obvious why this leads to a problem, so let's use an example:

 - The current transaction has `inputs_1` and `outputs_1` and the current block-in-preparation has mutator set accumulator `msa_1`, which is what results from applying `outputs_1` and `inputs_1` to the previous block's mutator set accumulator: `msa_1 = msa_0.add(outputs_1).remove(inputs_1)`.
 - The new transaction has `inputs_2` and `outputs_2`. The `accumulate_transaction` (up until now) computes the new mutator set accumulator as `msa_1.add(outputs_2).remove(inputs_2)`.
 - As far as mutator set accumulators go, additions commute with removals. The subtle caveat for this otherwise true statement is that it does require the removal records to be in sync with the mutator set at the time they are applied. If the removal records are not in sync, computing the next mutator set accumulator might fail. Indeed, this is what happened.
 - The removal records of the incoming transaction are not in sync with the mutator set accumulator `msa_1`.

So how do we get them in sync? We can't use the archival mutator set because we might not be running an archival node. We can't look at the new mutator set accumulator because we might need the chunk of the SWBF that was slid away and is now hidden by Merkleization. We can't revert the removal of `inputs_1` because we still need that slid chunk to restore the mutator set accumulator.

The solution in this PR is to modify the type signature of the function `accumulate_transaction`, which now takes an additional argument `previous_mutator_set_accumulator`. The new mutator set is computed by starting from this value and applying all addition records (`outputs_1 || outputs_2`) first and all removal records (`inputs_1 || inputs_2`) second. The halfway-in-between mutator set accumulator is ignored.

At some point we should consider a prettier solution at some point -- one that does not generate objects that are destined to be ignored. However, that sounds to me like an optimization with low priority and low payoff. It affects only miners (who need way more memory anyway) and it's not clear whether it can run any faster if it is implemented in this way.

This PR also:
 1. Drops the generic type argument `H` from all structs and functions associated with the mutator set. Throughout this code base we only ever use `Tip5` which itself is already hidden behind type alias `Hash`. The genericity dates to the time where we needed an alternative to the relatively slow Rescue-Prime hash functino.
 2. Removes the return values of type `Result<(),_>` from functions where there is no control path leading to error. Accordingly catch-and-report-error clauses where these functions are called, are removed as well.
