### PR TITLE
Remove emojihash from Neptune Dashboard Overview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,6 +935,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
+name = "emojihash-rs"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8fb8b3d5d170ae72b4ecdff636f1ff4d384bea0d1ede30dcad8f7890a624d"
+dependencies = [
+ "sha2 0.8.2",
+]
+
+[[package]]
 name = "enum-ordinalize"
 version = "3.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,15 +935,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
-name = "emojihash-rs"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8fb8b3d5d170ae72b4ecdff636f1ff4d384bea0d1ede30dcad8f7890a624d"
-dependencies = [
- "sha2 0.8.2",
-]
-
-[[package]]
 name = "enum-ordinalize"
 version = "3.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/src/bin/dashboard_src/overview_screen.rs
+++ b/src/bin/dashboard_src/overview_screen.rs
@@ -1,4 +1,5 @@
 use neptune_core::models::blockchain::type_scripts::neptune_coins::NeptuneCoins;
+use neptune_core::prelude::twenty_first;
 
 use std::net::SocketAddr;
 use std::time::SystemTime;
@@ -14,6 +15,7 @@ use itertools::Itertools;
 use neptune_core::config_models::network::Network;
 use neptune_core::models::blockchain::block::block_header::BlockHeader;
 use neptune_core::models::blockchain::block::block_height::BlockHeight;
