### PR TITLE
Thv/#145 reorganization of mempool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ test: export RUST_BACKTRACE = 1
 test:
 	$(info RUSTFLAGS is $(RUSTFLAGS))
 	cargo nextest r
+	cargo test --doc
 
 bench:
 	$(info RUSTFLAGS is $(RUSTFLAGS))

--- a/developer_docs/reorganizations.md
+++ b/developer_docs/reorganizations.md
@@ -1,0 +1,51 @@
+# How different parts of the state handle reorganizations
+Neptune is a blockchain which features recursive STARK proofs as part of its
+consensus mechanism. This implies that participants can synchronize trustlessly
+by simply downloading the latest block and verifying this. Unlike most other
+blockchains, it is not necessary to download all historical blocks to get a
+cryptographically verified view of the state of the blockchain.
+
+It is possible, though, to run an archival node that downloads all historical
+blocks. This archival node comes with additional functionality such as being
+able to reconstruct transaction's membership proofs, provide some historical
+transaction statistics, and allow other archival nodes to synchronize.
+
+This document provides an overview of how different parts of the client's state
+handle reorganizations.
+
+## State overview
+The client's state consists of the following parts:
+- wallet
+- light state
+- archival state (optional)
+- mempool
+
+The wallet handles transactions that the client holds the spending keys for.
+The light state contains the latest blocks which verifies the validity of the
+entire history of the blockchain. The archival state is optional and allows,
+among other things, the client to re-synchronize wallets that are no longer
+up-to-date. The mempool keeps track of transactions that are not yet included
+in blocks, thus allowing miners to confirm transactions by picking some from
+the mempool to include in the next block.
+
+### Wallet
+The wallet can handle reorganizations that are up to `n` blocks deep, where `n`
+can be controlled with the CLI argument `number_of_mps_per_utxo`.
+Reorganizations that are deeper than this will make the membership proofs of
+the transactions temporarily invalid until they can be recovered either through
+the client's own archival state (if it exists), or through a peer's archival
+state. This recovery process happens automatically.
+
+### Light State
+The light state only contains the latest block and thus can handle arbitrarily
+deep reorganizations.
+
+### Archival State
+The archival state can handle arbitrarily deep reorganizations.
+
+### Mempool
+The mempool can *currently* not handle reorganizations. If a reorganization
+occurs, all transactions in the mempool will be deleted, and the initiator of a
+transaction will have to publish the transaction again. The transactions that
+were included in blocks that are abandoned through this reorganization are not
+added to the mempool again, they also have to be published again.

--- a/developer_docs/reorganizations.md
+++ b/developer_docs/reorganizations.md
@@ -1,4 +1,4 @@
-# How different parts of the state handle reorganizations
+# How neptune-core handles reorganizations
 Neptune is a blockchain which features recursive STARK proofs as part of its
 consensus mechanism. This implies that participants can synchronize trustlessly
 by simply downloading the latest block and verifying this. Unlike most other
@@ -21,7 +21,7 @@ The client's state consists of the following parts:
 - mempool
 
 The wallet handles transactions that the client holds the spending keys for.
-The light state contains the latest blocks which verifies the validity of the
+The light state contains the latest block which verifies the validity of the
 entire history of the blockchain. The archival state is optional and allows,
 among other things, the client to re-synchronize wallets that are no longer
 up-to-date. The mempool keeps track of transactions that are not yet included

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,7 +138,7 @@ pub async fn initialize(cli_args: cli_args::Args) -> Result<()> {
         archival_state,
     };
     let blockchain_state = BlockchainState::Archival(blockchain_archival_state);
