### PR TITLE
126 speedup ammr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,12 @@ serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 serde_json = "1.0"
 strum = { version = "0.25", features = ["derive"] }
-tarpc = { version = "^0.34", features = ["tokio1", "serde-transport", "serde-transport-json", "tcp"] }
+tarpc = { version = "^0.34", features = [
+    "tokio1",
+    "serde-transport",
+    "serde-transport-json",
+    "tcp",
+] }
 tasm-lib = "0.2"
 tiny-bip39 = "1.0"
 tokio = { version = "1.37", features = ["full", "tracing"] }
@@ -110,11 +115,14 @@ harness = false
 name = "db_dbtvec"
 harness = false
 
+[[bench]]
+name = "archival_mmr"
+harness = false
+
 
 [patch.crates-io]
 # 15a708cf6fcbd9ed3e65e5e2067be6e622176328 is tip of branch: make_storage_async as of 2024-03-18
 tasm-lib = { git = "https://github.com/dan-da/tasm-lib.git", rev = "15a708cf6fcbd9ed3e65e5e2067be6e622176328" }
 
 # 81573735e9df4836ca16655fd31884271984bac7 = tip of branch: make_storage_async on 2024-03-18
-twenty-first = { git = "https://github.com/Neptune-Crypto/twenty-first.git", rev = "81573735e9df4836ca16655fd31884271984bac7"}
-
+twenty-first = { git = "https://github.com/Neptune-Crypto/twenty-first.git", rev = "81573735e9df4836ca16655fd31884271984bac7" }

--- a/benches/archival_mmr.rs
+++ b/benches/archival_mmr.rs
@@ -1,0 +1,122 @@
+use divan::Bencher;
+use leveldb::options::Options;
+use leveldb::options::ReadOptions;
+use leveldb::options::WriteOptions;
+use leveldb_sys::Compression;
+use neptune_core::database::storage::storage_schema::traits::*;
+use neptune_core::database::storage::storage_schema::DbtVec;
+use neptune_core::database::storage::storage_schema::SimpleRustyStorage;
+use neptune_core::database::NeptuneLevelDb;
+use neptune_core::util_types::mutator_set::archival_mmr::ArchivalMmr;
+use tasm_lib::twenty_first::shared_math::tip5::Tip5;
+use tasm_lib::Digest;
+
+fn main() {
+    divan::main();
+}
+
+/// These settings affect DB performance and correctness.
+///
+/// Adjust and re-run the benchmarks to see effects.
+///
+/// Rust docs:  (basic)
+///   https://docs.rs/rs-leveldb/0.1.5/leveldb/database/options/struct.Options.html
+///
+/// C++ docs:  (complete)
+///   https://github.com/google/leveldb/blob/068d5ee1a3ac40dabd00d211d5013af44be55bea/include/leveldb/options.h
+fn db_options() -> Option<Options> {
+    Some(Options {
+        // default: false
+        create_if_missing: true,
+
+        // default: false
+        error_if_exists: true,
+
+        // default: false
+        paranoid_checks: false,
+
+        // default: None  --> (4 * 1024 * 1024)
+        write_buffer_size: None,
+
+        // default: None   --> 1000
+        max_open_files: None,
+
+        // default: None   -->  4 * 1024
+        block_size: None,
+
+        // default: None   -->  16
+        block_restart_interval: None,
+
+        // default: Compression::No
+        //      or: Compression::Snappy
+        compression: Compression::No,
+
+        // default: None   --> 8MB
+        cache: None,
+        // cache: Some(Cache::new(1024)),
+        // note: tests put 128 bytes in each entry.
+        // 100 entries = 12,800 bytes.
+        // So Cache of 1024 bytes is 8% of total data set.
+        // that seems reasonably realistic to get some
+        // hits/misses.
+    })
+}
+
+async fn empty_ammr() -> (SimpleRustyStorage, ArchivalMmr<Tip5, DbtVec<Digest>>) {
+    let db = NeptuneLevelDb::open_new_test_database(
+        false,
+        db_options(),
+        Some(ReadOptions {
+            verify_checksums: false,
+            fill_cache: false,
+        }),
+        Some(WriteOptions { sync: true }),
+    )
+    .await
+    .unwrap();
+    let mut rusty_storage = SimpleRustyStorage::new(db);
+    let nv = rusty_storage
+        .schema
+        .new_vec::<Digest>("test-archival-mmr")
+        .await;
+
+    (rusty_storage, ArchivalMmr::new(nv).await)
+}
+
+mod append {
+    use super::*;
+
+    mod append_5000 {
+        const NUM_WRITE_ITEMS: usize = 5000;
+        use tasm_lib::twenty_first::shared_math::other::random_elements;
+
+        use super::*;
+
+        fn append_impl(bencher: Bencher, persist: bool) {
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            let (mut storage, mut ammr) = rt.block_on(empty_ammr());
+            let digests = random_elements(NUM_WRITE_ITEMS);
+
+            bencher.bench_local(|| {
+                rt.block_on(async {
+                    for new_leaf in digests.iter() {
+                        ammr.append(*new_leaf).await;
+                    }
+                    if persist {
+                        storage.persist().await;
+                    }
+                });
+            });
+        }
+
+        #[divan::bench]
+        fn append(bencher: Bencher) {
+            append_impl(bencher, false);
+        }
+
+        #[divan::bench]
+        fn append_and_persist(bencher: Bencher) {
+            append_impl(bencher, true);
+        }
+    }
+}