+use neptune_core::models::blockchain::shared::Hash;
 use neptune_core::rpc_server::RPCClient;
 use num_traits::Zero;
 use ratatui::{
@@ -23,6 +25,7 @@ use ratatui::{
 };
 use tarpc::context;
 use tokio::{select, task::JoinHandle, time};
+use twenty_first::util_types::algebraic_hasher::AlgebraicHasher;
 
 use super::dashboard_app::DashboardEvent;
 use super::screen::Screen;
@@ -388,6 +391,12 @@ impl Widget for OverviewScreen {
         lines.push(format!("synchronizing: {}", data.syncing));
 
         lines.push(format!("mining: {}", dashifnotset!(data.is_mining)));
+
+        let tip_digest = data.block_header.as_ref().map(Hash::hash);
+        lines.push(format!(
+            "tip digest:\n{}\n\n",
+            dashifnotset!(tip_digest),
+        ));
 
         lines.push(format!(
             "latest block timestamp: {}",

--- a/src/bin/dashboard_src/overview_screen.rs
+++ b/src/bin/dashboard_src/overview_screen.rs
@@ -1,5 +1,4 @@
 use neptune_core::models::blockchain::type_scripts::neptune_coins::NeptuneCoins;
-use neptune_core::prelude::twenty_first;
 
 use std::net::SocketAddr;
 use std::time::SystemTime;
@@ -15,7 +14,6 @@ use itertools::Itertools;
 use neptune_core::config_models::network::Network;
 use neptune_core::models::blockchain::block::block_header::BlockHeader;
 use neptune_core::models::blockchain::block::block_height::BlockHeight;
-use neptune_core::models::blockchain::shared::Hash;
 use neptune_core::rpc_server::RPCClient;
 use num_traits::Zero;
 use ratatui::{
@@ -25,8 +23,6 @@ use ratatui::{
 };
 use tarpc::context;
 use tokio::{select, task::JoinHandle, time};
-use twenty_first::util_types::algebraic_hasher::AlgebraicHasher;
-use twenty_first::util_types::emojihash_trait::Emojihash;
 
 use super::dashboard_app::DashboardEvent;
 use super::screen::Screen;
@@ -393,12 +389,11 @@ impl Widget for OverviewScreen {
 
         lines.push(format!("mining: {}", dashifnotset!(data.is_mining)));
 
-        // TODO: Do we want to show the emojihash here?
-        let tip_digest = data.block_header.as_ref().map(Hash::hash);
         lines.push(format!(
-            "tip digest:\n{}\n{}\n\n",
-            dashifnotset!(tip_digest.map(|x| x.emojihash())),
-            dashifnotset!(tip_digest),
+            "latest block timestamp: {}",
+            dashifnotset!(data.block_header.as_ref().map(|bh| {
+                neptune_core::utc_timestamp_to_localtime(bh.timestamp.value()).to_string()
+            })),
         ));
 
         lines.push(format!(

--- a/src/bin/dashboard_src/overview_screen.rs
+++ b/src/bin/dashboard_src/overview_screen.rs
@@ -392,7 +392,7 @@ impl Widget for OverviewScreen {
         lines.push(format!(
             "latest block timestamp: {}",
             dashifnotset!(data.block_header.as_ref().map(|bh| {
-                neptune_core::utc_timestamp_to_localtime(bh.timestamp.value()).to_string()
+                neptune_core::utc_timestamp_to_localtime(bh.timestamp.0.value()).to_string()
             })),
         ));
 

--- a/src/bin/dashboard_src/overview_screen.rs
+++ b/src/bin/dashboard_src/overview_screen.rs
@@ -393,10 +393,7 @@ impl Widget for OverviewScreen {
         lines.push(format!("mining: {}", dashifnotset!(data.is_mining)));
 
         let tip_digest = data.block_header.as_ref().map(Hash::hash);
-        lines.push(format!(
-            "tip digest:\n{}\n\n",
-            dashifnotset!(tip_digest),
-        ));
+        lines.push(format!("tip digest:\n{}\n\n", dashifnotset!(tip_digest),));
 
         lines.push(format!(
             "latest block timestamp: {}",

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -771,9 +771,7 @@ impl MainLoopHandler {
         let chosen_peer = chosen_peer.unwrap();
         info!(
             "Sending block batch request to {}\nrequesting blocks descending from {}\n height {}",
-            chosen_peer,
-            current_block_hash,
-            current_block_height
+            chosen_peer, current_block_hash, current_block_height
         );
         self.main_to_peer_broadcast_tx
             .send(MainToPeerThread::RequestBlockBatch(

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -24,7 +24,6 @@ use tokio::task::JoinHandle;
 use tokio::{select, signal, time};
 use tracing::{debug, error, info, warn};
 use twenty_first::amount::u32s::U32s;
-use twenty_first::util_types::emojihash_trait::Emojihash;
 
 use crate::models::channel::{
     MainToMiner, MainToPeerThread, MinerToMain, PeerThreadToMain, RPCServerToMain,
@@ -413,7 +412,7 @@ impl MainLoopHandler {
                     for new_block in blocks {
                         debug!(
                             "Storing block {} in database. Height: {}, Mined: {}",
-                            new_block.hash().emojihash(),
+                            new_block.hash(),
                             new_block.kernel.header.height,
                             new_block.kernel.header.timestamp.standard_format()
                         );
@@ -773,7 +772,7 @@ impl MainLoopHandler {
         info!(
             "Sending block batch request to {}\nrequesting blocks descending from {}\n height {}",
             chosen_peer,
-            current_block_hash.emojihash(),
+            current_block_hash,
             current_block_height
         );
         self.main_to_peer_broadcast_tx

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -41,7 +41,6 @@ use twenty_first::shared_math::b_field_element::BFieldElement;
 use twenty_first::shared_math::bfield_codec::BFieldCodec;
 use twenty_first::shared_math::digest::Digest;
 use twenty_first::util_types::algebraic_hasher::AlgebraicHasher;
-use twenty_first::util_types::emojihash_trait::Emojihash;
 
 use self::primitive_witness::SaltedUtxos;
 
@@ -279,7 +278,6 @@ fn create_block_transaction(
             .body
             .mutator_set_accumulator
             .hash()
-            .emojihash()
     );
 
     // Merge incoming transactions with the coinbase transaction
@@ -420,7 +418,7 @@ pub async fn mine(
                 let now = Timestamp::now();
                 assert!(new_block_info.block.is_valid(&latest_block, now), "Own mined block must be valid. Failed validity check after successful PoW check.");
 
-                info!("Found new {} block with block height {}. Hash: {}", global_state_lock.cli().network, new_block_info.block.kernel.header.height, new_block_info.block.hash().emojihash());
+                info!("Found new {} block with block height {}. Hash: {}", global_state_lock.cli().network, new_block_info.block.kernel.header.height, new_block_info.block.hash());
 
                 latest_block = *new_block_info.block.to_owned();
                 to_main.send(MinerToMain::NewBlockFound(new_block_info)).await?;

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -273,11 +273,7 @@ fn create_block_transaction(
 
     debug!(
         "Creating block transaction with mutator set hash: {}",
-        latest_block
-            .kernel
-            .body
-            .mutator_set_accumulator
-            .hash()
+        latest_block.kernel.body.mutator_set_accumulator.hash()
     );
 
     // Merge incoming transactions with the coinbase transaction

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -792,19 +792,11 @@ mod block_tests {
         assert!(
             v,
             "peaks: {} ({}) leaf count: {} index: {} path: {} number of blocks: {} leaf index: {}",
-            last_block_mmra
-                .get_peaks()
-                .iter()
-                .map(|d| d)
-                .join(","),
+            last_block_mmra.get_peaks().iter().join(","),
             last_block_mmra.get_peaks().len(),
             last_block_mmra.count_leaves(),
             membership_proof.leaf_index,
-            membership_proof
-                .authentication_path
-                .iter()
-                .map(|d| d)
-                .join(","),
+            membership_proof.authentication_path.iter().join(","),
             blocks.len(),
             membership_proof.leaf_index
         );

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -578,7 +578,6 @@ mod block_tests {
         util_types::mutator_set::archival_mmr::ArchivalMmr,
     };
     use strum::IntoEnumIterator;
-    use tasm_lib::twenty_first::util_types::emojihash_trait::Emojihash;
 
     use super::*;
 
@@ -644,13 +643,11 @@ mod block_tests {
             genesis_block.kernel
                 .body
                 .mutator_set_accumulator
-                .hash()
-                .emojihash(),
+                .hash(),
                 block_1.kernel
                     .body
                     .mutator_set_accumulator
                     .hash()
-                    .emojihash()
         );
 
         // Sanity checks
@@ -798,7 +795,7 @@ mod block_tests {
             last_block_mmra
                 .get_peaks()
                 .iter()
-                .map(|d| d.emojihash())
+                .map(|d| d)
                 .join(","),
             last_block_mmra.get_peaks().len(),
             last_block_mmra.count_leaves(),
@@ -806,7 +803,7 @@ mod block_tests {
             membership_proof
                 .authentication_path
                 .iter()
-                .map(|d| d.emojihash())
+                .map(|d| d)
                 .join(","),
             blocks.len(),
             membership_proof.leaf_index

--- a/src/models/blockchain/transaction/mod.rs
+++ b/src/models/blockchain/transaction/mod.rs
@@ -24,7 +24,6 @@ use triton_vm::prelude::NonDeterminism;
 use twenty_first::shared_math::b_field_element::BFieldElement;
 use twenty_first::shared_math::bfield_codec::BFieldCodec;
 use twenty_first::util_types::algebraic_hasher::AlgebraicHasher;
-use twenty_first::util_types::emojihash_trait::Emojihash;
 
 use self::primitive_witness::PrimitiveWitness;
 use self::transaction_kernel::TransactionKernel;
@@ -446,11 +445,11 @@ impl Transaction {
                 );
                 debug!(
                     "witness mutator set hash: {}",
-                    primitive_witness.mutator_set_accumulator.hash().emojihash()
+                    primitive_witness.mutator_set_accumulator.hash()
                 );
                 debug!(
                     "kernel mutator set hash: {}",
-                    self.kernel.mutator_set_hash.emojihash()
+                    self.kernel.mutator_set_hash
                 );
                 return false;
             }
@@ -505,7 +504,7 @@ impl Transaction {
             {
                 warn!(
                     "Type script {} not satisfied for transaction: {}",
-                    type_script_hash.emojihash(),
+                    type_script_hash,
                     e
                 );
                 return false;
@@ -545,14 +544,14 @@ impl Transaction {
                 "observed: {}",
                 witnessed_removal_record_hashes
                     .iter()
-                    .map(|d| d.emojihash())
+                    .map(|d| d)
                     .join(",")
             );
             warn!(
                 "listed: {}",
                 listed_removal_record_hashes
                     .iter()
-                    .map(|d| d.emojihash())
+                    .map(|d| d)
                     .join(",")
             );
             return false;
@@ -565,11 +564,11 @@ impl Transaction {
             warn!("Transaction's mutator set hash does not correspond to the mutator set that the removal records were derived from. Therefore: can't verify that the inputs even exist.");
             debug!(
                 "Transaction mutator set hash: {}",
-                self.kernel.mutator_set_hash.emojihash()
+                self.kernel.mutator_set_hash
             );
             debug!(
                 "Witness mutator set hash: {}",
-                primitive_witness.mutator_set_accumulator.hash().emojihash()
+                primitive_witness.mutator_set_accumulator.hash()
             );
             return false;
         }

--- a/src/models/blockchain/transaction/mod.rs
+++ b/src/models/blockchain/transaction/mod.rs
@@ -544,14 +544,12 @@ impl Transaction {
                 "observed: {}",
                 witnessed_removal_record_hashes
                     .iter()
-                    .map(|d| d)
                     .join(",")
             );
             warn!(
                 "listed: {}",
                 listed_removal_record_hashes
                     .iter()
-                    .map(|d| d)
                     .join(",")
             );
             return false;

--- a/src/models/blockchain/transaction/mod.rs
+++ b/src/models/blockchain/transaction/mod.rs
@@ -447,10 +447,7 @@ impl Transaction {
                     "witness mutator set hash: {}",
                     primitive_witness.mutator_set_accumulator.hash()
                 );
-                debug!(
-                    "kernel mutator set hash: {}",
-                    self.kernel.mutator_set_hash
-                );
+                debug!("kernel mutator set hash: {}", self.kernel.mutator_set_hash);
                 return false;
             }
             let removal_record = primitive_witness.mutator_set_accumulator.drop(item, msmp);
@@ -504,8 +501,7 @@ impl Transaction {
             {
                 warn!(
                     "Type script {} not satisfied for transaction: {}",
-                    type_script_hash,
-                    e
+                    type_script_hash, e
                 );
                 return false;
             }
@@ -542,16 +538,9 @@ impl Transaction {
                 .collect_vec();
             warn!(
                 "observed: {}",
-                witnessed_removal_record_hashes
-                    .iter()
-                    .join(",")
+                witnessed_removal_record_hashes.iter().join(",")
             );
-            warn!(
-                "listed: {}",
-                listed_removal_record_hashes
-                    .iter()
-                    .join(",")
-            );
+            warn!("listed: {}", listed_removal_record_hashes.iter().join(","));
             return false;
         }
 

--- a/src/models/blockchain/transaction/validity/tasm/hash_index_list.rs
+++ b/src/models/blockchain/transaction/validity/tasm/hash_index_list.rs
@@ -241,8 +241,8 @@ mod tests {
             tasm_digests,
             rust_digests,
             "\ntasm: ({})\nrust: ({})",
-            tasm_digests.iter().map(|d| d).join(", "),
-            rust_digests.iter().map(|d| d).join(", ")
+            tasm_digests.iter().join(", "),
+            rust_digests.iter().join(", ")
         );
     }
 }

--- a/src/models/blockchain/transaction/validity/tasm/hash_index_list.rs
+++ b/src/models/blockchain/transaction/validity/tasm/hash_index_list.rs
@@ -145,9 +145,7 @@ mod tests {
         traits::function::ShadowedFunction,
     };
     use triton_vm::prelude::{Digest, NonDeterminism};
-    use twenty_first::{
-        shared_math::{bfield_codec::BFieldCodec, tip5::DIGEST_LENGTH}
-    };
+    use twenty_first::shared_math::{bfield_codec::BFieldCodec, tip5::DIGEST_LENGTH};
 
     use super::*;
 

--- a/src/models/blockchain/transaction/validity/tasm/hash_index_list.rs
+++ b/src/models/blockchain/transaction/validity/tasm/hash_index_list.rs
@@ -146,8 +146,7 @@ mod tests {
     };
     use triton_vm::prelude::{Digest, NonDeterminism};
     use twenty_first::{
-        shared_math::{bfield_codec::BFieldCodec, tip5::DIGEST_LENGTH},
-        util_types::emojihash_trait::Emojihash,
+        shared_math::{bfield_codec::BFieldCodec, tip5::DIGEST_LENGTH}
     };
 
     use super::*;
@@ -242,8 +241,8 @@ mod tests {
             tasm_digests,
             rust_digests,
             "\ntasm: ({})\nrust: ({})",
-            tasm_digests.iter().map(|d| d.emojihash()).join(", "),
-            rust_digests.iter().map(|d| d.emojihash()).join(", ")
+            tasm_digests.iter().map(|d| d).join(", "),
+            rust_digests.iter().map(|d| d).join(", ")
         );
     }
 }

--- a/src/models/state/archival_state.rs
+++ b/src/models/state/archival_state.rs
@@ -564,18 +564,11 @@ impl ArchivalState {
         let block_header = self
             .get_block_header(block_digest)
             .await
-            .unwrap_or_else(|| {
-                panic!(
-                    "Could not get block header by digest: {}",
-                    block_digest
-                )
-            });
-        let tip_header = self.get_block_header(tip_digest).await.unwrap_or_else(|| {
-            panic!(
-                "Could not get block header by digest: {}",
-                tip_digest
-            )
-        });
+            .unwrap_or_else(|| panic!("Could not get block header by digest: {}", block_digest));
+        let tip_header = self
+            .get_block_header(tip_digest)
+            .await
+            .unwrap_or_else(|| panic!("Could not get block header by digest: {}", tip_digest));
 
         // If block is tip or parent to tip, then block belongs to canonical chain
         if tip_digest == block_digest || tip_header.prev_block_digest == block_digest {

--- a/src/models/state/archival_state.rs
+++ b/src/models/state/archival_state.rs
@@ -7,7 +7,6 @@ use memmap2::MmapOptions;
 use num_traits::Zero;
 use std::ops::DerefMut;
 use std::path::PathBuf;
-use tasm_lib::twenty_first::util_types::emojihash_trait::Emojihash;
 use tokio::io::AsyncSeekExt;
 use tokio::io::AsyncWriteExt;
 use tokio::io::SeekFrom;
@@ -544,9 +543,8 @@ impl ArchivalState {
                 .await
                 .unwrap_or_else(
                     || panic!(
-                        "Cannot get block header from digest, even though digest was fetched from height. Digest: {}/{}",
-                        child_digest,
-                        child_digest.emojihash()
+                        "Cannot get block header from digest, even though digest was fetched from height. Digest: {}",
+                        child_digest
                     )
                 );
             if child_header.prev_block_digest == parent_block_digest {
@@ -568,16 +566,14 @@ impl ArchivalState {
             .await
             .unwrap_or_else(|| {
                 panic!(
-                    "Could not get block header by digest: {}/{}",
-                    block_digest,
-                    block_digest.emojihash()
+                    "Could not get block header by digest: {}",
+                    block_digest
                 )
             });
         let tip_header = self.get_block_header(tip_digest).await.unwrap_or_else(|| {
             panic!(
-                "Could not get block header by digest: {}/{}",
-                tip_digest,
-                tip_digest.emojihash()
+                "Could not get block header by digest: {}",
+                tip_digest
             )
         });
 

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -696,11 +696,7 @@ mod tests {
 
         debug!(
             "Just made block with previous mutator set hash {}",
-            block_2
-                .kernel
-                .body
-                .mutator_set_accumulator
-                .hash()
+            block_2.kernel.body.mutator_set_accumulator.hash()
         );
         debug!(
             "Just made block with next mutator set hash {}",

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -412,7 +412,6 @@ mod tests {
     use num_bigint::BigInt;
     use num_traits::Zero;
     use rand::{random, rngs::StdRng, thread_rng, Rng, SeedableRng};
-    use tasm_lib::twenty_first::util_types::emojihash_trait::Emojihash;
     use tracing::debug;
     use tracing_test::traced_test;
 
@@ -688,7 +687,7 @@ mod tests {
 
         debug!(
             "mempool now has transaction relative to mutator set hash {}",
-            tx_by_other_updated.kernel.mutator_set_hash.emojihash()
+            tx_by_other_updated.kernel.mutator_set_hash
         );
 
         let (block_3_with_no_input, _, _) =
@@ -702,7 +701,6 @@ mod tests {
                 .body
                 .mutator_set_accumulator
                 .hash()
-                .emojihash()
         );
         debug!(
             "Just made block with next mutator set hash {}",
@@ -711,12 +709,11 @@ mod tests {
                 .body
                 .mutator_set_accumulator
                 .hash()
-                .emojihash()
         );
 
         debug!(
             "tx_by_other_updated has mutator set hash: {}",
-            tx_by_other_updated.kernel.mutator_set_hash.emojihash()
+            tx_by_other_updated.kernel.mutator_set_hash
         );
         block_3_with_updated_tx
             .accumulate_transaction(

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -21,7 +21,6 @@ use tracing::{debug, error, info, warn};
 use twenty_first::shared_math::bfield_codec::BFieldCodec;
 use twenty_first::shared_math::digest::Digest;
 use twenty_first::util_types::algebraic_hasher::AlgebraicHasher;
-use twenty_first::util_types::emojihash_trait::Emojihash;
 
 use super::coin_with_possible_timelock::CoinWithPossibleTimeLock;
 use super::rusty_wallet_database::RustyWalletDatabase;
@@ -433,7 +432,7 @@ impl WalletState {
                 let receiver_preimage = addition_record_to_utxo_info[&addition_record].2;
                 info!(
                     "Received UTXO in block {}, height {}: value = {}",
-                    new_block.hash().emojihash(),
+                    new_block.hash(),
                     new_block.kernel.header.height,
                     utxo.coins
                         .iter()
@@ -704,7 +703,7 @@ impl WalletState {
                 wallet_status.synced_unspent_timelocked_amount(timestamp),
                 wallet_status.unsynced_unspent.len(),
                 wallet_status.unsynced_unspent_amount(),
-                tip_digest.emojihash());
+                tip_digest);
         }
 
         let mut ret: Vec<(Utxo, LockScript, MsMembershipProof)> = vec![];


### PR DESCRIPTION
This is my first contribution to Neptune  that addresses Issue #26 

## Before Change

![Screenshot from 2024-04-08 16-02-36](https://github.com/Neptune-Crypto/neptune-core/assets/161740412/5d3fb55c-2883-4461-869e-a2a372cad7c9)



## After Change Image

![Screenshot from 2024-04-10 12-50-47](https://github.com/Neptune-Crypto/neptune-core/assets/161740412/d1e53082-1b93-48f6-b6a8-ab1690234420)


I didn't quite follow in the code why the default value of of the timestamp is July 1, 2024, or perhaps value this is explained by some issue syncing to the blockchain on my machine, I am open to feedback on this.

