### PR TITLE
make long-running CPU tasks run on tokio's blocking threadpool.

### DIFF
--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -407,6 +407,7 @@ impl MainLoopHandler {
                         if !stay_in_sync_mode {
                             info!("Exiting sync mode");
                             global_state_mut.net.syncing = false;
+                            self.main_to_miner_tx.send(MainToMiner::StopSyncing)?;
                         }
                     }
 
@@ -463,6 +464,7 @@ impl MainLoopHandler {
                     socket_addr, claimed_max_height, claimed_max_pow_family
                 );
                     global_state_mut.net.syncing = true;
+                    self.main_to_miner_tx.send(MainToMiner::StartSyncing)?;
                 }
             }
             PeerThreadToMain::RemovePeerMaxBlockHeight(socket_addr) => {

--- a/src/models/channel.rs
+++ b/src/models/channel.rs
@@ -24,6 +24,9 @@ pub enum MainToMiner {
 
     StopMining,
     StartMining,
+
+    StartSyncing,
+    StopSyncing,
     // SetCoinbasePubkey,
 }
 

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -564,8 +564,8 @@ impl GlobalState {
             .wallet_secret
             .nth_generation_spending_key(0);
 
-        // assemble transaction object
-        Ok(Self::create_transaction_from_data(
+        // assemble transaction object (lengthy operation)
+        Self::create_transaction_from_data(
             spending_key,
             inputs,
             spendable_utxos_and_mps,
@@ -576,7 +576,8 @@ impl GlobalState {
             timestamp.as_millis() as u64,
             mutator_set_accumulator,
             privacy,
-        ))
+        )
+        .await
     }
 
     /// Given a list of UTXOs with receiver data, assemble owned and synced and spendable
@@ -639,7 +640,47 @@ impl GlobalState {
     /// Assembles a transaction kernel and supporting witness or proof(s) from
     /// the given transaction data.
     #[allow(clippy::too_many_arguments)]
-    fn create_transaction_from_data(
+    async fn create_transaction_from_data(
+        spending_key: SpendingKey,
+        inputs: Vec<RemovalRecord>,
+        spendable_utxos_and_mps: Vec<(Utxo, LockScript, MsMembershipProof)>,
+        outputs: Vec<AdditionRecord>,
+        output_utxos: Vec<Utxo>,
+        fee: NeptuneCoins,
+        public_announcements: Vec<PublicAnnouncement>,
+        timestamp: u64,
+        mutator_set_accumulator: MutatorSetAccumulator,
+        privacy: bool,
+    ) -> Result<Transaction> {
+        // note: this executes the prover which can take a very
+        //       long time, perhaps minutes.  As such, we use
+        //       spawn_blocking() to execute on tokio's blocking
+        //       threadpool and avoid blocking the tokio executor
+        //       and other async tasks.
+        let transaction = tokio::task::spawn_blocking(move || {
+            Self::create_transaction_from_data_worker(
+                spending_key,
+                inputs,
+                spendable_utxos_and_mps,
+                outputs,
+                output_utxos,
+                fee,
+                public_announcements,
+                timestamp,
+                mutator_set_accumulator,
+                privacy,
+            )
+        })
+        .await?;
+        Ok(transaction)
+    }
+
+    // note: this executes the prover which can take a very
+    //       long time, perhaps minutes. It should never be
+    //       called directly.
+    //       Use create_transaction_from_data() instead.
+    #[allow(clippy::too_many_arguments)]
+    fn create_transaction_from_data_worker(
         spending_key: SpendingKey,
         inputs: Vec<RemovalRecord>,
         spendable_utxos_and_mps: Vec<(Utxo, LockScript, MsMembershipProof)>,
@@ -1285,7 +1326,7 @@ mod global_state_tests {
             .nth_generation_spending_key(0);
 
         // assemble transaction object
-        Ok(GlobalState::create_transaction_from_data(
+        GlobalState::create_transaction_from_data(
             spending_key,
             inputs,
             spendable_utxos_and_mps,
@@ -1296,7 +1337,8 @@ mod global_state_tests {
             timestamp,
             mutator_set_accumulator,
             privacy,
-        ))
+        )
+        .await
     }
 
     #[traced_test]


### PR DESCRIPTION
Partially addresses #122.

This PR makes the following potentially CPU intensive operations execute on tokio's blocking threadpool, so they do not block the tokio executor:

* `create_transaction_from_data()` which calls the prover
* the inner mining loop (still single-threaded)
* calls to triton_vm::program::Program::run() in `Transaction`

I am making this a PR rather than just pushing the commits for two reasons:

1. bring greater team awareness to the need to run any lengthy CPU ops on tokio's threadpool (or separate OS thread) and examples/methodology for doing so.
2. solicit input/suggestions as to other potentially lengthy/blocking computations.  (please comment in #122)
3. `spawn_blocking()` expects a non-async fn, so I changed the (inner) mining loop so it doesn't make any async calls, which means it can't check the global state `syncing` flag.  Instead the main loop notifies the (outer) mining loop when syncing starts and stops, which in turn halts or starts the (inner) mining loop which is running in tokio's threadpool.  This should speed the inner mining loop a little, as it no longer needs to acquire a lock after computing each hash.  Anyway, I thought @Sword-Smith may wish to review this change.

note: #130 has macros for logging fn call duration.  Once that is merged, we can easily log duration of any suspected targets to determine which are worth moving to the blocking threadpool.

Commits:

```
    perf: add spawn_blocking around script execution
    
    Wraps spawn_blocking around triton::program::Program::run() calls
    within Transaction::validate_primitive_witness().
    
    This enables tokio to put potentially lengthy blocking code on its own
    thread.
    
    There are additional ::run() calls in consensus/mod.rs however
    they are within sync code, and spawn_blocking() can only be called
    from within an async fn. Making those async is a big refactor, so
    it is possible future work.
```

```
    perf: wrap mining loop with spawn_blocking()
    
    The mining loop is very CPU intensive and thus very async-unfriendly.
    
    We wrap the loop with spawn-blocking so it can execute on tokio's
    blocking threadpool and thus avoid blocking async tasks on the
    same thread.
```

```
    fix: send syncing start/stop messages to miner
    
    The mining loop is no longer async as it is wrapped by
    spawn_blocking().

    Thus it can no longer await async futures.  So we cannot check
    the GlobalState syncing flag, which requires an async lock
    acquisition.
    
    Instead, the main task sends StartSyncing and StopSyncing
    messages to the mining task which cancels the mining thread
    when it receives StartSyncing.
```

```
    perf: wrap tx prover with spawn_blocking
    
    The prover may take a very long time (minutes) to run and should not
    block the tokio executor.
    
    As such, we wrap `create_transaction_from_data()` with
    `spawn_blocking()` in order to execute this task in tokio's blocking
    threadpool.
```
