### PR TITLE
perf: split lengthy fn(s) to improve concurrency

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,141 +1,20 @@
-/// executes an expression, times duration, and emits trace! message
-///
-/// The trace level is `tracing::Level::TRACE` by default.
-///
-/// Accepts arguments in 3 forms:
-///   duration!(myfunc())
-///   duration!(myfunc(), message)
-///   duration!(myfunc(), message, trace_level)
-#[allow(unused_macros)]
-macro_rules! duration {
-    ($target: expr, $message: expr, $lvl: expr) => {{
-        let (output, duration) = $crate::time_fn_call(|| $target);
-        let msg = format!(
-            "at {}:{}{}\n-- executed expression --\n{}\n -- duration: {} secs --",
-            file!(),
-            line!(),
-            if $message.len() > 0 {
-                format! {"\n{}", $message}
-            } else {
-                "".to_string()
-            },
-            stringify!($target),
-            duration
-        );
-        match $lvl {
-            tracing::Level::INFO => tracing::info!("{}", msg),
-            tracing::Level::TRACE => tracing::trace!("{}", msg),
-            tracing::Level::DEBUG => tracing::trace!("{}", msg),
-            tracing::Level::WARN => tracing::warn!("{}", msg),
-            tracing::Level::ERROR => tracing::error!("{}", msg),
+macro_rules! fn_name_bare {
+    () => {{
+        fn f() {}
+        fn type_name_of<T>(_: T) -> &'static str {
+            std::any::type_name::<T>()
         }
-        output
+        type_name_of(f)
+            .rsplit("::")
+            .find(|&part| part != "f" && part != "{{closure}}")
+            .expect("Short function name")
     }};
-    ($target: expr, $message: expr) => {
-        $crate::macros::duration!($target, $message, tracing::Level::TRACE)
-    };
-    ($target: expr) => {
-        $crate::macros::duration!($target, "", tracing::Level::TRACE)
-    };
 }
 
-/// executes an expression, times duration, and emits info! message
-///
-/// Accepts arguments in 2 forms:
-///   duration!(myfunc())
-///   duration!(myfunc(), message)
-#[allow(unused_macros)]
-macro_rules! duration_info {
-    ($target: expr) => {
-        $crate::macros::duration!($target, "", tracing::Level::INFO)
-    };
-    ($target: expr, $message: expr) => {
-        $crate::macros::duration!($target, $message, tracing::Level::INFO)
-    };
-}
-
-/// executes an expression, times duration, and emits debug! message
-///
-/// Accepts arguments in 2 forms:
-///   duration!(myfunc())
-///   duration!(myfunc(), message)
-#[allow(unused_macros)]
-macro_rules! duration_debug {
-    ($target: expr) => {
-        $crate::macros::duration!($target, "", tracing::Level::DEBUG)
-    };
-    ($target: expr, $message: expr) => {
-        $crate::macros::duration!($target, $message, tracing::Level::DEBUG)
-    };
-}
-
-/// executes an async expression, times duration, and emits trace! message
-///
-/// Accepts arguments in 3 forms:
-///   duration!(myfunc())
-///   duration!(myfunc(), message)
-///   duration!(myfunc(), message, trace_level)
-#[allow(unused_macros)]
-macro_rules! duration_async {
-    ($target: expr, $message: expr, $lvl: expr) => {{
-        let (output, duration) = $crate::time_fn_call_async({ $target }).await;
-        let msg = format!(
-            "at {}:{}{}\n-- executed expression --\n{}\n -- duration: {} secs --",
-            file!(),
-            line!(),
-            if $message.len() > 0 {
-                format! {"\n{}", $message}
-            } else {
-                "".to_string()
-            },
-            stringify!($target),
-            duration
-        );
-        match $lvl {
-            tracing::Level::INFO => tracing::info!("{}", msg),
-            tracing::Level::TRACE => tracing::trace!("{}", msg),
-            tracing::Level::DEBUG => tracing::trace!("{}", msg),
-            tracing::Level::WARN => tracing::warn!("{}", msg),
-            tracing::Level::ERROR => tracing::error!("{}", msg),
-        }
-        output
+macro_rules! fn_name {
+    () => {{
+        format!("{}()", crate::macros::fn_name_bare!())
     }};
-    ($target: expr, $message: expr) => {
-        $crate::macros::duration_async!($target, $message, tracing::Level::TRACE)
-    };
-    ($target: expr) => {
-        $crate::macros::duration_async!($target, "", tracing::Level::TRACE)
-    };
-}
-
-/// executes an async expression, times duration, and emits info! message
-///
-/// Accepts arguments in 2 forms:
-///   duration!(myfunc())
-///   duration!(myfunc(), message)
-#[allow(unused_macros)]
-macro_rules! duration_async_info {
-    ($target: expr) => {
-        $crate::macros::duration_async!($target, "", tracing::Level::INFO)
-    };
-    ($target: expr, $message: expr) => {
-        $crate::macros::duration_async!($target, $message, tracing::Level::INFO)
-    };
-}
-
-/// executes an async expression, times duration, and emits debug! message
-///
-/// Accepts arguments in 2 forms:
-///   duration!(myfunc())
-///   duration!(myfunc(), message)
-#[allow(unused_macros)]
-macro_rules! duration_async_debug {
-    ($target: expr) => {
-        $crate::macros::duration_async!($target, "", tracing::Level::DEBUG)
-    };
-    ($target: expr, $message: expr) => {
-        $crate::macros::duration_async!($target, $message, tracing::Level::DEBUG)
-    };
 }
 
 // These allow the macros to be used as
@@ -144,67 +23,22 @@ macro_rules! duration_async_debug {
 // see: https://stackoverflow.com/a/67140319/10087197
 
 #[allow(unused_imports)]
-pub(crate) use duration;
+pub(crate) use fn_name;
 #[allow(unused_imports)]
-pub(crate) use duration_async;
-#[allow(unused_imports)]
-pub(crate) use duration_async_debug;
-#[allow(unused_imports)]
-pub(crate) use duration_async_info;
-#[allow(unused_imports)]
-pub(crate) use duration_debug;
-#[allow(unused_imports)]
-pub(crate) use duration_info;
+pub(crate) use fn_name_bare;
 
 #[cfg(test)]
 mod test {
 
     use super::*;
-    use tracing::Level;
-
-    fn fibonacci(n: u32) -> u32 {
-        match n {
-            0 => 1,
-            1 => 1,
-            _ => fibonacci(n - 1) + fibonacci(n - 2),
-        }
-    }
-
-    async fn fibonacci_async(n: u32) -> u32 {
-        match n {
-            0 => 1,
-            1 => 1,
-            _ => fibonacci(n - 1) + fibonacci(n - 2),
-        }
-    }
 
     #[test]
-    fn duration_tests() {
-        duration!(fibonacci(1));
-        duration!(fibonacci(2), "fibonacci - 2".to_string());
-        duration!(fibonacci(3), "fibonacci - 3", Level::INFO);
-
-        duration_info!(fibonacci(4));
-        duration_info!(fibonacci(5), "fibonacci - 5");
-        duration_info!(fibonacci(6), "fibonacci - 6".to_string());
-
-        duration_debug!(fibonacci(7));
-        duration_debug!(fibonacci(8), "fibonacci - 8");
-        duration_debug!(fibonacci(9), "fibonacci - 9".to_string());
+    fn fn_name_test() {
+        assert_eq!(fn_name!(), "fn_name_test()");
     }
 
     #[tokio::test]
-    async fn duration_async_tests() {
-        duration_async!(fibonacci_async(1));
-        duration_async!(fibonacci_async(2), "fibonacci_async - 2".to_string());
-        duration_async!(fibonacci_async(3), "fibonacci_async - 3", Level::INFO);
-
-        duration_async_info!(fibonacci_async(4));
-        duration_async_info!(fibonacci_async(5), "fibonacci_async - 5");
-        duration_async_info!(fibonacci_async(6), "fibonacci_async - 6".to_string());
-
-        duration_async_debug!(fibonacci_async(7));
-        duration_async_debug!(fibonacci_async(8), "fibonacci_async - 8");
-        duration_async_debug!(fibonacci_async(9), "fibonacci_async - 9".to_string());
+    async fn async_fn_name_test() {
+        assert_eq!(fn_name!(), "async_fn_name_test()");
     }
 }

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -345,7 +345,7 @@ impl MainLoopHandler {
                 }
 
                 global_state_mut
-                    .set_new_self_mined_tip(
+                    .set_new_self_mined_tip_atomic(
                         new_block.as_ref().clone(),
                         new_block_info.coinbase_utxo_info.as_ref().clone(),
                     )
@@ -429,7 +429,7 @@ impl MainLoopHandler {
                             new_block.kernel.header.timestamp.standard_format()
                         );
 
-                        global_state_mut.set_new_tip(new_block).await?;
+                        global_state_mut.set_new_tip_atomic(new_block).await?;
                     }
                 }
 

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -327,7 +327,14 @@ impl Block {
             difficulty: MINIMUM_DIFFICULTY.into(),
         };
 
-        Self::new(header, body, BlockType::Genesis)
+        let block = Self::new(header, body, BlockType::Genesis);
+
+        debug!(
+            "Instantiated genesis block with digest\n  str: {}\n  hex: {}",
+            block.hash(),
+            block.hash().to_hex()
+        );
+        block
     }
 
     fn premine_distribution(_network: Network) -> Vec<(ReceivingAddress, NeptuneCoins)> {

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -315,7 +315,7 @@ impl Mempool {
     /// Remove from the mempool all transactions that become invalid because
     /// of a newly received block. Also update all mutator set data for mempool
     /// transactions that were not removed.
-    pub async fn update_with_block(
+    pub fn update_with_block(
         &mut self,
         previous_mutator_set_accumulator: MutatorSetAccumulator,
         block: &Block,
@@ -653,11 +653,11 @@ mod tests {
             ))
             .await;
         other_global_state
-            .set_new_tip(block_1.clone())
+            .set_new_tip_atomic(block_1.clone())
             .await
             .unwrap();
         premine_receiver_global_state
-            .set_new_tip(block_1.clone())
+            .set_new_tip_atomic(block_1.clone())
             .await
             .unwrap();
 
@@ -736,12 +736,10 @@ mod tests {
 
         // Update the mempool with block 2 and verify that the mempool now only contains one tx
         assert_eq!(2, mempool.len());
-        mempool
-            .update_with_block(
-                block_1.kernel.body.mutator_set_accumulator.clone(),
-                &block_2,
-            )
-            .await;
+        mempool.update_with_block(
+            block_1.kernel.body.mutator_set_accumulator.clone(),
+            &block_2,
+        );
         assert_eq!(1, mempool.len());
 
         // Create a new block to verify that the non-mined transaction contains
@@ -780,12 +778,10 @@ mod tests {
         for _ in 0..11 {
             let (next_block, _, _) =
                 make_mock_block(&previous_block, None, other_receiver_address, rng.gen());
-            mempool
-                .update_with_block(
-                    previous_block.kernel.body.mutator_set_accumulator.clone(),
-                    &next_block,
-                )
-                .await;
+            mempool.update_with_block(
+                previous_block.kernel.body.mutator_set_accumulator.clone(),
+                &next_block,
+            );
             previous_block = next_block;
         }
 
@@ -805,12 +801,10 @@ mod tests {
             "Block with tx with updated mutator set data must be valid after 10 blocks have been mined"
         );
 
-        mempool
-            .update_with_block(
-                previous_block.kernel.body.mutator_set_accumulator.clone(),
-                &block_14,
-            )
-            .await;
+        mempool.update_with_block(
+            previous_block.kernel.body.mutator_set_accumulator.clone(),
+            &block_14,
+        );
 
         assert!(
             mempool.is_empty(),
@@ -894,7 +888,7 @@ mod tests {
                 rng.gen(),
             );
             premine_receiver_global_state
-                .set_new_tip(next_block.clone())
+                .set_new_tip_atomic(next_block.clone())
                 .await
                 .unwrap();
 
@@ -942,7 +936,7 @@ mod tests {
             "Sanity check that new tip has height 1"
         );
         premine_receiver_global_state
-            .set_new_tip(block_1b.clone())
+            .set_new_tip_atomic(block_1b.clone())
             .await
             .unwrap();
 

--- a/src/models/state/wallet/mod.rs
+++ b/src/models/state/wallet/mod.rs
@@ -962,7 +962,7 @@ mod wallet_tests {
                 .await;
         }
         premine_receiver_global_state
-            .set_new_tip(block_1.clone())
+            .set_new_tip_atomic(block_1.clone())
             .await
             .unwrap();
 
@@ -1026,7 +1026,7 @@ mod wallet_tests {
                 )
                 .await?;
             premine_receiver_global_state
-                .set_new_tip(next_block.clone())
+                .set_new_tip_atomic(next_block.clone())
                 .await
                 .unwrap();
         }
@@ -1097,7 +1097,7 @@ mod wallet_tests {
             )
             .await?;
         premine_receiver_global_state
-            .set_new_tip(block_2_b.clone())
+            .set_new_tip_atomic(block_2_b.clone())
             .await
             .unwrap();
         premine_receiver_global_state

--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -1493,7 +1493,7 @@ mod peer_loop_tests {
             .to_address();
         let (block_1, _, _) =
             make_mock_block_with_valid_pow(&genesis_block, None, a_recipient_address, rng.gen());
-        global_state_mut.set_new_tip(block_1.clone()).await?;
+        global_state_mut.set_new_tip_atomic(block_1.clone()).await?;
         drop(global_state_mut);
 
         let mock_peer_messages = Mock::new(vec![
@@ -1566,11 +1566,19 @@ mod peer_loop_tests {
         let (block_3_b, _, _) =
             make_mock_block_with_valid_pow(&block_2_b, None, a_recipient_address, rng.gen());
 
-        global_state_mut.set_new_tip(block_1.clone()).await?;
-        global_state_mut.set_new_tip(block_2_a.clone()).await?;
-        global_state_mut.set_new_tip(block_2_b.clone()).await?;
-        global_state_mut.set_new_tip(block_3_b.clone()).await?;
-        global_state_mut.set_new_tip(block_3_a.clone()).await?;
+        global_state_mut.set_new_tip_atomic(block_1.clone()).await?;
+        global_state_mut
+            .set_new_tip_atomic(block_2_a.clone())
+            .await?;
+        global_state_mut
+            .set_new_tip_atomic(block_2_b.clone())
+            .await?;
+        global_state_mut
+            .set_new_tip_atomic(block_3_b.clone())
+            .await?;
+        global_state_mut
+            .set_new_tip_atomic(block_3_a.clone())
+            .await?;
 
         drop(global_state_mut);
 
@@ -1658,11 +1666,19 @@ mod peer_loop_tests {
         let (block_3_b, _, _) =
             make_mock_block_with_valid_pow(&block_2_b, None, a_recipient_address, rng.gen());
 
-        global_state_mut.set_new_tip(block_1.clone()).await?;
-        global_state_mut.set_new_tip(block_2_a.clone()).await?;
-        global_state_mut.set_new_tip(block_2_b.clone()).await?;
-        global_state_mut.set_new_tip(block_3_b.clone()).await?;
-        global_state_mut.set_new_tip(block_3_a.clone()).await?;
+        global_state_mut.set_new_tip_atomic(block_1.clone()).await?;
+        global_state_mut
+            .set_new_tip_atomic(block_2_a.clone())
+            .await?;
+        global_state_mut
+            .set_new_tip_atomic(block_2_b.clone())
+            .await?;
+        global_state_mut
+            .set_new_tip_atomic(block_3_b.clone())
+            .await?;
+        global_state_mut
+            .set_new_tip_atomic(block_3_a.clone())
+            .await?;
 
         drop(global_state_mut);
 
@@ -1724,11 +1740,19 @@ mod peer_loop_tests {
         let (block_3_b, _, _) =
             make_mock_block_with_valid_pow(&block_2_b, None, a_recipient_address, rng.gen());
 
-        global_state_mut.set_new_tip(block_1.clone()).await?;
-        global_state_mut.set_new_tip(block_2_a.clone()).await?;
-        global_state_mut.set_new_tip(block_2_b.clone()).await?;
-        global_state_mut.set_new_tip(block_3_b.clone()).await?;
-        global_state_mut.set_new_tip(block_3_a.clone()).await?;
+        global_state_mut.set_new_tip_atomic(block_1.clone()).await?;
+        global_state_mut
+            .set_new_tip_atomic(block_2_a.clone())
+            .await?;
+        global_state_mut
+            .set_new_tip_atomic(block_2_b.clone())
+            .await?;
+        global_state_mut
+            .set_new_tip_atomic(block_3_b.clone())
+            .await?;
+        global_state_mut
+            .set_new_tip_atomic(block_3_a.clone())
+            .await?;
 
         drop(global_state_mut);
 
@@ -1951,7 +1975,7 @@ mod peer_loop_tests {
             own_recipient_address,
             rng.gen(),
         );
-        global_state_mut.set_new_tip(block_1.clone()).await?;
+        global_state_mut.set_new_tip_atomic(block_1.clone()).await?;
 
         drop(global_state_mut);
 
@@ -2039,7 +2063,7 @@ mod peer_loop_tests {
             make_mock_block_with_valid_pow(&block_2.clone(), None, a_recipient_address, rng.gen());
         let (block_4, _, _) =
             make_mock_block_with_valid_pow(&block_3.clone(), None, a_recipient_address, rng.gen());
-        global_state_mut.set_new_tip(block_1.clone()).await?;
+        global_state_mut.set_new_tip_atomic(block_1.clone()).await?;
         drop(global_state_mut);
 
         let mock = Mock::new(vec![
@@ -2215,7 +2239,7 @@ mod peer_loop_tests {
             make_mock_block_with_valid_pow(&block_3.clone(), None, a_recipient_address, rng.gen());
         let (block_5, _, _) =
             make_mock_block_with_valid_pow(&block_4.clone(), None, a_recipient_address, rng.gen());
-        global_state_mut.set_new_tip(block_1.clone()).await?;
+        global_state_mut.set_new_tip_atomic(block_1.clone()).await?;
         drop(global_state_mut);
 
         let mock = Mock::new(vec![
@@ -2329,7 +2353,7 @@ mod peer_loop_tests {
             make_mock_block_with_valid_pow(&block_2.clone(), None, a_recipient_address, rng.gen());
         let (block_4, _, _) =
             make_mock_block_with_valid_pow(&block_3.clone(), None, a_recipient_address, rng.gen());
-        global_state_mut.set_new_tip(block_1.clone()).await?;
+        global_state_mut.set_new_tip_atomic(block_1.clone()).await?;
         drop(global_state_mut);
 
         let (hsd_1, sa_1) = get_dummy_peer_connection_data_genesis(network, 1).await;

--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -1423,7 +1423,7 @@ mod rpc_server_tests {
         state_lock
             .lock_guard_mut()
             .await
-            .set_new_self_mined_tip(
+            .set_new_self_mined_tip_atomic(
                 block_1,
                 ExpectedUtxo::new(
                     cb_utxo,

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -280,7 +280,10 @@ pub async fn add_block_to_archival_state(
 ) -> Result<()> {
     archival_state.write_block_as_tip(&new_block).await?;
 
-    archival_state.update_mutator_set(&new_block).await.unwrap();
+    archival_state
+        .update_mutator_set_atomic(&new_block)
+        .await
+        .unwrap();
 
     Ok(())
 }

--- a/src/util_types/mutator_set/archival_mutator_set.rs
+++ b/src/util_types/mutator_set/archival_mutator_set.rs
@@ -296,7 +296,7 @@ where
 
     /// Determine whether the given `AdditionRecord` can be reversed.
     /// Equivalently, determine if it was added last.
-    pub async fn add_is_reversible(&mut self, addition_record: &AdditionRecord) -> bool {
+    pub async fn add_is_reversible(&self, addition_record: &AdditionRecord) -> bool {
         let leaf_index = self.aocl.count_leaves().await - 1;
         let digest = self.aocl.get_leaf_async(leaf_index).await;
         addition_record.canonical_commitment == digest

--- a/src/util_types/mutator_set/removal_record.rs
+++ b/src/util_types/mutator_set/removal_record.rs
@@ -37,7 +37,7 @@ use super::shared::NUM_TRIALS;
 use super::MutatorSetError;
 
 #[derive(Debug, Clone, PartialEq, Eq, BFieldCodec, Arbitrary)]
-pub struct AbsoluteIndexSet([u128; NUM_TRIALS as usize]);
+pub struct AbsoluteIndexSet([u128; NUM_TRIALS as usize]); // 720 bytes
 
 impl GetSize for AbsoluteIndexSet {
     fn get_stack_size() -> usize {
@@ -167,7 +167,7 @@ impl<'de> Deserialize<'de> for AbsoluteIndexSet {
     Clone, Debug, Deserialize, Serialize, PartialEq, Eq, GetSize, BFieldCodec, TasmObject, Arbitrary,
 )]
 pub struct RemovalRecord {
-    pub absolute_indices: AbsoluteIndexSet,
+    pub absolute_indices: AbsoluteIndexSet, // 720 bytes
     pub target_chunks: ChunkDictionary,
 }
 
@@ -203,16 +203,11 @@ impl RemovalRecord {
         // Collect all indices for all removal records that are being updated
         let mut chunk_index_to_rr_index: HashMap<u64, Vec<usize>> = HashMap::new();
         removal_records.iter().enumerate().for_each(|(i, rr)| {
-            let indices = &rr.absolute_indices;
-            let chunks_set: HashSet<u64> = indices
+            rr.absolute_indices
                 .to_array()
                 .iter()
                 .map(|x| (x / CHUNK_SIZE as u128) as u64)
-                .collect();
-
-            chunks_set
-                .iter()
-                .for_each(|chnkidx| chunk_index_to_rr_index.entry(*chnkidx).or_default().push(i));
+                .for_each(|chnkidx| chunk_index_to_rr_index.entry(chnkidx).or_default().push(i));
         });
 
         // Find the removal records that need a new dictionary entry for the chunk


### PR DESCRIPTION
addresses #183.
obsoletes #186.

Summary:  This PR gives us a knob we can twist to favor either concurrency or read+write atomicity.   The intent is to give us greater flexibility as we move forward with processing "real" data... fuller blocks, longer proof times, etc.

### Illustration:

There are several methods with the following general behavior:

```
fn update_some_state(&mut self, ..) -> Result<()> {
    // perform one or more loops that gather data and update state.
}
```

Often the reading can be quite slow, such as fetching blocks from disk in a loop in order to examine the inputs and outputs.

This is bad for concurrency as the caller must be holding a write-lock over GlobalState in order to call an &mut self method.  So all other tasks that read or write app-state are blocked.

So the above fn can be split as follows:

```
fn prepare_update_some_state(&self, ..) -> Result<Updates> {
    // perform one or more loops that gather data. (slowly)
}

fn finalize_update_some_state(&mut self, updates: Updates) -> Result<()> {
    // update state (as fast as possible)
}
```

Now the i/o intensive read ops are performed in an &self method that only requires the caller to hold a read-lock over GlobalState.  This allows all other read-only tasks to progress.  Only tasks that attempt to modify state will be blocked.

The finalize method performs the state mutation as before but now it can do so much more quickly because all the data gathering and calcs are already done.

This is a win for concurrency but it comes at a cost.  If the caller acquires read-lock for read method and then write-lock for the write method, we have lost atomicity over the entire read+write.   That may be too high of a price to pay, depending on the operation.  Still the caller now has the option to do it either way.  The caller can either:
1. favor atomic: acquire read+write lock, perform read, perform write
2. favor concurrent: acquire read lock, perform read, acquire write lock, perform write.

Note that for (2) the read is atomic and the write is atomic, but the read+write is not atomic.

### Batching

Some of the read methods are potentially updating too much data to keep it all in RAM for the caller to pass it to the write method.  In this case, batching is used and the pattern becomes:

```
fn prepare_update_some_state(&self, start_idx, batch_size, ..) -> Result<Updates> {
    // perform one or more loops that gather data. (slowly)
}

fn finalize_update_some_state(&mut self, updates: Updates) -> Result<()> {
    // update state (as fast as possible)
}
```

So the caller may then call the read and write methods in a loop.  If concurrency is favored then the caller would acquire read-lock for each read and write-lock for each write.    Note that in this case, the reads and writes are only atomic per batch.

### Backwards compatibility

wrapper methods are provided for the caller that preserve the original &mut self behavior.  eg:

```
fn update_some_state(&mut self, ..) -> Result<()> {
    let updates = prepare_update_some_state(..)?;
    finalize_update_some_state(updates)
}
```

### Smaller Fns

There is also a small win in that this refactoring breaks some of these fn into smaller units such that the logic/purpose of each becomes clearer in isolation.  The best example is update_mutator_set().

### Methods changed

* WalletState::update_wallet_state_with_new_block()
* ArchivalState::update_mutator_set()
* GlobalState::resync_membership_proofs()
* GlobalState::set_new_tip()

of special note:
* In this PR the calling code is (still) favoring read+write atomicity for all of the above *except* resync_membership_proofs().  I *think* that should be ok, but am also fine with making it favor atomicity for now (until such time that it becomes a perf problem).
* update_mutator_set() is complex and potentially updates a lot of data.  It was separated into several fn and batching is used.
* set_new_tip() has two separate impls.   GlobalState::set_new_tip_atomic() and GlobalStateLock::set_new_tip_concurrent().  The latter is available if we should ever need it but presently unused.

### ScopeDurationLogger

This PR also adds a new type, `ScopeDurationLogger` that makes it a one-liner to enable logging of [slow] methods (or any scope).  By default "slow" means > 0.1 seconds.   If a given scope takes longer than the "slow" threshold, a warning will be emitted to the log.  Otherwise nothing is logged. This makes it convenient to sprinkle the ScopeDurationLogger anywhere we think a fn *might* be slow eventually but it won't clutter up the log unless it actually *is* slow.

The slow logging threshold defaults to 0.1 seconds and can be changed via:
* env var: LOG_SLOW_FN_THRESHOLD.  (can also be set in Cargo.toml)
* `ScopeDurationLogger::new_with_threshold()`

This replaces the older duration_* macros that had to be used by the caller.

`ScopeDurationLogger` could actually be made into a fn decoration macro for slightly cleaner usage.  But I think that requires use syn to modify the fn and I didn't think it worth the time to learn/impl, especially as it is already a one-liner.  so, maybe later.

Details:
 * log genesis block digest
 * rename GlobalState::set_new_tip() -> set_new_tip_atomic()
 * impl ScopeDurationLogger and use it to log method durations
 * split WalletState::update_wallet_state_with_new_block()
 * split ArchivalState::update_mutator_set()
 * add experimental GlobalStateLock::set_new_tip_concurrent() (not used)
 * split GlobalState::resync_membership_proofs()
 * remove duration_* macros
 * add fn_name, fn_name_bare macros