### PR TITLE
feat: offchain utxo notifications

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ bincode = "1.3"
 bytes = "1.6"
 bytesize = "1.3"
 chrono = "=0.4.34"
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "string"] }
 clap_complete = "4.4"
 console-subscriber = "0.2"
 crossterm = "0.27"

--- a/src/bin/neptune-cli.rs
+++ b/src/bin/neptune-cli.rs
@@ -41,7 +41,7 @@ use tarpc::tokio_serde::formats::Json;
 const SELF: &str = "self";
 const ANONYMOUS: &str = "anonymous";
 
-/// for parsing SendToMany <output> arguments.
+/// for parsing SendToMany `<output>` arguments.
 #[derive(Debug, Clone)]
 struct TransactionOutput {
     address: String,

--- a/src/bin/neptune-cli.rs
+++ b/src/bin/neptune-cli.rs
@@ -1,36 +1,52 @@
 use std::io;
 use std::io::stdout;
+use std::io::Read;
 use std::io::Write;
 use std::net::IpAddr;
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::str::FromStr;
 
+use anyhow::anyhow;
 use anyhow::bail;
 use anyhow::Result;
 use clap::CommandFactory;
 use clap::Parser;
+use clap::Subcommand;
 use clap_complete::generate;
 use clap_complete::Shell;
+use itertools::EitherOrBoth;
+use itertools::Itertools;
 use neptune_core::config_models::data_directory::DataDirectory;
 use neptune_core::config_models::network::Network;
 use neptune_core::models::blockchain::block::block_selector::BlockSelector;
-use neptune_core::models::blockchain::transaction::UtxoNotifyMethod;
+use neptune_core::models::blockchain::transaction::OwnedUtxoNotifyMethod;
+use neptune_core::models::blockchain::transaction::TxParams;
+use neptune_core::models::blockchain::transaction::UnownedUtxoNotifyMethod;
+use neptune_core::models::blockchain::transaction::UtxoNotification;
 use neptune_core::models::blockchain::type_scripts::neptune_coins::NeptuneCoins;
 use neptune_core::models::state::wallet::address::KeyType;
 use neptune_core::models::state::wallet::address::ReceivingAddress;
 use neptune_core::models::state::wallet::coin_with_possible_timelock::CoinWithPossibleTimeLock;
 use neptune_core::models::state::wallet::wallet_status::WalletStatus;
 use neptune_core::models::state::wallet::WalletSecret;
+use neptune_core::models::state::TxOutputMeta;
 use neptune_core::rpc_server::RPCClient;
+use serde::Deserialize;
+use serde::Serialize;
 use tarpc::client;
 use tarpc::context;
 use tarpc::tokio_serde::formats::Json;
 
-// for parsing SendToMany <output> arguments.
+const SELF: &str = "self";
+const ANONYMOUS: &str = "anonymous";
+
+/// for parsing SendToMany <output> arguments.
 #[derive(Debug, Clone)]
 struct TransactionOutput {
     address: String,
     amount: NeptuneCoins,
+    recipient: String,
 }
 
 /// We impl FromStr deserialization so that clap can parse the --outputs arg of
@@ -41,28 +57,36 @@ struct TransactionOutput {
 impl FromStr for TransactionOutput {
     type Err = anyhow::Error;
 
-    /// parses address:amount into TransactionOutput{address, amount}
+    /// parses address:amount:recipient or address:amount into TransactionOutput{address, amount, recipient}
     ///
-    /// This is used by the outputs arg of send-to-many command.
-    /// Usage looks like:
+    /// This is used by the outputs arg of send-to-many command.  Usage looks
+    /// like:
     ///
-    ///     <OUTPUTS>...  format: address:amount address:amount ...
+    ///     <OUTPUTS>...  format: address:amount address:amount:recipient ...
     ///
-    /// So each output is space delimited and the two fields are
-    /// colon delimted.
+    /// So each output is space delimited and the 2 (or 3) fields are colon
+    /// delimited.
     ///
-    /// This format was chosen because it should be simple for humans
-    /// to generate on the command-line.
+    /// if `recipient` is omitted for any output, then it defaults to
+    /// "anonymous".
+    ///
+    /// This format was chosen because it should be simple for humans to
+    /// generate on the command-line.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let parts = s.split(':').collect::<Vec<_>>();
 
-        if parts.len() != 2 {
+        if parts.len() != 2 && parts.len() != 3 {
             anyhow::bail!("Invalid transaction output.  missing :")
         }
 
         Ok(Self {
             address: parts[0].to_string(),
             amount: NeptuneCoins::from_str(parts[1])?,
+            recipient: match parts.len() {
+                3 if !parts[2].trim().is_empty() => parts[2].trim(),
+                _ => ANONYMOUS,
+            }
+            .to_string(),
         })
     }
 }
@@ -79,80 +103,274 @@ impl TransactionOutput {
     }
 }
 
-#[derive(Debug, Parser)]
+/// AddressEnum is used by send and send-to-many to distinguish between
+/// key-types when writing utxo-transfer file(s) for any off-chain-serialized
+/// utxos.
+///
+/// the issue is that it is useful to display the address in the file, or even an
+/// abbreviation in the filename. This aids the sender in identifying the utxo
+/// and routing it to the intended recipient.
+///
+/// however this should never be done for symmetric keys as it would expose the
+/// private key, so we only display the receiver_identifier.
+///
+/// normally unowned utxo-transfer would not be using symmetric keys, however
+/// there are some use cases for it such as when a person or org holds multiple
+/// wallets and is transferrng between them.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum AddressEnum {
+    Generation {
+        address_abbrev: String,
+        address: String,
+        receiver_identifier: String,
+    },
+    Symmetric {
+        receiver_identifier: String,
+    },
+}
+impl TryFrom<(&ReceivingAddress, Network)> for AddressEnum {
+    type Error = anyhow::Error;
+
+    fn try_from(v: (&ReceivingAddress, Network)) -> Result<Self> {
+        let (addr, network) = v;
+        Ok(match *addr {
+            ReceivingAddress::Generation(_) => Self::Generation {
+                address_abbrev: addr.to_bech32m_abbreviated(network)?,
+                address: addr.to_bech32m(network)?,
+                receiver_identifier: addr.receiver_identifier().to_string(),
+            },
+            ReceivingAddress::Symmetric(_) => Self::Symmetric {
+                receiver_identifier: addr.receiver_identifier().to_string(),
+            },
+        })
+    }
+}
+impl AddressEnum {
+    fn short_id(&self) -> &str {
+        match *self {
+            Self::Generation {
+                ref address_abbrev, ..
+            } => address_abbrev,
+            Self::Symmetric {
+                ref receiver_identifier,
+                ..
+            } => receiver_identifier,
+        }
+    }
+}
+
+/// represents a UtxoTransfer entry in a utxo-transfer file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UtxoTransferEntry {
+    pub data_format: String,
+    pub recipient: String,
+    pub amount: String,
+    pub utxo_transfer_encrypted: String,
+    pub address_info: AddressEnum,
+}
+
+impl UtxoTransferEntry {
+    fn data_format() -> String {
+        "neptune-utxo-transfer-v1.0".to_string()
+    }
+}
+
+/// represents data format of input to claim-utxo
+#[derive(Debug, Clone, Subcommand)]
+pub enum ClaimUtxoFormat {
+    /// reads utxo-transfer-encrypted field of the utxo-transfer json file.
+    Raw {
+        /// will be read from stdin if not present
+        raw: Option<String>,
+    },
+    /// reads contents of a utxo-transfer json file
+    Json {
+        /// will be read from stdin if not present
+        json: Option<String>,
+    },
+    /// reads a utxo-transfer json file
+    File {
+        /// path to the file
+        path: PathBuf,
+    },
+}
+
+/// represents cli command
+#[derive(Debug, Clone, Parser)]
 enum Command {
     /// Dump shell completions.
     Completions,
 
     /******** READ STATE ********/
+    /// retrieve network that neptune-core is running on
     Network,
+
+    /// retrieve address for peers to contact this neptune-core node
     OwnListenAddressForPeers,
+
+    /// retrieve instance-id of this neptune-core node
     OwnInstanceId,
+
+    /// retrieve current block height
     BlockHeight,
+
+    /// retrieve information about a block
     BlockInfo {
         /// one of: `genesis, tip, height/<n>, digest/<hex>`
         block_selector: BlockSelector,
     },
+
+    /// retrieve confirmations
     Confirmations,
+
+    /// retrieve info about peers
     PeerInfo,
+
+    /// retrieve list of sanctioned peers
     AllSanctionedPeers,
+
+    /// retrieve digest/hash of newest block
     TipDigest,
-    LatestTipDigests {
-        n: usize,
-    },
-    TipHeader,
+
+    /// retrieve digests of newest n blocks
+    LatestTipDigests { n: usize },
+
+    /// retrieve block-header of any block
     Header {
         /// one of: `genesis, tip, height/<n>, digest/<hex>`
         block_selector: BlockSelector,
     },
+
+    /// retrieve confirmed balance
     SyncedBalance,
+
+    /// retrieve wallet status information
     WalletStatus,
-    OwnReceivingAddress,
+
+    /// retrieve next unused receiving address
+    NextReceivingAddress {
+        #[clap(value_enum, default_value_t = KeyType::Generation)]
+        key_type: KeyType,
+    },
+
+    /// list known coins
     ListCoins,
+
+    /// retrieve count of transactions in the mempool
     MempoolTxCount,
+
+    /// retrieve size of mempool in bytes (in RAM)
     MempoolSize,
 
     /******** CHANGE STATE ********/
+    /// shutdown neptune-core
     Shutdown,
+
+    /// clear all peer standings
     ClearAllStandings,
-    ClearStandingByIp {
-        ip: IpAddr,
-    },
+
+    /// clear peer standing for a given IP address
+    ClearStandingByIp { ip: IpAddr },
+
+    /// send to a single recipient
     Send {
-        amount: NeptuneCoins,
+        /// recipient's address
         address: String,
+
+        /// amount to send
+        amount: NeptuneCoins,
+
+        /// transaction fee
         fee: NeptuneCoins,
+
+        /// recipient name or label, for local usage only
+        #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new(), default_value = ANONYMOUS)]
+        recipient: String,
+
+        /// how to notify our wallet of utxos.
+        #[clap(long, value_enum, default_value_t)]
+        owned_utxo_notify_method: OwnedUtxoNotifyMethod,
+
+        /// how to notify recipient's wallet of utxos.
+        #[clap(long, value_enum, default_value_t)]
+        unowned_utxo_notify_method: UnownedUtxoNotifyMethod,
     },
+
+    /// send to multiple recipients
     SendToMany {
-        /// format: address:amount address:amount ...
+        /// transaction outputs. format: address:amount:recipient address:amount ...
+        ///
+        /// recipient is a local-only label and will be "anonymous" if omitted.
         #[clap(value_parser, num_args = 1.., required=true, value_delimiter = ' ')]
         outputs: Vec<TransactionOutput>,
+
+        /// transaction fee
         fee: NeptuneCoins,
+
+        /// how to notify our wallet of utxos.
+        #[clap(long, value_enum, default_value_t)]
+        owned_utxo_notify_method: OwnedUtxoNotifyMethod,
+
+        /// how to notify recipient's wallet(s) of utxos.
+        #[clap(long, value_enum, default_value_t)]
+        unowned_utxo_notify_method: UnownedUtxoNotifyMethod,
     },
+    /// claim an off-chain utxo-transfer.
+    ClaimUtxo {
+        #[clap(subcommand)]
+        format: ClaimUtxoFormat,
+    },
+
+    /// pause mining
     PauseMiner,
+
+    /// resume mining
     RestartMiner,
+
+    /// prune monitored utxos from abandoned chains
     PruneAbandonedMonitoredUtxos,
 
     /******** WALLET ********/
+    /// generate a new wallet
     GenerateWallet {
-        #[clap(long, default_value_t=Network::default())]
+        #[clap(long, default_value_t)]
         network: Network,
+
+        /// neptune-core data directory containing wallet and blockchain state
+        #[clap(long)]
+        data_dir: Option<PathBuf>,
     },
+    /// displays path to wallet secrets file
     WhichWallet {
-        #[clap(long, default_value_t=Network::default())]
+        #[clap(long, default_value_t)]
         network: Network,
+
+        /// neptune-core data directory containing wallet and blockchain state
+        #[clap(long)]
+        data_dir: Option<PathBuf>,
     },
+    /// export mnemonic seed phrase
     ExportSeedPhrase {
-        #[clap(long, default_value_t=Network::default())]
+        #[clap(long, default_value_t)]
         network: Network,
+
+        /// neptune-core data directory containing wallet and blockchain state
+        #[clap(long)]
+        data_dir: Option<PathBuf>,
     },
+    /// import mnemonic seed phrase
     ImportSeedPhrase {
-        #[clap(long, default_value_t=Network::default())]
+        #[clap(long, default_value_t)]
         network: Network,
+
+        /// neptune-core data directory containing wallet and blockchain state
+        #[clap(long)]
+        data_dir: Option<PathBuf>,
     },
 }
 
