### PR TITLE
Optimize get_peaks_and_heights for archival MMR.

### DIFF
--- a/src/util_types/mutator_set/archival_mmr.rs
+++ b/src/util_types/mutator_set/archival_mmr.rs
@@ -232,13 +232,13 @@ impl<H: AlgebraicHasher, Storage: StorageVec<Digest>> ArchivalMmr<H, Storage> {
         let (peak_heights, peak_node_indices) = get_peak_heights_and_peak_node_indices(leaf_count);
         let peaks = self.digests.get_many(&peak_node_indices).await;
 
-        let peak_heights_and_values: Vec<_> = peaks
+        let peaks_and_heights: Vec<_> = peaks
             .iter()
             .zip(peak_heights.iter())
             .map(|(&x, &y)| (x, y))
             .collect();
 
-        peak_heights_and_values
+        peaks_and_heights
     }
 
     /// Remove the last leaf from the archival MMR


### PR DESCRIPTION
This PR is a response to Issue #125 

I chose to keep the `get_peaks_and_heights_async` and place the new functionality inside it rather than in `get_peaks` because the async function is used 5 or 6 times within the test suite.  I ran the benchmarks before and after the change and obtained the following results:

Master:

![before_change](https://github.com/Neptune-Crypto/neptune-core/assets/161740412/6002eda8-c6ac-4977-9a4e-ce26c601b367)


My PR:

![after_change](https://github.com/Neptune-Crypto/neptune-core/assets/161740412/29e59719-478e-4ec9-bff1-37bb891b92c9)


In multiple runs I noticed the same small but consistent improvement on my machine, its possible that in setups with different tradeoffs between disk I/O and CPU speed, the difference would be more pronounced. 

EDIT: 

I definitely see even more gains after removing the `get_peaks_and_heights_async` function completely



![deeper_cut](https://github.com/Neptune-Crypto/neptune-core/assets/161740412/28a8e7bd-3b8d-4f17-8e2e-7b3133d33be3)