-    let mempool = Mempool::new(cli_args.max_mempool_size);
+    let mempool = Mempool::new(cli_args.max_mempool_size, latest_block.hash());
     let global_state_lock = GlobalStateLock::new(
         wallet_state,
         blockchain_state,

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -73,11 +73,15 @@ pub struct Mempool {
     /// both descending and ascending order.
     #[get_size(ignore)] // This is relatively small compared to `LookupTable`
     queue: DoublePriorityQueue<Digest, FeeDensity>,
+
+    /// Records the digest of the block that the transactions were synced to.
+    /// Used to discover reorganizations.
+    tip_digest: Digest,
 }
 
 impl Mempool {
     /// instantiate a new, empty `Mempool`
-    pub fn new(max_total_size: ByteSize) -> Self {
+    pub fn new(max_total_size: ByteSize, tip_digest: Digest) -> Self {
         let table = Default::default();
         let queue = Default::default();
         let max_total_size = max_total_size.0.try_into().unwrap();
@@ -85,7 +89,13 @@ impl Mempool {
             max_total_size,
             tx_dictionary: table,
             queue,
+            tip_digest,
         }
+    }
+
+    /// Update the block digest to which all transactions are synced.
+    fn set_tip_digest_sync_label(&mut self, tip_digest: Digest) {
+        self.tip_digest = tip_digest;
     }
 
     /// check if transaction exists in mempool
@@ -181,6 +191,12 @@ impl Mempool {
         }
 
         None
+    }
+
+    /// Delete all transactions from the mempool.
+    pub fn clear(&mut self) {
+        self.queue.clear();
+        self.tx_dictionary.clear();
     }
 
     /// Return the number of transactions currently stored in the Mempool.
@@ -304,6 +320,15 @@ impl Mempool {
         previous_mutator_set_accumulator: MutatorSetAccumulator,
         block: &Block,
     ) {
+        // If we discover a reorganization, we currently just clear the mempool,
+        // as we don't have the ability to roll transaction removal record integrity
+        // proofs back to previous blocks. It would be nice if we could handle a
+        // reorganization that's at least a few blocks deep though.
+        let previous_block_digest = block.header().prev_block_digest;
+        if self.tip_digest != previous_block_digest {
+            self.clear();
+        }
+
         // The general strategy is to check whether the SWBF index set of a given
         // transaction in the mempool is disjoint (*i.e.*, not contained by) the
         // SWBF indices coming from the block transaction. If they are not disjoint,
@@ -356,6 +381,10 @@ impl Mempool {
         // transactions in the mempool. So we should shrink it to max size after
         // applying the block.
         self.shrink_to_max_size();
+
+        // Update the sync-label to keep track of reorganizations
+        let current_block_digest = block.hash();
+        self.set_tip_digest_sync_label(current_block_digest);
     }
 
     /// Shrink the memory pool to the value of its `max_size` field.
@@ -423,6 +452,7 @@ mod tests {
             make_mock_block, make_mock_transaction_with_wallet, mock_genesis_global_state,
             mock_genesis_wallet_state,
         },
+        util_types::mutator_set::shared::{BATCH_SIZE, CHUNK_SIZE, WINDOW_SIZE},
     };
     use anyhow::Result;
     use itertools::Itertools;
@@ -434,8 +464,9 @@ mod tests {
 
     #[tokio::test]
     pub async fn insert_then_get_then_remove_then_get() {
-        let mut mempool = Mempool::new(ByteSize::gb(1));
         let network = Network::Alpha;
+        let genesis_block = Block::genesis_block(network);
+        let mut mempool = Mempool::new(ByteSize::gb(1), genesis_block.hash());
         let wallet_state = mock_genesis_wallet_state(WalletSecret::devnet_wallet(), network).await;
         let transaction = make_mock_transaction_with_wallet(
             vec![],
@@ -464,7 +495,8 @@ mod tests {
 
     // Create a mempool with n transactions.
     async fn setup(transactions_count: u32, network: Network) -> Mempool {
-        let mut mempool = Mempool::new(ByteSize::gb(1));
+        let genesis_block = Block::genesis_block(network);
+        let mut mempool = Mempool::new(ByteSize::gb(1), genesis_block.hash());
         let wallet_state = mock_genesis_wallet_state(WalletSecret::devnet_wallet(), network).await;
         for i in 0..transactions_count {
             let t = make_mock_transaction_with_wallet(
@@ -492,6 +524,7 @@ mod tests {
             assert!(curr_fee_density <= prev_fee_density);
             prev_fee_density = curr_fee_density;
         }
+
         assert!(!mempool.is_empty())
     }
 
@@ -507,15 +540,17 @@ mod tests {
             assert!(curr_fee_density <= prev_fee_density);
             prev_fee_density = curr_fee_density;
         }
+
         assert!(!mempool.is_empty())
     }
 
     #[traced_test]
     #[tokio::test]
     async fn prune_stale_transactions() {
-        let wallet_state =
-            mock_genesis_wallet_state(WalletSecret::devnet_wallet(), Network::Alpha).await;
-        let mut mempool = Mempool::new(ByteSize::gb(1));
+        let network = Network::Alpha;
+        let genesis_block = Block::genesis_block(network);
+        let mut mempool = Mempool::new(ByteSize::gb(1), genesis_block.hash());
+        let wallet_state = mock_genesis_wallet_state(WalletSecret::devnet_wallet(), network).await;
         assert!(
             mempool.is_empty(),
             "Mempool must be empty after initialization"
@@ -524,7 +559,7 @@ mod tests {
         let eight_days_ago = Timestamp::now() - Timestamp::days(8);
         let timestamp = Some(eight_days_ago);
 
-        for i in 0u32..5 {
+        for i in 0u32..6 {
             let t = make_mock_transaction_with_wallet(
                 vec![],
                 vec![],
@@ -545,7 +580,8 @@ mod tests {
             );
             mempool.insert(&t);
         }
-        assert_eq!(mempool.len(), 10);
+
+        assert_eq!(mempool.len(), 11);
         mempool.prune_stale_transactions();
         assert_eq!(mempool.len(), 5)
     }
@@ -553,6 +589,9 @@ mod tests {
     #[traced_test]
     #[tokio::test]
     async fn remove_transactions_with_block_test() -> Result<()> {
+        // We need the global state to construct a transaction. This global state
+        // has a wallet which receives a premine-UTXO.
+
         let seed = {
             let mut rng: StdRng =
                 SeedableRng::from_rng(thread_rng()).expect("failure lifting thread_rng to StdRng");
@@ -570,14 +609,13 @@ mod tests {
         };
 
         let mut rng: StdRng = SeedableRng::from_seed(seed);
-        // We need the global state to construct a transaction. This global state
-        // has a wallet which receives a premine-UTXO.
+
         let network = Network::RegTest;
         let devnet_wallet = WalletSecret::devnet_wallet();
-        let premine_receiver_global_state_lock =
+        let premine_receiver_global_state =
             mock_genesis_global_state(network, 2, devnet_wallet).await;
         let mut premine_receiver_global_state =
-            premine_receiver_global_state_lock.lock_guard_mut().await;
+            premine_receiver_global_state.lock_guard_mut().await;
 
         let premine_wallet_secret = &premine_receiver_global_state.wallet_state.wallet_secret;
         let premine_receiver_spending_key = premine_wallet_secret.nth_generation_spending_key(0);
@@ -596,17 +634,6 @@ mod tests {
             make_mock_block(&genesis_block, None, other_receiver_address, rng.gen());
 
         // Update both states with block 1
-        premine_receiver_global_state
-            .wallet_state
-            .update_wallet_state_with_new_block(
-                &genesis_block.kernel.body.mutator_set_accumulator,
-                &block_1,
-            )
-            .await?;
-        premine_receiver_global_state
-            .chain
-            .light_state_mut()
-            .set_block(block_1.clone());
         other_global_state
             .wallet_state
             .expected_utxos
@@ -618,16 +645,13 @@ mod tests {
             )
             .expect("UTXO notification from miner must be accepted");
         other_global_state
-            .wallet_state
-            .update_wallet_state_with_new_block(
-                &genesis_block.kernel.body.mutator_set_accumulator,
-                &block_1,
-            )
-            .await?;
-        other_global_state
-            .chain
-            .light_state_mut()
-            .set_block(block_1.clone());
+            .set_new_tip(block_1.clone())
+            .await
+            .unwrap();
+        premine_receiver_global_state
+            .set_new_tip(block_1.clone())
+            .await
+            .unwrap();
 
         // Create a transaction that's valid to be included in block 2
         let mut output_utxos_generated_by_me: Vec<UtxoReceiverData> = vec![];
@@ -645,6 +669,7 @@ mod tests {
                 utxo: new_utxo,
             });
         }
+
         let mut now = genesis_block.kernel.header.timestamp;
         let seven_months = Timestamp::months(7);
         let tx_by_preminer = premine_receiver_global_state
@@ -655,8 +680,8 @@ mod tests {
             )
             .await?;
 
-        // Add this transaction to the mempool
-        let mut mempool = Mempool::new(ByteSize::gb(1));
+        // Add this transaction to a mempool
+        let mut mempool = Mempool::new(ByteSize::gb(1), block_1.hash());
         mempool.insert(&tx_by_preminer);
 
         // Create another transaction that's valid to be included in block 2, but isn't actually
@@ -704,28 +729,14 @@ mod tests {
         // updated and valid-again mutator set data
         let mut tx_by_other_updated: Transaction =
             mempool.get_transactions_for_block(usize::MAX)[0].clone();
-
-        debug!(
-            "mempool now has transaction relative to mutator set hash {}",
-            tx_by_other_updated.kernel.mutator_set_hash
+        assert!(
+            tx_by_other_updated.is_confirmable_relative_to(&block_2.body().mutator_set_accumulator),
+            "Block with tx with updated mutator set data must be confirmable wrt. block_2"
         );
 
         let (block_3_with_no_input, _, _) =
             make_mock_block(&block_2, None, premine_receiver_address, rng.gen());
         let mut block_3_with_updated_tx = block_3_with_no_input.clone();
-
-        debug!(
-            "Just made block with previous mutator set hash {}",
-            block_2.kernel.body.mutator_set_accumulator.hash()
-        );
-        debug!(
-            "Just made block with next mutator set hash {}",
-            block_3_with_updated_tx
-                .kernel
-                .body
-                .mutator_set_accumulator
-                .hash()
-        );
 
         debug!(
             "tx_by_other_updated has mutator set hash: {}",
@@ -743,11 +754,11 @@ mod tests {
             "Block with tx with updated mutator set data must be valid"
         );
 
-        // Mine 10 more blocks without including the transaction but while still keeping the
-        // mempool updated. After these 10 blocks are mined, the transaction must still be
+        // Mine 11 blocks without including the transaction but while still keeping the
+        // mempool updated. After these 11 blocks are mined, the transaction must still be
         // valid.
-        let mut previous_block = block_3_with_no_input;
-        for _ in 0..10 {
+        let mut previous_block = block_2;
+        for _ in 0..11 {
             let (next_block, _, _) =
                 make_mock_block(&previous_block, None, other_receiver_address, rng.gen());
             mempool
@@ -788,6 +799,140 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn reorganization_does_not_crash_mempool() {
+        // Verify that reorganizations do not crash the client, and other
+        // qualities.
+
+        // First put a transaction into the mempool. Then mine block 1a does
+        // not contain this transaction, such that mempool is still non-empty.
+        // Then mine a a block 1b that also does not contain this transaction.
+        let network = Network::RegTest;
+        let devnet_wallet = WalletSecret::devnet_wallet();
+        let premine_receiver_global_state =
+            mock_genesis_global_state(network, 2, devnet_wallet).await;
+        let mut premine_receiver_global_state =
+            premine_receiver_global_state.lock_guard_mut().await;
+        let premine_address = premine_receiver_global_state
+            .wallet_state
+            .wallet_secret
+            .nth_generation_spending_key(0)
+            .to_address();
+        let other_wallet_secret = WalletSecret::new_random();
+        let other_address = other_wallet_secret
+            .nth_generation_spending_key(0)
+            .to_address();
+
+        let utxo = Utxo::new(
+            premine_address.lock_script(),
+            NeptuneCoins::new(1).to_native_coins(),
+        );
+        let tx_receiver_data = UtxoReceiverData {
+            utxo,
+            receiver_privacy_digest: premine_address.privacy_digest,
+            sender_randomness: random(),
+            public_announcement: PublicAnnouncement::default(),
+        };
+
+        let genesis_block = premine_receiver_global_state
+            .chain
+            .archival_state()
+            .genesis_block()
+            .to_owned();
+        let now = genesis_block.kernel.header.timestamp;
+        let in_seven_years = now + Timestamp::months(7 * 12);
+        let unmined_tx = premine_receiver_global_state
+            .create_transaction(vec![tx_receiver_data], NeptuneCoins::new(1), in_seven_years)
+            .await
+            .unwrap();
+
+        premine_receiver_global_state.mempool.insert(&unmined_tx);
+
+        let mut rng = thread_rng();
+
+        // Add enough blocks to move the active window. The transaction must stay in
+        // the mempool, since it is not being mined.
+        let mut current_block = genesis_block.clone();
+        const NUM_BLOCKS_TO_SLIDE_ENTIRE_ACTIVE_WINDOW: u32 = WINDOW_SIZE / CHUNK_SIZE * BATCH_SIZE;
+
+        // This will invalidate the removal record with a probability of
+        // 99.995 %. So a later test will fail 1/20'000 times.
+        const PROBABLY_ENOUGH_BLOCKS_TO_INVALIDATE_REMOVAL_RECORD: u32 =
+            NUM_BLOCKS_TO_SLIDE_ENTIRE_ACTIVE_WINDOW / 5;
+        for _ in 0..PROBABLY_ENOUGH_BLOCKS_TO_INVALIDATE_REMOVAL_RECORD {
+            let (next_block, _, _) = make_mock_block(
+                &current_block,
+                Some(in_seven_years),
+                other_address,
+                rng.gen(),
+            );
+            premine_receiver_global_state
+                .set_new_tip(next_block.clone())
+                .await
+                .unwrap();
+
+            let mempool_txs = premine_receiver_global_state
+                .mempool
+                .get_transactions_for_block(usize::MAX);
+            assert_eq!(
+                1,
+                mempool_txs.len(),
+                "The inserted tx must stay in the mempool"
+            );
+            assert!(
+                mempool_txs[0]
+                    .is_confirmable_relative_to(&next_block.body().mutator_set_accumulator),
+                "Mempool tx must stay confirmable after each new block has been applied"
+            );
+            assert_eq!(
+                next_block.hash(),
+                premine_receiver_global_state.mempool.tip_digest,
+                "Mempool's sync digest must be set correctly"
+            );
+
+            current_block = next_block;
+        }
+
+        let tx_from_mempool0: Transaction = premine_receiver_global_state
+            .mempool
+            .get_transactions_for_block(usize::MAX)[0]
+            .clone();
+        assert!(
+            !tx_from_mempool0
+                .is_confirmable_relative_to(&genesis_block.body().mutator_set_accumulator),
+            "tx may not be confirmable relative to the genesis block"
+        );
+
+        // Now make a deep reorganization and verify that nothing crashes
+        let (block_1b, _, _) = make_mock_block(
+            &genesis_block,
+            Some(in_seven_years),
+            other_address,
+            rng.gen(),
+        );
+        assert!(
+            block_1b.header().height.previous().is_genesis(),
+            "Sanity check that new tip has height 1"
+        );
+        premine_receiver_global_state
+            .set_new_tip(block_1b.clone())
+            .await
+            .unwrap();
+
+        // Verify that all retained txs (if any) are confirmable against
+        // the new tip.
+        assert!(
+            premine_receiver_global_state
+                .mempool
+                .get_transactions_for_block(usize::MAX)
+                .iter()
+                .all(|tx| tx.is_confirmable_relative_to(&block_1b.body().mutator_set_accumulator)),
+            "All retained txs in the mempool must be confirmable relative to the new block.
+             Or the mempool must be empty."
+        );
     }
 
     #[traced_test]

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -112,7 +112,7 @@ impl Mempool {
         self.tx_dictionary.get(&transaction_id)
     }
 
-    /// Returns `Some(txid, transaction)` iff a transcation conflicts with a transaction
+    /// Returns `Some(txid, transaction)` iff a transaction conflicts with a transaction
     /// that's already in the mempool. Returns `None` otherwise.
     fn transaction_conflicts_with(
         &self,

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -412,12 +412,14 @@ impl Mempool {
     /// # Example
     ///
     /// ```
-    /// use neptune_core::models::state::mempool::Mempool;
     /// use bytesize::ByteSize;
+    /// use neptune_core::models::blockchain::block::Block;
+    /// use neptune_core::models::state::mempool::Mempool;
+    /// use neptune_core::config_models::network::Network;
     ///
     /// let network = Network::Main;
     /// let genesis_block = Block::genesis_block(network);
-    /// let mempool = Mempool::new(ByteSize::gb(1), genesis_block);
+    /// let mempool = Mempool::new(ByteSize::gb(1), genesis_block.hash());
     /// // insert transactions here.
     /// let mut most_valuable_transactions = vec![];
     /// for (transaction_digest, fee_density) in mempool.get_sorted_iter() {

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -140,6 +140,8 @@ impl Mempool {
     /// Insert a transaction into the mempool. It is the caller's responsibility to validate
     /// the transaction. Also, the caller must ensure that the witness type is correct --
     /// this method accepts only fully proven transactions (or, for the time being, faith witnesses).
+    /// The caller must also ensure that the transaction does not have a timestamp
+    /// in the too distant future.
     pub fn insert(&mut self, transaction: &Transaction) -> Option<Digest> {
         match transaction.witness.vast.witness_type {
             WitnessType::RawWitness(_) => panic!("Can only insert fully proven transactions into mempool; not accepting raw witnesses."),

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -415,7 +415,9 @@ impl Mempool {
     /// use neptune_core::models::state::mempool::Mempool;
     /// use bytesize::ByteSize;
     ///
-    /// let mempool = Mempool::new(ByteSize::gb(1));
+    /// let network = Network::Main;
+    /// let genesis_block = Block::genesis_block(network);
+    /// let mempool = Mempool::new(ByteSize::gb(1), genesis_block);
     /// // insert transactions here.
     /// let mut most_valuable_transactions = vec![];
     /// for (transaction_digest, fee_density) in mempool.get_sorted_iter() {

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -194,7 +194,7 @@ pub async fn mock_genesis_global_state(
         light_state,
         archival_state,
     });
-    let mempool = Mempool::new(ByteSize::gb(1));
+    let mempool = Mempool::new(ByteSize::gb(1), genesis_block.hash());
     let cli_args = cli_args::Args {
         network,
         ..Default::default()

--- a/src/util_types/mutator_set.rs
+++ b/src/util_types/mutator_set.rs
@@ -45,6 +45,10 @@ pub enum MutatorSetError {
     RequestedAoclAuthPathOutOfBounds((u64, u64)),
     RequestedSwbfAuthPathOutOfBounds((u64, u64)),
     MutatorSetIsEmpty,
+    AbsoluteRemovalIndexIsFutureIndex {
+        current_max_chunk_index: u64,
+        saw_chunk_index: u64,
+    },
 }
 
 /// Get the (absolute) indices for removing this item from the mutator set.

--- a/src/util_types/mutator_set/ms_membership_proof.rs
+++ b/src/util_types/mutator_set/ms_membership_proof.rs
@@ -24,7 +24,6 @@ use twenty_first::util_types::mmr::mmr_trait::Mmr;
 
 use super::addition_record::AdditionRecord;
 use super::chunk_dictionary::{pseudorandom_chunk_dictionary, ChunkDictionary};
-use super::get_swbf_indices;
 use super::mutator_set_accumulator::MutatorSetAccumulator;
 use super::removal_record::AbsoluteIndexSet;
 use super::removal_record::RemovalRecord;
@@ -32,6 +31,7 @@ use super::shared::{
     get_batch_mutation_argument_for_removal_record,
     prepare_authenticated_batch_modification_for_removal_record_reversion, BATCH_SIZE, CHUNK_SIZE,
 };
+use super::{commit, get_swbf_indices};
 impl Error for MembershipProofError {}
 
 impl fmt::Display for MembershipProofError {
@@ -58,6 +58,14 @@ pub struct MsMembershipProof {
 }
 
 impl MsMembershipProof {
+    pub fn addition_record(&self, item: Digest) -> AdditionRecord {
+        commit(
+            item,
+            self.sender_randomness,
+            self.receiver_preimage.hash::<Hash>(),
+        )
+    }
+
     /// Compute the indices that will be added to the SWBF if this item is removed.
     pub fn compute_indices(&self, item: Digest) -> AbsoluteIndexSet {
         AbsoluteIndexSet::new(&get_swbf_indices(

--- a/src/util_types/mutator_set/shared.rs
+++ b/src/util_types/mutator_set/shared.rs
@@ -15,6 +15,10 @@ pub const CHUNK_SIZE: u32 = 1 << 12;
 pub const BATCH_SIZE: u32 = 1 << 3;
 pub const NUM_TRIALS: u32 = 45;
 
+/// Given a set of absolute indices, return a hashmap of
+/// {chunk_index => absolute_indices}
+/// where the values are sorted after chunk index, i.e. put in the correct
+/// chunk bucket.
 pub fn indices_to_hash_map(all_indices: &[u128; NUM_TRIALS as usize]) -> HashMap<u64, Vec<u128>> {
     all_indices
         .iter()


### PR DESCRIPTION
Simple solution to the inability of the mempool to handle reorganizations: Clear the mempool if that happens.

Context: all transactions need to contain proofs relating to the mutator set of the latest block. 3rd parties can update this information in the common case (new ti is child of previous tip), but this proof updating is complicated for reorganizations. So for now, we just clear the mempool in the case of a reorganization.