--- a/benches/archival_mmr.rs
+++ b/benches/archival_mmr.rs
@@ -159,8 +159,8 @@ mod mutate {
                     for (new_leaf, leaf_index) in
                         digests.iter().zip(leaf_index_of_mutated_leafs.iter())
                     {
-                        let mp = ammr.prove_membership_async(*leaf_index).await.0;
-                        ammr.mutate_leaf(&mp, *new_leaf).await;
+                        let _mp = ammr.prove_membership_async(*leaf_index).await.0;
+                        ammr.mutate_leaf(*leaf_index, *new_leaf).await;
                     }
                     if persist {
                         storage.persist().await;

--- a/benches/archival_mmr.rs
+++ b/benches/archival_mmr.rs
@@ -159,7 +159,6 @@ mod mutate {
                     for (new_leaf, leaf_index) in
                         digests.iter().zip(leaf_index_of_mutated_leafs.iter())
                     {
-                        let _mp = ammr.prove_membership_async(*leaf_index).await.0;
                         ammr.mutate_leaf(*leaf_index, *new_leaf).await;
                     }
                     if persist {

--- a/benches/archival_mmr.rs
+++ b/benches/archival_mmr.rs
@@ -216,7 +216,7 @@ mod batch_mutate_leaf_and_update_mps {
 
             let mut mps = leaf_indices_for_mps_to_preserve
                 .iter()
-                .map(|i| rt.block_on(async { ammr.prove_membership_async(*i).await.0 }))
+                .map(|i| rt.block_on(async { ammr.prove_membership_async(*i).await }))
                 .collect_vec();
 
             bencher.bench_local(|| {

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -793,7 +793,7 @@ mod block_tests {
 
         let index = thread_rng().gen_range(0..blocks.len() - 1);
         let block_digest = blocks[index].hash();
-        let (membership_proof, _) = ammr.prove_membership_async(index as u64).await;
+        let membership_proof = ammr.prove_membership_async(index as u64).await;
         let (v, _) = membership_proof.verify(
             &last_block_mmra.get_peaks(),
             block_digest,

--- a/src/models/blockchain/transaction/validity/tasm/verify_aocl_membership.rs
+++ b/src/models/blockchain/transaction/validity/tasm/verify_aocl_membership.rs
@@ -210,7 +210,8 @@ mod tests {
 
                 let leaf_index = rng.next_u64() % num_leafs;
                 let leaf = mmr.get_leaf_async(leaf_index).await;
-                let (mmr_mp, peaks) = mmr.prove_membership_async(leaf_index).await;
+                let peaks = mmr.get_peaks().await;
+                let mmr_mp = mmr.prove_membership_async(leaf_index).await;
                 let mut msmp = pseudorandom_mutator_set_membership_proof(rng.gen());
                 msmp.auth_path_aocl = mmr_mp;
 

--- a/src/util_types/mutator_set/archival_mmr.rs
+++ b/src/util_types/mutator_set/archival_mmr.rs
@@ -123,19 +123,21 @@ where
         }
     }
 
-    /// Modify a bunch of leafs and keep a set of membership proofs in sync.
+    /// Modify a bunch of leafs and keep a set of membership proofs in sync. Notice that this
+    /// function is not just the application of `mutate_leaf` multiple times, as it also preserves
+    /// a list of membership proofs.
     pub async fn batch_mutate_leaf_and_update_mps(
         &mut self,
         membership_proofs: &mut [&mut MmrMembershipProof<H>],
-        mutation_data: Vec<(MmrMembershipProof<H>, Digest)>,
+        mutation_data: Vec<(u64, Digest)>,
     ) -> Vec<usize> {
         assert!(
-            mutation_data.iter().map(|md| md.0.leaf_index).all_unique(),
+            mutation_data.iter().map(|md| md.0).all_unique(),
             "Duplicated leaves are not allowed in membership proof updater"
         );
 
-        for (mp, digest) in mutation_data.iter() {
-            self.mutate_leaf(mp.leaf_index, *digest).await;
+        for (leaf_index, digest) in mutation_data.iter() {
+            self.mutate_leaf(*leaf_index, *digest).await;
         }
 
         let mut modified_mps: Vec<usize> = vec![];

--- a/src/util_types/mutator_set/archival_mutator_set.rs
+++ b/src/util_types/mutator_set/archival_mutator_set.rs
@@ -299,7 +299,7 @@ where
 
             // update archival mmr
             self.swbf_inactive
-                .mutate_leaf_raw_async(chunk_index, Hash::hash(&new_chunk))
+                .mutate_leaf(chunk_index, Hash::hash(&new_chunk))
                 .await;
 
             self.chunks.set(chunk_index, new_chunk).await;

--- a/src/util_types/mutator_set/archival_mutator_set.rs
+++ b/src/util_types/mutator_set/archival_mutator_set.rs
@@ -170,7 +170,7 @@ where
             )));
         }
 
-        Ok(self.aocl.prove_membership_async(index).await.0)
+        Ok(self.aocl.prove_membership_async(index).await)
     }
 
     /// Returns an authentication path for a chunk in the sliding window Bloom filter
@@ -184,11 +184,8 @@ where
             )));
         }
 
-        let chunk_auth_path: mmr::mmr_membership_proof::MmrMembershipProof<Hash> = self
-            .swbf_inactive
-            .prove_membership_async(chunk_index)
-            .await
-            .0;
+        let chunk_auth_path: mmr::mmr_membership_proof::MmrMembershipProof<Hash> =
+            self.swbf_inactive.prove_membership_async(chunk_index).await;
 
         // This check should never fail. It would mean that chunks are missing but that the
         // archival MMR has the membership proof for the chunk. That would be a programming
@@ -237,11 +234,8 @@ where
                 self.chunks.len().await > chunk_index,
                 "Chunks must be known if its authentication path is known."
             );
