### PR TITLE
feat: Add snippet for storing RRI-claim in dyn memory

### DIFF
--- a/src/models/blockchain/transaction/validity/tasm.rs
+++ b/src/models/blockchain/transaction/validity/tasm.rs
@@ -2,5 +2,6 @@ pub(crate) mod coinbase_amount;
 pub mod compute_indices;
 mod hash_removal_record_indices;
 mod hash_utxo;
+pub mod proof_collection;
 pub mod removal_records_integrity;
 pub mod transaction_kernel_mast_hash;

--- a/src/models/blockchain/transaction/validity/tasm/proof_collection.rs
+++ b/src/models/blockchain/transaction/validity/tasm/proof_collection.rs
@@ -1,1 +1,1 @@
-pub mod store_removal_records_integrity_claim;
+pub mod claims;

--- a/src/models/blockchain/transaction/validity/tasm/proof_collection.rs
+++ b/src/models/blockchain/transaction/validity/tasm/proof_collection.rs
@@ -1,0 +1,1 @@
+pub mod store_removal_records_integrity_claim;

--- a/src/models/blockchain/transaction/validity/tasm/proof_collection/claims.rs
+++ b/src/models/blockchain/transaction/validity/tasm/proof_collection/claims.rs
@@ -1,2 +1,3 @@
+pub mod store_collect_lock_scripts_claim;
 pub mod store_k2os_claim;
 pub mod store_rri_claim;

--- a/src/models/blockchain/transaction/validity/tasm/proof_collection/claims.rs
+++ b/src/models/blockchain/transaction/validity/tasm/proof_collection/claims.rs
@@ -1,0 +1,2 @@
+pub mod store_k2os_claim;
+pub mod store_rri_claim;

