### PR TITLE
docs(consensus::transaction): Add motivation for TX-validity

### DIFF
--- a/docs/src/consensus/transaction.md
+++ b/docs/src/consensus/transaction.md
@@ -14,6 +14,12 @@ Note that while addition records and removal records are both commitments to UTX
 
 ## Validity
 
+Transaction validity is designed to check four conditions:
+1. All involved lockscripts halt gracefully
+2. All involved typescripts halt gracefully
+3. All input UTXOs (except for an optional coinbase) are present in the append-only commitment list
+4. All input UTXOs are *not* present in the sliding-window Bloom filter.
+
 A transaction is *valid* if (any of):
 
  - ***a)*** it has a valid witness (including spending keys and mutator set membership proofs)


### PR DESCRIPTION
Add motivation and overview of what transaction validity implies.