### PR TITLE
refactor create_transaction,  avoid holding lock across prove()

### DIFF
--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -520,7 +520,10 @@ mod mine_loop_tests {
 
     use crate::{
         config_models::network::Network,
-        models::{consensus::timestamp::Timestamp, state::UtxoReceiverData},
+        models::{
+            consensus::timestamp::Timestamp,
+            state::{ChangeNotifyMethod, UtxoReceiver},
+        },
         tests::shared::mock_genesis_global_state,
     };
 
@@ -576,13 +579,14 @@ mod mine_loop_tests {
         };
         let (tx_by_preminer, tx_data) = premine_receiver_global_state
             .create_transaction(
-                vec![UtxoReceiverData::fake_announcement(
+                vec![UtxoReceiver::fake_announcement(
                     tx_output,
                     sender_randomness,
                     receiver_privacy_digest,
                 )],
                 NeptuneCoins::new(1),
                 now + Timestamp::months(7),
+                ChangeNotifyMethod::default(),
             )
             .await
             .unwrap();

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -575,7 +575,7 @@ mod mine_loop_tests {
             coins: four_neptune_coins,
             lock_script_hash: LockScript::anyone_can_spend().hash(),
         };
-        let tx_by_preminer = premine_receiver_global_state
+        let (tx_by_preminer, _) = premine_receiver_global_state
             .create_transaction(
                 vec![
                     (UtxoReceiverData {

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -709,9 +709,8 @@ mod block_tests {
 
     use crate::{
         config_models::network::Network,
-        database::storage::storage_schema::SimpleRustyStorage,
-        database::NeptuneLevelDb,
-        models::{state::wallet::WalletSecret, state::UtxoReceiverData},
+        database::{storage::storage_schema::SimpleRustyStorage, NeptuneLevelDb},
+        models::state::{wallet::WalletSecret, ChangeNotifyMethod, UtxoReceiver},
         tests::shared::{
             make_mock_block, make_mock_block_with_valid_pow, mock_genesis_global_state,
         },
@@ -755,7 +754,7 @@ mod block_tests {
         // create a new transaction, merge it into block 1 and check that block 1 is still valid
         let new_utxo = Utxo::new_native_coin(other_address.lock_script(), NeptuneCoins::new(10));
         let reciever_data =
-            UtxoReceiverData::fake_announcement(new_utxo, random(), other_address.privacy_digest);
+            UtxoReceiver::fake_announcement(new_utxo, random(), other_address.privacy_digest);
         let (new_tx, tx_data) = global_state_lock
             .lock_guard()
             .await
@@ -763,6 +762,7 @@ mod block_tests {
                 vec![reciever_data],
                 NeptuneCoins::new(1),
                 now + seven_months,
+                ChangeNotifyMethod::default(),
             )
             .await
             .unwrap();

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -763,7 +763,7 @@ mod block_tests {
             sender_randomness: random(),
             utxo: new_utxo,
         };
-        let new_tx = global_state_lock
+        let (new_tx, _) = global_state_lock
             .lock_guard_mut()
             .await
             .create_transaction(

--- a/src/models/blockchain/transaction/mod.rs
+++ b/src/models/blockchain/transaction/mod.rs
@@ -727,7 +727,7 @@ mod transaction_tests {
     //     let other_wallet = wallet::WalletSecret::new(wallet::generate_secret_key());
 
     //     // Create a transaction that's valid after the Genesis block
-    //     let receiver_data = vec![UtxoReceiverData {
+    //     let receiver_data = vec![UtxoReceiver {
     //         utxo: Utxo {
     //             lock_script: LockScript(vec![]),
     //             coins: Into::<Amount>::into(5).to_native_coins(),

--- a/src/models/state/archival_state.rs
+++ b/src/models/state/archival_state.rs
@@ -1023,7 +1023,7 @@ mod archival_state_tests {
                 own_receiving_address,
                 rng.gen(),
             );
-            let sender_tx = genesis_receiver_global_state
+            let (sender_tx, _) = genesis_receiver_global_state
                 .create_transaction(
                     vec![UtxoReceiverData {
                         public_announcement: PublicAnnouncement::default(),
@@ -1157,7 +1157,7 @@ mod archival_state_tests {
                 public_announcement: PublicAnnouncement::default(),
             },
         ];
-        let sender_tx = global_state_lock
+        let (sender_tx, _) = global_state_lock
             .lock_guard_mut()
             .await
             .create_transaction(receiver_data, NeptuneCoins::new(4), now + seven_months)
@@ -1285,7 +1285,7 @@ mod archival_state_tests {
                     public_announcement: PublicAnnouncement::default(),
                 },
             ];
-            let sender_tx = global_state
+            let (sender_tx, _) = global_state
                 .create_transaction(receiver_data, NeptuneCoins::new(4), now + seven_months)
                 .await
                 .unwrap();
@@ -1431,7 +1431,7 @@ mod archival_state_tests {
                 lock_script_hash: LockScript::anyone_can_spend().hash(),
             },
         };
-        let sender_tx = global_state_lock
+        let (sender_tx, _) = global_state_lock
             .lock_guard_mut()
             .await
             .create_transaction(vec![receiver_data], one_money, now + seven_months)
@@ -1667,7 +1667,7 @@ mod archival_state_tests {
                 public_announcement: PublicAnnouncement::default(),
             },
         ];
-        let tx_from_alice = alice_state_lock
+        let (tx_from_alice, _) = alice_state_lock
             .lock_guard_mut()
             .await
             .create_transaction(

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -678,7 +678,7 @@ mod tests {
 
         let mut now = genesis_block.kernel.header.timestamp;
         let seven_months = Timestamp::months(7);
-        let tx_by_preminer = premine_receiver_global_state
+        let (tx_by_preminer, _) = premine_receiver_global_state
             .create_transaction(
                 output_utxos_generated_by_me,
                 NeptuneCoins::new(1),
@@ -704,7 +704,7 @@ mod tests {
             receiver_privacy_digest: other_receiver_address.privacy_digest,
             public_announcement: PublicAnnouncement::default(),
         }];
-        let tx_by_other_original = other_global_state
+        let (tx_by_other_original, _) = other_global_state
             .create_transaction(
                 output_utxo_data_by_miner,
                 NeptuneCoins::new(1),
@@ -966,7 +966,7 @@ mod tests {
             sender_randomness: random(),
             public_announcement: PublicAnnouncement::default(),
         };
-        let tx_by_preminer_low_fee = preminer_state
+        let (tx_by_preminer_low_fee, _) = preminer_state
             .create_transaction(
                 vec![receiver_data.clone()],
                 NeptuneCoins::new(1),
@@ -988,7 +988,7 @@ mod tests {
 
         // Insert a transaction that spends the same UTXO and has a higher fee.
         // Verify that this replaces the previous transaction.
-        let tx_by_preminer_high_fee = preminer_state
+        let (tx_by_preminer_high_fee, _) = preminer_state
             .create_transaction(
                 vec![receiver_data.clone()],
                 NeptuneCoins::new(10),
@@ -1007,7 +1007,7 @@ mod tests {
 
         // Insert a conflicting transaction with a lower fee and verify that it
         // does *not* replace the existing transaction.
-        let tx_by_preminer_medium_fee = preminer_state
+        let (tx_by_preminer_medium_fee, _) = preminer_state
             .create_transaction(
                 vec![receiver_data],
                 NeptuneCoins::new(4),

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -567,8 +567,8 @@ impl GlobalState {
     /// creates a Transaction.
     ///
     /// UtxoReceiver::auto() should normally be used.  This will generate
-    /// OffChain notifications for UTXOs destined for our wallet and OnChain
-    /// notifications for all other UTXOs.
+    /// OffChain notifications for UTXOs destined for our wallet and
+    /// OnChainPubKey notifications for all other UTXOs.
     ///
     /// Likewise ChangeNotifyMethod::default() should be used, which corresponds
     /// to ChangeNotifyMethod::OffChain.  This controls notification behavior
@@ -652,7 +652,7 @@ impl GlobalState {
         let mut public_announcements = receiver_data
             .iter()
             .filter_map(|rd| match &rd.utxo_notify_method {
-                UtxoNotifyMethod::OnChain(pa) => Some(pa.clone()),
+                UtxoNotifyMethod::OnChainPubKey(pa) => Some(pa.clone()),
                 _ => None,
             })
             .collect_vec();
@@ -675,7 +675,8 @@ impl GlobalState {
 
             match change_notify_method {
                 ChangeNotifyMethod::OffChain => expected_utxos.push(change_expected_utxo),
-                ChangeNotifyMethod::OnChain => {
+                ChangeNotifyMethod::OnChainSymmetricKey => unimplemented!(),
+                ChangeNotifyMethod::OnChainPubKey => {
                     public_announcements.push(change_public_announcement)
                 }
             }
@@ -1418,7 +1419,7 @@ mod global_state_tests {
         let public_announcement = recipient_address
             .generate_public_announcement(&output_utxo, sender_randomness)
             .unwrap();
-        let receiver_data = vec![UtxoReceiver::onchain(
+        let receiver_data = vec![UtxoReceiver::onchain_pubkey(
             output_utxo.clone(),
             sender_randomness,
             receiver_privacy_digest,
@@ -1501,7 +1502,7 @@ mod global_state_tests {
                 .generate_public_announcement(&utxo, other_sender_randomness)
                 .unwrap();
             output_utxos.push(utxo.clone());
-            other_receiver_data.push(UtxoReceiver::onchain(
+            other_receiver_data.push(UtxoReceiver::onchain_pubkey(
                 utxo,
                 other_sender_randomness,
                 other_receiver_digest,

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -246,6 +246,14 @@ pub struct UtxoReceiverData {
     pub public_announcement: PublicAnnouncement,
 }
 
+#[derive(Debug, Clone)]
+pub struct ChangeUtxoData {
+    pub change_utxo: Utxo,
+    pub change_addition_record: AdditionRecord,
+    pub change_sender_randomness: Digest,
+    pub receiver_preimage: Digest,
+}
+
 impl GlobalState {
     pub fn new(
         wallet_state: WalletState,
@@ -393,7 +401,7 @@ impl GlobalState {
     /// (*i.e.*, synced and never or no longer timelocked) and that sum to
     /// enough funds.
     pub async fn assemble_inputs_for_transaction(
-        &mut self,
+        &self,
         total_spend: NeptuneCoins,
         timestamp: Timestamp,
     ) -> Result<Vec<(Utxo, LockScript, MsMembershipProof)>> {
@@ -439,9 +447,10 @@ impl GlobalState {
     }
 
     /// Generate a change UTXO and transaction output to ensure that the difference
-    /// in input amount and output amount goes back to us. Also, make sure to expect
-    /// the UTXO so that we can synchronize it after it is confirmed.
-    pub async fn add_change(&mut self, change_amount: NeptuneCoins) -> (AdditionRecord, Utxo) {
+    /// in input amount and output amount goes back to us.
+    /// The caller should also notify the wallet to expect the change Utxo
+    /// so that we can synchronize it after it is confirmed.
+    pub async fn add_change(&self, change_amount: NeptuneCoins) -> ChangeUtxoData {
         // generate utxo
         let own_spending_key_for_change = self
             .wallet_state
@@ -467,20 +476,14 @@ impl GlobalState {
             receiver_digest,
         );
 
-        // Add change UTXO to pool of expected incoming UTXOs
         let receiver_preimage = own_spending_key_for_change.privacy_preimage;
-        let _change_addition_record = self
-            .wallet_state
-            .expected_utxos
-            .add_expected_utxo(
-                change_utxo.clone(),
-                change_sender_randomness,
-                receiver_preimage,
-                UtxoNotifier::Myself,
-            )
-            .expect("Adding change UTXO to UTXO notification pool must succeed");
 
-        (change_addition_record, change_utxo)
+        ChangeUtxoData {
+            change_utxo,
+            change_sender_randomness,
+            receiver_preimage,
+            change_addition_record,
+        }
     }
 
     /// Generate a primitive witness for a transaction from various disparate witness data.
@@ -532,13 +535,13 @@ impl GlobalState {
     /// Returns the transaction and a vector containing the sender
     /// randomness for each output UTXO.
     pub async fn create_transaction(
-        &mut self,
+        &self,
         receiver_data: Vec<UtxoReceiverData>,
         fee: NeptuneCoins,
         timestamp: Timestamp,
-    ) -> Result<Transaction> {
+    ) -> Result<(Transaction, Option<ChangeUtxoData>)> {
         // UTXO data: inputs, outputs, and supporting witness data
-        let (inputs, spendable_utxos_and_mps, outputs, output_utxos) = self
+        let (inputs, spendable_utxos_and_mps, outputs, output_utxos, change_utxo_data) = self
             .generate_utxo_data_for_transaction(&receiver_data, fee, timestamp)
             .await?;
 
@@ -562,20 +565,23 @@ impl GlobalState {
             .wallet_secret
             .nth_generation_spending_key(0);
 
-        // assemble transaction object (lengthy operation)
-        Self::create_transaction_from_data(
-            spending_key,
-            inputs,
-            spendable_utxos_and_mps,
-            outputs,
-            output_utxos,
-            fee,
-            public_announcements,
-            timestamp,
-            mutator_set_accumulator,
-            privacy,
-        )
-        .await
+        // assemble transaction object
+        Ok((
+            Self::create_transaction_from_data(
+                spending_key,
+                inputs,
+                spendable_utxos_and_mps,
+                outputs,
+                output_utxos,
+                fee,
+                public_announcements,
+                timestamp,
+                mutator_set_accumulator,
+                privacy,
+            )
+            .await?,
+            change_utxo_data,
+        ))
     }
 
     /// Given a list of UTXOs with receiver data, assemble owned and synced and spendable
@@ -583,7 +589,7 @@ impl GlobalState {
     /// and produce a list of removal records, input UTXOs (with lock scripts and
     /// membership proofs), addition records, and output UTXOs.
     async fn generate_utxo_data_for_transaction(
-        &mut self,
+        &self,
         receiver_data: &[UtxoReceiverData],
         fee: NeptuneCoins,
         timestamp: Timestamp,
@@ -592,6 +598,7 @@ impl GlobalState {
         Vec<(Utxo, LockScript, MsMembershipProof)>,
         Vec<AdditionRecord>,
         Vec<Utxo>,
+        Option<ChangeUtxoData>,
     )> {
         // total amount to be spent -- determines how many and which UTXOs to use
         let total_spend: NeptuneCoins = receiver_data
@@ -625,14 +632,22 @@ impl GlobalState {
         let mut output_utxos = receiver_data.iter().map(|rd| rd.utxo.clone()).collect_vec();
 
         // keep track of change (if any)
+        let mut maybe_change_utxo_data = None;
         if total_spend < input_amount {
             let change_amount = input_amount.checked_sub(&total_spend).unwrap();
-            let (change_addition_record, change_utxo) = self.add_change(change_amount).await;
-            outputs.push(change_addition_record);
-            output_utxos.push(change_utxo.clone());
+            let change_utxo_data = self.add_change(change_amount).await;
+            outputs.push(change_utxo_data.change_addition_record);
+            output_utxos.push(change_utxo_data.change_utxo.clone());
+            maybe_change_utxo_data = Some(change_utxo_data);
         }
 
-        Ok((inputs, spendable_utxos_and_mps, outputs, output_utxos))
+        Ok((
+            inputs,
+            spendable_utxos_and_mps,
+            outputs,
+            output_utxos,
+            maybe_change_utxo_data,
+        ))
     }
 
     /// Assembles a transaction kernel and supporting witness or proof(s) from
@@ -1327,7 +1342,7 @@ mod global_state_tests {
         timestamp: Timestamp,
     ) -> Result<Transaction> {
         // UTXO data: inputs, outputs, and supporting witness data
-        let (inputs, spendable_utxos_and_mps, outputs, output_utxos) = global_state_lock
+        let (inputs, spendable_utxos_and_mps, outputs, output_utxos, _) = global_state_lock
             .lock_guard_mut()
             .await
             .generate_utxo_data_for_transaction(receiver_data, fee, timestamp)
@@ -2133,7 +2148,7 @@ mod global_state_tests {
             },
         ];
         let now = genesis_block.kernel.header.timestamp;
-        let tx_from_alice = alice_state_lock
+        let (tx_from_alice, _) = alice_state_lock
             .lock_guard_mut()
             .await
             .create_transaction(receiver_data_from_alice.clone(), NeptuneCoins::new(1), now)
@@ -2168,7 +2183,7 @@ mod global_state_tests {
                 public_announcement: PublicAnnouncement::default(),
             },
         ];
-        let tx_from_bob = bob_state_lock
+        let (tx_from_bob, _) = bob_state_lock
             .lock_guard_mut()
             .await
             .create_transaction(receiver_data_from_bob.clone(), NeptuneCoins::new(2), now)

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -439,7 +439,7 @@ impl GlobalState {
                 commit(
                     Hash::hash(&rd.utxo),
                     rd.sender_randomness,
-                    rd.receiver_preimage,
+                    rd.receiver_privacy_digest,
                 )
             })
             .collect_vec()
@@ -584,7 +584,7 @@ impl GlobalState {
     /// Example:
     ///
     /// ```compile_fail
-    /// let utxo_receivers = vec![UtxoReceiver::auto(&wallet_state, &address, utxo, sender_randomness, receiver_preimage)];
+    /// let utxo_receivers = vec![UtxoReceiver::auto(&wallet_state, &address, utxo, sender_randomness, receiver_privacy_digest)];
     /// let (transaction, tx_data) = state.create_transaction(utxo_receivers, fee, now, ChangeNotifyMethod::default()).await?;
     /// state.add_expected_utxos_to_wallet(tx_data.expected_utxos).await?;
     /// ```

--- a/src/models/state/utxo_receiver.rs
+++ b/src/models/state/utxo_receiver.rs
@@ -66,7 +66,6 @@ impl UtxoReceiver {
         address: &ReceivingAddress,
         utxo: Utxo,
         sender_randomness: Digest,
-        receiver_privacy_digest: Digest,
     ) -> Result<Self> {
         let utxo_notify_method = match wallet_state.is_wallet_utxo(&utxo) {
             true => UtxoNotifyMethod::OffChain,
@@ -77,7 +76,7 @@ impl UtxoReceiver {
         Ok(Self {
             utxo,
             sender_randomness,
-            receiver_privacy_digest,
+            receiver_privacy_digest: address.privacy_digest,
             utxo_notify_method,
         })
     }
@@ -161,18 +160,16 @@ mod tests {
 
         let utxo = Utxo::new(address.lock_script(), NeptuneCoins::one().to_native_coins());
 
-        let receiver_privacy_digest = address.privacy_digest;
         let sender_randomness = state
             .wallet_state
             .wallet_secret
-            .generate_sender_randomness(block_height, receiver_privacy_digest);
+            .generate_sender_randomness(block_height, address.privacy_digest);
 
         let utxo_receiver = UtxoReceiver::auto(
             &state.wallet_state,
             &address,
             utxo.clone(),
             sender_randomness,
-            receiver_privacy_digest,
         )?;
 
         assert!(matches!(
@@ -182,7 +179,7 @@ mod tests {
         assert_eq!(utxo_receiver.sender_randomness, sender_randomness);
         assert_eq!(
             utxo_receiver.receiver_privacy_digest,
-            receiver_privacy_digest
+            address.privacy_digest
         );
         assert_eq!(utxo_receiver.utxo, utxo);
         Ok(())
@@ -202,18 +199,16 @@ mod tests {
 
         let utxo = Utxo::new(address.lock_script(), NeptuneCoins::one().to_native_coins());
 
-        let receiver_privacy_digest = address.privacy_digest;
         let sender_randomness = state
             .wallet_state
             .wallet_secret
-            .generate_sender_randomness(block_height, receiver_privacy_digest);
+            .generate_sender_randomness(block_height, address.privacy_digest);
 
         let utxo_receiver = UtxoReceiver::auto(
             &state.wallet_state,
             &address,
             utxo.clone(),
             sender_randomness,
-            receiver_privacy_digest,
         )?;
 
         assert!(matches!(
@@ -223,7 +218,7 @@ mod tests {
         assert_eq!(utxo_receiver.sender_randomness, sender_randomness);
         assert_eq!(
             utxo_receiver.receiver_privacy_digest,
-            receiver_privacy_digest
+            address.privacy_digest
         );
         assert_eq!(utxo_receiver.utxo, utxo);
         Ok(())

--- a/src/models/state/utxo_receiver.rs
+++ b/src/models/state/utxo_receiver.rs
@@ -7,22 +7,43 @@ use crate::models::state::wallet::utxo_notification_pool::ExpectedUtxo;
 use crate::prelude::twenty_first::math::digest::Digest;
 use anyhow::Result;
 
+/// enumerates how a transaction recipient can be notified
+/// that a Utxo exists which they can claim/spend.
 #[derive(Debug, Clone)]
 pub enum UtxoNotifyMethod {
-    Onchain(PublicAnnouncement),
-    Offchain,
+    OnChain(PublicAnnouncement),
+    OffChain,
 }
 
+/// enumerates how a transaction recipient can be notified
+/// that a Change Utxo exists which they can claim/spend.
+///
+/// note: This is equivalent to [UtxoNotifyMethod] but does
+/// not carry any data.  Also, it defaults to `OffChain`.
 #[derive(Debug, Clone)]
-pub struct UtxoReceiverData {
+pub enum ChangeNotifyMethod {
+    OnChain,
+    OffChain,
+}
+
+impl Default for ChangeNotifyMethod {
+    fn default() -> Self {
+        Self::OffChain
+    }
+}
+
+/// Contains data that a UTXO recipient needs to be notified
+/// about and claim a given UTXO
+#[derive(Debug, Clone)]
+pub struct UtxoReceiver {
     pub utxo: Utxo,
     pub sender_randomness: Digest,
     pub receiver_preimage: Digest,
     pub utxo_notify_method: UtxoNotifyMethod,
 }
 
-impl From<&UtxoReceiverData> for ExpectedUtxo {
-    fn from(d: &UtxoReceiverData) -> Self {
+impl From<&UtxoReceiver> for ExpectedUtxo {
+    fn from(d: &UtxoReceiver) -> Self {
         ExpectedUtxo::new(
             d.utxo.clone(),
             d.sender_randomness,
@@ -32,7 +53,38 @@ impl From<&UtxoReceiverData> for ExpectedUtxo {
     }
 }
 
-impl UtxoReceiverData {
+impl UtxoReceiver {
+    /// automatically generates `UtxoReceiver` from a `ReceivingAddress` and
+    /// `Utxo` info.
+    ///
+    /// If the `Utxo` can be claimed by our wallet then private OffChain
+    /// notification will be used.  Else `OnChain` notification.
+    ///
+    /// This method should normally be used when instantiating `UtxoReceiver`
+    pub fn auto(
+        wallet_state: &WalletState,
+        address: &ReceivingAddress,
+        utxo: Utxo,
+        sender_randomness: Digest,
+        receiver_preimage: Digest,
+    ) -> Result<Self> {
+        let utxo_notify_method = match wallet_state.is_wallet_utxo(&utxo) {
+            true => UtxoNotifyMethod::OffChain,
+            false => UtxoNotifyMethod::OnChain(
+                address.generate_public_announcement(&utxo, sender_randomness)?,
+            ),
+        };
+        Ok(Self {
+            utxo,
+            sender_randomness,
+            receiver_preimage,
+            utxo_notify_method,
+        })
+    }
+
+    /// instantiates `UtxoReceiver` using OnChain notification method.
+    ///
+    /// For normal situations, auto() should be used instead.
     pub fn onchain(
         utxo: Utxo,
         sender_randomness: Digest,
@@ -43,40 +95,23 @@ impl UtxoReceiverData {
             utxo,
             sender_randomness,
             receiver_preimage,
-            utxo_notify_method: UtxoNotifyMethod::Onchain(public_announcement),
+            utxo_notify_method: UtxoNotifyMethod::OnChain(public_announcement),
         }
     }
 
+    /// instantiates `UtxoReceiver` using OffChain notification method.
+    ///
+    /// For normal situations, auto() should be used instead.
     pub fn offchain(utxo: Utxo, sender_randomness: Digest, receiver_preimage: Digest) -> Self {
         Self {
             utxo,
             sender_randomness,
             receiver_preimage,
-            utxo_notify_method: UtxoNotifyMethod::Offchain,
+            utxo_notify_method: UtxoNotifyMethod::OffChain,
         }
     }
 
-    pub fn auto(
-        wallet_state: &WalletState,
-        address: &ReceivingAddress,
-        utxo: Utxo,
-        sender_randomness: Digest,
-        receiver_preimage: Digest,
-    ) -> Result<Self> {
-        let utxo_notify_method = match wallet_state.is_wallet_utxo(&utxo) {
-            true => UtxoNotifyMethod::Onchain(
-                address.generate_public_announcement(&utxo, sender_randomness)?,
-            ),
-            false => UtxoNotifyMethod::Offchain,
-        };
-        Ok(Self {
-            utxo,
-            sender_randomness,
-            receiver_preimage,
-            utxo_notify_method,
-        })
-    }
-
+    // only for tests
     #[cfg(test)]
     pub fn fake_announcement(
         utxo: Utxo,
@@ -87,10 +122,11 @@ impl UtxoReceiverData {
             utxo,
             sender_randomness,
             receiver_preimage,
-            utxo_notify_method: UtxoNotifyMethod::Onchain(PublicAnnouncement::default()),
+            utxo_notify_method: UtxoNotifyMethod::OnChain(PublicAnnouncement::default()),
         }
     }
 
+    // only for tests
     #[cfg(test)]
     pub fn random(utxo: Utxo) -> Self {
         Self::fake_announcement(utxo, rand::random(), rand::random())

--- a/src/models/state/utxo_receiver.rs
+++ b/src/models/state/utxo_receiver.rs
@@ -38,7 +38,7 @@ impl Default for ChangeNotifyMethod {
 pub struct UtxoReceiver {
     pub utxo: Utxo,
     pub sender_randomness: Digest,
-    pub receiver_preimage: Digest,
+    pub receiver_privacy_digest: Digest,
     pub utxo_notify_method: UtxoNotifyMethod,
 }
 
@@ -47,7 +47,7 @@ impl From<&UtxoReceiver> for ExpectedUtxo {
         ExpectedUtxo::new(
             d.utxo.clone(),
             d.sender_randomness,
-            d.receiver_preimage,
+            d.receiver_privacy_digest,
             UtxoNotifier::Myself,
         )
     }
@@ -66,7 +66,7 @@ impl UtxoReceiver {
         address: &ReceivingAddress,
         utxo: Utxo,
         sender_randomness: Digest,
-        receiver_preimage: Digest,
+        receiver_privacy_digest: Digest,
     ) -> Result<Self> {
         let utxo_notify_method = match wallet_state.is_wallet_utxo(&utxo) {
             true => UtxoNotifyMethod::OffChain,
@@ -77,7 +77,7 @@ impl UtxoReceiver {
         Ok(Self {
             utxo,
             sender_randomness,
-            receiver_preimage,
+            receiver_privacy_digest,
             utxo_notify_method,
         })
     }
@@ -88,13 +88,13 @@ impl UtxoReceiver {
     pub fn onchain(
         utxo: Utxo,
         sender_randomness: Digest,
-        receiver_preimage: Digest,
+        receiver_privacy_digest: Digest,
         public_announcement: PublicAnnouncement,
     ) -> Self {
         Self {
             utxo,
             sender_randomness,
-            receiver_preimage,
+            receiver_privacy_digest,
             utxo_notify_method: UtxoNotifyMethod::OnChain(public_announcement),
         }
     }
@@ -102,11 +102,15 @@ impl UtxoReceiver {
     /// instantiates `UtxoReceiver` using OffChain notification method.
     ///
     /// For normal situations, auto() should be used instead.
-    pub fn offchain(utxo: Utxo, sender_randomness: Digest, receiver_preimage: Digest) -> Self {
+    pub fn offchain(
+        utxo: Utxo,
+        sender_randomness: Digest,
+        receiver_privacy_digest: Digest,
+    ) -> Self {
         Self {
             utxo,
             sender_randomness,
-            receiver_preimage,
+            receiver_privacy_digest,
             utxo_notify_method: UtxoNotifyMethod::OffChain,
         }
     }
@@ -116,12 +120,12 @@ impl UtxoReceiver {
     pub fn fake_announcement(
         utxo: Utxo,
         sender_randomness: Digest,
-        receiver_preimage: Digest,
+        receiver_privacy_digest: Digest,
     ) -> Self {
         Self {
             utxo,
             sender_randomness,
-            receiver_preimage,
+            receiver_privacy_digest,
             utxo_notify_method: UtxoNotifyMethod::OnChain(PublicAnnouncement::default()),
         }
     }
@@ -176,7 +180,10 @@ mod tests {
             UtxoNotifyMethod::OnChain(_)
         ));
         assert_eq!(utxo_receiver.sender_randomness, sender_randomness);
-        assert_eq!(utxo_receiver.receiver_preimage, receiver_privacy_digest);
+        assert_eq!(
+            utxo_receiver.receiver_privacy_digest,
+            receiver_privacy_digest
+        );
         assert_eq!(utxo_receiver.utxo, utxo);
         Ok(())
     }
@@ -214,7 +221,10 @@ mod tests {
             UtxoNotifyMethod::OffChain
         ));
         assert_eq!(utxo_receiver.sender_randomness, sender_randomness);
-        assert_eq!(utxo_receiver.receiver_preimage, receiver_privacy_digest);
+        assert_eq!(
+            utxo_receiver.receiver_privacy_digest,
+            receiver_privacy_digest
+        );
         assert_eq!(utxo_receiver.utxo, utxo);
         Ok(())
     }

--- a/src/models/state/utxo_receiver.rs
+++ b/src/models/state/utxo_receiver.rs
@@ -1,0 +1,98 @@
+use super::wallet::address::generation_address::ReceivingAddress;
+use super::wallet::utxo_notification_pool::UtxoNotifier;
+use super::wallet::wallet_state::WalletState;
+use super::PublicAnnouncement;
+use super::Utxo;
+use crate::models::state::wallet::utxo_notification_pool::ExpectedUtxo;
+use crate::prelude::twenty_first::math::digest::Digest;
+use anyhow::Result;
+
+#[derive(Debug, Clone)]
+pub enum UtxoNotifyMethod {
+    Onchain(PublicAnnouncement),
+    Offchain,
+}
+
+#[derive(Debug, Clone)]
+pub struct UtxoReceiverData {
+    pub utxo: Utxo,
+    pub sender_randomness: Digest,
+    pub receiver_preimage: Digest,
+    pub utxo_notify_method: UtxoNotifyMethod,
+}
+
+impl From<&UtxoReceiverData> for ExpectedUtxo {
+    fn from(d: &UtxoReceiverData) -> Self {
+        ExpectedUtxo::new(
+            d.utxo.clone(),
+            d.sender_randomness,
+            d.receiver_preimage,
+            UtxoNotifier::Myself,
+        )
+    }
+}
+
+impl UtxoReceiverData {
+    pub fn onchain(
+        utxo: Utxo,
+        sender_randomness: Digest,
+        receiver_preimage: Digest,
+        public_announcement: PublicAnnouncement,
+    ) -> Self {
+        Self {
+            utxo,
+            sender_randomness,
+            receiver_preimage,
+            utxo_notify_method: UtxoNotifyMethod::Onchain(public_announcement),
+        }
+    }
+
+    pub fn offchain(utxo: Utxo, sender_randomness: Digest, receiver_preimage: Digest) -> Self {
+        Self {
+            utxo,
+            sender_randomness,
+            receiver_preimage,
+            utxo_notify_method: UtxoNotifyMethod::Offchain,
+        }
+    }
+
+    pub fn auto(
+        wallet_state: &WalletState,
+        address: &ReceivingAddress,
+        utxo: Utxo,
+        sender_randomness: Digest,
+        receiver_preimage: Digest,
+    ) -> Result<Self> {
+        let utxo_notify_method = match wallet_state.is_wallet_utxo(&utxo) {
+            true => UtxoNotifyMethod::Onchain(
+                address.generate_public_announcement(&utxo, sender_randomness)?,
+            ),
+            false => UtxoNotifyMethod::Offchain,
+        };
+        Ok(Self {
+            utxo,
+            sender_randomness,
+            receiver_preimage,
+            utxo_notify_method,
+        })
+    }
+
+    #[cfg(test)]
+    pub fn fake_announcement(
+        utxo: Utxo,
+        sender_randomness: Digest,
+        receiver_preimage: Digest,
+    ) -> Self {
+        Self {
+            utxo,
+            sender_randomness,
+            receiver_preimage,
+            utxo_notify_method: UtxoNotifyMethod::Onchain(PublicAnnouncement::default()),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn random(utxo: Utxo) -> Self {
+        Self::fake_announcement(utxo, rand::random(), rand::random())
+    }
+}

--- a/src/models/state/wallet/mod.rs
+++ b/src/models/state/wallet/mod.rs
@@ -866,7 +866,7 @@ mod wallet_tests {
         };
         let receiver_data_to_other = vec![receiver_data_12_to_other, receiver_data_one_to_other];
         let mut now = genesis_block.kernel.header.timestamp;
-        let valid_tx = premine_receiver_global_state
+        let (valid_tx, _) = premine_receiver_global_state
             .create_transaction(
                 receiver_data_to_other.clone(),
                 NeptuneCoins::new(2),
@@ -1130,7 +1130,7 @@ mod wallet_tests {
             },
             sender_randomness: random(),
         };
-        let tx_from_preminer = premine_receiver_global_state
+        let (tx_from_preminer, _) = premine_receiver_global_state
             .create_transaction(vec![receiver_data_six.clone()], NeptuneCoins::new(4), now)
             .await
             .unwrap();

--- a/src/models/state/wallet/mod.rs
+++ b/src/models/state/wallet/mod.rs
@@ -366,7 +366,7 @@ mod wallet_tests {
     use crate::models::blockchain::type_scripts::neptune_coins::NeptuneCoins;
     use crate::models::consensus::timestamp::Timestamp;
     use crate::models::state::wallet::utxo_notification_pool::UtxoNotifier;
-    use crate::models::state::UtxoReceiverData;
+    use crate::models::state::{ChangeNotifyMethod, UtxoReceiver};
     use crate::tests::shared::{
         make_mock_block, make_mock_transaction_with_generation_key, mock_genesis_global_state,
         mock_genesis_wallet_state,
@@ -754,7 +754,7 @@ mod wallet_tests {
             next_block.kernel.header.height
         );
 
-        let receiver_data = vec![UtxoReceiverData::fake_announcement(
+        let receiver_data = vec![UtxoReceiver::fake_announcement(
             Utxo {
                 lock_script_hash: LockScript::anyone_can_spend().hash(),
                 coins: NeptuneCoins::new(200).to_native_coins(),
@@ -832,7 +832,7 @@ mod wallet_tests {
         let previous_msa = genesis_block.kernel.body.mutator_set_accumulator.clone();
         let (mut block_1, _, _) = make_mock_block(&genesis_block, None, own_address, rng.gen());
 
-        let receiver_data_12_to_other = UtxoReceiverData::fake_announcement(
+        let receiver_data_12_to_other = UtxoReceiver::fake_announcement(
             Utxo {
                 coins: NeptuneCoins::new(12).to_native_coins(),
                 lock_script_hash: own_address.lock_script().hash(),
@@ -846,7 +846,7 @@ mod wallet_tests {
                 ),
             own_address.privacy_digest,
         );
-        let receiver_data_one_to_other = UtxoReceiverData::fake_announcement(
+        let receiver_data_one_to_other = UtxoReceiver::fake_announcement(
             Utxo {
                 coins: NeptuneCoins::new(1).to_native_coins(),
                 lock_script_hash: own_address.lock_script().hash(),
@@ -867,6 +867,7 @@ mod wallet_tests {
                 receiver_data_to_other.clone(),
                 NeptuneCoins::new(2),
                 now + seven_months,
+                ChangeNotifyMethod::default(),
             )
             .await
             .unwrap();
@@ -1123,7 +1124,7 @@ mod wallet_tests {
             "Block must be valid before merging txs"
         );
 
-        let receiver_data_six = UtxoReceiverData::fake_announcement(
+        let receiver_data_six = UtxoReceiver::fake_announcement(
             Utxo {
                 coins: NeptuneCoins::new(4).to_native_coins(),
                 lock_script_hash: own_address.lock_script().hash(),
@@ -1132,7 +1133,12 @@ mod wallet_tests {
             own_address.privacy_digest,
         );
         let (tx_from_preminer, tx_data_preminer) = premine_receiver_global_state
-            .create_transaction(vec![receiver_data_six.clone()], NeptuneCoins::new(4), now)
+            .create_transaction(
+                vec![receiver_data_six.clone()],
+                NeptuneCoins::new(4),
+                now,
+                ChangeNotifyMethod::default(),
+            )
             .await
             .unwrap();
 

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -303,7 +303,7 @@ impl WalletState {
     // funds.  We could also perform a sequential scan at startup (or import)
     // of keys that have received funds, up to some "gap".  In bitcoin/bip32
     // this gap is defined as 20 keys in a row that have never received funds.
-    fn get_known_spending_keys(&self) -> Vec<SpendingKey> {
+    pub fn get_known_spending_keys(&self) -> Vec<SpendingKey> {
         // for we always return just the 1st key.
         vec![self.wallet_secret.nth_generation_spending_key(0)]
     }

--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -1,6 +1,7 @@
 use crate::models::blockchain::type_scripts::neptune_coins::NeptuneCoins;
 use crate::models::consensus::timestamp::Timestamp;
 use crate::models::state::wallet::coin_with_possible_timelock::CoinWithPossibleTimeLock;
+use crate::models::state::wallet::utxo_notification_pool::UtxoNotifier;
 use crate::prelude::twenty_first;
 
 use anyhow::Result;
@@ -549,7 +550,7 @@ impl RPC for NeptuneRPCServer {
 
         // note: for future changes:
         // No consensus data should be read within this read-lock.
-        // Else a write lock must be used instead and held until
+        // Else the lock must be held until
         // create_transaction() completes, so entire op is atomic.
         // See: https://github.com/Neptune-Crypto/neptune-core/issues/134
         let state = self.state.lock_guard().await;
@@ -593,23 +594,57 @@ impl RPC for NeptuneRPCServer {
         }
 
         // All cryptographic data must be in relation to a single block
-        // and a write-lock must therefore be held over GlobalState to ensure this.
+        // and a read-lock must therefore be held over GlobalState to ensure this.
+        // Note that create_transaction() does not modify any state.
         let transaction_result = self
             .state
-            .lock_guard_mut()
+            .lock_guard()
             .await
             .create_transaction(receiver_data, fee, now)
             .await;
 
-        let transaction = match transaction_result {
-            Ok(tx) => tx,
+        let (transaction, maybe_change_utxo_data) = match transaction_result {
+            Ok((tx, data)) => (tx, data),
             Err(err) => {
                 tracing::error!("Could not create transaction: {}", err);
                 return None;
             }
         };
 
-        // 2. Send transaction message to main
+        // 2. Inform wallet.
+        //
+        //    If we have a change Utxo, we add it to pool
+        //    of expected incoming UTXOs so that we can
+        //    synchronize it after it is confirmed.
+        //
+        //    Here we modify state, so we briefly acquire write-lock.
+        //    TBD:
+        //      a) is this really necessary?  why can't wallet be
+        //         informed of change UTXO when block is received like
+        //         any other incoming utxo?  If not necessary, we can
+        //         avoid any mutation/write during send().
+        //      b) if it's necessary to notify wallet of incoming change
+        //         which adds to balance, should we not also notify
+        //         of all utxos that could affect wallet's balance?
+        //         In particular, it seems like the wallet balance
+        //         should decrease by the amount spent.
+        if let Some(change_utxo_data) = maybe_change_utxo_data {
+            let _change_addition_record = self
+                .state
+                .lock_guard_mut()
+                .await
+                .wallet_state
+                .expected_utxos
+                .add_expected_utxo(
+                    change_utxo_data.change_utxo,
+                    change_utxo_data.change_sender_randomness,
+                    change_utxo_data.receiver_preimage,
+                    UtxoNotifier::Myself,
+                )
+                .expect("Adding change UTXO to UTXO notification pool must succeed");
+        }
+
+        // 3. Send transaction message to main
         let response: Result<(), SendError<RPCServerToMain>> = self
             .rpc_server_to_main_tx
             .send(RPCServerToMain::Send(Box::new(transaction.clone())))

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -714,7 +714,7 @@ pub async fn make_mock_transaction_with_generation_key(
     let public_announcements = receiver_data
         .iter()
         .filter_map(|x| match &x.utxo_notify_method {
-            UtxoNotifyMethod::OnChain(pa) => Some(pa.clone()),
+            UtxoNotifyMethod::OnChainPubKey(pa) => Some(pa.clone()),
             _ => None,
         })
         .collect_vec();

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -73,7 +73,7 @@ use crate::models::state::wallet::address::generation_address;
 use crate::models::state::wallet::wallet_state::WalletState;
 use crate::models::state::wallet::WalletSecret;
 use crate::models::state::GlobalStateLock;
-use crate::models::state::UtxoReceiverData;
+use crate::models::state::UtxoReceiver;
 use crate::util_types::mutator_set::addition_record::pseudorandom_addition_record;
 use crate::util_types::mutator_set::addition_record::AdditionRecord;
 use crate::util_types::mutator_set::chunk_dictionary::pseudorandom_chunk_dictionary;
@@ -690,7 +690,7 @@ pub fn random_option<T>(thing: T) -> Option<T> {
 // keep fn interface. Can be helper function to `create_transaction`.
 pub async fn make_mock_transaction_with_generation_key(
     input_utxos_mps_keys: Vec<(Utxo, MsMembershipProof, generation_address::SpendingKey)>,
-    receiver_data: Vec<UtxoReceiverData>,
+    receiver_data: Vec<UtxoReceiver>,
     fee: NeptuneCoins,
     tip_msa: MutatorSetAccumulator,
 ) -> Transaction {
@@ -714,7 +714,7 @@ pub async fn make_mock_transaction_with_generation_key(
     let public_announcements = receiver_data
         .iter()
         .filter_map(|x| match &x.utxo_notify_method {
-            UtxoNotifyMethod::Onchain(pa) => Some(pa.clone()),
+            UtxoNotifyMethod::OnChain(pa) => Some(pa.clone()),
             _ => None,
         })
         .collect_vec();

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -706,7 +706,7 @@ pub async fn make_mock_transaction_with_generation_key(
         let addition_record = commit(
             Hash::hash(&rd.utxo),
             rd.sender_randomness,
-            rd.receiver_preimage,
+            rd.receiver_privacy_digest,
         );
         outputs.push(addition_record);
     }

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -4,6 +4,7 @@ use crate::models::blockchain::type_scripts::neptune_coins::pseudorandom_amount;
 use crate::models::blockchain::type_scripts::neptune_coins::NeptuneCoins;
 use crate::models::consensus::timestamp::Timestamp;
 use crate::models::consensus::ValidityTree;
+use crate::models::state::UtxoNotifyMethod;
 use crate::prelude::twenty_first;
 use crate::util_types::mutator_set::commit;
 use crate::util_types::mutator_set::get_swbf_indices;
@@ -705,14 +706,17 @@ pub async fn make_mock_transaction_with_generation_key(
         let addition_record = commit(
             Hash::hash(&rd.utxo),
             rd.sender_randomness,
-            rd.receiver_privacy_digest,
+            rd.receiver_preimage,
         );
         outputs.push(addition_record);
     }
 
     let public_announcements = receiver_data
         .iter()
-        .map(|x| x.public_announcement.clone())
+        .filter_map(|x| match &x.utxo_notify_method {
+            UtxoNotifyMethod::Onchain(pa) => Some(pa.clone()),
+            _ => None,
+        })
         .collect_vec();
     let timestamp = Timestamp::now();
 


### PR DESCRIPTION
Closes #122.   Obsoletes #136 

This PR builds on #136 which modifies GlobalState::create_transaction() to take `&self` instead of `&mut self` and makes the state update (for expected_utxo) responsibility of the caller.  The primary motivation is to avoid holding a write lock across the call to prove() which may take a very long time.

This PR focuses on improving the flexibility and ergonomics of the create_transaction() API.

In particular, it improves on #136 in the following ways:
 * handles the general case of `notify wallet of any incoming utxos` instead of the sub-case of `notify wallet of incoming change utxo` -- as discussed with @aszepieniec.
 * enables the caller to individually specify that each output utxo use either on-chain or off-chain notification, and to easily default to off-chain for utxos that our wallet can claim and on-chain for all other utxos.
 * create_transaction() now returns a tuple (Transaction, TransactionDetails) where the latter contains all the tx components, including ExpectedUtxos, which caller must use to inform the wallet.
 * adds rpc endpoint `send_to_many()` which exposes multi-output functionality at the rpc level.    The `send()` endpoint now just wraps `send_to_many()`.
 * adds a test case for `send_to_many()` RPC
 * adds a mock MainLoop channel endpoint for `send_to_many()` to transmit to, which avoids an error case that was previously not logged and now triggered by the test case.
 * adds `UtxoNotifyMethod` and `ChangeNotifyMethod` enums for selecting `OnChainPubKey` and `OffChain` notifications:   aka `PublicAnnouncement` and `ExpectedUtxo`.  It also has a variant `OnChainSymetricKey` in preparation for when we add symmetric-key notifications as alternative to OffChain.
 * Simplifies creation of `UtxoReceiver` struct, which represents each output passed to `create_transaction()`.

These changes are a bit experimental.  I think they are a net overall improvement to the API, but am open to criticisms/suggestions.

I should point out that the ability to select onchain/offchain notification per output utxo is available at the level of the rust API, ie `create_transaction()`, but is *not* available in the RPC API, which just uses the defaults.  So this functionality is not presently exposed to end-users.

One further change worth mentioning:  this eliminates the pause/unpause miner steps inside send/send_to_many rpc calls.  As I see it, a new block could arrive at any moment from a peer while we are creating/proving, so there is nothing special about mining in that regard.   Maybe there's an argument to be made that we can have CPU contention and the Tx will take longer to prove(), however I don't think that is valid right now while mining is single-threaded.   I am open to putting this back if it should prove necessary, but right now I don't see a need for the added complexity.

For purposes of reviewing, I would recommend to start with rpc_server.rs to see how usage has changed, then models/state/mod.rs and models/state/utxo_receiver.rs for most impl changes.  Other files are mostly unit test adaptations.

- [x] TODO:  I just realized I also should add send_to_many command to neptune-cli.  That can happen in a follow-up commit.  (done in 592ff16)

ALSO:  I noticed that our wallet is always just using derivation index 0.  I wrote a couple wallet functions that pretend this is not the case, ie `is_wallet_utxo()` and `get_known_spending_keys()`.    This seems an area that needs attention, ie the wallet should keep track (state) of the last-used key index and increment each time a new wallet address is requested.