-#[derive(Debug, Parser)]
+/// represents top-level cli args
+#[derive(Debug, Clone, Parser)]
 #[clap(name = "neptune-cli", about = "An RPC client")]
 struct Config {
     /// Sets the server address to connect to.
@@ -161,9 +379,6 @@ struct Config {
 
     #[clap(subcommand)]
     command: Command,
-
-    #[structopt(long, short, default_value = "alpha")]
-    pub network: Network,
 }
 
 #[tokio::main]
@@ -180,30 +395,25 @@ async fn main() -> Result<()> {
                 bail!("Unknown shell.  Shell completions not available.")
             }
         }
-        Command::WhichWallet { network } => {
-            // The root path is where both the wallet and all databases are stored
-            let data_dir = DataDirectory::get(None, network)?;
+        Command::WhichWallet { network, data_dir } => {
+            let wallet_dir = DataDirectory::get(data_dir, network)?.wallet_directory_path();
 
             // Get wallet object, create various wallet secret files
-            let wallet_dir = data_dir.wallet_directory_path();
             let wallet_file = WalletSecret::wallet_secret_path(&wallet_dir);
             if !wallet_file.exists() {
-                println!("No wallet file found at {}.", wallet_file.display());
+                bail!("No wallet file found at {}.", wallet_file.display());
             } else {
                 println!("{}", wallet_file.display());
             }
             return Ok(());
         }
-        Command::GenerateWallet { network } => {
-            // The root path is where both the wallet and all databases are stored
-            let data_dir = DataDirectory::get(None, network)?;
+        Command::GenerateWallet { network, data_dir } => {
+            let wallet_dir = DataDirectory::get(data_dir, network)?.wallet_directory_path();
 
             // Get wallet object, create various wallet secret files
-            let wallet_dir = data_dir.wallet_directory_path();
             DataDirectory::create_dir_if_not_exists(&wallet_dir).await?;
 
-            let (_, secret_file_paths) =
-                WalletSecret::read_from_file_or_create(&wallet_dir).unwrap();
+            let (_, secret_file_paths) = WalletSecret::read_from_file_or_create(&wallet_dir)?;
 
             println!(
                 "Wallet stored in: {}\nMake sure you also see this path if you run the neptune-core client",
@@ -217,19 +427,16 @@ async fn main() -> Result<()> {
 
             return Ok(());
         }
-        Command::ImportSeedPhrase { network } => {
-            // The root path is where both the wallet and all databases are stored
-            let data_dir = DataDirectory::get(None, network)?;
-            let wallet_dir = data_dir.wallet_directory_path();
+        Command::ImportSeedPhrase { network, data_dir } => {
+            let wallet_dir = DataDirectory::get(data_dir, network)?.wallet_directory_path();
             let wallet_file = WalletSecret::wallet_secret_path(&wallet_dir);
 
             // if the wallet file already exists,
             if wallet_file.exists() {
-                println!(
+                bail!(
                     "Cannot import seed phrase; wallet file {} already exists. Move it to another location (or remove it) to import a seed phrase.",
                     wallet_file.display()
                 );
-                return Ok(());
             }
 
             // read seed phrase from user input
@@ -261,8 +468,7 @@ async fn main() -> Result<()> {
             }
             let wallet_secret = match WalletSecret::from_phrase(&phrase) {
                 Err(_) => {
-                    println!("Invalid seed phrase. Please try again.");
-                    return Ok(());
+                    bail!("Invalid seed phrase.");
                 }
                 Ok(ws) => ws,
             };
@@ -272,9 +478,7 @@ async fn main() -> Result<()> {
             DataDirectory::create_dir_if_not_exists(&wallet_dir).await?;
             match wallet_secret.save_to_disk(&wallet_file) {
                 Err(e) => {
-                    println!("Could not save imported wallet to disk.");
-                    println!("Error:");
-                    println!("{e}");
+                    bail!("Could not save imported wallet to disk. {e}");
                 }
                 Ok(_) => {
                     println!("Success.");
@@ -283,19 +487,17 @@ async fn main() -> Result<()> {
 
             return Ok(());
         }
-        Command::ExportSeedPhrase { network } => {
+        Command::ExportSeedPhrase { network, data_dir } => {
             // The root path is where both the wallet and all databases are stored
-            let data_dir = DataDirectory::get(None, network)?;
+            let wallet_dir = DataDirectory::get(data_dir, network)?.wallet_directory_path();
 
             // Get wallet object, create various wallet secret files
-            let wallet_dir = data_dir.wallet_directory_path();
             let wallet_file = WalletSecret::wallet_secret_path(&wallet_dir);
             if !wallet_file.exists() {
-                println!(
-                    "Cannot export seed phrase because there is no wallet.dat file to export from."
+                bail!(
+                    concat!("Cannot export seed phrase because there is no wallet.dat file to export from.\n",
+                    "Generate one using `neptune-cli generate-wallet` or `neptune-wallet-gen`, or import a seed phrase using `neptune-cli import-seed-phrase`.")
                 );
-                println!("Generate one using `neptune-cli generate-wallet` or `neptune-wallet-gen`, or import a seed phrase using `neptune-cli import-seed-phrase`.");
-                return Ok(());
             }
             let wallet_secret = match WalletSecret::read_from_file(&wallet_file) {
                 Err(e) => {
@@ -319,7 +521,7 @@ async fn main() -> Result<()> {
     let client = RPCClient::new(client::Config::default(), transport.await?).spawn();
     let ctx = context::current();
 
-    match args.command {
+    match args.clone().command {
         Command::Completions
         | Command::GenerateWallet { .. }
         | Command::WhichWallet { .. }
@@ -396,21 +598,10 @@ async fn main() -> Result<()> {
                 println!("{hash}");
             }
         }
-        Command::TipHeader => {
-            let val = client
-                .header(ctx, BlockSelector::Tip)
-                .await?
-                .expect("Tip header should be found");
-            println!("{val}")
-        }
-        Command::Header { block_selector } => {
-            let res = client.header(ctx, block_selector).await?;
-            if res.is_none() {
-                println!("Block did not exist in database.");
-            } else {
-                println!("{}", res.unwrap());
-            }
-        }
+        Command::Header { block_selector } => match client.header(ctx, block_selector).await? {
+            Some(header) => println!("{}", header),
+            None => println!("Block did not exist in database."),
+        },
         Command::SyncedBalance => {
             let val = client.synced_balance(ctx).await?;
             println!("{val}");
@@ -419,11 +610,9 @@ async fn main() -> Result<()> {
             let wallet_status: WalletStatus = client.wallet_status(ctx).await?;
             println!("{}", serde_json::to_string_pretty(&wallet_status)?);
         }
-        Command::OwnReceivingAddress => {
-            let rec_addr = client
-                .next_receiving_address(ctx, KeyType::Generation)
-                .await?;
-            println!("{}", rec_addr.to_bech32m(args.network).unwrap())
+        Command::NextReceivingAddress { key_type } => {
+            let rec_addr = client.next_receiving_address(ctx, key_type).await?;
+            println!("{}", rec_addr.to_bech32m(client.network(ctx).await?)?)
         }
         Command::MempoolTxCount => {
             let count: usize = client.mempool_tx_count(ctx).await?;
@@ -449,34 +638,92 @@ async fn main() -> Result<()> {
             println!("Cleared standing of {}", ip);
         }
         Command::Send {
-            amount,
             address,
+            amount,
             fee,
+            recipient,
+            owned_utxo_notify_method,
+            unowned_utxo_notify_method,
         } => {
             // Parse on client
-            let receiving_address = ReceivingAddress::from_bech32m(&address, args.network)?;
+            let data_dir = client.data_directory(ctx).await?;
+            let network = client.network(ctx).await?;
+            let receiving_address = ReceivingAddress::from_bech32m(&address, network)?;
+            let parsed_outputs = vec![(receiving_address, amount)];
+            let recipients = vec![recipient];
 
-            client
-                .send(
+            let (tx_params, tx_output_meta) = client
+                .generate_tx_params(
                     ctx,
-                    amount,
-                    receiving_address,
-                    UtxoNotifyMethod::OnChain,
+                    parsed_outputs.clone(),
                     fee,
+                    owned_utxo_notify_method,
+                    unowned_utxo_notify_method,
                 )
-                .await?;
-            println!("Send completed.");
+                .await?
+                .map_err(|s| anyhow!(s))?;
+
+            let tx_digest = client
+                .send(ctx, tx_params.clone())
+                .await?
+                .map_err(|s| anyhow!(s))?;
+
+            process_utxo_notifications(&data_dir, network, tx_params, tx_output_meta, recipients)?;
+            println!("Send completed. Tx Digest: {}", tx_digest.to_hex());
         }
-        Command::SendToMany { outputs, fee } => {
+        Command::SendToMany {
+            outputs,
+            fee,
+            owned_utxo_notify_method,
+            unowned_utxo_notify_method,
+        } => {
+            let data_dir = client.data_directory(ctx).await?;
+            let network = client.network(ctx).await?;
             let parsed_outputs = outputs
-                .into_iter()
-                .map(|o| o.to_receiving_address_amount_tuple(args.network))
+                .iter()
+                .map(|o| o.to_receiving_address_amount_tuple(network))
                 .collect::<Result<Vec<_>>>()?;
 
+            let (tx_params, tx_output_meta) = client
+                .generate_tx_params(
+                    ctx,
+                    parsed_outputs.clone(),
+                    fee,
+                    owned_utxo_notify_method,
+                    unowned_utxo_notify_method,
+                )
+                .await?
+                .map_err(|s| anyhow!(s))?;
+
+            let tx_digest = client
+                .send(ctx, tx_params.clone())
+                .await?
+                .map_err(|s| anyhow!(s))?;
+
+            let recipients = outputs.into_iter().map(|o| o.recipient).collect_vec();
+            process_utxo_notifications(&data_dir, network, tx_params, tx_output_meta, recipients)?;
+            println!("Send completed. Tx Digest: {}", tx_digest.to_hex());
+        }
+        Command::ClaimUtxo { format } => {
+            let utxo_transfer_encrypted = match format {
+                ClaimUtxoFormat::Raw { raw } => val_or_stdin_line(raw)?,
+                ClaimUtxoFormat::File { path } => {
+                    let buf = std::fs::read_to_string(path)?;
+                    let utxo_transfer_entry: UtxoTransferEntry = serde_json::from_str(&buf)?;
+                    utxo_transfer_entry.utxo_transfer_encrypted
+                }
+                ClaimUtxoFormat::Json { json } => {
+                    let buf = val_or_stdin(json)?;
+                    let utxo_transfer_entry: UtxoTransferEntry = serde_json::from_str(&buf)?;
+                    utxo_transfer_entry.utxo_transfer_encrypted
+                }
+            };
             client
-                .send_to_many(ctx, parsed_outputs, UtxoNotifyMethod::OnChain, fee)
-                .await?;
-            println!("Send completed.");
+                .claim_utxo(ctx, utxo_transfer_encrypted)
+                .await?
+                .map_err(|s| anyhow!(s))?;
+
+            println!("Success.  1 Utxo Transfer was imported.");
         }
         Command::PauseMiner => {
             println!("Sending command to pause miner.");
@@ -496,4 +743,140 @@ async fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+// processes utxo-notifications in TxParams outputs, if any.
+//
+// 1. find off-chain-serialized outputs and add metadata
+//    (address, label, owner-type)
+// 2. create utxo-transfer dir if not existing
+// 3. write out one UtxoTransferEntry in a json file, per output
+// 4. provide instructions for sender and receiver. (if needed)
+fn process_utxo_notifications(
+    root_data_dir: &DataDirectory,
+    network: Network,
+    tx_params: TxParams,
+    tx_output_meta: Vec<TxOutputMeta>,
+    recipients: Vec<String>,
+) -> anyhow::Result<()> {
+    assert_eq!(tx_params.tx_output_list().len(), tx_output_meta.len());
+    assert!(tx_output_meta.len() >= recipients.len());
+
+    let data_dir = root_data_dir.utxo_transfer_directory_path();
+
+    // find off-chain-serialized outputs and add metadata
+    // (address, label, owner-type)
+    let mut entries = tx_params
+        .tx_output_list()
+        .iter()
+        .zip(tx_output_meta)
+        .zip_longest(recipients)
+        .map(|pair| match pair {
+            EitherOrBoth::Both((o, m), r) => (o, m, r),
+            EitherOrBoth::Left((o, m)) => (o, m, SELF.to_string()),
+            EitherOrBoth::Right(_) => unreachable!(),
+        })
+        .filter_map(|(o, m, recipient)| match &o.utxo_notification {
+            UtxoNotification::OffChainSerialized(x) => Some((
+                m.receiving_address,
+                o.utxo.get_native_currency_amount(),
+                x,
+                match m.self_owned {
+                    true => SELF.to_string(),
+                    false => recipient,
+                },
+            )),
+            _ => None,
+        })
+        .peekable();
+
+    if entries.peek().is_some() {
+        // create utxo-transfer dir if not existing
+        std::fs::create_dir_all(&data_dir)?;
+
+        println!("\n*** Utxo Transfer Files ***\n");
+    }
+
+    // write out one UtxoTransferEntry in a json file, per output
+    let mut wrote_file_cnt = 0usize;
+    for (address, amount, utxo_transfer_encrypted, recipient) in entries {
+        let file_dir = data_dir.join(&recipient);
+        std::fs::create_dir_all(&file_dir)?;
+
+        let entry = UtxoTransferEntry {
+            data_format: UtxoTransferEntry::data_format(),
+            recipient: recipient.clone(),
+            amount: amount.to_string(),
+            utxo_transfer_encrypted: utxo_transfer_encrypted.to_bech32m(network)?,
+            address_info: (&address, network).try_into()?,
+        };
+
+        let mut file_name = format!("{}-{}.json", entry.address_info.short_id(), entry.amount);
+        let file_path = (1..)
+            .filter_map(|i| {
+                let path = file_dir.join(&file_name);
+                file_name = format!("{}-{}.{}.json", recipient, entry.amount, i);
+                match path.exists() {
+                    false => Some(path),
+                    true => None,
+                }
+            })
+            .next()
+            .ok_or_else(|| anyhow!("could not determine file path"))?;
+
+        let file = std::fs::File::create_new(&file_path)?;
+        let mut writer = std::io::BufWriter::new(file);
+        serde_json::to_writer_pretty(&mut writer, &entry)?;
+        writer.flush()?;
+
+        wrote_file_cnt += 1;
+
+        println!("wrote {}", file_path.display());
+    }
+
+    // provide instructions for sender and receiver. (if needed)
+    if wrote_file_cnt > 0 {
+        println!("\n*** Important - Read or risk losing funds ***\n");
+        println!(
+            "
+{wrote_file_cnt} transaction outputs were each written to individual files for off-chain transfer.
+
+-- Sender Instructions --
+
+You must transfer each file to the corresponding recipient for claiming or they will never be able to claim the funds.
+
+You should also provide them the following recipient instructions.
+
+-- Recipient Instructions --
+
+run `neptune-cli claim-utxo file <file>` or use equivalent claim functionality of your chosen wallet software.
+"
+        );
+    }
+
+    Ok(())
+}
+
+// retrieves value from Option or else from first line of stdin (trimmed).
+fn val_or_stdin_line<T: std::fmt::Display>(val: Option<T>) -> Result<String> {
+    match val {
+        Some(v) => Ok(v.to_string()),
+        None => {
+            let mut buffer = String::new();
+            std::io::stdin().read_line(&mut buffer)?;
+            Ok(buffer.trim().to_string())
+        }
+    }
+}
+
+// retrieves value from Option or else from stdin (trimmed).
+fn val_or_stdin<T: std::fmt::Display>(val: Option<T>) -> Result<String> {
+    match val {
+        Some(v) => Ok(v.to_string()),
+        None => {
+            let mut buffer = String::new();
+            std::io::stdin().read_to_string(&mut buffer)?;
+            Ok(buffer.trim().to_string())
+        }
+    }
 }

--- a/src/config_models/data_directory.rs
+++ b/src/config_models/data_directory.rs
@@ -4,6 +4,8 @@ use std::path::PathBuf;
 use anyhow::Context;
 use anyhow::Result;
 use directories::ProjectDirs;
+use serde::Deserialize;
+use serde::Serialize;
 
 use crate::config_models::network::Network;
 use crate::models::database::DATABASE_DIRECTORY_ROOT_NAME;
@@ -17,8 +19,10 @@ use crate::models::state::wallet::WALLET_DB_NAME;
 use crate::models::state::wallet::WALLET_DIRECTORY;
 use crate::models::state::wallet::WALLET_OUTPUT_COUNT_DB_NAME;
 
+const UTXO_TRANSFER_DIRECTORY: &str = "utxo-transfer";
+
 // TODO: Add `rusty_leveldb::Options` and `fs::OpenOptions` here too, since they keep being repeated.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DataDirectory {
     data_dir: PathBuf,
 }
@@ -89,6 +93,18 @@ impl DataDirectory {
     /// This directory lives within `DataDirectory::database_dir_path()`.
     pub fn banned_ips_database_dir_path(&self) -> PathBuf {
         self.database_dir_path().join(Path::new(BANNED_IPS_DB_NAME))
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    ///
+    /// utxo-transfer path
+    ///
+    /// for storing off-chain serialized transfer files.
+    ///
+    /// note: this is not used by neptune-core, but is used/shared by
+    ///       neptune-cli, neptune-dashboard
+    pub fn utxo_transfer_directory_path(&self) -> PathBuf {
+        self.data_dir.join(Path::new(UTXO_TRANSFER_DIRECTORY))
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/config_models/network.rs
+++ b/src/config_models/network.rs
@@ -5,35 +5,36 @@ use std::time::UNIX_EPOCH;
 
 use serde::Deserialize;
 use serde::Serialize;
-use strum::EnumIter;
 use tasm_lib::twenty_first::math::b_field_element::BFieldElement;
 
 use crate::models::consensus::timestamp::Timestamp;
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Default, EnumIter)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Default, clap::ValueEnum)]
 pub enum Network {
     /// First iteration of testnet. Not feature-complete. Soon to be deprecated.
     #[default]
     Alpha,
 
-    /// Upcoming iteration of testnet. Not feature-complete either but moreso than
-    /// Alpha. Soon to be set as default.
+    /// Upcoming iteration of testnet.
+    ///
+    /// Not feature-complete either but moreso than Alpha. Soon to be set as default.
     Beta,
 
     /// Main net. Feature-complete. Fixed launch date. Not ready yet.
     Main,
 
-    /// Feature-complete (or as feature-complete as possible) test network separate
-    /// from whichever network is currently running. For integration tests involving
-    /// multiple nodes over a network.
+    /// Feature-complete test network (eventually).
+    ///
+    /// For integration tests involving multiple nodes over a network.
     Testnet,
 
-    /// Network for individual unit and integration tests. The timestamp for the
-    /// RegTest genesis block is set to now, rounded down to the first block of
-    /// 10 hours. As a result, there is a small probability that tests fail
-    /// because they generate the genesis block twice on two opposite sides of a
-    /// round timestamp.
-    RegTest,
+    /// Network for development and tests.
+    ///
+    /// The timestamp for the RegTest genesis block is set to now, rounded down
+    /// to the first block of 10 hours. As a result, there is a small
+    /// probability that tests fail because they generate the genesis block
+    /// twice on two opposite sides of a round timestamp.
+    Regtest,
 }
 impl Network {
     pub(crate) fn launch_date(&self) -> Timestamp {
@@ -44,7 +45,7 @@ impl Network {
         const TEN_HOURS_AS_MS: u64 = 1000 * 60 * 60 * 10;
         let now_rounded = (now / TEN_HOURS_AS_MS) * TEN_HOURS_AS_MS;
         match self {
-            Network::RegTest => Timestamp(BFieldElement::new(now_rounded)),
+            Network::Regtest => Timestamp(BFieldElement::new(now_rounded)),
             // 1 July 2024 (might be revised though)
             Network::Alpha | Network::Testnet | Network::Beta | Network::Main => {
                 Timestamp(BFieldElement::new(1719792000000u64))
@@ -58,7 +59,7 @@ impl fmt::Display for Network {
         let string = match self {
             Network::Alpha => "alpha".to_string(),
             Network::Testnet => "testnet".to_string(),
-            Network::RegTest => "regtest".to_string(),
+            Network::Regtest => "regtest".to_string(),
             Network::Beta => "beta".to_string(),
             Network::Main => "main".to_string(),
         };
@@ -72,7 +73,7 @@ impl FromStr for Network {
         match input {
             "alpha" => Ok(Network::Alpha),
             "testnet" => Ok(Network::Testnet),
-            "regtest" => Ok(Network::RegTest),
+            "regtest" => Ok(Network::Regtest),
             "beta" => Ok(Network::Beta),
             "main" => Ok(Network::Main),
             _ => Err(format!("Failed to parse {} as network", input)),

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -1024,11 +1024,6 @@ impl MainLoopHandler {
                 self.main_to_peer_broadcast_tx
                     .send(MainToPeerTask::TransactionNotification(notification))?;
 
-                // insert transaction into mempool
-                self.global_state_lock
-                    .lock_mut(|s| s.mempool.insert(&transaction))
-                    .await;
-
                 // do not shut down
                 Ok(false)
             }

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -51,7 +51,7 @@ use crate::util_types::mutator_set::mutator_set_accumulator::MutatorSetAccumulat
 const MOCK_MAX_BLOCK_SIZE: u32 = 1_000_000;
 
 /// Prepare a Block for mining
-fn make_block_template(
+pub(crate) fn make_block_template(
     previous_block: &Block,
     transaction: Transaction,
     mut block_timestamp: Timestamp,
@@ -299,7 +299,7 @@ fn make_coinbase_transaction(
 /// Create the transaction that goes into the block template. The transaction is
 /// built from the mempool and from the coinbase transaction. Also returns the
 /// "sender randomness" used in the coinbase transaction.
-fn create_block_transaction(
+pub(crate) fn create_block_transaction(
     latest_block: &Block,
     global_state: &GlobalState,
     timestamp: Timestamp,
@@ -540,7 +540,7 @@ mod mine_loop_tests {
     #[tokio::test]
     async fn block_template_is_valid_test() -> Result<()> {
         // Verify that a block template made with transaction from the mempool is a valid block
-        let network = Network::RegTest;
+        let network = Network::Regtest;
         let mut premine_receiver_global_state_lock =
             mock_genesis_global_state(network, 2, WalletSecret::devnet_wallet()).await;
         let mut premine_receiver_global_state =
@@ -663,7 +663,7 @@ mod mine_loop_tests {
     #[traced_test]
     #[tokio::test]
     async fn mined_block_has_proof_of_work() -> Result<()> {
-        let network = Network::RegTest;
+        let network = Network::Regtest;
         let global_state_lock =
             mock_genesis_global_state(network, 2, WalletSecret::devnet_wallet()).await;
 
@@ -714,7 +714,7 @@ mod mine_loop_tests {
     #[traced_test]
     #[tokio::test]
     async fn block_timestamp_represents_time_block_found() -> Result<()> {
-        let network = Network::RegTest;
+        let network = Network::Regtest;
         let global_state_lock =
             mock_genesis_global_state(network, 2, WalletSecret::devnet_wallet()).await;
 
@@ -786,7 +786,7 @@ mod mine_loop_tests {
     #[traced_test]
     #[tokio::test]
     async fn mine_ten_blocks_in_ten_seconds() -> Result<()> {
-        let network = Network::RegTest;
+        let network = Network::Regtest;
         let global_state_lock =
             mock_genesis_global_state(network, 2, WalletSecret::devnet_wallet()).await;
 

--- a/src/models/blockchain/block/block_height.rs
+++ b/src/models/blockchain/block/block_height.rs
@@ -1,6 +1,7 @@
 use std::cmp::Ordering;
 use std::fmt::Display;
 use std::ops::Add;
+use std::ops::AddAssign;
 use std::ops::Sub;
 
 use get_size::GetSize;
@@ -79,6 +80,20 @@ impl Add<usize> for BlockHeight {
 
     fn add(self, rhs: usize) -> Self::Output {
         Self(BFieldElement::new(self.0.value() + rhs as u64))
+    }
+}
+
+impl Add<Self> for BlockHeight {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self(BFieldElement::new(self.0.value() + rhs.0.value()))
+    }
+}
+
+impl AddAssign for BlockHeight {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
     }
 }
 

--- a/src/models/blockchain/block/block_selector.rs
+++ b/src/models/blockchain/block/block_selector.rs
@@ -20,11 +20,11 @@ use serde::Deserialize;
 use serde::Serialize;
 use thiserror::Error;
 
-use crate::models::state::GlobalState;
 use crate::twenty_first::error::TryFromHexDigestError;
 use crate::twenty_first::math::digest::Digest;
 
 use super::block_height::BlockHeight;
+use super::traits::BlockchainBlockSelector;
 
 /// Provides alternatives for looking up a block.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -104,18 +104,22 @@ impl FromStr for BlockSelector {
 
 impl BlockSelector {
     /// returns Digest for this selector, if it exists.
-    pub async fn as_digest(&self, state: &GlobalState) -> Option<Digest> {
+    pub async fn as_digest(&self, state: &impl BlockchainBlockSelector) -> Option<Digest> {
         match self {
             BlockSelector::Digest(d) => Some(*d),
-            BlockSelector::Height(h) => {
-                state
-                    .chain
-                    .archival_state()
-                    .block_height_to_canonical_block_digest(*h, state.chain.light_state().hash())
-                    .await
-            }
-            BlockSelector::Tip => Some(state.chain.light_state().hash()),
-            BlockSelector::Genesis => Some(state.chain.archival_state().genesis_block().hash()),
+            BlockSelector::Height(h) => state.height_to_canonical_digest(*h).await,
+            BlockSelector::Tip => Some(state.tip_digest()),
+            BlockSelector::Genesis => Some(state.genesis_digest()),
+        }
+    }
+
+    /// returns Digest for this selector, if it exists.
+    pub async fn as_height(&self, state: &impl BlockchainBlockSelector) -> Option<BlockHeight> {
+        match self {
+            BlockSelector::Digest(d) => state.digest_to_canonical_height(*d).await,
+            BlockSelector::Height(h) => Some(*h),
+            BlockSelector::Tip => Some(state.tip_height()),
+            BlockSelector::Genesis => Some(BlockHeight::genesis()),
         }
     }
 }

--- a/src/models/blockchain/block/traits.rs
+++ b/src/models/blockchain/block/traits.rs
@@ -1,0 +1,31 @@
+//! traits for working with blocks
+
+use tasm_lib::Digest;
+
+use super::block_height::BlockHeight;
+
+/// an interface for any type that provides data to
+/// [BlockSelector](super::block_selector::BlockSelector) to read from the
+/// blockchain.
+///
+/// note: this trait enables BlockSelector to abstract over BlockchainState and
+/// &ArchivalState.  The latter is necessary for use in ArchivalState methods
+/// which take &self.
+pub trait BlockchainBlockSelector {
+    /// returns the tip digest
+    fn tip_digest(&self) -> Digest;
+
+    /// returns the tip height
+    fn tip_height(&self) -> BlockHeight;
+
+    /// returns genesis digest.
+    fn genesis_digest(&self) -> Digest;
+
+    // returns digest of canonical block at the given height
+    #[allow(async_fn_in_trait)]
+    async fn height_to_canonical_digest(&self, h: BlockHeight) -> Option<Digest>;
+
+    // returns height of canonical block with the given digest
+    #[allow(async_fn_in_trait)]
+    async fn digest_to_canonical_height(&self, d: Digest) -> Option<BlockHeight>;
+}

--- a/src/models/blockchain/transaction/transaction_input.rs
+++ b/src/models/blockchain/transaction/transaction_input.rs
@@ -4,26 +4,46 @@ use super::utxo::LockScript;
 use super::utxo::Utxo;
 use crate::models::blockchain::shared::Hash;
 use crate::models::blockchain::type_scripts::neptune_coins::NeptuneCoins;
-use crate::models::state::wallet::address::SpendingKey;
 use crate::util_types::mutator_set::ms_membership_proof::MsMembershipProof;
 use crate::util_types::mutator_set::mutator_set_accumulator::MutatorSetAccumulator;
 use crate::util_types::mutator_set::removal_record::RemovalRecord;
+use serde::Deserialize;
+use serde::Serialize;
 use std::ops::Deref;
 use std::ops::DerefMut;
+use tasm_lib::triton_vm::prelude::BFieldCodec;
+use tasm_lib::triton_vm::prelude::BFieldElement;
 use tasm_lib::twenty_first::prelude::AlgebraicHasher;
+use tasm_lib::Digest;
 
 /// represents a transaction input, as accepted by
 /// [create_transaction()](crate::models::state::GlobalState::create_transaction())
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TxInput {
-    pub spending_key: SpendingKey,
+    pub unlock_key: Digest,
     pub utxo: Utxo,
     pub lock_script: LockScript,
     pub ms_membership_proof: MsMembershipProof,
 }
 
+#[cfg(test)]
+impl TxInput {
+    pub fn new_random(amount: NeptuneCoins) -> Self {
+        use crate::models::state::wallet::address::generation_address::GenerationSpendingKey;
+        use crate::util_types::mutator_set::ms_membership_proof::pseudorandom_mutator_set_membership_proof;
+
+        let lock_script = LockScript::anyone_can_spend();
+        Self {
+            unlock_key: GenerationSpendingKey::derive_from_seed(rand::random()).unlock_key,
+            utxo: Utxo::new_native_coin(lock_script.clone(), amount),
+            lock_script,
+            ms_membership_proof: pseudorandom_mutator_set_membership_proof(rand::random()),
+        }
+    }
+}
+
 /// Represents a list of [TxInput]
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct TxInputList(Vec<TxInput>);
 
 impl Deref for TxInputList {
@@ -37,6 +57,12 @@ impl Deref for TxInputList {
 impl DerefMut for TxInputList {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
+    }
+}
+
+impl From<TxInput> for TxInputList {
+    fn from(t: TxInput) -> Self {
+        Self(vec![t])
     }
 }
 
@@ -100,14 +126,19 @@ impl TxInputList {
         self.lock_scripts_iter().into_iter().collect()
     }
 
-    /// retrieves spending keys
-    pub fn spending_keys_iter(&self) -> impl IntoIterator<Item = SpendingKey> + '_ {
-        self.0.iter().map(|u| u.spending_key)
+    /// retrieves unlock keys
+    pub fn unlock_keys_iter(&self) -> impl Iterator<Item = Digest> + '_ {
+        self.0.iter().map(|u| u.unlock_key)
     }
 
-    /// retrieves spending keys
-    pub fn spending_keys(&self) -> Vec<SpendingKey> {
-        self.spending_keys_iter().into_iter().collect()
+    /// retrieves unlock keys
+    pub fn unlock_keys(&self) -> Vec<Digest> {
+        self.unlock_keys_iter().collect()
+    }
+
+    /// retrieves unlock keys as lock script witnesses
+    pub fn lock_script_witnesses(&self) -> Vec<Vec<BFieldElement>> {
+        self.unlock_keys_iter().map(|uk| uk.encode()).collect()
     }
 
     /// retrieves membership proofs

--- a/src/models/blockchain/transaction/transaction_kernel.rs
+++ b/src/models/blockchain/transaction/transaction_kernel.rs
@@ -237,7 +237,7 @@ pub mod transaction_kernel_tests {
                 canonical_commitment: random(),
             }],
             public_announcements: Default::default(),
-            fee: NeptuneCoins::one(),
+            fee: NeptuneCoins::one_nau(),
             coinbase: None,
             timestamp: Default::default(),
             mutator_set_hash: rng.gen::<Digest>(),

--- a/src/models/blockchain/transaction/transaction_output.rs
+++ b/src/models/blockchain/transaction/transaction_output.rs
@@ -57,7 +57,7 @@ pub enum UnownedUtxoNotifyMethod {
 /// [PublicAnnouncement] is essentially opaque however one can determine the key
 /// type via [`KeyType::try_from::<PublicAnnouncement>()`](crate::models::state::wallet::address::KeyType::try_from::<PublicAnnouncement>())
 ///
-/// see also: [UtxoNotifyMethod], [KeyType](crate::models::state::wallet::address::KeyType)
+/// see also: [UnownedUtxoNotifyMethod], [KeyType](crate::models::state::wallet::address::KeyType)
 ///
 /// future work:
 ///

--- a/src/models/blockchain/transaction/transaction_params.rs
+++ b/src/models/blockchain/transaction/transaction_params.rs
@@ -1,0 +1,253 @@
+//! This module implements TxParams which is used as input to
+//! create_transaction() and the send() rpc.
+use num_traits::CheckedSub;
+use serde::Deserialize;
+use serde::Serialize;
+use thiserror::Error;
+
+use crate::models::blockchain::type_scripts::neptune_coins::NeptuneCoins;
+use crate::models::consensus::timestamp::Timestamp;
+
+use super::TxInputList;
+use super::TxOutputList;
+
+/// represents validation errors when constructing TxParams
+#[derive(Debug, Clone, Error)]
+pub enum TxParamsError {
+    #[error("inputs ({inputs_sum}) is less than outputs ({outputs_sum})")]
+    InsufficientInputs {
+        inputs_sum: NeptuneCoins,
+        outputs_sum: NeptuneCoins,
+    },
+
+    #[error("negative amount is not permitted for inputs or outputs")]
+    NegativeAmount,
+}
+
+// About serialization+validation
+//
+// the goal is to validate inside the impl Deserialize to ensure
+// correct-by-construction using the "parse, don't validate" design philosophy.
+//
+// unfortunately serde does not yet directly support validating when using
+// derive Deserialize.  So a workaround pattern is to create a shadow
+// struct with the same fields that gets deserialized without validation
+// and then use try_from to validate and construct the target.
+//
+// see: https://github.com/serde-rs/serde/issues/642#issuecomment-683276351
+
+/// In RPC usage TxParams will typically be created by the generate_tx_params()
+/// RPC and then used as an argument to the send() RPC.  For the send RPC, it
+/// is an untrusted data source.
+///
+/// Basic validation of input/output amounts occurs when TxParams is constructed
+/// including via deserialization (on both client and server).
+///
+/// This means that validation occurs on the client as well as on the server
+/// before create_transaction() is ever called.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(try_from = "TxParamsShadow")]
+pub struct TxParams {
+    tx_input_list: TxInputList,
+    tx_output_list: TxOutputList,
+    timestamp: Timestamp,
+}
+
+// note: this only exists to get deserialized without validation.  we also
+// derive Serialize for unit tests (only) in order to simulate invalid input
+// data.
+#[cfg_attr(test, derive(Serialize))]
+#[derive(Deserialize)]
+struct TxParamsShadow {
+    tx_input_list: TxInputList,
+    tx_output_list: TxOutputList,
+    timestamp: Timestamp,
+}
+
+impl std::convert::TryFrom<TxParamsShadow> for TxParams {
+    type Error = TxParamsError;
+
+    fn try_from(s: TxParamsShadow) -> Result<Self, Self::Error> {
+        Self::new_with_timestamp(s.tx_input_list, s.tx_output_list, s.timestamp)
+    }
+}
+
+impl TxParams {
+    /// construct a new TxParams using the current time
+    pub fn new(tx_inputs: TxInputList, tx_outputs: TxOutputList) -> Result<Self, TxParamsError> {
+        Self::new_with_timestamp(tx_inputs, tx_outputs, Timestamp::now())
+    }
+
+    /// construct a new TxParams with a custom timestamp
+    pub fn new_with_timestamp(
+        tx_input_list: TxInputList,
+        tx_output_list: TxOutputList,
+        timestamp: Timestamp,
+    ) -> Result<Self, TxParamsError> {
+        // validate that all input and output amounts are non-negative. (zero is allowed)
+        for amount in tx_input_list
+            .iter()
+            .map(|i| i.utxo.get_native_currency_amount())
+            .chain(
+                tx_output_list
+                    .iter()
+                    .map(|o| o.utxo.get_native_currency_amount()),
+            )
+        {
+            if amount.is_negative() {
+                return Err(TxParamsError::NegativeAmount);
+            }
+        }
+
+        if tx_input_list.total_native_coins() < tx_output_list.total_native_coins() {
+            return Err(TxParamsError::InsufficientInputs {
+                inputs_sum: tx_input_list.total_native_coins(),
+                outputs_sum: tx_output_list.total_native_coins(),
+            });
+        }
+
+        // todo: consider validating that all inputs are spendable now.
+        // todo: any other validations?
+
+        Ok(Self {
+            tx_input_list,
+            tx_output_list,
+            timestamp,
+        })
+    }
+
+    /// return the fee amount which is sum(inputs) - sum(outputs)
+    ///
+    /// fee will always be >= 0, guaranteed by [Self::new()]
+    pub fn fee(&self) -> NeptuneCoins {
+        // note: the unwrap will never fail because fee always >= 0, else a serious bug.
+        self.tx_input_list
+            .total_native_coins()
+            .checked_sub(&self.tx_output_list.total_native_coins())
+            .unwrap()
+    }
+
+    /// get the transaction inputs
+    pub fn tx_input_list(&self) -> &TxInputList {
+        &self.tx_input_list
+    }
+
+    /// get the transaction outputs
+    pub fn tx_output_list(&self) -> &TxOutputList {
+        &self.tx_output_list
+    }
+
+    /// get the timestamp
+    pub fn timestamp(&self) -> &Timestamp {
+        &self.timestamp
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::models::blockchain::transaction::TxInput;
+    use crate::models::blockchain::transaction::TxOutput;
+
+    use super::*;
+
+    #[test]
+    pub fn validate_insufficient_inputs() -> anyhow::Result<()> {
+        let tx_input = TxInput::new_random(NeptuneCoins::new(15));
+        let tx_output = TxOutput::new_random(NeptuneCoins::new(20));
+
+        // test TxParams::new()
+        assert!(matches!(
+            TxParams::new(tx_input.clone().into(), tx_output.clone().into()),
+            Err(TxParamsError::InsufficientInputs { .. })
+        ));
+
+        // test TxParams::new_with_timestamp()
+        assert!(matches!(
+            TxParams::new_with_timestamp(
+                tx_input.clone().into(),
+                tx_output.clone().into(),
+                Timestamp::now()
+            ),
+            Err(TxParamsError::InsufficientInputs { .. })
+        ));
+
+        // test TxParams::deserialize()
+        {
+            let serialized = bincode::serialize(&TxParamsShadow {
+                tx_input_list: tx_input.clone().into(),
+                tx_output_list: tx_output.clone().into(),
+                timestamp: Timestamp::now(),
+            })?;
+
+            let result = bincode::deserialize::<TxParams>(&serialized);
+            assert!(matches!(
+                *result.unwrap_err(),
+                bincode::ErrorKind::Custom(s) if s == TxParams::new(tx_input.into(), tx_output.into()).unwrap_err().to_string()
+            ));
+        }
+
+        Ok(())
+    }
+
+    // validates that a NegativeAmount error occurs if inputs has a negative-amount entry.
+    // checks TxParams::new(), TxParams::new_with_timestamp() and TxParams::deserialize()
+    #[test]
+    pub fn validate_negative_input_amount() -> anyhow::Result<()> {
+        worker::validate_negative_amount("-5".parse().unwrap(), NeptuneCoins::new(15))
+    }
+
+    // validates that a NegativeAmount error occurs if outputs has a negative-amount entry.
+    // checks TxParams::new(), TxParams::new_with_timestamp() and TxParams::deserialize()
+    #[test]
+    pub fn validate_negative_output_amount() -> anyhow::Result<()> {
+        worker::validate_negative_amount(NeptuneCoins::new(15), "-5".parse().unwrap())
+    }
+
+    mod worker {
+        use super::*;
+
+        // validates that a NegativeAmount error occurs if inputs or outputs has a negative-amount entry.
+        // requires that caller pass a negative value for at least one arg.
+        // checks TxParams::new(), TxParams::new_with_timestamp() and TxParams::deserialize()
+        pub fn validate_negative_amount(
+            input_amt: NeptuneCoins,
+            output_amt: NeptuneCoins,
+        ) -> anyhow::Result<()> {
+            let tx_input = TxInput::new_random(input_amt);
+            let tx_output = TxOutput::new_random(output_amt);
+
+            // test TxParams::new()
+            assert!(matches!(
+                TxParams::new(tx_input.clone().into(), tx_output.clone().into()),
+                Err(TxParamsError::NegativeAmount { .. })
+            ));
+
+            // test TxParams::new_with_timestamp()
+            assert!(matches!(
+                TxParams::new_with_timestamp(
+                    tx_input.clone().into(),
+                    tx_output.clone().into(),
+                    Timestamp::now()
+                ),
+                Err(TxParamsError::NegativeAmount)
+            ));
+
+            // test TxParams::deserialize()
+            {
+                let serialized = bincode::serialize(&TxParamsShadow {
+                    tx_input_list: tx_input.clone().into(),
+                    tx_output_list: tx_output.clone().into(),
+                    timestamp: Timestamp::now(),
+                })?;
+
+                let result = bincode::deserialize::<TxParams>(&serialized);
+                assert!(matches!(
+                    *result.unwrap_err(),
+                    bincode::ErrorKind::Custom(s) if s == TxParams::new(tx_input.into(), tx_output.into()).unwrap_err().to_string()
+                ));
+            }
+
+            Ok(())
+        }
+    }
+}

--- a/src/models/blockchain/type_scripts/neptune_coins.rs
+++ b/src/models/blockchain/type_scripts/neptune_coins.rs
@@ -65,12 +65,12 @@ impl NeptuneCoins {
         product
     }
 
-    /// Return the element that corresponds to 1. Use in tests only.
-    pub fn one() -> NeptuneCoins {
+    /// Return the element that corresponds to 1 nau. Use in tests only.
+    pub fn one_nau() -> NeptuneCoins {
         NeptuneCoins(1u128)
     }
 
-    /// Create an Amount object of the given number of coins.
+    /// Create an Amount object of the given number of whole coins.
     pub fn new(num_coins: u32) -> NeptuneCoins {
         assert!(
             num_coins <= 42000000,

--- a/src/models/state/blockchain_state.rs
+++ b/src/models/state/blockchain_state.rs
@@ -1,5 +1,10 @@
+use tasm_lib::Digest;
+
 use super::archival_state::ArchivalState;
 use super::light_state::LightState;
+
+use crate::models::blockchain::block::block_height::BlockHeight;
+use crate::models::blockchain::block::traits::BlockchainBlockSelector;
 
 /// `BlockChainState` provides an `Archival` variant
 /// for full nodes and a `Light` variant for light nodes.
@@ -13,11 +18,10 @@ use super::light_state::LightState;
 ///
 // silence possible clippy bug / false positive.
 // see: https://github.com/rust-lang/rust-clippy/issues/9798
-#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum BlockchainState {
     /// represents a Archival blockchain state
-    Archival(BlockchainArchivalState),
+    Archival(ArchivalState),
     /// represents Light node blockchain state (ie the current tip)
     Light(LightState),
 }
@@ -35,18 +39,7 @@ impl BlockchainState {
     #[inline]
     pub fn archival_state(&self) -> &ArchivalState {
         match self {
-            Self::Archival(bac) => &bac.archival_state,
-            Self::Light(_) => panic!("archival_state not available in LightState mode"),
-        }
-    }
-
-    /// retrieve blockchain archival state.
-    ///
-    /// panics if called by a light node.
-    #[inline]
-    pub fn blockchain_archival_state(&self) -> &BlockchainArchivalState {
-        match self {
-            Self::Archival(bac) => bac,
+            Self::Archival(a) => a,
             Self::Light(_) => panic!("archival_state not available in LightState mode"),
         }
     }
@@ -57,7 +50,7 @@ impl BlockchainState {
     #[inline]
     pub fn archival_state_mut(&mut self) -> &mut ArchivalState {
         match self {
-            Self::Archival(bac) => &mut bac.archival_state,
+            Self::Archival(a) => a,
             Self::Light(_) => panic!("archival_state not available in LightState mode"),
         }
     }
@@ -66,8 +59,8 @@ impl BlockchainState {
     #[inline]
     pub fn light_state(&self) -> &LightState {
         match self {
-            Self::Archival(bac) => &bac.light_state,
-            Self::Light(light_state) => light_state,
+            Self::Archival(a) => a.tip(),
+            Self::Light(l) => l,
         }
     }
 
@@ -75,20 +68,56 @@ impl BlockchainState {
     #[inline]
     pub fn light_state_mut(&mut self) -> &mut LightState {
         match self {
-            Self::Archival(bac) => &mut bac.light_state,
-            Self::Light(light_state) => light_state,
+            Self::Archival(a) => a.tip_mut(),
+            Self::Light(l) => l,
         }
     }
 }
 
-/// The `BlockchainArchivalState` contains database access to block headers.
-///
-/// It is divided into `ArchivalState` and `LightState`.
-#[derive(Debug)]
-pub struct BlockchainArchivalState {
-    /// Historical blockchain data, persisted
-    pub archival_state: ArchivalState,
+impl BlockchainBlockSelector for BlockchainState {
+    // doc'ed in trait
+    fn tip_digest(&self) -> Digest {
+        self.light_state().hash()
+    }
 
-    /// The present tip.
-    pub light_state: LightState,
+    // doc'ed in trait
+    fn tip_height(&self) -> BlockHeight {
+        self.light_state().header().height
+    }
+
+    // doc'ed in trait
+    //
+    // panics for light-state
+    // Probably LightState should be modified to hold the genesis block
+    // the way that ArchivalState does.
+    fn genesis_digest(&self) -> Digest {
+        match self {
+            Self::Archival(a) => a.genesis_digest(),
+            Self::Light(_) => todo!(),
+        }
+    }
+
+    // doc'ed in trait
+    //
+    // panics for light-state as it does not have any history
+    // the only way it could impl this would be to query peer(s)
+    // or some decentralized data-storage layer.
+    async fn height_to_canonical_digest(&self, h: BlockHeight) -> Option<Digest> {
+        match self {
+            Self::Archival(a) => a.height_to_canonical_digest(h).await,
+            Self::Light(_) => unimplemented!(),
+        }
+    }
+
+    // doc'ed in trait
+    //
+    // panics for light-state as it does not have any history
+    // the only way it could impl this would be to query peer(s)
+    // or some decentralized data-storage layer.
+    async fn digest_to_canonical_height(&self, d: Digest) -> Option<BlockHeight> {
+        match self {
+            Self::Archival(a) => a.digest_to_canonical_height(d).await,
+            Self::Light(_) => unimplemented!(),
+        }
+    }
 }

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -522,7 +522,7 @@ mod tests {
     #[tokio::test]
     async fn get_densest_transactions() {
         // Verify that transactions are returned ordered by fee density, with highest fee density first
-        let mempool = setup(10, Network::RegTest).await;
+        let mempool = setup(10, Network::Regtest).await;
 
         let max_fee_density: FeeDensity = FeeDensity::new(BigInt::from(u128::MAX), BigInt::from(1));
         let mut prev_fee_density = max_fee_density;
@@ -617,7 +617,7 @@ mod tests {
 
         let mut rng: StdRng = SeedableRng::from_seed(seed);
 
-        let network = Network::RegTest;
+        let network = Network::Regtest;
         let devnet_wallet = WalletSecret::devnet_wallet();
         let mut premine_receiver_global_state =
             mock_genesis_global_state(network, 2, devnet_wallet).await;
@@ -829,7 +829,7 @@ mod tests {
         // First put a transaction into the mempool. Then mine block 1a does
         // not contain this transaction, such that mempool is still non-empty.
         // Then mine a a block 1b that also does not contain this transaction.
-        let network = Network::RegTest;
+        let network = Network::Regtest;
         let devnet_wallet = WalletSecret::devnet_wallet();
         let mut premine_receiver_global_state =
             mock_genesis_global_state(network, 2, devnet_wallet).await;
@@ -963,7 +963,7 @@ mod tests {
     #[tokio::test]
     async fn conflicting_txs_preserve_highest_fee() -> Result<()> {
         // Create a global state object, controlled by a preminer who receives a premine-UTXO.
-        let network = Network::RegTest;
+        let network = Network::Regtest;
         let mut preminer_state_lock =
             mock_genesis_global_state(network, 2, WalletSecret::devnet_wallet()).await;
         let now = Block::genesis_block(network).kernel.header.timestamp;

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -225,7 +225,7 @@ impl GlobalStateLock {
 
     /// Generate tx params for use by `create_transaction()` and `send()`
     ///
-    /// This method simplifies building [TxParam].  It should be used
+    /// This method simplifies building [TxParams].  It should be used
     /// when the following are true:
     ///  * each output is sent to a `ReceivingAddress`
     ///  * each output sends a non-zero amount of native coins.
@@ -235,7 +235,7 @@ impl GlobalStateLock {
     ///  * the change spending key can be a `SymmetricKey`
     ///  * no non-native coins or custom lockscripts are used.
     ///
-    /// Otherwise, the [TxParam] must be generated some other way.
+    /// Otherwise, the [TxParams] must be generated some other way.
     ///
     /// params:
     ///  + outputs: a list of (ReceivingAddress,amount) where amount is > 0.
@@ -663,8 +663,8 @@ impl GlobalState {
 
     /// generates [TxOutputList] from a list of address:amount pairs (outputs).
     ///
-    /// This is a helper method for generating the `TxOutputList` that
-    /// is required by [Self::create_transaction()] and [Self::create_raw_transaction()].
+    /// This is a helper method for generating the `TxOutputList` that is part
+    /// of [TxParams].
     ///
     /// Each output may use either `OnChain` or `OffChain` notifications.  See documentation of
     /// of [TxOutput::auto()] for a description of the logic and the
@@ -714,7 +714,7 @@ impl GlobalState {
     ///
     /// This is useful when ReceivingAddress is not available, such as when
     /// creating output Utxo directly from lockscripts or using non-native
-    /// coins/tokens.  Otherwise [generate_tx_params()] is preferred.
+    /// coins/tokens.  Otherwise [Self::generate_tx_params()] is preferred.
     pub async fn generate_tx_params_from_tx_outputs(
         &self,
         mut tx_output_list: TxOutputList,

--- a/src/models/state/wallet/address.rs
+++ b/src/models/state/wallet/address.rs
@@ -1,5 +1,5 @@
 mod address_type;
-mod common;
+pub(super) mod common;
 
 pub mod generation_address;
 pub mod symmetric_key;

--- a/src/models/state/wallet/address/address_type.rs
+++ b/src/models/state/wallet/address/address_type.rs
@@ -32,7 +32,7 @@ use super::symmetric_key;
 pub enum KeyType {
     /// private/public keypair. (give public key to 3rd parties)
     ///
-    /// [generation_address] built on [twenty_first::math::lattice::kem]
+    /// [generation_address] built on [lattice::kem](tasm_lib::prelude::twenty_first::math::lattice::kem)
     ///
     /// wraps a symmetric key built on aes-256-gcm
     Generation = generation_address::GENERATION_FLAG_U8,

--- a/src/models/state/wallet/address/common.rs
+++ b/src/models/state/wallet/address/common.rs
@@ -1,3 +1,4 @@
+use crate::config_models::network::Network;
 use crate::models::blockchain::shared::Hash;
 use crate::models::blockchain::transaction::utxo::LockScript;
 use crate::models::blockchain::transaction::PublicAnnouncement;
@@ -143,6 +144,15 @@ pub fn lock_script(spending_lock: Digest) -> LockScript {
     );
 
     instructions.into()
+}
+
+/// returns human-readable-prefix for the given network
+pub fn network_hrp_char(network: Network) -> char {
+    match network {
+        Network::Alpha | Network::Beta | Network::Main => 'm',
+        Network::Testnet => 't',
+        Network::Regtest => 'r',
+    }
 }
 
 #[cfg(test)]

--- a/src/models/state/wallet/expected_utxo.rs
+++ b/src/models/state/wallet/expected_utxo.rs
@@ -72,4 +72,5 @@ pub enum UtxoNotifier {
     Cli,
     Myself,
     Premine,
+    Claim,
 }

--- a/src/models/state/wallet/mod.rs
+++ b/src/models/state/wallet/mod.rs
@@ -311,7 +311,7 @@ impl WalletSecret {
     /// 3. is that a big problem?
     ///
     /// Apparently not.  privacy does not depend on the sender_randomness
-    /// being unique.  see [1].
+    /// being unique.
     ///
     /// So it is decided not to include tx_timestamp and output_index since
     /// inclusion would defeat our stated goal.
@@ -325,7 +325,7 @@ impl WalletSecret {
     /// This asymmetry is a bit gross, but does not appear to be an actual
     /// problem.
     ///
-    /// [1] further discussion at:
+    /// further discussion:
     /// <https://github.com/Neptune-Crypto/neptune-core/issues/181>
     pub fn generate_sender_randomness(
         &self,

--- a/src/models/state/wallet/monitored_utxo.rs
+++ b/src/models/state/wallet/monitored_utxo.rs
@@ -72,9 +72,13 @@ impl MonitoredUtxo {
     }
 
     /// Get the most recent (block hash, membership proof) entry in the database,
-    /// if any.
-    pub fn get_latest_membership_proof_entry(&self) -> Option<(Digest, MsMembershipProof)> {
-        self.blockhash_to_membership_proof.iter().next().cloned()
+    pub fn get_latest_membership_proof_entry(&self) -> Option<&(Digest, MsMembershipProof)> {
+        self.blockhash_to_membership_proof.iter().next()
+    }
+
+    /// Get the oldest (block hash, membership proof) entry in the database,
+    pub fn get_oldest_membership_proof_entry(&self) -> Option<&(Digest, MsMembershipProof)> {
+        self.blockhash_to_membership_proof.back()
     }
 
     /// Returns true if the MUTXO was abandoned

--- a/src/models/state/wallet/utxo_transfer.rs
+++ b/src/models/state/wallet/utxo_transfer.rs
@@ -1,0 +1,136 @@
+//! This module contains types for transferring [Utxo] notifications between parties
+//! outside of neptune-core.  (out-of-band)
+//!
+//! Such transfers look like:
+//!
+//! 1. sender creates tx params with `rpc.generate_tx_params()` and specifies
+//!    UnownedUtxoNotifyMethod::OffchainSerialized for at least 1 output utxo.
+//! 2. sender sends tx with `rpc.send(tx_params)`
+//! 3. sender reads tx_params.tx_output_list().utxo_transfer_iter() to obtain
+//!    list of `UtxoTransferEncrypted` that must be transferred out-of-band
+//!    as well as a list of `TxOutputMeta` that has a `ReceivingAddress` for each
+//!    `UtxoTransferEncrypted`
+//! 4. sender serializes the `UtxoTransferEncrypted` into bech32m, possibly
+//!    along with some metadata.  (see neptune-cli source-code for a standard
+//!    file-format)
+//! 5. sender transmits the bech32m encoded `UtxoTransferEncrypted` to the owner
+//!    of the `ReceivingAddress`.
+//! 6. recipient calls rpc.claim_utxo() passing it the received bech32m string.
+//! 7. the recipients wallet is now notified of the utxo and applies it towards
+//!    wallet balance, etc.
+
+use crate::config_models::network::Network;
+use crate::models::blockchain::transaction::utxo::Utxo;
+use crate::prelude::twenty_first;
+use anyhow::bail;
+use anyhow::Result;
+use bech32::FromBase32;
+use bech32::ToBase32;
+use get_size::GetSize;
+use serde::{Deserialize, Serialize};
+use tasm_lib::triton_vm::prelude::BFieldElement;
+use twenty_first::math::tip5::Digest;
+
+use super::address::{ReceivingAddress, SpendingKey};
+
+/// intended for transferring utxo-notification secrets between parties
+///
+/// this type intentionally does not impl Serialize, Deserialize because it
+/// should not be transferred directly, but rather encrypted inside
+/// UtxoTransferEncrypted
+#[derive(Clone, Debug, PartialEq, Eq, Hash, GetSize)]
+pub struct UtxoTransfer {
+    pub utxo: Utxo,
+    pub sender_randomness: Digest,
+}
+
+impl UtxoTransfer {
+    /// instantiate
+    pub fn new(utxo: Utxo, sender_randomness: Digest) -> Self {
+        Self {
+            utxo,
+            sender_randomness,
+        }
+    }
+
+    /// encrypts the UtxoTransfer to a [ReceivingAddress] creating a [UtxoTransferEncrypted].
+    pub fn encrypt_to_address(
+        &self,
+        address: &ReceivingAddress,
+    ) -> anyhow::Result<UtxoTransferEncrypted> {
+        Ok(UtxoTransferEncrypted {
+            ciphertext: address.encrypt(&self.utxo, self.sender_randomness)?,
+            receiver_identifier: address.receiver_identifier(),
+        })
+    }
+}
+
+/// an encrypted wrapper for UtxoTransfer.
+///
+/// This type is intended to be serialized and actually transferred between
+/// parties.
+///
+/// note: bech32m encoding of this type is considered standard and is
+/// recommended over serde serialization.
+///
+/// the receiver_identifier enables the receiver to find the matching
+/// `SpendingKey` in their wallet.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, GetSize, Serialize, Deserialize)]
+pub struct UtxoTransferEncrypted {
+    /// contains encrypted UtxoTransfer
+    pub ciphertext: Vec<BFieldElement>,
+
+    /// enables the receiver to find the matching `SpendingKey` in their wallet.
+    pub receiver_identifier: BFieldElement,
+}
+
+impl UtxoTransferEncrypted {
+    /// decrypts into a [UtxoTransfer]
+    pub fn decrypt_with_spending_key(
+        &self,
+        spending_key: &SpendingKey,
+    ) -> anyhow::Result<UtxoTransfer> {
+        let (utxo, sender_randomness) = spending_key.decrypt(&self.ciphertext)?;
+
+        Ok(UtxoTransfer {
+            utxo,
+            sender_randomness,
+        })
+    }
+
+    /// encodes into a bech32m string for the given network
+    pub fn to_bech32m(&self, network: Network) -> Result<String> {
+        let hrp = Self::get_hrp(network);
+        let payload = bincode::serialize(self)?;
+        let variant = bech32::Variant::Bech32m;
+        match bech32::encode(&hrp, payload.to_base32(), variant) {
+            Ok(enc) => Ok(enc),
+            Err(e) => bail!("Could not encode UtxoTransferEncrypted as bech32m because error: {e}"),
+        }
+    }
+
+    /// decodes from a bech32m string and verifies it matches `network`
+    pub fn from_bech32m(encoded: &str, network: Network) -> Result<Self> {
+        let (hrp, data, variant) = bech32::decode(encoded)?;
+
+        if variant != bech32::Variant::Bech32m {
+            bail!("Can only decode bech32m addresses.");
+        }
+
+        if hrp != *Self::get_hrp(network) {
+            bail!("Could not decode bech32m address because of invalid prefix");
+        }
+
+        let payload = Vec::<u8>::from_base32(&data)?;
+
+        match bincode::deserialize(&payload) {
+            Ok(ra) => Ok(ra),
+            Err(e) => bail!("Could not decode bech32m because of error: {e}"),
+        }
+    }
+
+    /// returns human readable prefix (hrp) of a utxo-transfer-encrypted, specific to `network`
+    pub fn get_hrp(network: Network) -> String {
+        format!("utxo{}", super::address::common::network_hrp_char(network))
+    }
+}

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -335,7 +335,7 @@ impl WalletState {
     ///   n = number of ExpectedUtxo in database. (all-time)
     ///   m = number of transaction outputs.
     ///
-    /// see https://github.com/Neptune-Crypto/neptune-core/pull/175#issuecomment-2302511025
+    /// see <https://github.com/Neptune-Crypto/neptune-core/pull/175#issuecomment-2302511025>
     ///
     /// Returns an iterator of [AnnouncedUtxo]. (addition record, UTXO, sender randomness, receiver_preimage)
     pub async fn scan_for_expected_utxos<'a>(
@@ -357,7 +357,7 @@ impl WalletState {
 
     /// check if wallet already has the provided `expected_utxo`
     ///
-    /// note that [WalletState::add_expected_utxo()] prevents duplicate
+    /// note that `WalletState::add_expected_utxo()` prevents duplicate
     /// [ExpectedUtxo], however its possible for distinct `ExpectedUtxo` to
     /// include the same `Utxo`.
     ///

--- a/src/models/state/wallet/wallet_status.rs
+++ b/src/models/state/wallet/wallet_status.rs
@@ -40,6 +40,15 @@ pub struct WalletStatus {
 }
 
 impl WalletStatus {
+    /// returns native currency sum of unspent utxo that have been confirmed in a block
+    pub fn synced_unspent_amount(&self) -> NeptuneCoins {
+        self.synced_unspent
+            .iter()
+            .map(|(wse, _)| wse.utxo.get_native_currency_amount())
+            .sum::<NeptuneCoins>()
+    }
+
+    /// returns native currency sum of unspent utxo that have been confirmed in a block and are available to spend at timestamp
     pub fn synced_unspent_available_amount(&self, timestamp: Timestamp) -> NeptuneCoins {
         self.synced_unspent
             .iter()
@@ -48,6 +57,8 @@ impl WalletStatus {
             .map(|utxo| utxo.get_native_currency_amount())
             .sum::<NeptuneCoins>()
     }
+
+    /// returns native currency sum of unspent utxo that have been confirmed in a block and are timelocked but otherwise available to spend at timestamp
     pub fn synced_unspent_timelocked_amount(&self, timestamp: Timestamp) -> NeptuneCoins {
         self.synced_unspent
             .iter()
@@ -56,18 +67,24 @@ impl WalletStatus {
             .map(|utxo| utxo.get_native_currency_amount())
             .sum::<NeptuneCoins>()
     }
+
+    /// returns native currency sum of unspent utxo that have not been confirmed in a block
     pub fn unsynced_unspent_amount(&self) -> NeptuneCoins {
         self.unsynced_unspent
             .iter()
             .map(|wse| wse.utxo.get_native_currency_amount())
             .sum::<NeptuneCoins>()
     }
+
+    /// returns native currency sum of spent utxo that have been confirmed in a block
     pub fn synced_spent_amount(&self) -> NeptuneCoins {
         self.synced_spent
             .iter()
             .map(|wse| wse.utxo.get_native_currency_amount())
             .sum::<NeptuneCoins>()
     }
+
+    /// returns native currency sum of spent utxo that have not been confirmed in a block
     pub fn unsynced_spent_amount(&self) -> NeptuneCoins {
         self.unsynced_spent
             .iter()

--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -1305,8 +1305,8 @@ mod peer_loop_tests {
             .await
             .chain
             .archival_state()
-            .get_tip()
-            .await;
+            .tip()
+            .to_owned();
         let mut nonce = different_genesis_block.kernel.header.nonce;
         nonce[2].increment();
         different_genesis_block.set_header_nonce(nonce);
@@ -1384,13 +1384,13 @@ mod peer_loop_tests {
         let (peer_broadcast_tx, _from_main_rx_clone, to_main_tx, mut to_main_rx1, state_lock, hsd) =
             get_test_genesis_setup(network, 0).await?;
         let peer_address = get_dummy_socket_address(0);
-        let genesis_block: Block = state_lock
+        let genesis_block = state_lock
             .lock_guard()
             .await
             .chain
             .archival_state()
-            .get_tip()
-            .await;
+            .tip()
+            .to_owned();
 
         // Make a with hash above what the implied threshold from
         // `target_difficulty` requires
@@ -1485,14 +1485,14 @@ mod peer_loop_tests {
         ) = get_test_genesis_setup(network, 0).await?;
         let mut global_state_mut = state_lock.lock_guard_mut().await;
         let peer_address = get_dummy_socket_address(0);
-        let genesis_block: Block = global_state_mut.chain.archival_state().get_tip().await;
+        let genesis_block = global_state_mut.chain.archival_state().tip();
 
         let a_wallet_secret = WalletSecret::new_random();
         let a_recipient_address = a_wallet_secret
             .nth_generation_spending_key_for_tests(0)
             .to_address();
         let (block_1, _, _) =
-            make_mock_block_with_valid_pow(&genesis_block, None, a_recipient_address, rng.gen());
+            make_mock_block_with_valid_pow(genesis_block, None, a_recipient_address, rng.gen());
         global_state_mut.set_new_tip(block_1.clone()).await?;
         drop(global_state_mut);
 
@@ -1549,7 +1549,7 @@ mod peer_loop_tests {
         let (_peer_broadcast_tx, from_main_rx_clone, to_main_tx, _to_main_rx1, mut state_lock, hsd) =
             get_test_genesis_setup(network, 0).await?;
         let mut global_state_mut = state_lock.lock_guard_mut().await;
-        let genesis_block: Block = global_state_mut.chain.archival_state().get_tip().await;
+        let genesis_block = global_state_mut.chain.archival_state().tip().to_owned();
         let peer_address = get_dummy_socket_address(0);
         let a_wallet_secret = WalletSecret::new_random();
         let a_recipient_address = a_wallet_secret
@@ -1641,7 +1641,7 @@ mod peer_loop_tests {
         let (_peer_broadcast_tx, from_main_rx_clone, to_main_tx, _to_main_rx1, mut state_lock, hsd) =
             get_test_genesis_setup(network, 0).await?;
         let mut global_state_mut = state_lock.lock_guard_mut().await;
-        let genesis_block: Block = global_state_mut.chain.archival_state().get_tip().await;
+        let genesis_block = global_state_mut.chain.archival_state().tip().to_owned();
         let peer_address = get_dummy_socket_address(0);
         let a_wallet_secret = WalletSecret::new_random();
         let a_recipient_address = a_wallet_secret
@@ -1707,14 +1707,14 @@ mod peer_loop_tests {
         let (_peer_broadcast_tx, from_main_rx_clone, to_main_tx, _to_main_rx1, mut state_lock, hsd) =
             get_test_genesis_setup(network, 0).await?;
         let mut global_state_mut = state_lock.lock_guard_mut().await;
-        let genesis_block: Block = global_state_mut.chain.archival_state().get_tip().await;
+        let genesis_block = global_state_mut.chain.archival_state().tip();
         let peer_address = get_dummy_socket_address(0);
         let a_wallet_secret = WalletSecret::new_random();
         let a_recipient_address = a_wallet_secret
             .nth_generation_spending_key_for_tests(0)
             .to_address();
         let (block_1, _, _) =
-            make_mock_block_with_valid_pow(&genesis_block, None, a_recipient_address, rng.gen());
+            make_mock_block_with_valid_pow(genesis_block, None, a_recipient_address, rng.gen());
         let (block_2_a, _, _) =
             make_mock_block_with_valid_pow(&block_1, None, a_recipient_address, rng.gen());
         let (block_3_a, _, _) =
@@ -1761,7 +1761,7 @@ mod peer_loop_tests {
     #[traced_test]
     #[tokio::test]
     async fn test_peer_loop_receival_of_first_block() -> Result<()> {
-        let network = Network::RegTest;
+        let network = Network::Regtest;
         let mut rng = thread_rng();
         // Scenario: client only knows genesis block. Then receives block 1.
         let (_peer_broadcast_tx, from_main_rx_clone, to_main_tx, mut to_main_rx1, state_lock, hsd) =
@@ -1771,13 +1771,13 @@ mod peer_loop_tests {
             .nth_generation_spending_key_for_tests(0)
             .to_address();
         let peer_address = get_dummy_socket_address(0);
-        let genesis_block: Block = state_lock
+        let genesis_block = state_lock
             .lock_guard()
             .await
             .chain
             .archival_state()
-            .get_tip()
-            .await;
+            .tip()
+            .to_owned();
 
         let (mock_block_1, _, _) =
             make_mock_block_with_valid_pow(&genesis_block, None, a_recipient_address, rng.gen());
@@ -1828,17 +1828,17 @@ mod peer_loop_tests {
         let mut rng = thread_rng();
         // In this scenario, the client only knows the genesis block (block 0) and then
         // receives block 2, meaning that block 1 will have to be requested.
-        let network = Network::RegTest;
+        let network = Network::Regtest;
         let (_peer_broadcast_tx, from_main_rx_clone, to_main_tx, mut to_main_rx1, state_lock, hsd) =
             get_test_genesis_setup(network, 0).await?;
         let peer_address = get_dummy_socket_address(0);
-        let genesis_block: Block = state_lock
+        let genesis_block = state_lock
             .lock_guard()
             .await
             .chain
             .archival_state()
-            .get_tip()
-            .await;
+            .tip()
+            .to_owned();
         let a_wallet_secret = WalletSecret::new_random();
         let a_recipient_address = a_wallet_secret
             .nth_generation_spending_key_for_tests(0)
@@ -1900,7 +1900,7 @@ mod peer_loop_tests {
     #[tokio::test]
     async fn prevent_ram_exhaustion_test() -> Result<()> {
         let mut rng = thread_rng();
-        let network = Network::RegTest;
+        let network = Network::Regtest;
         // In this scenario the peer sends more blocks than the client allows to store in the
         // fork-reconciliation field. This should result in abandonment of the fork-reconciliation
         // process as the alternative is that the program will crash because it runs out of RAM.
@@ -1921,7 +1921,7 @@ mod peer_loop_tests {
         let mut global_state_mut = state_lock.lock_guard_mut().await;
 
         let (hsd1, peer_address1) = get_dummy_peer_connection_data_genesis(Network::Alpha, 1).await;
-        let genesis_block: Block = global_state_mut.chain.archival_state().get_tip().await;
+        let genesis_block = global_state_mut.chain.archival_state().tip();
         let own_recipient_address = global_state_mut
             .wallet_state
             .wallet_secret
@@ -2011,7 +2011,7 @@ mod peer_loop_tests {
         let mut rng = thread_rng();
         // In this scenario, the client know the genesis block (block 0) and block 1, it
         // then receives block 4, meaning that block 3 and 2 will have to be requested.
-        let network = Network::RegTest;
+        let network = Network::Regtest;
         let (
             _peer_broadcast_tx,
             from_main_rx_clone,
@@ -2022,7 +2022,7 @@ mod peer_loop_tests {
         ) = get_test_genesis_setup(network, 0).await?;
         let mut global_state_mut = state_lock.lock_guard_mut().await;
         let peer_address: SocketAddr = get_dummy_socket_address(0);
-        let genesis_block: Block = global_state_mut.chain.archival_state().get_tip().await;
+        let genesis_block = global_state_mut.chain.archival_state().tip();
         let a_wallet_secret = WalletSecret::new_random();
         let a_recipient_address = a_wallet_secret
             .nth_generation_spending_key_for_tests(0)
@@ -2101,13 +2101,13 @@ mod peer_loop_tests {
         let mut rng = thread_rng();
         // In this scenario, the client only knows the genesis block (block 0) and then
         // receives block 3, meaning that block 2 and 1 will have to be requested.
-        let network = Network::RegTest;
+        let network = Network::Regtest;
         let (_peer_broadcast_tx, from_main_rx_clone, to_main_tx, mut to_main_rx1, state_lock, hsd) =
             get_test_genesis_setup(network, 0).await?;
         let global_state = state_lock.lock_guard().await;
         let peer_address = get_dummy_socket_address(0);
 
-        let genesis_block: Block = global_state.chain.archival_state().get_tip().await;
+        let genesis_block = global_state.chain.archival_state().tip();
         let a_wallet_secret = WalletSecret::new_random();
         let a_recipient_address = a_wallet_secret
             .nth_generation_spending_key_for_tests(0)
@@ -2185,7 +2185,7 @@ mod peer_loop_tests {
         // then receives block 4, meaning that block 3, 2, and 1 will have to be requested.
         // But the requests are interrupted by the peer sending another message: a new block
         // notification.
-        let network = Network::RegTest;
+        let network = Network::Regtest;
         let (
             _peer_broadcast_tx,
             from_main_rx_clone,
@@ -2200,7 +2200,7 @@ mod peer_loop_tests {
             .nth_generation_spending_key_for_tests(0)
             .to_address();
         let peer_socket_address: SocketAddr = get_dummy_socket_address(0);
-        let genesis_block: Block = global_state_mut.chain.archival_state().get_tip().await;
+        let genesis_block = global_state_mut.chain.archival_state().tip();
         let (block_1, _, _) = make_mock_block_with_valid_pow(
             &genesis_block.clone(),
             None,
@@ -2295,7 +2295,7 @@ mod peer_loop_tests {
         // for a list of peers.
 
         let mut rng = thread_rng();
-        let network = Network::RegTest;
+        let network = Network::Regtest;
         let (
             _peer_broadcast_tx,
             from_main_rx_clone,
@@ -2312,7 +2312,7 @@ mod peer_loop_tests {
             .into_values()
             .collect::<Vec<_>>();
 
-        let genesis_block: Block = global_state_mut.chain.archival_state().get_tip().await;
+        let genesis_block = global_state_mut.chain.archival_state().tip();
         let a_wallet_secret = WalletSecret::new_random();
         let a_recipient_address = a_wallet_secret
             .nth_generation_spending_key_for_tests(0)


### PR DESCRIPTION
### Overview

Implements support for off-chain utxo notifications in neptune-core and neptune-cli.

### Example Usage (neptune-cli)

bob: 
```
$ neptune-cli next-receiving-address > bob.address
```

alice:
```
$ neptune-cli send `cat bob.address` 15 0.1 bob --unowned-utxo-notify-method off-chain-serialized

*** Utxo Transfer Files ***

wrote /tmp/demo/.alice/neptune-core/regtest/utxo-transfer/bob/nolgar1k3tawld...vj487mwx-15.json

*** Important - Read or risk losing funds ***


1 transaction outputs were each written to individual files for off-chain transfer.

-- Sender Instructions --

You must transfer each file to the corresponding recipient for claiming or they will never be able to claim the funds.

You should also provide them the following recipient instructions.

-- Recipient Instructions --

run `neptune-cli claim-utxo file <file>` or use equivalent claim functionality of your chosen wallet software.

Send completed. Tx Digest: 8b634f77ce8edf764769c1b9d8eaf2e71bf3b10572b27f7af53202d6a0dd3119d983eac092eb1f82
```

bob: 
```
$ neptune-cli claim_utxo file nolgar1k3tawld...vj487mwx-15.json

Success.  1 Utxo Transfer was imported.
```

### Demo

![claim-utxo](https://github.com/user-attachments/assets/14cc0d1e-122e-4f5a-9308-a6f32ab8c028)

### Utxo transfer file location, naming, and serialization

neptune-cli generates one file per output notification serialized via json pretty-print.  It is intended to be human and machine readable.

The file path is `<neptune-data-dir>/utxo-transfer/<recipient>/<basename>.json`

where:
* `neptune-data-dir` is retrieved from neptune-core via RPC.
* `recipient` is a label provided by --recipient arg, or "anonymous" by default, or "self" if the output is owned by "our" wallet.
* `basename` is
    * `nolga<pubkeyfirst8char>...<pubkeylast8char>`   (for generation addresses)
    * `<recipient_id>` (for symmetric keys)

note: `recipient` is a local label that never leaves the local device.

note: recipient id is used for symmetric keys to avoid exposing any secret key material.

### Utxo transfer file data

The data consists of single `UtxoTransferEntry`, defined as:

```
pub struct UtxoTransferEntry {
    pub data_format: String,
    pub recipient: String,
    pub amount: String,
    pub utxo_transfer_encrypted: String,
    pub address_info: AddressEnum,
}
pub enum AddressEnum {
    Generation {
        address_abbrev: String,
        address: String,
        receiver_identifier: String,
    },
    Symmetric {
        receiver_identifier: String,
    },
}
```

The only field necessary for claiming is `utxo_transfer_encrypted`.  Everything else is for informational purposes only, with the intent to help the sender route the utxo to the correct recipient.   In particular, the address field is useful to match against the address that was originally provided to generate_tx_params().

The recipient label is intentionally NOT included in the file itself or the filename because doing so might expose private information during transit, and also a sender might not wish the recipient to see the sender's private label for the recipient.

### UtxoTransfer and UtxoTransferEncrypted

utxo secrets are placed in UtxoTransfer and then encrypted to the recipient's pubkey creating UtxoTransferEncrypted.  The latter is then encoded with bech32 into a network-specific String.

```
pub struct UtxoTransfer {
    pub utxo: Utxo,
    pub sender_randomness: Digest,
}
pub struct UtxoTransferEncrypted {
    /// contains encrypted UtxoTransfer
    pub ciphertext: Vec<BFieldElement>,

    /// enables the receiver to find the matching `SpendingKey` in their wallet.
    pub receiver_identifier: BFieldElement,
}
```

### Claiming with neptune-cli

The neptune-cli `claim_utxo` command accepts 3 forms of data:
1. file:  path to a file containing a single json encoded UtxoTransferEntry
2. json: string containing a single json encoded UtxoTransferEntry
3. raw: string containing bech32 encoded UtxoTransferEncrypted.

(1) is the intended/default usage.  (2) and (3) are provided for added convenience or special cases.

### claim_utxo rpc

claiming works by:
1. decode bech32 network-specific string into `UtxoTransferEncrypted`
2. find the known wallet key that corresponds to recipient_id
3. decrypt ciphertext into UtxoTransfer
4. find monitored_utxo and/or expected_utxo that match target utxo.
5. find block in which utxo's parent Tx was confirmed, if any
    5a. if found, get blocks from confirmation to tip.
    5b. create a new monitored utxo and add membership proofs, etc.
6. perform mutations/writes:
    6a. add expected utxo to wallet. (always)
    6b. add monitored utxo to wallet (if confirmed)
    6c. persist wallet.

### neptune-core refactors

To make this work smoothly it was necessary to refactor send(), create_transaction() and related APIs.  A nice benefit is that send() and create_transaction() now both work for any possible Tx, ie arbitrary lock-scripts and arbitrary Coins.  Also the caller specifies all inputs and ouputs, including change output.

To make it easier for the caller to determine input and calculate change, two rpc are available:  generate_tx_params() and generate_tx_params_from_tx_outputs().  The former accepts the same params that send() used to (plus 2 more option) and is intended for simple usage when sending native-coin amounts to one or more recipients with ReceivingAddress.   The latter is for sending to arbitrary LockScript and Coin, but chooses inputs and generates a change address. 

See doc-comments for more description of these and other changes.

### Claiming modes

unconfirmed.  Claiming can occur before the corresponding tx is confirmed in a block or after.  If it occurs before, all that happens is for an ExpectedUtxo to be added to the wallet.   Note that this will not be reflected in the wallet balance until the tx is confirmed.  See #184.

confirmed. If claiming is performed after the tx is confirmed then additional computation is required.  In particular a new MonitoredUtxo must be created and it must have a MembershipProof for every block since the tx was created until the tip.  This requires an archival-node.   It also must be marked as spent in the unusual case that a newly-claimed utxo has somehow already been spent.

In the confirmed mode, the wallet balance will immediately reflect the claimed funds once claim_utxo() rpc completes. 

### New unit tests:

* claim_utxo_owned_before_confirmed
* claim_utxo_owned_after_confirmed
* claim_utxo_unowned_before_confirmed
* claim_utxo_unowned_after_confirmed
* validate_insufficient_inputs
* validate_negative_input_amount
* validate_negative_output_amount

### Design Decisions

These are some decisions I had to think about, and my rationale.  Not written in stone.

1. owned off-chain serialized notifications.   For change output or any other "owned" utxo there doesn't seem to be a really compelling use case for offchain serialized notifications.   For now I decided to leave them in (a) for completeness, and (b) for the use-case of practicing.   When performing any kind of cryptocurrency Tx it is often advisable to practice with your own wallet first, and this provides a way to do that.  Counter arguments would be that they add cognitive load, eg to understand the optional send() flags, and also require special handling for symmetric keys.

8. single or multiple utxo entries per utxo-transfer file.   It is possible for a tx to have multiple outputs destined for the same receiving address.   In which case it would make sense to place them both in the same file.  However this usage seems likely to be uncommon and it just seems overall simpler to go with a one-utxo-per-file approach.

9. who writes the utxo-transfer files.  It could be that neptune-core writes these files and just provides the client with a path, or that the client writes them.  I chose the latter, as it permits an rpc client on a different device to work with the APIs and generally seems more flexible.    A drawback is that neptune-cli and neptune-dashboard will each have to write them, but that logic can be shared easily enough.

Unresolved:

1. I'm not entirely happy with naming yet and open to revisiting.   In particular:

I'm not sure "utxo-transfer" is quite right though I like it is pretty short and conveys a send/receive action.  The UtxoTransfer struct does contain a `Utxo` struct, but I think it more correct to say the transfer takes place onchain, and this is just a notification of it.  But we already have a `struct UtxoNotification` in neptune-core.  Perhaps it should be renamed?  Another possibility might be "utxo-secrets".

2. The enum type OffchainSerialized is kinda verbose and is not really consistent with the "utxo-transfer" naming used elsewhere.   Though they both refer to the same thing.  So it would be good to sync those up somehow.

3. There are presently no unit tests for the case when a utxo has already been spent before it is claimed.   That should be impl'd before this PR is merged.

4,  There is presently no support for offchain utxo-transfers in neptune-dashboard.   I figured it's better to get buy-off on the direction in this PR before tackling tui for the feature.

Doubts / Concerns:

This functionality should be considered highly experimental.   It relies on end-users (or 3rd party systems) to transmit secrets and secure data against loss.  Failure to do so can result in permanent loss-of-funds.   It's one of those "with great power comes great responsibility" kind of things.

I have a concern (a) that people will manage to lose funds with this, and (b) that could create a bad image/perception for neptune-cash.

At the same time, it is an interesting feature/innovation and possibly could help with scaling and offloading data to other systems.  I don't think we can predict now all the different ways it could be used.  So it may well be worth trying out and we shouldn't let perfect be the enemy of the good.

### For Reviewers.

I would suggest the most important things to look at are:

neptune-core:
* WalletState::prepare_claim_utxo_in_block
* WalletState::finalize_claim_utxo_in_block
* UtxoTransfer, UtxoTransferEncrypted
* GlobalState::create_transaction(), generate_tx_params().
* changes to the rpc API.

neptune-cli:
 * changes to the send and send-to-many commands.
 * format of the json file.  (UtxoTransferEntry)

### Changes

neptune-core:
* add DataDirectory::utxo_transfer_directory_path()
* make DataDirectory serializable
* derive(clap::ValueEnum) for Network
* improve Network doc-comments for use in neptune-cli help.
* Network::RegTest --> Regtest
* impl Add,AddAssign for BlockHeight
* simplify BlockSelector impl
* add Block::genesis_prev_block_digest()
* add trait BlockchainBlockSelector
* make TxInput serializable
* change TxIput::spending_key to unlock_key
* add type alias TxAddressOutput = (ReceivingAddress, NeptuneCoins)
* split UtxoNotifyMethod into Owned and Unowned variants.
* make UtxoNotification serializable
* add OffChainSerialized to utxo notification enums.
* make TxOutput serializable
* add TxOutput::offchain_serialized()
* add UtxoTransferList::utxo_transfer_iter()
* rename TransactionDetails --> TxParams
* rename NeptuneCoins::one() -> one_nau()
* derive clap::ValueEnum for KeyType
* make SpendingKey serializable
* add ReceivingAddress::bech32m_abbreviated()
* make GenerationSpendingKey serializable
* impl bech32m for SymmetricKey with prefix "nsk"
* add UtxoNotifier::Claim variant
* add struct wallet::UtxoTransfer
* prevent dups in WalletState::add_expected_utxo()
* add WalletState::has_expected_utxo()
* add WalletState::find_monitored_utxo()
* add WalletState::find_known_spending_key_for_receiver_identifier()
* add WalletState::prepare_claim_utxo_in_block()
* add WalletState::finalize_claim_utxo_in_block()
* add WalletStatus::synced_unspent_amount()
* cache tip block in ArchivalState.
* add ArchivalState::canonical_block_stream_asc()
* add ArchivalState::canonical_block_stream_desc()
* impl BlockchainBlockSelector for ArchivalState
* impl BlockchainBlockSelector for BlockchainState
* remove BlockchainArchivalState
* add GlobalStateLock::generate_tx_params()
* add GlobalStateLock::send()
* simplify create_transaction()
* log detailed message when storing block.
* add struct TxOutputMeta
* add shared test method mine_block_to_wallet()
* insert tx into mempool in GlobalStateLock::send() rather than main loop.
* add rpc data_directory()
* add rpc generate_tx_params()
* add rpc generate_tx_params_from_tx_outputs()
* add rpc claim_utxo()
* remove rpc send_to_many()
* add rpc test: claim_utxo_owned_before_confirmed()
* add rpc test: claim_utxo_owned_after_confirmed()
* add rpc test: claim_utxo_unowned_before_confirmed()
* add rpc test: claim_utxo_unowned_after_confirmed()

neptune-cli:
* add doc-comment description of every command for help
* remove redundant tip-header command
* renamed own-receiving-address --> next-receiving-address
* next-receiving-address accepts key-type arg
* send accepts optional params: recipient, unowned-utxo-notify-method, owned-utxo-notify-method
* send-to-many accepts same parameters parsed from outputs list.
* send and send-to-many create utxo-transfer file(s) if necessary and instructions for sender and recipient.
* improved help-text of send, send-to-many. shows variants of enum params.
* send and send-to-many obtain data_dir from neptune-core.
* added claim-utxo command.
* wallet maintenance commands accept optional data_dir
* --network is now command specific.

cargo.toml:
* add clap feature "string"