### PR TITLE
perf: avoid holding write-lock across prove()

### DIFF
--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -508,7 +508,7 @@ mod mine_loop_tests {
             coins: four_neptune_coins,
             lock_script_hash: LockScript::anyone_can_spend().hash(),
         };
-        let tx_by_preminer = premine_receiver_global_state
+        let (tx_by_preminer, _) = premine_receiver_global_state
             .create_transaction(
                 vec![
                     (UtxoReceiverData {

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -623,7 +623,7 @@ mod block_tests {
             sender_randomness: random(),
             utxo: new_utxo,
         };
-        let new_tx = global_state_lock
+        let (new_tx, _) = global_state_lock
             .lock_guard_mut()
             .await
             .create_transaction(

--- a/src/models/state/archival_state.rs
+++ b/src/models/state/archival_state.rs
@@ -1004,7 +1004,7 @@ mod archival_state_tests {
                 own_receiving_address,
                 rng.gen(),
             );
-            let sender_tx = genesis_receiver_global_state
+            let (sender_tx, _) = genesis_receiver_global_state
                 .create_transaction(
                     vec![UtxoReceiverData {
                         public_announcement: PublicAnnouncement::default(),
@@ -1150,7 +1150,7 @@ mod archival_state_tests {
                 public_announcement: PublicAnnouncement::default(),
             },
         ];
-        let sender_tx = global_state_lock
+        let (sender_tx, _) = global_state_lock
             .lock_guard_mut()
             .await
             .create_transaction(receiver_data, NeptuneCoins::new(4), now + seven_months)
@@ -1284,7 +1284,7 @@ mod archival_state_tests {
                     public_announcement: PublicAnnouncement::default(),
                 },
             ];
-            let sender_tx = global_state
+            let (sender_tx, _) = global_state
                 .create_transaction(receiver_data, NeptuneCoins::new(4), now + seven_months)
                 .await
                 .unwrap();
@@ -1436,7 +1436,7 @@ mod archival_state_tests {
                 lock_script_hash: LockScript::anyone_can_spend().hash(),
             },
         };
-        let sender_tx = global_state_lock
+        let (sender_tx, _) = global_state_lock
             .lock_guard_mut()
             .await
             .create_transaction(vec![receiver_data], one_money, now + seven_months)
@@ -1697,7 +1697,7 @@ mod archival_state_tests {
                 public_announcement: PublicAnnouncement::default(),
             },
         ];
-        let tx_from_alice = alice_state_lock
+        let (tx_from_alice, _) = alice_state_lock
             .lock_guard_mut()
             .await
             .create_transaction(

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -631,7 +631,7 @@ mod tests {
         }
         let mut now = genesis_block.kernel.header.timestamp;
         let seven_months = Timestamp::months(7);
-        let tx_by_preminer = premine_receiver_global_state
+        let (tx_by_preminer, _) = premine_receiver_global_state
             .create_transaction(
                 output_utxos_generated_by_me,
                 NeptuneCoins::new(1),
@@ -657,7 +657,7 @@ mod tests {
             receiver_privacy_digest: other_receiver_address.privacy_digest,
             public_announcement: PublicAnnouncement::default(),
         }];
-        let tx_by_other_original = other_global_state
+        let (tx_by_other_original, _) = other_global_state
             .create_transaction(
                 output_utxo_data_by_miner,
                 NeptuneCoins::new(1),
@@ -802,7 +802,7 @@ mod tests {
             sender_randomness: random(),
             public_announcement: PublicAnnouncement::default(),
         };
-        let tx_by_preminer_low_fee = preminer_state
+        let (tx_by_preminer_low_fee, _) = preminer_state
             .create_transaction(
                 vec![receiver_data.clone()],
                 NeptuneCoins::new(1),
@@ -824,7 +824,7 @@ mod tests {
 
         // Insert a transaction that spends the same UTXO and has a higher fee.
         // Verify that this replaces the previous transaction.
-        let tx_by_preminer_high_fee = preminer_state
+        let (tx_by_preminer_high_fee, _) = preminer_state
             .create_transaction(
                 vec![receiver_data.clone()],
                 NeptuneCoins::new(10),
@@ -843,7 +843,7 @@ mod tests {
 
         // Insert a conflicting transaction with a lower fee and verify that it
         // does *not* replace the existing transaction.
-        let tx_by_preminer_medium_fee = preminer_state
+        let (tx_by_preminer_medium_fee, _) = preminer_state
             .create_transaction(
                 vec![receiver_data],
                 NeptuneCoins::new(4),

--- a/src/models/state/wallet/mod.rs
+++ b/src/models/state/wallet/mod.rs
@@ -868,7 +868,7 @@ mod wallet_tests {
         };
         let receiver_data_to_other = vec![receiver_data_12_to_other, receiver_data_one_to_other];
         let mut now = genesis_block.kernel.header.timestamp;
-        let valid_tx = premine_receiver_global_state
+        let (valid_tx, _) = premine_receiver_global_state
             .create_transaction(
                 receiver_data_to_other.clone(),
                 NeptuneCoins::new(2),
@@ -1138,7 +1138,7 @@ mod wallet_tests {
             },
             sender_randomness: random(),
         };
-        let tx_from_preminer = premine_receiver_global_state
+        let (tx_from_preminer, _) = premine_receiver_global_state
             .create_transaction(vec![receiver_data_six.clone()], NeptuneCoins::new(4), now)
             .await
             .unwrap();


### PR DESCRIPTION
Addresses #122

note: the logic changes are in src/models/state/mod.rs and src/rpc_server.rs.  All other files are just updating syntax in unit tests.

Previously a write-lock was held across `create_transaction()` which includes a lengthy (potentially minutes) call to `prove`.  This would be unacceptably bad for concurrency as most p2p and rpc operations would block waiting for the lock until `prove()` finally finishes.

This commit makes create_transaction() take `&self` instead of `&mut self`.  So it is now a read-only op.

Only a single mutation was being performed inside `add_change()` which is indirectly called by `create_transaction()`.  This is now moved into `send()` RPC after `create_transaction()` completes. The write-lock acquisition is likewise moved, so it should only be held very briefly while adding a record to wallet's `expected_utxos`.

I am making this a draft PR because:
a) 4 tests are failing due to the change and need to be fixed.
b) I have some q's I would like to resolve about updating the wallet before I consider this ready to merge.
c) it's possible this could be done a different way or more elegantly.  I don't really like that create_transaction() now returns a tuple instead of just a `Transaction`.

I put my q's in a comment within `send()`.  I will expand on them here:

1. Is it really necessary to add the change Utxo to wallet's expected UTXOs when creating a Tx?  Why can't the wallet be informed of change UTXO when Tx enters mempool and/or block is confirmed like any other incoming utxo?  I ask because If it is not necessary, we could then avoid any mutation/write (and write lock) during send().

2. A comment in the code indicates that we add the change UTXO to pool of expected incoming UTXOs so that we can synchronize it after it is confirmed.  I don't understand this.  a) What is meant by "synchronize" and why wouldn't it synchronize?   b) what is special about this change UTXO vs the other UTXOs in the transaction we are sending (that we don't write anywhere)?

Regarding making this commit more elegant.   I created a new struct ChangeUtxoData to return data from CreateTransaction for the caller to update wallet if necessary.  I'm not 100% certain this new struct is necessary. There is already `UtxoReceiverData` which is similar.  Anyway, I would say this area is worth reviewing.  And also if it turns out we don't really have to update the wallet state, then `ChangeUtxoData` can go away anyway.