--- a/src/models/blockchain/transaction/validity/tasm/proof_collection/claims/store_collect_lock_scripts_claim.rs
+++ b/src/models/blockchain/transaction/validity/tasm/proof_collection/claims/store_collect_lock_scripts_claim.rs
@@ -1,0 +1,280 @@
+use tasm_lib::data_type::DataType;
+use tasm_lib::memory::write_words_to_memory_leave_pointer;
+use tasm_lib::prelude::*;
+use tasm_lib::traits::basic_snippet::BasicSnippet;
+use tasm_lib::triton_vm::prelude::*;
+use tasm_lib::Digest;
+use tasm_lib::{field, field_with_size};
+
+use crate::models::blockchain::transaction::validity::collect_lock_scripts::CollectLockScripts;
+use crate::models::blockchain::transaction::validity::proof_collection::ProofCollection;
+use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
+
+pub(super) struct StoreCollectLockScriptsClaim;
+
+impl BasicSnippet for StoreCollectLockScriptsClaim {
+    fn inputs(&self) -> Vec<(DataType, String)> {
+        vec![(DataType::VoidPointer, "proof_collection_pointer".to_owned())]
+    }
+
+    fn outputs(&self) -> Vec<(DataType, String)> {
+        vec![(DataType::VoidPointer, "claim".to_owned())]
+    }
+
+    fn entrypoint(&self) -> String {
+        "tasm_neptune_transaction_proof_collection_store_collect_lock_scripts_claim".to_owned()
+    }
+
+    fn code(&self, library: &mut Library) -> Vec<LabelledInstruction> {
+        let entrypoint = self.entrypoint();
+        let push_digest = |d: Digest| {
+            let [d0, d1, d2, d3, d4] = d.values();
+            triton_asm! {
+                push {d4}
+                push {d3}
+                push {d2}
+                push {d1}
+                push {d0}
+            }
+        };
+        let push_collect_lock_scripts_hash = push_digest(CollectLockScripts.program().hash());
+
+        let load_digest_reversed = triton_asm!(
+            read_mem 1
+            addi 2
+            read_mem 1
+            addi 2
+            read_mem 1
+            addi 2
+            read_mem 1
+            addi 2
+            read_mem 1
+            pop 1
+        );
+        let dyn_malloc = library.import(Box::new(DynMalloc));
+        let claim_pointer_pointer = library.kmalloc(1);
+
+        let proof_collection_field_salted_inputs_hash = field!(ProofCollection::salted_inputs_hash);
+        let proof_collection_field_and_size_lock_script_hashes =
+            field_with_size!(ProofCollection::lock_script_hashes);
+
+        const SIZE_OF_PROGRAM_DIGEST_AND_INPUT_FIELD: isize = 12;
+        let write_rest_of_claim = write_words_to_memory_leave_pointer(
+            SIZE_OF_PROGRAM_DIGEST_AND_INPUT_FIELD.try_into().unwrap(),
+        );
+
+        let lock_script_hashes_loop_label = format!("{entrypoint}_lock_script_hashes_loop");
+        let lock_script_hashes_loop = triton_asm!(
+            // INVARIANT: _ (*ls_hashes[last+1]_lw) *ls_hashes[n]_lw (*claim.output[n])
+            {lock_script_hashes_loop_label}:
+                /* Loop end-condition */
+                dup 2
+                dup 2
+                eq
+                skiz
+                    return
+
+                dup 1
+                read_mem {Digest::LEN}
+                addi {Digest::LEN * 2}
+                swap 7
+                pop 1
+                // _ (*ls_hashes[last+1]_lw) *ls_hashes[n+1]_lw (*claim.output[n]) [ls_hash[n]]
+
+                dup 5
+                write_mem {Digest::LEN}
+                swap 1
+                pop 1
+                // _ (*ls_hashes[last+1]_lw) *ls_hashes[n+1]_lw (*claim.output[n+1])
+
+                recurse
+        );
+
+        let assert_correct_size_indicator = triton_asm!(
+            // _ ls_hashes_len ls_hashes_si
+
+            /* Calculate expected size-indicator */
+            swap 1
+            push {Digest::LEN}
+            mul
+            addi 1
+            // _ ls_hashes_si (5 * ls_hashes_len + 1)
+
+            dup 1
+            eq
+            assert
+            // _ ls_hashes_si
+        );
+
+        triton_asm!(
+            {entrypoint}:
+                // _ *proof_collection
+
+                /* Put the entire encoding onto the stack, then write to memory */
+                {&push_collect_lock_scripts_hash}
+                // _ *proof_collection [program_digest]
+
+                dup 5
+                {&proof_collection_field_salted_inputs_hash}
+                // _ *proof_collection [program_digest] *salted_inputs_hash
+
+                /* Load claim-input reversed, since given as input in stream-form */
+                {&load_digest_reversed}
+                // _ *proof_collection [program_digest] [reversed(salted_inputs_hash)]
+
+                push {Digest::LEN}
+                push {Digest::LEN + 1}
+                // _ *proof_collection [program_digest] [salted_inputs_hash] input_len input_si
+
+                dup 12
+                {&proof_collection_field_and_size_lock_script_hashes}
+                // _ *proof_collection [program_digest] [salted_inputs_hash] input_len input_si *ls_hashes ls_hashes_si
+
+                /* Calculate end of `ls_hashes` list */
+                dup 1
+                dup 1
+                add
+                addi {Digest::LEN - 1}
+                // _ *proof_collection [program_digest] [salted_inputs_hash] input_len input_si *ls_hashes ls_hashes_si (*ls_hashes[last+1]_lw)
+
+
+                /* Get length of list of lock script hashes */
+                swap 2
+                // _ *proof_collection [program_digest] [salted_inputs_hash] input_len input_si (*ls_hashes[last+1]_lw) ls_hashes_si *ls_hashes
+
+                read_mem 1
+                addi {1 + Digest::LEN}
+                // _ *proof_collection [program_digest] [salted_inputs_hash] input_len input_si (*ls_hashes[last+1]_lw) ls_hashes_si ls_hashes_len *ls_hashes[0]_lw
+
+                swap 2
+                // _ *proof_collection [program_digest] [salted_inputs_hash] input_len input_si (*ls_hashes[last+1]_lw) *ls_hashes[0]_lw ls_hashes_len ls_hashes_si
+
+                {&assert_correct_size_indicator}
+                // _ *proof_collection [program_digest] [salted_inputs_hash] input_len input_si (*ls_hashes[last+1]_lw) *ls_hashes[0]_lw ls_hashes_si
+
+                dup 0
+                addi -1
+                swap 1
+                // _ *proof_collection [program_digest] [salted_inputs_hash] input_len input_si (*ls_hashes[last+1]_lw) *ls_hashes[0]_lw output_len output_si
+
+                call {dyn_malloc}
+                // _ *proof_collection [program_digest] [salted_inputs_hash] input_len input_si (*ls_hashes[last+1]_lw) *ls_hashes[0]_lw output_len output_si *claim
+
+                dup 0
+                push {claim_pointer_pointer}
+                write_mem 1
+                pop 1
+                // _ *proof_collection [program_digest] [salted_inputs_hash] input_len input_si (*ls_hashes[last+1]_lw) *ls_hashes[0]_lw output_len output_si *claim
+
+                /* Write size-indicator and length for claims `output` field */
+                write_mem 2
+                // _ *proof_collection [program_digest] [salted_inputs_hash] input_len input_si (*ls_hashes[last+1]_lw) *ls_hashes[0]_lw (*claim + 2)
+
+                call {lock_script_hashes_loop_label}
+                // _ *proof_collection [program_digest] [salted_inputs_hash] input_len input_si (*ls_hashes[last+1]_lw) *ls_hashes[last+1]_lw (*claim.input)
+
+                swap 2
+                pop 2
+                // _ *proof_collection [program_digest] [salted_inputs_hash] input_len input_si (*claim.input)
+
+                {&write_rest_of_claim}
+                // _ *proof_collection (*claim + n)
+
+                pop 2
+
+                push {claim_pointer_pointer}
+                read_mem 1
+                pop 1
+                // _ *claim
+
+                return
+
+                {&lock_script_hashes_loop}
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use itertools::Itertools;
+    use proptest::prelude::Arbitrary;
+    use proptest::prelude::Strategy;
+    use proptest::test_runner::TestRunner;
+    use rand::rngs::StdRng;
+    use rand::Rng;
+    use rand::RngCore;
+    use rand::SeedableRng;
+    use tasm_lib::memory::encode_to_memory;
+    use tasm_lib::rust_shadowing_helper_functions;
+    use tasm_lib::snippet_bencher::BenchmarkCase;
+    use tasm_lib::traits::function::Function;
+    use tasm_lib::traits::function::FunctionInitialState;
+    use tasm_lib::traits::function::ShadowedFunction;
+    use tasm_lib::traits::rust_shadow::RustShadow;
+
+    use crate::models::blockchain::transaction::primitive_witness::PrimitiveWitness;
+
+    use super::*;
+
+    #[test]
+    fn unit_test() {
+        ShadowedFunction::new(StoreCollectLockScriptsClaim).test();
+    }
+
+    impl Function for StoreCollectLockScriptsClaim {
+        fn rust_shadow(
+            &self,
+            stack: &mut Vec<BFieldElement>,
+            memory: &mut HashMap<BFieldElement, BFieldElement>,
+        ) {
+            fn claim_ptr_ptr_in_isolated_run() -> BFieldElement {
+                bfe!(-2)
+            }
+
+            // _ *proof_collection
+            let proof_collection_pointer = stack.pop().unwrap();
+
+            let proof_collection: ProofCollection =
+                *ProofCollection::decode_from_memory(memory, proof_collection_pointer).unwrap();
+
+            let claim = proof_collection.collect_lock_scripts_claim();
+            let claim_pointer =
+                rust_shadowing_helper_functions::dyn_malloc::dynamic_allocator(memory);
+            encode_to_memory(memory, claim_pointer, &claim);
+
+            // Mimic population of static memory
+            memory.insert(claim_ptr_ptr_in_isolated_run(), claim_pointer);
+
+            stack.push(claim_pointer);
+        }
+
+        fn pseudorandom_initial_state(
+            &self,
+            seed: [u8; 32],
+            _bench_case: Option<BenchmarkCase>,
+        ) -> FunctionInitialState {
+            let mut test_runner = TestRunner::deterministic();
+            let mut rng: StdRng = SeedableRng::from_seed(seed);
+
+            let num_inputs = rng.gen_range(0usize..4);
+            let primitive_witness = PrimitiveWitness::arbitrary_with((num_inputs, 2, 2))
+                .new_tree(&mut test_runner)
+                .unwrap()
+                .current();
+            let proof_collection = ProofCollection::produce(&primitive_witness);
+
+            let pw_pointer = rng.next_u32();
+            let pw_pointer = bfe!(pw_pointer);
+
+            let mut memory = HashMap::default();
+            encode_to_memory(&mut memory, pw_pointer, &proof_collection);
+
+            FunctionInitialState {
+                stack: [self.init_stack_for_isolated_run(), vec![pw_pointer]].concat(),
+                memory,
+            }
+        }
+    }
+}

--- a/src/models/blockchain/transaction/validity/tasm/proof_collection/claims/store_k2os_claim.rs
+++ b/src/models/blockchain/transaction/validity/tasm/proof_collection/claims/store_k2os_claim.rs
@@ -1,0 +1,208 @@
+use tasm_lib::data_type::DataType;
+use tasm_lib::field;
+use tasm_lib::memory::write_words_to_memory_leave_pointer;
+use tasm_lib::prelude::*;
+use tasm_lib::traits::basic_snippet::BasicSnippet;
+use tasm_lib::triton_vm::prelude::*;
+use tasm_lib::Digest;
+
+use crate::models::blockchain::transaction::validity::kernel_to_outputs::KernelToOutputs;
+use crate::models::blockchain::transaction::validity::proof_collection::ProofCollection;
+use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
+
+pub(super) struct StoreK2osClaim;
+
+impl BasicSnippet for StoreK2osClaim {
+    fn inputs(&self) -> Vec<(DataType, String)> {
+        vec![
+            (DataType::Digest, "transaction_kernel_digest".to_owned()),
+            (DataType::VoidPointer, "proof_collection_pointer".to_owned()),
+        ]
+    }
+
+    fn outputs(&self) -> Vec<(DataType, String)> {
+        vec![(DataType::VoidPointer, "claim".to_owned())]
+    }
+
+    fn entrypoint(&self) -> String {
+        "tasm_neptune_transaction_proof_collection_store_k2os_claim".to_owned()
+    }
+
+    fn code(&self, library: &mut Library) -> Vec<LabelledInstruction> {
+        let entrypoint = self.entrypoint();
+        let dyn_malloc = library.import(Box::new(DynMalloc));
+
+        let push_digest = |d: Digest| {
+            let [d0, d1, d2, d3, d4] = d.values();
+            triton_asm! {
+                push {d4}
+                push {d3}
+                push {d2}
+                push {d1}
+                push {d0}
+            }
+        };
+        let push_k2os_program_hash = push_digest(KernelToOutputs.program().hash());
+
+        let proof_collection_field_salted_outputs_hash =
+            field!(ProofCollection::salted_outputs_hash);
+
+        let load_digest = triton_asm!(
+            // _ *digest
+
+            addi {Digest::LEN - 1}
+            read_mem {Digest::LEN}
+            pop 1
+            // _ [digest]
+        );
+
+        const ENCODED_CLAIM_SIZE: isize = 19;
+        let write_claim_to_memory =
+            write_words_to_memory_leave_pointer(ENCODED_CLAIM_SIZE.try_into().unwrap());
+
+        triton_asm!(
+            {entrypoint}:
+                // _ [txk_digest] *proof_collection
+
+                /* Put the entire encoding onto the stack, then write to memory */
+                {&push_k2os_program_hash}
+                // _ [txk_digest] *proof_collection [program_digest]
+
+                dup 6
+                dup 8
+                dup 10
+                dup 12
+                dup 14
+                // _ [txk_digest] *proof_collection [program_digest] [reversed(txk_digest)]
+
+                push {Digest::LEN}
+                push {Digest::LEN + 1}
+                // _ [txk_digest] *proof_collection [program_digest] [reversed(txk_digest)] input_len input_si
+
+                dup 12
+                {&proof_collection_field_salted_outputs_hash}
+                // _ [txk_digest] *proof_collection [program_digest] [reversed(txk_digest)] input_len input_si *salted_inputs_hash
+
+                {&load_digest}
+                // _ [txk_digest] *proof_collection [program_digest] [reversed(txk_digest)] input_len input_si [salted_inputs_hash]
+
+                push {Digest::LEN}
+                push {Digest::LEN + 1}
+                // _ [txk_digest] *proof_collection [program_digest] [reversed(txk_digest)] input_len input_si [salted_inputs_hash] output_si output_len
+
+                call {dyn_malloc}
+                // _ [txk_digest] *proof_collection [program_digest] [reversed(txk_digest)] input_len input_si [salted_inputs_hash] output_si output_len *claim
+
+                {&write_claim_to_memory}
+                // _ [txk_digest] *proof_collection (*claim + 19)
+
+                addi {-ENCODED_CLAIM_SIZE}
+                // _ [txk_digest] *proof_collection *claim
+
+                swap 6
+                pop 5
+                pop 1
+                // _ *claim
+
+                return
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use itertools::Itertools;
+    use proptest::prelude::Arbitrary;
+    use proptest::prelude::Strategy;
+    use proptest::test_runner::TestRunner;
+    use rand::rngs::StdRng;
+    use rand::RngCore;
+    use rand::SeedableRng;
+    use tasm_lib::memory::encode_to_memory;
+    use tasm_lib::rust_shadowing_helper_functions;
+    use tasm_lib::snippet_bencher::BenchmarkCase;
+    use tasm_lib::traits::function::Function;
+    use tasm_lib::traits::function::FunctionInitialState;
+    use tasm_lib::traits::function::ShadowedFunction;
+    use tasm_lib::traits::rust_shadow::RustShadow;
+
+    use crate::models::blockchain::transaction::primitive_witness::PrimitiveWitness;
+
+    use super::*;
+
+    #[test]
+    fn unit_test() {
+        ShadowedFunction::new(StoreK2osClaim).test();
+    }
+
+    impl Function for StoreK2osClaim {
+        fn rust_shadow(
+            &self,
+            stack: &mut Vec<BFieldElement>,
+            memory: &mut HashMap<BFieldElement, BFieldElement>,
+        ) {
+            // _ [txk_digest] *proof_collection
+            let proof_collection_pointer = stack.pop().unwrap();
+            let txk_digest = Digest::new([
+                stack.pop().unwrap(),
+                stack.pop().unwrap(),
+                stack.pop().unwrap(),
+                stack.pop().unwrap(),
+                stack.pop().unwrap(),
+            ]);
+
+            let proof_collection: ProofCollection =
+                *ProofCollection::decode_from_memory(memory, proof_collection_pointer).unwrap();
+            assert_eq!(
+                txk_digest, proof_collection.kernel_mast_hash,
+                "Inconsistent initial state detected"
+            );
+
+            let claim = proof_collection.kernel_to_outputs_claim();
+            let claim_pointer =
+                rust_shadowing_helper_functions::dyn_malloc::dynamic_allocator(memory);
+            encode_to_memory(memory, claim_pointer, &claim);
+
+            stack.push(claim_pointer);
+        }
+
+        fn pseudorandom_initial_state(
+            &self,
+            seed: [u8; 32],
+            _bench_case: Option<BenchmarkCase>,
+        ) -> FunctionInitialState {
+            let mut test_runner = TestRunner::deterministic();
+            let primitive_witness = PrimitiveWitness::arbitrary_with((2, 2, 2))
+                .new_tree(&mut test_runner)
+                .unwrap()
+                .current();
+            let proof_collection = ProofCollection::produce(&primitive_witness);
+
+            let mut rng: StdRng = SeedableRng::from_seed(seed);
+            let pw_pointer = rng.next_u32();
+            let pw_pointer = bfe!(pw_pointer);
+
+            let mut memory = HashMap::default();
+            encode_to_memory(&mut memory, pw_pointer, &proof_collection);
+
+            let transaction_kernel_digest = proof_collection.kernel_mast_hash;
+
+            let txk_digest_on_stack = transaction_kernel_digest
+                .values()
+                .into_iter()
+                .rev()
+                .collect_vec();
+            FunctionInitialState {
+                stack: [
+                    self.init_stack_for_isolated_run(),
+                    txk_digest_on_stack,
+                    vec![pw_pointer],
+                ]
+                .concat(),
+                memory,
+            }
+        }
+    }
+}

--- a/src/models/blockchain/transaction/validity/tasm/proof_collection/store_removal_records_integrity_claim.rs
+++ b/src/models/blockchain/transaction/validity/tasm/proof_collection/store_removal_records_integrity_claim.rs
@@ -1,0 +1,200 @@
+use tasm_lib::data_type::DataType;
+use tasm_lib::field;
+use tasm_lib::memory::write_words_to_memory_leave_pointer;
+use tasm_lib::prelude::*;
+use tasm_lib::traits::basic_snippet::BasicSnippet;
+use tasm_lib::triton_vm::prelude::*;
+use tasm_lib::Digest;
+
+use crate::models::blockchain::transaction::validity::proof_collection::ProofCollection;
+use crate::models::blockchain::transaction::validity::removal_records_integrity::RemovalRecordsIntegrity;
+use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
+
+pub(super) struct StoreRemovalRecordsIntegrityClaim;
+
+impl BasicSnippet for StoreRemovalRecordsIntegrityClaim {
+    fn inputs(&self) -> Vec<(DataType, String)> {
+        vec![
+            (DataType::Digest, "transaction_kernel_digest".to_owned()),
+            (DataType::VoidPointer, "proof_collection_pointer".to_owned()),
+        ]
+    }
+
+    fn outputs(&self) -> Vec<(DataType, String)> {
+        vec![(DataType::VoidPointer, "claim".to_owned())]
+    }
+
+    fn entrypoint(&self) -> String {
+        "tasm_neptune_transaction_validity_proof_collection_store_rri_claim".to_owned()
+    }
+
+    fn code(&self, library: &mut Library) -> Vec<LabelledInstruction> {
+        let entrypoint = self.entrypoint();
+        let dyn_malloc = library.import(Box::new(DynMalloc));
+
+        let push_digest = |d: Digest| {
+            let [d0, d1, d2, d3, d4] = d.values();
+            triton_asm! {
+                push {d4}
+                push {d3}
+                push {d2}
+                push {d1}
+                push {d0}
+            }
+        };
+        let push_rri_hash = push_digest(RemovalRecordsIntegrity.program().hash());
+
+        let proof_collection_field_salted_inputs_hash = field!(ProofCollection::salted_inputs_hash);
+
+        const ENCODED_CLAIM_SIZE: isize = 19;
+        let write_claim_to_memory =
+            write_words_to_memory_leave_pointer(ENCODED_CLAIM_SIZE.try_into().unwrap());
+
+        triton_asm!(
+            {entrypoint}:
+                // _ [txk_digest] *proof_collection
+
+                /* Put the entire encoding onto the stack, then write to memory */
+                {&push_rri_hash}
+                // _ [txk_digest] *proof_collection [program_digest]
+
+                dup 6
+                dup 8
+                dup 10
+                dup 12
+                dup 14
+                // _ [txk_digest] *proof_collection [program_digest] [reversed(txk_digest)]
+
+                push {Digest::LEN}
+                push {Digest::LEN + 1}
+                // _ [txk_digest] *proof_collection [program_digest] [reversed(txk_digest)] input_si input_len
+
+                dup 12
+                {&proof_collection_field_salted_inputs_hash}
+                // _ [txk_digest] *proof_collection [program_digest] [reversed(txk_digest)] input_si input_len *salted_inputs_hash
+
+                addi {Digest::LEN - 1}
+                read_mem {Digest::LEN}
+                pop 1
+                // _ [txk_digest] *proof_collection [program_digest] [reversed(txk_digest)] input_si input_len [salted_inputs_hash]
+
+                push {Digest::LEN}
+                push {Digest::LEN + 1}
+                // _ [txk_digest] *proof_collection [program_digest] [reversed(txk_digest)] input_si input_len [salted_inputs_hash] output_si output_len
+
+                call {dyn_malloc}
+                // _ [txk_digest] *proof_collection [program_digest] [reversed(txk_digest)] input_si input_len [salted_inputs_hash] output_si output_len *claim
+
+                {&write_claim_to_memory}
+                // _ [txk_digest] *proof_collection (*claim + 19)
+
+                addi {-ENCODED_CLAIM_SIZE}
+                // _ [txk_digest] *proof_collection *claim
+
+                swap 6
+                pop 5
+                pop 1
+                // _ *claim
+
+                return
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use itertools::Itertools;
+    use proptest::prelude::Arbitrary;
+    use proptest::prelude::Strategy;
+    use proptest::test_runner::TestRunner;
+    use rand::rngs::StdRng;
+    use rand::RngCore;
+    use rand::SeedableRng;
+    use tasm_lib::memory::encode_to_memory;
+    use tasm_lib::rust_shadowing_helper_functions;
+    use tasm_lib::snippet_bencher::BenchmarkCase;
+    use tasm_lib::traits::function::Function;
+    use tasm_lib::traits::function::FunctionInitialState;
+    use tasm_lib::traits::function::ShadowedFunction;
+    use tasm_lib::traits::rust_shadow::RustShadow;
+
+    use crate::models::blockchain::transaction::primitive_witness::PrimitiveWitness;
+
+    use super::*;
+
+    #[test]
+    fn unit_test() {
+        ShadowedFunction::new(StoreRemovalRecordsIntegrityClaim).test();
+    }
+
+    impl Function for StoreRemovalRecordsIntegrityClaim {
+        fn rust_shadow(
+            &self,
+            stack: &mut Vec<BFieldElement>,
+            memory: &mut HashMap<BFieldElement, BFieldElement>,
+        ) {
+            // _ [txk_digest] *proof_collection
+            let proof_collection_pointer = stack.pop().unwrap();
+            let txk_digest = Digest::new([
+                stack.pop().unwrap(),
+                stack.pop().unwrap(),
+                stack.pop().unwrap(),
+                stack.pop().unwrap(),
+                stack.pop().unwrap(),
+            ]);
+
+            let proof_collection: ProofCollection =
+                *ProofCollection::decode_from_memory(memory, proof_collection_pointer).unwrap();
+            assert_eq!(
+                txk_digest, proof_collection.kernel_mast_hash,
+                "Inconsistent initial state detected"
+            );
+
+            let claim = proof_collection.removal_records_integrity_claim();
+            let claim_pointer =
+                rust_shadowing_helper_functions::dyn_malloc::dynamic_allocator(memory);
+            encode_to_memory(memory, claim_pointer, &claim);
+
+            stack.push(claim_pointer);
+        }
+
+        fn pseudorandom_initial_state(
+            &self,
+            seed: [u8; 32],
+            _bench_case: Option<BenchmarkCase>,
+        ) -> FunctionInitialState {
+            let mut test_runner = TestRunner::deterministic();
+            let primitive_witness = PrimitiveWitness::arbitrary_with((2, 2, 2))
+                .new_tree(&mut test_runner)
+                .unwrap()
+                .current();
+            let proof_collection = ProofCollection::produce(&primitive_witness);
+
+            let mut rng: StdRng = SeedableRng::from_seed(seed);
+            let pw_pointer = rng.next_u32();
+            let pw_pointer = bfe!(pw_pointer);
+
+            let mut memory = HashMap::default();
+            encode_to_memory(&mut memory, pw_pointer, &proof_collection);
+
+            let transaction_kernel_digest = proof_collection.kernel_mast_hash;
+
+            let txk_digest_on_stack = transaction_kernel_digest
+                .values()
+                .into_iter()
+                .rev()
+                .collect_vec();
+            FunctionInitialState {
+                stack: [
+                    self.init_stack_for_isolated_run(),
+                    txk_digest_on_stack,
+                    vec![pw_pointer],
+                ]
+                .concat(),
+                memory,
+            }
+        }
+    }
+}

--- a/test_data/0d9d5d3a40da7c9e1c36b9c0390aa3fa8e4e51550543c953b45c0648d26e0a0d110cab9b3b6ca012.proof
+++ b/test_data/0d9d5d3a40da7c9e1c36b9c0390aa3fa8e4e51550543c953b45c0648d26e0a0d110cab9b3b6ca012.proof
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d80d17ad55796faac26072b7c3dd7ec1fcf93409c50e06a663146a2de8a535f5
+size 717368

--- a/test_data/2802e3ddc01ac5c17e148d3250c37a18b8271038325d78bdf4addf80efefc7e78c4260b40d408b54.proof
+++ b/test_data/2802e3ddc01ac5c17e148d3250c37a18b8271038325d78bdf4addf80efefc7e78c4260b40d408b54.proof
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63fe80e60d948225e95b650c3cd6a8083af867d94dba17dfba789ea5fbdabbb2
+size 858944

--- a/test_data/283ca70810e042f133e4bb9ddb0939f191317aedab4262845c4d9a61fbd31f4c551a09128a31f270.proof
+++ b/test_data/283ca70810e042f133e4bb9ddb0939f191317aedab4262845c4d9a61fbd31f4c551a09128a31f270.proof
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7676a31d3b0ed8faab441b40faac7c1aecdda414c21e2d86a793a4538dd9e2b
+size 668896

--- a/test_data/4e9be1c1df1229cfb81d7cd6d004266376baea7b02284aac6e5cf7c08c725b1f5ea59a4257c1a3fa.proof
+++ b/test_data/4e9be1c1df1229cfb81d7cd6d004266376baea7b02284aac6e5cf7c08c725b1f5ea59a4257c1a3fa.proof
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4df1ef777fb50ce07471594185976c478efaf1d1bdeac9ec1fc16daf341a9271
+size 712048

--- a/test_data/5364505764d30e5771d1f1c7165254e77fad715b0d7c08582ec6da22530fa5c19a6a6c76a3566dcd.proof
+++ b/test_data/5364505764d30e5771d1f1c7165254e77fad715b0d7c08582ec6da22530fa5c19a6a6c76a3566dcd.proof
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86e006a8075279580168c9a605f231fea88ff54847adb0b35b7a5d1c275a9cde
+size 716728

--- a/test_data/65d6be47fd2734317c1f41e663d0ed0e55a727bdc17e5af98f92d8e4add990a7516667c5eadec99d.proof
+++ b/test_data/65d6be47fd2734317c1f41e663d0ed0e55a727bdc17e5af98f92d8e4add990a7516667c5eadec99d.proof
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8208bf7720412a36cd203cae089090f4d21adbf903d1a6702407edce3224dce
+size 535768

--- a/test_data/738ac43c7fbe92be4b174859ee5b72b83b30c8df7db3c4c2f07bcddd9bfe8fe5acde36ce2f6f2b06.proof
+++ b/test_data/738ac43c7fbe92be4b174859ee5b72b83b30c8df7db3c4c2f07bcddd9bfe8fe5acde36ce2f6f2b06.proof
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:528d35120f7041e53b0ed8bce41ffe4cc92312b7e21a8f070a0d53fb397522f0
+size 811632

--- a/test_data/84bf4432da12725fce90abb1a5650d6bfda15ef31c0ed3c1e0de506b8401d54845cbc41761a5fb18.proof
+++ b/test_data/84bf4432da12725fce90abb1a5650d6bfda15ef31c0ed3c1e0de506b8401d54845cbc41761a5fb18.proof
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79c920dc8fb17212d95befe7d7f57504032b256bbf3e19a870b2e7042f5d9579
+size 865384

--- a/test_data/895605d29e5a39e81f018c82d300c38044df5f9f75d7ad968187e4a45b3965893f6cca23c88d2a97.proof
+++ b/test_data/895605d29e5a39e81f018c82d300c38044df5f9f75d7ad968187e4a45b3965893f6cca23c88d2a97.proof
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6debe8a338ba7aaef77884f82bd98e6e80a44add20e80cbe6e11789efb7f6124
+size 718088

--- a/test_data/bb2a368284a23ff11374823587aa407847f339262ebb3f8f7b72ad21b6765fe498c2705714ed47c9.proof
+++ b/test_data/bb2a368284a23ff11374823587aa407847f339262ebb3f8f7b72ad21b6765fe498c2705714ed47c9.proof
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3650b1c955f16423c1fce5fdeb6c4f77081c7f43ce95c0596345c60e3ebf1a99
+size 714248

--- a/test_data/c309bed6b36c131c56445ba588df664c8bf94b4bcae98538a798403ea69c16acf7726227e7e145e6.proof
+++ b/test_data/c309bed6b36c131c56445ba588df664c8bf94b4bcae98538a798403ea69c16acf7726227e7e145e6.proof
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76a7f0bbd4a2034e9ed73be2f23e3d8610b545af59c93e7d6574ec8c9d13b737
+size 708328

--- a/test_data/c5d809759791d4a3300c6e53d3927f5212080f3c7d5dc8649c03a1eff7a1fb09afda34303dae9087.proof
+++ b/test_data/c5d809759791d4a3300c6e53d3927f5212080f3c7d5dc8649c03a1eff7a1fb09afda34303dae9087.proof
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:083ca33a998ef86e8b35ae2f49b514c54b0deedd9d8460699c670029f3df7fc2
+size 625904

--- a/test_data/cd16c05e5d52eb7ff48a93aa4bc48b4f2c7751a040f5160c76a6f1086d298e335901033a85b16954.proof
+++ b/test_data/cd16c05e5d52eb7ff48a93aa4bc48b4f2c7751a040f5160c76a6f1086d298e335901033a85b16954.proof
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8588a025183643ff08f26d5082dbc0983ecef89ca36f60ad3c73c93937bcd8c5
+size 532888

--- a/test_data/d4fc9034fc3839a854a296bbf2470da14614519349f58539d230acc6228ad21c3140e9113e3c7d8e.proof
+++ b/test_data/d4fc9034fc3839a854a296bbf2470da14614519349f58539d230acc6228ad21c3140e9113e3c7d8e.proof
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:984ed5f4f1b8333d29534367d57714095915757263a578edf2d85555a9f9cef1
+size 534488

--- a/test_data/d88252bda0c127d9e61d13e99f12ff2a4304e8232da0c8dd3d9822afeb6cb70b78c07c37930804a4.proof
+++ b/test_data/d88252bda0c127d9e61d13e99f12ff2a4304e8232da0c8dd3d9822afeb6cb70b78c07c37930804a4.proof
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6936360e28a807a629d941a145fc6a2e703270be3cdb6f7bf24590d3991d6a5f
+size 719248

--- a/test_data/e65aab7d1c033a4e82ad0fc5e64ff343a46d7c8962abaa92a1a29ab89cb9a0d5b209989a0c497a1e.proof
+++ b/test_data/e65aab7d1c033a4e82ad0fc5e64ff343a46d7c8962abaa92a1a29ab89cb9a0d5b209989a0c497a1e.proof
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5eba84b38c3d7b8f1fe8ec643e2319e000c4dfe01cf8ec5698ab8438ee9acf34
+size 676976

--- a/test_data/eb186ef807d8ff6a5f272ee92b50b43728fab0f569a8954a916e5fdd130f5908ee7696b3872b0125.proof
+++ b/test_data/eb186ef807d8ff6a5f272ee92b50b43728fab0f569a8954a916e5fdd130f5908ee7696b3872b0125.proof
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a3a8badd34c1ebf5e35018e059285cc5018544f5696c934197b93e658a10061
+size 713648

--- a/test_data/ee513b03a9c2104f9f2fdbd2a731f482979975bf7658b48b0113568bb8fdf43e60180ac61252adb2.proof
+++ b/test_data/ee513b03a9c2104f9f2fdbd2a731f482979975bf7658b48b0113568bb8fdf43e60180ac61252adb2.proof
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eeaa76b5598cfe688bec520b116f8a99ef6906a56a01e7488068237dbc21a909
+size 716288


### PR DESCRIPTION
Here's the pattern I would go with. I think it can be generalized somewhat to handle more claims as well, but I'm not sure that's actually a good idea. Let me know what you think.