### PR TITLE
Feature : Get CPU temperature over the RPC 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1608,6 +1608,7 @@ dependencies = [
  "serde_json",
  "sha3",
  "strum 0.25.0",
+ "systemstat",
  "tarpc",
  "tasm-lib",
  "test-strategy",
@@ -2629,6 +2630,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "systemstat"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a24aec24a9312c83999a28e3ef9db7e2afd5c64bf47725b758cdc1cafd5b0bd2"
+dependencies = [
+ "bytesize",
+ "lazy_static",
+ "libc",
+ "nom",
+ "time",
+ "winapi",
+]
+
+[[package]]
 name = "tarpc"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2673,7 +2688,7 @@ dependencies = [
  "const_format",
  "derive_tasm_object",
  "hex",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "ndarray",
  "num",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ leveldb-sys = "2.0.9"
 async-trait = "0.1.77"
 async-stream = "0.3.5"
 sha3 = "0.10.8"
+systemstat = "0.2.3"
 
 [dev-dependencies]
 test-strategy = "0.3"

--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -752,7 +752,7 @@ impl RPC for NeptuneRPCServer {
             .await
     }
 
-    async fn cpu_temp(self, _context: Context) -> Option<f64> {
+    async fn cpu_temp(self, _context: tarpc::context::Context) -> Option<f64> {
         let current_system = System::new();
         match current_system.cpu_temp() {
             Ok(temp) => Some(temp.into()),

--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -1111,7 +1111,7 @@ mod rpc_server_tests {
     #[traced_test]
     #[tokio::test]
     async fn test_can_get_server_temperature() {
-        let (rpc_server, state_lock) =
+        let (rpc_server, _state_lock) =
             test_rpc_server(Network::Alpha, WalletSecret::new_random(), 2).await;
         let current_server_temperature = rpc_server.get_cpu_temps(context::current()).await;
         // Silicon Macs do not provide CPU temperature using systemstat

--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -749,7 +749,7 @@ impl RPC for NeptuneRPCServer {
             .await
     }
 
-    async fn cpu_temp(self, _context: tarpc::context::Context) -> Option<f64> {
+    async fn cpu_temp(self, _context: Context) -> Option<f64> {
         let current_system = System::new();
         match current_system.cpu_temp() {
             Ok(temp) => Some(temp.into()),

--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -1148,7 +1148,7 @@ mod rpc_server_tests {
         } else {
             assert!(current_server_temperature.is_some());
         }
-  }
+    }
 
     #[traced_test]
     #[tokio::test]

--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -199,7 +199,7 @@ pub trait RPC {
     async fn shutdown() -> bool;
 
     /// Get CPU temperature.
-    async fn get_cpu_temps() -> Option<f64>;
+    async fn cpu_temp() -> Option<f64>;
 }
 
 #[derive(Clone)]
@@ -723,7 +723,7 @@ impl RPC for NeptuneRPCServer {
             .await
     }
 
-    async fn get_cpu_temps(self, _context: tarpc::context::Context) -> Option<f64> {
+    async fn cpu_temp(self, _context: tarpc::context::Context) -> Option<f64> {
         let current_system = System::new();
         match current_system.cpu_temp() {
             Ok(temp) => Some(temp.into()),
@@ -1113,7 +1113,7 @@ mod rpc_server_tests {
     async fn test_can_get_server_temperature() {
         let (rpc_server, _state_lock) =
             test_rpc_server(Network::Alpha, WalletSecret::new_random(), 2).await;
-        let current_server_temperature = rpc_server.get_cpu_temps(context::current()).await;
+        let current_server_temperature = rpc_server.cpu_temp(context::current()).await;
         // Silicon Macs do not provide CPU temperature using systemstat
         if std::env::consts::OS == "macos" {
             assert!(current_server_temperature.is_none());

--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -1138,7 +1138,6 @@ mod rpc_server_tests {
         Ok(())
     }
 
-    #[allow(clippy::shadow_unrelated)]
     #[traced_test]
     #[tokio::test]
     async fn test_can_get_server_temperature() {


### PR DESCRIPTION
Addresses : #138.

**Description**:

This pull request introduces the implementation of the get_cpu_temps method, which retrieves the CPU temperature for use in the dashboard. This feature leverages the systemstat library.

The `get_cpu_temps` method is located in` /src/rpc_server.rs` to facilitate its use via the RPC server.

It's important to note that the systemstat library does not support CPU temperature retrieval on Silicon Macs, as Apple has disabled this feature. Consequently, the associated test is designed to expect a None result when running on macOS.


As in `/src/bin/dashboard_src/overview_screen.rs`, `cpu_temperature` is a Option<f64>, I converted the f32 we get from `systemstat` into f64.