-            let chunk_membership_proof: mmr::mmr_membership_proof::MmrMembershipProof<Hash> = self
-                .swbf_inactive
-                .prove_membership_async(chunk_index)
-                .await
-                .0;
+            let chunk_membership_proof: mmr::mmr_membership_proof::MmrMembershipProof<Hash> =
+                self.swbf_inactive.prove_membership_async(chunk_index).await;
             target_chunks
                 .dictionary
                 .insert(chunk_index, (chunk_membership_proof, chunk.to_owned()));

--- a/src/util_types/mutator_set/chunk_dictionary.rs
+++ b/src/util_types/mutator_set/chunk_dictionary.rs
@@ -141,7 +141,7 @@ mod chunk_dict_tests {
         let archival_mmr = mock::get_ammr_from_digests::<H>(leaf_hashes).await;
 
         let key1: u64 = 898989;
-        let mp1: MmrMembershipProof<H> = archival_mmr.prove_membership_async(1).await.0;
+        let mp1: MmrMembershipProof<H> = archival_mmr.prove_membership_async(1).await;
         let chunk1: Chunk = {
             Chunk {
                 relative_indices: (0..CHUNK_SIZE).collect(),
@@ -153,7 +153,7 @@ mod chunk_dict_tests {
         // Insert two more element and verify that the hash is deterministic which implies that the
         // elements in the preimage are sorted deterministically.
         let key2: u64 = 8989;
-        let mp2: MmrMembershipProof<H> = archival_mmr.prove_membership_async(2).await.0;
+        let mp2: MmrMembershipProof<H> = archival_mmr.prove_membership_async(2).await;
         let mut chunk2 = Chunk::empty_chunk();
         chunk2.insert(CHUNK_SIZE / 2 + 1);
         let value2 = (mp2, chunk2);
@@ -215,7 +215,7 @@ mod chunk_dict_tests {
         let key: u64 = 898989;
         let leaf_hashes: Vec<Digest> = random_elements(3);
         let archival_mmr = mock::get_ammr_from_digests::<H>(leaf_hashes).await;
-        let mp: MmrMembershipProof<H> = archival_mmr.prove_membership_async(1).await.0;
+        let mp: MmrMembershipProof<H> = archival_mmr.prove_membership_async(1).await;
         let chunk = Chunk {
             relative_indices: (0..CHUNK_SIZE).collect(),
         };


### PR DESCRIPTION
Some optimizations of the archival-MMR which is used extensively by the archival mutator set. 

The method `prove_membership_async` changes its interface to only return the authentication path (membership proof) and not also the peaks of the MMR. If the peaks are needed, they can be requested separately.

`append` is more than 2x faster, and more than 10x (30x in one measurement) faster for the `append_and_persist` benchmark. The other benchmarks show improvements of around 20-50 %.

`append` and `batch_mutate_leaf_and_update_mps` are the most relevant methods, as they are used by the archival mutator set which is what we're aiming to speed up in #127.

Previous code:
```
Timer precision: 20 ns
archival_mmr                         fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ append                                          │               │               │               │         │
│  ╰─ append_5000                                  │               │               │               │         │
│     ├─ append                      20.34 ms      │ 76.49 ms      │ 24.05 ms      │ 24.84 ms      │ 100     │ 100
│     ╰─ append_and_persist          35.23 ms      │ 571.3 ms      │ 316.2 ms      │ 315.8 ms      │ 100     │ 100
├─ batch_mutate_leaf_and_update_mps                │               │               │               │         │
│  ╰─ mutate_100_of_10000                          │               │               │               │         │
│     ├─ leaf_mutation               1.67 ms       │ 3.219 ms      │ 1.682 ms      │ 1.725 ms      │ 100     │ 100
│     ╰─ leaf_mutation_and_persist   23.85 ms      │ 37.78 ms      │ 28.61 ms      │ 28.21 ms      │ 100     │ 100
╰─ mutate                                          │               │               │               │         │
   ╰─ mutate_100_of_10000                          │               │               │               │         │
      ├─ leaf_mutation               1.907 ms      │ 2.419 ms      │ 1.943 ms      │ 2.002 ms      │ 100     │ 100
      ╰─ leaf_mutation_and_persist   30.19 ms      │ 45.85 ms      │ 35.24 ms      │ 36.32 ms      │ 100     │ 100
```

This PR:
```
Timer precision: 50 ns
archival_mmr                         fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ append                                          │               │               │               │         │
│  ╰─ append_5000                                  │               │               │               │         │
│     ├─ append                      8.73 ms       │ 62.24 ms      │ 9.767 ms      │ 10.69 ms      │ 100     │ 100
│     ╰─ append_and_persist          17.61 ms      │ 28.69 ms      │ 18.86 ms      │ 19.34 ms      │ 100     │ 100
├─ batch_mutate_leaf_and_update_mps                │               │               │               │         │
│  ╰─ mutate_100_of_10000                          │               │               │               │         │
│     ├─ leaf_mutation               1.479 ms      │ 2.247 ms      │ 1.485 ms      │ 1.537 ms      │ 100     │ 100
│     ╰─ leaf_mutation_and_persist   18.14 ms      │ 29.83 ms      │ 26.65 ms      │ 26.43 ms      │ 100     │ 100
╰─ mutate                                          │               │               │               │         │
   ╰─ mutate_100_of_10000                          │               │               │               │         │
      ├─ leaf_mutation               1.328 ms      │ 2.682 ms      │ 1.336 ms      │ 1.392 ms      │ 100     │ 100
      ╰─ leaf_mutation_and_persist   8.355 ms      │ 25.51 ms      │ 9.262 ms      │ 9.466 ms      │ 100     │ 100
```

This closes #126.