### PR TITLE
#184 unconfirmed balance pr

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,16 @@ pub async fn initialize(cli_args: cli_args::Args) -> Result<()> {
     DataDirectory::create_dir_if_not_exists(&data_dir.root_dir_path()).await?;
     info!("Data directory is {}", data_dir);
 
+    // Get wallet object, create various wallet secret files
+    let wallet_dir = data_dir.wallet_directory_path();
+    DataDirectory::create_dir_if_not_exists(&wallet_dir).await?;
+    let (wallet_secret, _) =
+        WalletSecret::read_from_file_or_create(&data_dir.wallet_directory_path())?;
+    info!("Now getting wallet state. This may take a while if the database needs pruning.");
+    let wallet_state =
+        WalletState::new_from_wallet_secret(&data_dir, wallet_secret, &cli_args).await;
+    info!("Got wallet state.");
+
     // Connect to or create databases for block index, peers, mutator set, block sync
     let block_index_db = ArchivalState::initialize_block_index_database(&data_dir).await?;
     info!("Got block index database");
@@ -101,7 +111,7 @@ pub async fn initialize(cli_args: cli_args::Args) -> Result<()> {
     info!("Got archival mutator set");
 
     let archival_state = ArchivalState::new(
-        data_dir.clone(),
+        data_dir,
         block_index_db,
         archival_mutator_set,
         cli_args.network,
@@ -155,16 +165,6 @@ pub async fn initialize(cli_args: cli_args::Args) -> Result<()> {
         latest_block.hash(),
     );
 
-    // Get wallet object, create various wallet secret files
-    let wallet_dir = data_dir.wallet_directory_path();
-    DataDirectory::create_dir_if_not_exists(&wallet_dir).await?;
-    let (wallet_secret, _) =
-        WalletSecret::read_from_file_or_create(&data_dir.wallet_directory_path())?;
-    info!("Now getting wallet state. This may take a while if the database needs pruning.");
-    let wallet_state =
-        WalletState::new_from_wallet_secret(&data_dir, wallet_secret, &cli_args).await;
-    info!("Got wallet state.");
-
     let mut global_state_lock = GlobalStateLock::new(
         wallet_state,
         blockchain_state,
@@ -192,11 +192,8 @@ pub async fn initialize(cli_args: cli_args::Args) -> Result<()> {
         .await?;
     info!("UTXO restoration check complete");
 
-    let mut task_join_handles = vec![];
-
-    task_join_handles.push(spawn_wallet_task(global_state_lock.clone()).await?);
-
     // Connect to peers, and provide each peer task with a thread-safe copy of the state
+    let mut task_join_handles = vec![];
     for peer_address in global_state_lock.cli().peers.clone() {
         let peer_state_var = global_state_lock.clone(); // bump arc refcount
         let main_to_peer_broadcast_rx_clone: broadcast::Receiver<MainToPeerTask> =
@@ -301,33 +298,6 @@ pub async fn initialize(cli_args: cli_args::Args) -> Result<()> {
             task_join_handles,
         )
         .await
-}
-
-pub(crate) async fn spawn_wallet_task(
-    mut global_state_lock: GlobalStateLock,
-) -> Result<tokio::task::JoinHandle<()>> {
-    let mut mempool_subscriber = global_state_lock.lock_guard().await.mempool.subscribe();
-
-    let wallet_join_handle = tokio::task::Builder::new()
-        .name("wallet_mempool_listener")
-        .spawn(async move {
-            let mut events: std::collections::VecDeque<_> = Default::default();
-
-            while let Ok(event) = mempool_subscriber.recv().await {
-                events.push_back(event);
-
-                if let Ok(mut gs) = global_state_lock.try_lock_guard_mut() {
-                    while let Some(e) = events.pop_front() {
-                        gs.wallet_state
-                            .handle_mempool_event(e)
-                            .await
-                            .expect("Wallet should handle mempool event without error");
-                    }
-                }
-            }
-        })?;
-
-    Ok(wallet_join_handle)
 }
 
 /// Time a fn call.  Duration is returned as a float in seconds.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,16 +90,6 @@ pub async fn initialize(cli_args: cli_args::Args) -> Result<()> {
     DataDirectory::create_dir_if_not_exists(&data_dir.root_dir_path()).await?;
     info!("Data directory is {}", data_dir);
 
-    // Get wallet object, create various wallet secret files
-    let wallet_dir = data_dir.wallet_directory_path();
-    DataDirectory::create_dir_if_not_exists(&wallet_dir).await?;
-    let (wallet_secret, _) =
-        WalletSecret::read_from_file_or_create(&data_dir.wallet_directory_path())?;
-    info!("Now getting wallet state. This may take a while if the database needs pruning.");
-    let wallet_state =
-        WalletState::new_from_wallet_secret(&data_dir, wallet_secret, &cli_args).await;
-    info!("Got wallet state.");
-
     // Connect to or create databases for block index, peers, mutator set, block sync
     let block_index_db = ArchivalState::initialize_block_index_database(&data_dir).await?;
     info!("Got block index database");
@@ -111,7 +101,7 @@ pub async fn initialize(cli_args: cli_args::Args) -> Result<()> {
     info!("Got archival mutator set");
 
     let archival_state = ArchivalState::new(
-        data_dir,
+        data_dir.clone(),
         block_index_db,
         archival_mutator_set,
         cli_args.network,
@@ -164,6 +154,17 @@ pub async fn initialize(cli_args: cli_args::Args) -> Result<()> {
         cli_args.max_mempool_num_tx,
         latest_block.hash(),
     );
+
+    // Get wallet object, create various wallet secret files
+    let wallet_dir = data_dir.wallet_directory_path();
+    DataDirectory::create_dir_if_not_exists(&wallet_dir).await?;
+    let (wallet_secret, _) =
+        WalletSecret::read_from_file_or_create(&data_dir.wallet_directory_path())?;
+    info!("Now getting wallet state. This may take a while if the database needs pruning.");
+    let wallet_state =
+        WalletState::new_from_wallet_secret(&data_dir, wallet_secret, &cli_args).await;
+    info!("Got wallet state.");
+
     let mut global_state_lock = GlobalStateLock::new(
         wallet_state,
         blockchain_state,
@@ -191,8 +192,11 @@ pub async fn initialize(cli_args: cli_args::Args) -> Result<()> {
         .await?;
     info!("UTXO restoration check complete");
 
-    // Connect to peers, and provide each peer task with a thread-safe copy of the state
     let mut task_join_handles = vec![];
+
+    task_join_handles.push(spawn_wallet_task(global_state_lock.clone()).await?);
+
+    // Connect to peers, and provide each peer task with a thread-safe copy of the state
     for peer_address in global_state_lock.cli().peers.clone() {
         let peer_state_var = global_state_lock.clone(); // bump arc refcount
         let main_to_peer_broadcast_rx_clone: broadcast::Receiver<MainToPeerTask> =
@@ -297,6 +301,33 @@ pub async fn initialize(cli_args: cli_args::Args) -> Result<()> {
             task_join_handles,
         )
         .await
+}
+
+pub(crate) async fn spawn_wallet_task(
+    mut global_state_lock: GlobalStateLock,
+) -> Result<tokio::task::JoinHandle<()>> {
+    let mut mempool_subscriber = global_state_lock.lock_guard().await.mempool.subscribe();
+
+    let wallet_join_handle = tokio::task::Builder::new()
+        .name("wallet_mempool_listener")
+        .spawn(async move {
+            let mut events: std::collections::VecDeque<_> = Default::default();
+
+            while let Ok(event) = mempool_subscriber.recv().await {
+                events.push_back(event);
+
+                if let Ok(mut gs) = global_state_lock.try_lock_guard_mut() {
+                    while let Some(e) = events.pop_front() {
+                        gs.wallet_state
+                            .handle_mempool_event(e)
+                            .await
+                            .expect("Wallet should handle mempool event without error");
+                    }
+                }
+            }
+        })?;
+
+    Ok(wallet_join_handle)
 }
 
 /// Time a fn call.  Duration is returned as a float in seconds.

--- a/src/locks/tokio/atomic_rw.rs
+++ b/src/locks/tokio/atomic_rw.rs
@@ -241,6 +241,9 @@ impl<T> AtomicRw<T> {
         AtomicRwWriteGuard::new(guard, &self.lock_callback_info)
     }
 
+    /// Attempt to acquire write lock immediately.
+    ///
+    /// If the lock cannot be acquired without waiting, an error is returned.
     pub fn try_lock_guard_mut(&mut self) -> Result<AtomicRwWriteGuard<T>, TryLockError> {
         self.try_acquire_write_cb();
         let guard = self.inner.try_write()?;

--- a/src/locks/tokio/atomic_rw.rs
+++ b/src/locks/tokio/atomic_rw.rs
@@ -6,6 +6,7 @@ use futures::future::BoxFuture;
 use tokio::sync::RwLock;
 use tokio::sync::RwLockReadGuard;
 use tokio::sync::RwLockWriteGuard;
+use tokio::sync::TryLockError;
 
 use super::LockAcquisition;
 use super::LockCallbackFn;
@@ -238,6 +239,12 @@ impl<T> AtomicRw<T> {
         self.try_acquire_write_cb();
         let guard = self.inner.write().await;
         AtomicRwWriteGuard::new(guard, &self.lock_callback_info)
+    }
+
+    pub fn try_lock_guard_mut(&mut self) -> Result<AtomicRwWriteGuard<T>, TryLockError> {
+        self.try_acquire_write_cb();
+        let guard = self.inner.try_write()?;
+        Ok(AtomicRwWriteGuard::new(guard, &self.lock_callback_info))
     }
 
     /// Immutably access the data of type `T` in a closure and possibly return a result of type `R`

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -539,8 +539,8 @@ impl MainLoopHandler {
 
                 // Insert into mempool
                 global_state_mut
-                    .mempool
-                    .insert(pt2m_transaction.transaction.to_owned())?;
+                    .mempool_insert(pt2m_transaction.transaction.to_owned())
+                    .await?;
 
                 // send notification to peers
                 let transaction_notification: TransactionNotification =
@@ -998,7 +998,7 @@ impl MainLoopHandler {
                 // Handle mempool cleanup, i.e. removing stale/too old txs from mempool
                 _ = &mut mempool_cleanup_timer => {
                     debug!("Timer: mempool-cleaner job");
-                    self.global_state_lock.lock_guard_mut().await.mempool.prune_stale_transactions()?;
+                    self.global_state_lock.lock_guard_mut().await.mempool_prune_stale_transactions().await?;
 
                     // Reset the timer to run this branch again in P seconds
                     mempool_cleanup_timer.as_mut().reset(tokio::time::Instant::now() + mempool_cleanup_timer_interval);
@@ -1056,8 +1056,8 @@ impl MainLoopHandler {
                 self.global_state_lock
                     .lock_guard_mut()
                     .await
-                    .mempool
-                    .insert(*transaction)?;
+                    .mempool_insert(*transaction)
+                    .await?;
 
                 // do not shut down
                 Ok(false)

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -540,7 +540,7 @@ impl MainLoopHandler {
                 // Insert into mempool
                 global_state_mut
                     .mempool
-                    .insert(&pt2m_transaction.transaction);
+                    .insert(pt2m_transaction.transaction.to_owned())?;
 
                 // send notification to peers
                 let transaction_notification: TransactionNotification =
@@ -998,7 +998,7 @@ impl MainLoopHandler {
                 // Handle mempool cleanup, i.e. removing stale/too old txs from mempool
                 _ = &mut mempool_cleanup_timer => {
                     debug!("Timer: mempool-cleaner job");
-                    self.global_state_lock.lock_mut(|s| s.mempool.prune_stale_transactions()).await;
+                    self.global_state_lock.lock_guard_mut().await.mempool.prune_stale_transactions()?;
 
                     // Reset the timer to run this branch again in P seconds
                     mempool_cleanup_timer.as_mut().reset(tokio::time::Instant::now() + mempool_cleanup_timer_interval);
@@ -1054,8 +1054,10 @@ impl MainLoopHandler {
 
                 // insert transaction into mempool
                 self.global_state_lock
-                    .lock_mut(|s| s.mempool.insert(&transaction))
-                    .await;
+                    .lock_guard_mut()
+                    .await
+                    .mempool
+                    .insert(*transaction)?;
 
                 // do not shut down
                 Ok(false)

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -636,12 +636,11 @@ mod mine_loop_tests {
         // no need to inform wallet of expected utxos; block template validity
         // is what is being tested
 
-        alice
-            .lock_guard_mut()
-            .await
-            .mempool
-            .insert(tx_by_preminer)?;
-        assert_eq!(1, alice.lock_guard().await.mempool.len());
+        {
+            let mut alice_gsm = alice.lock_guard_mut().await;
+            alice_gsm.mempool_insert(tx_by_preminer).await?;
+            assert_eq!(1, alice_gsm.mempool.len());
+        }
 
         // Build transaction for block
         let (transaction_non_empty_mempool, _new_coinbase_sender_randomness) = {

--- a/src/models/blockchain/transaction/transaction_output.rs
+++ b/src/models/blockchain/transaction/transaction_output.rs
@@ -33,7 +33,7 @@ pub enum UtxoNotificationMedium {
 ///
 /// see also: [UtxoNotification]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-enum UtxoNotifyMethod {
+pub(crate) enum UtxoNotifyMethod {
     /// the utxo notification should be transferred to recipient encrypted on the blockchain
     OnChain(ReceivingAddress),
 

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -1332,7 +1332,7 @@ impl GlobalState {
             myself
                 .mempool
                 .update_with_block(previous_ms_accumulator, &new_block)
-                .await;
+                .await?;
 
             myself.chain.light_state_mut().set_block(new_block);
 

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -1382,6 +1382,24 @@ impl GlobalState {
     pub fn cli(&self) -> &cli_args::Args {
         &self.cli
     }
+
+    /// clears all Tx from mempool and notifies wallet of changes.
+    pub async fn mempool_clear(&mut self) -> Result<()> {
+        let events = self.mempool.clear()?;
+        self.wallet_state.handle_mempool_events(events).await
+    }
+
+    /// adds Tx to mempool and notifies wallet of change.
+    pub async fn mempool_insert(&mut self, transaction: Transaction) -> Result<()> {
+        let events = self.mempool.insert(transaction)?;
+        self.wallet_state.handle_mempool_events(events).await
+    }
+
+    /// prunes stale tx in mempool and notifies wallet of changes.
+    pub async fn mempool_prune_stale_transactions(&mut self) -> Result<()> {
+        let events = self.mempool.prune_stale_transactions()?;
+        self.wallet_state.handle_mempool_events(events).await
+    }
 }
 
 #[cfg(test)]

--- a/src/models/state/wallet/rusty_wallet_database.rs
+++ b/src/models/state/wallet/rusty_wallet_database.rs
@@ -17,6 +17,9 @@ pub struct RustyWalletDatabase {
     // list of utxos we have already received in a block
     monitored_utxos: DbtVec<MonitoredUtxo>,
 
+    // list of utxos presently in the mempool
+    // monitored_mempool_utxos: DbtVec<Utxo>,
+
     // list of off-chain utxos we are expecting to receive in a future block
     expected_utxos: DbtVec<ExpectedUtxo>,
 

--- a/src/models/state/wallet/rusty_wallet_database.rs
+++ b/src/models/state/wallet/rusty_wallet_database.rs
@@ -17,9 +17,6 @@ pub struct RustyWalletDatabase {
     // list of utxos we have already received in a block
     monitored_utxos: DbtVec<MonitoredUtxo>,
 
-    // list of utxos presently in the mempool
-    // monitored_mempool_utxos: DbtVec<Utxo>,
-
     // list of off-chain utxos we are expecting to receive in a future block
     expected_utxos: DbtVec<ExpectedUtxo>,
 

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -18,6 +18,7 @@ use tokio::io::BufWriter;
 use tracing::debug;
 use tracing::error;
 use tracing::info;
+use tracing::trace;
 use tracing::warn;
 use twenty_first::math::bfield_codec::BFieldCodec;
 use twenty_first::math::digest::Digest;
@@ -68,6 +69,8 @@ pub struct WalletState {
     pub number_of_mps_per_utxo: usize,
     wallet_directory_path: PathBuf,
 
+    /// these two fields are for monitoring wallet-affecting utxos in the mempool.
+    /// key is Tx hash.  for removing watched utxos when a tx is removed from mempool.
     mempool_spent_utxos: HashMap<Digest, Vec<(Utxo, AbsoluteIndexSet, u64)>>,
     mempool_unspent_utxos: HashMap<Digest, Vec<AnnouncedUtxo>>,
 }
@@ -269,10 +272,30 @@ impl WalletState {
             .collect_vec()
     }
 
-    pub async fn handle_mempool_event(&mut self, event: MempoolEvent) -> Result<()> {
+    /// handles a list of mempool events
+    pub(in crate::models::state) async fn handle_mempool_events(
+        &mut self,
+        events: impl IntoIterator<Item = MempoolEvent>,
+    ) -> Result<()> {
+        for event in events {
+            self.handle_mempool_event(event).await?
+        }
+        Ok(())
+    }
+
+    /// handles a single mempool event.
+    ///
+    /// note: the wallet watches the mempool in order to keep track of
+    /// unconfirmed utxos sent from or to the wallet. This enables
+    /// calculation of unconfirmed balance.  It also lays foundation for
+    /// spending unconfirmed utxos. (issue #189)
+    pub(in crate::models::state) async fn handle_mempool_event(
+        &mut self,
+        event: MempoolEvent,
+    ) -> Result<()> {
         match event {
             MempoolEvent::AddTx(tx) => {
-                debug!("handling mempool AddTx event.");
+                trace!("handling mempool AddTx event.");
 
                 let spent_utxos = self.scan_for_spent_utxos(&tx.kernel).await;
 
@@ -286,10 +309,13 @@ impl WalletState {
                 self.mempool_unspent_utxos.insert(tx_hash, announced_utxos);
             }
             MempoolEvent::RemoveTx(tx) => {
-                debug!("handling mempool RemoveTx event.");
+                trace!("handling mempool RemoveTx event.");
                 let tx_hash = Hash::hash(&tx);
                 self.mempool_spent_utxos.remove(&tx_hash);
                 self.mempool_unspent_utxos.remove(&tx_hash);
+            }
+            MempoolEvent::UpdateTxMutatorSet(_tx_hash_pre_update, _tx_post_update) => {
+                // Utxos are not affected by MutatorSet update, so this is a no-op.
             }
         }
         Ok(())
@@ -1488,6 +1514,15 @@ mod tests {
         use crate::models::state::wallet::address::ReceivingAddress;
         use crate::tests::shared::mine_block_to_wallet;
 
+        /// basic test for confirmed and unconfirmed balance.
+        ///
+        /// This test:
+        ///  1. mines a block to self worth 100
+        ///  2. sends 5 to a 3rd party, and 95 change back to self.
+        ///  3. verifies that confirmed balance is 100
+        ///  4. verifies that unconfirmed balance is 95
+        ///  5. empties the mempool (removing our unconfirmed tx)
+        ///  6. verifies that unconfirmed balance is 100
         #[traced_test]
         #[tokio::test]
         async fn confirmed_and_unconfirmed_balance() -> Result<()> {
@@ -1495,18 +1530,20 @@ mod tests {
             let network = Network::RegTest;
             let mut global_state_lock =
                 mock_genesis_global_state(network, 0, WalletSecret::new_random()).await;
-            let _wallet_task_jh = crate::spawn_wallet_task(global_state_lock.clone()).await?;
             let change_key = global_state_lock
                 .lock_guard_mut()
                 .await
                 .wallet_state
                 .next_unused_spending_key(KeyType::Generation);
+
             let coinbase_amt = NeptuneCoins::new(100);
             let send_amt = NeptuneCoins::new(5);
 
+            // mine a block to our wallet.  we should have 100 coins after.
             let tip_digest = mine_block_to_wallet(&mut global_state_lock).await?.hash();
 
             let tx = {
+                // verify that confirmed and unconfirmed balance are both 100.
                 let gs = global_state_lock.lock_guard().await;
                 assert_eq!(
                     gs.wallet_state
@@ -1521,7 +1558,7 @@ mod tests {
                     coinbase_amt
                 );
 
-                // --- Setup. generate an output that our wallet cannot claim. ---
+                // generate an output that our wallet cannot claim.
                 let outputs = vec![(
                     ReceivingAddress::from(GenerationReceivingAddress::derive_from_seed(rng.gen())),
                     send_amt,
@@ -1541,16 +1578,16 @@ mod tests {
                 tx
             };
 
+            // add the tx to the mempool.
+            // note that the wallet should be notified of these changes.
             global_state_lock
                 .lock_guard_mut()
                 .await
-                .mempool
-                .insert(tx)?;
-
-            // we must yield so the wallet task can process the mempool events
-            tokio::task::yield_now().await;
+                .mempool_insert(tx)
+                .await?;
 
             {
+                // verify that confirmed balance is still 100
                 let gs = global_state_lock.lock_guard().await;
                 assert_eq!(
                     gs.wallet_state
@@ -1558,21 +1595,23 @@ mod tests {
                         .await,
                     coinbase_amt
                 );
-                debug!("calculated confirmed balance");
+                // verify that unconfirmed balance is now 95.
                 assert_eq!(
                     gs.wallet_state
                         .unconfirmed_balance(tip_digest, Timestamp::now())
                         .await,
                     coinbase_amt.checked_sub(&send_amt).unwrap()
                 );
-                debug!("calculated unconfirmed balance");
             }
 
-            global_state_lock.lock_guard_mut().await.mempool.clear()?;
+            // clear the mempool, which drops our unconfirmed tx.
+            global_state_lock
+                .lock_guard_mut()
+                .await
+                .mempool_clear()
+                .await?;
 
-            // we must yield so the wallet task can process the mempool events
-            tokio::task::yield_now().await;
-
+            // verify that wallet's unconfirmed balance is 100 again.
             assert_eq!(
                 global_state_lock
                     .lock_guard()

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 use anyhow::bail;
 use anyhow::Result;
 use itertools::Itertools;
+use num_traits::CheckedSub;
 use num_traits::Zero;
 use serde_derive::Deserialize;
 use serde_derive::Serialize;
@@ -35,6 +36,7 @@ use super::wallet_status::WalletStatus;
 use super::wallet_status::WalletStatusElement;
 use super::WalletSecret;
 use super::WALLET_INCOMING_SECRETS_FILE_NAME;
+
 use crate::config_models::cli_args::Args;
 use crate::config_models::data_directory::DataDirectory;
 use crate::database::storage::storage_schema::traits::*;
@@ -50,6 +52,7 @@ use crate::models::blockchain::type_scripts::native_currency::NativeCurrency;
 use crate::models::blockchain::type_scripts::neptune_coins::NeptuneCoins;
 use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
 use crate::models::proof_abstractions::timestamp::Timestamp;
+use crate::models::state::mempool::MempoolEvent;
 use crate::models::state::wallet::monitored_utxo::MonitoredUtxo;
 use crate::prelude::twenty_first;
 use crate::util_types::mutator_set::addition_record::AdditionRecord;
@@ -63,8 +66,10 @@ pub struct WalletState {
     pub wallet_db: RustyWalletDatabase,
     pub wallet_secret: WalletSecret,
     pub number_of_mps_per_utxo: usize,
-
     wallet_directory_path: PathBuf,
+
+    mempool_spent_utxos: HashMap<Digest, Vec<(Utxo, AbsoluteIndexSet, u64)>>,
+    mempool_unspent_utxos: HashMap<Digest, Vec<AnnouncedUtxo>>,
 }
 
 /// Contains the cryptographic (non-public) data that is needed to recover the mutator set
@@ -200,6 +205,8 @@ impl WalletState {
             wallet_secret,
             number_of_mps_per_utxo: cli_args.number_of_mps_per_utxo,
             wallet_directory_path: data_dir.wallet_directory_path(),
+            mempool_spent_utxos: Default::default(),
+            mempool_unspent_utxos: Default::default(),
         };
 
         // Wallet state has to be initialized with the genesis block, otherwise the outputs
@@ -260,6 +267,78 @@ impl WalletState {
                 )
             })
             .collect_vec()
+    }
+
+    pub async fn handle_mempool_event(&mut self, event: MempoolEvent) -> Result<()> {
+        match event {
+            MempoolEvent::AddTx(tx) => {
+                debug!("handling mempool AddTx event.");
+
+                let spent_utxos = self.scan_for_spent_utxos(&tx.kernel).await;
+
+                let announced_utxos = self
+                    .scan_for_announced_utxos(&tx.kernel)
+                    .chain(self.scan_for_expected_utxos(&tx.kernel).await)
+                    .collect_vec();
+
+                let tx_hash = Hash::hash(&tx);
+                self.mempool_spent_utxos.insert(tx_hash, spent_utxos);
+                self.mempool_unspent_utxos.insert(tx_hash, announced_utxos);
+            }
+            MempoolEvent::RemoveTx(tx) => {
+                debug!("handling mempool RemoveTx event.");
+                let tx_hash = Hash::hash(&tx);
+                self.mempool_spent_utxos.remove(&tx_hash);
+                self.mempool_unspent_utxos.remove(&tx_hash);
+            }
+        }
+        Ok(())
+    }
+
+    pub fn mempool_spent_utxos_iter(&self) -> impl Iterator<Item = &Utxo> {
+        self.mempool_spent_utxos
+            .values()
+            .flatten()
+            .map(|(utxo, ..)| utxo)
+    }
+
+    pub fn mempool_unspent_utxos_iter(&self) -> impl Iterator<Item = &Utxo> {
+        self.mempool_unspent_utxos
+            .values()
+            .flatten()
+            .map(|a| &a.utxo)
+    }
+
+    pub async fn confirmed_balance(
+        &self,
+        tip_digest: Digest,
+        timestamp: Timestamp,
+    ) -> NeptuneCoins {
+        let wallet_status = self.get_wallet_status_from_lock(tip_digest).await;
+
+        wallet_status.synced_unspent_available_amount(timestamp)
+    }
+
+    pub async fn unconfirmed_balance(
+        &self,
+        tip_digest: Digest,
+        timestamp: Timestamp,
+    ) -> NeptuneCoins {
+        self.confirmed_balance(tip_digest, timestamp)
+            .await
+            .checked_sub(
+                &self
+                    .mempool_spent_utxos_iter()
+                    .map(|u| u.get_native_currency_amount())
+                    .sum(),
+            )
+            .unwrap()
+            .safe_add(
+                self.mempool_unspent_utxos_iter()
+                    .map(|u| u.get_native_currency_amount())
+                    .sum(),
+            )
+            .unwrap()
     }
 
     // note: does not verify we do not have any dups.
@@ -1398,6 +1477,113 @@ mod tests {
                 .body()
                 .mutator_set_accumulator
                 .verify(Hash::hash(&utxo), &ms_membership_proof));
+        }
+    }
+
+    mod wallet_balance {
+        use generation_address::GenerationReceivingAddress;
+
+        use super::*;
+        use crate::models::blockchain::transaction::transaction_output::UtxoNotificationMedium;
+        use crate::models::state::wallet::address::ReceivingAddress;
+        use crate::tests::shared::mine_block_to_wallet;
+
+        #[traced_test]
+        #[tokio::test]
+        async fn confirmed_and_unconfirmed_balance() -> Result<()> {
+            let mut rng = thread_rng();
+            let network = Network::RegTest;
+            let mut global_state_lock =
+                mock_genesis_global_state(network, 0, WalletSecret::new_random()).await;
+            let _wallet_task_jh = crate::spawn_wallet_task(global_state_lock.clone()).await?;
+            let change_key = global_state_lock
+                .lock_guard_mut()
+                .await
+                .wallet_state
+                .next_unused_spending_key(KeyType::Generation);
+            let coinbase_amt = NeptuneCoins::new(100);
+            let send_amt = NeptuneCoins::new(5);
+
+            let tip_digest = mine_block_to_wallet(&mut global_state_lock).await?.hash();
+
+            let tx = {
+                let gs = global_state_lock.lock_guard().await;
+                assert_eq!(
+                    gs.wallet_state
+                        .confirmed_balance(tip_digest, Timestamp::now())
+                        .await,
+                    coinbase_amt
+                );
+                assert_eq!(
+                    gs.wallet_state
+                        .unconfirmed_balance(tip_digest, Timestamp::now())
+                        .await,
+                    coinbase_amt
+                );
+
+                // --- Setup. generate an output that our wallet cannot claim. ---
+                let outputs = vec![(
+                    ReceivingAddress::from(GenerationReceivingAddress::derive_from_seed(rng.gen())),
+                    send_amt,
+                )];
+
+                let tx_outputs = gs.generate_tx_outputs(outputs, UtxoNotificationMedium::OnChain);
+
+                let (tx, _change_output) = gs
+                    .create_transaction(
+                        tx_outputs,
+                        change_key,
+                        UtxoNotificationMedium::OnChain,
+                        NeptuneCoins::zero(),
+                        Timestamp::now(),
+                    )
+                    .await?;
+                tx
+            };
+
+            global_state_lock
+                .lock_guard_mut()
+                .await
+                .mempool
+                .insert(tx)?;
+
+            // we must yield so the wallet task can process the mempool events
+            tokio::task::yield_now().await;
+
+            {
+                let gs = global_state_lock.lock_guard().await;
+                assert_eq!(
+                    gs.wallet_state
+                        .confirmed_balance(tip_digest, Timestamp::now())
+                        .await,
+                    coinbase_amt
+                );
+                debug!("calculated confirmed balance");
+                assert_eq!(
+                    gs.wallet_state
+                        .unconfirmed_balance(tip_digest, Timestamp::now())
+                        .await,
+                    coinbase_amt.checked_sub(&send_amt).unwrap()
+                );
+                debug!("calculated unconfirmed balance");
+            }
+
+            global_state_lock.lock_guard_mut().await.mempool.clear()?;
+
+            // we must yield so the wallet task can process the mempool events
+            tokio::task::yield_now().await;
+
+            assert_eq!(
+                global_state_lock
+                    .lock_guard()
+                    .await
+                    .wallet_state
+                    .unconfirmed_balance(tip_digest, Timestamp::now())
+                    .await,
+                coinbase_amt
+            );
+
+            Ok(())
         }
     }
 

--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -2574,8 +2574,8 @@ mod peer_loop_tests {
         state_lock
             .lock_guard_mut()
             .await
-            .mempool
-            .insert(transaction_1.clone())?;
+            .mempool_insert(transaction_1.clone())
+            .await?;
         assert!(
             !state_lock.lock_guard().await.mempool.is_empty(),
             "Mempool must be non-empty after insertion"

--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -2522,7 +2522,7 @@ mod peer_loop_tests {
 
     #[traced_test]
     #[tokio::test]
-    async fn populated_mempool_request_tx_test() {
+    async fn populated_mempool_request_tx_test() -> Result<()> {
         let network = Network::Main;
         // In this scenario the peer is informed of a transaction that it already knows
         let (
@@ -2575,7 +2575,7 @@ mod peer_loop_tests {
             .lock_guard_mut()
             .await
             .mempool
-            .insert(&transaction_1);
+            .insert(transaction_1.clone())?;
         assert!(
             !state_lock.lock_guard().await.mempool.is_empty(),
             "Mempool must be non-empty after insertion"
@@ -2600,5 +2600,6 @@ mod peer_loop_tests {
             Err(TryRecvError::Disconnected) => panic!("to_main channel must still be open"),
             Ok(_) => panic!("to_main channel must be empty"),
         };
+        Ok(())
     }
 }

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -802,3 +802,27 @@ pub async fn mock_genesis_archival_state(
 
     (archival_state, peer_db, data_dir)
 }
+
+// this will create and store the next block including any transactions
+// presently in the mempool.  The coinbase will go to our own wallet.
+//
+// the stored block does NOT have valid proof-of-work.
+pub async fn mine_block_to_wallet(global_state_lock: &mut GlobalStateLock) -> Result<Block> {
+    let state = global_state_lock.lock_guard().await;
+    let tip_block = state.chain.light_state();
+
+    let timestamp = Timestamp::now();
+    let (transaction, coinbase_expected_utxo) =
+        crate::mine_loop::create_block_transaction(tip_block, &state, timestamp).await?;
+
+    let (header, body, proof) =
+        crate::mine_loop::make_block_template(tip_block, transaction, timestamp, None);
+    let block = Block::new(header, body, proof);
+    drop(state);
+
+    global_state_lock
+        .store_coinbase_block(block.clone(), coinbase_expected_utxo)
+        .await?;
+
+    Ok(block)
+}


### PR DESCRIPTION
closes #184.

Implements unconfirmed balance feature for rust api, rpc-api, neptune-cli, and neptune-dashboard.

neptune-cli usage:  

(after node mines 2 blocks and sends 5 coins to another wallet.)

```
$ neptune-cli --server-addr synced-balance
200

$ neptune-cli synced-balance-unconfirmed
195
```

neptune-dashboard display:

![screenshot-unconfirmed-balance](https://github.com/user-attachments/assets/4361f8b8-85a0-4b9a-8461-6b96a4010b78)

The unconfirmed balance is calculated as:

```
synced_balance - sum(mempool_spent_owned_utxos) + sum(mempool_unspent_owned_utxos).
```

(using checked_sub() and safe_add() NeptuneCoins methods).

Implementation:

Tthe mempool returns one or more MempoolEvents from every fn that mutates the mempool.   All mutating calls must be performed though GlobalState methods which catch the events and forward them to WalletState::handle_mempool_events().   In this way, the wallet is able to learn when Tx are added or removed from the mempool and scan for inputs or outputs that are owned by the wallet.  Matching utxos are stored in a map keyed by Tx hash, and are removed immediately when corresponding tx is removed from mempool.    Importantly, this impl makes the mempool and wallet updates atomic, so they are always in sync.

note: my first impl used tokio broadcast channels to notify the wallet of mempool events, however it was not atomic and required a separate wallet task to listen for mempool events.  The present solution is simpler and better.

a unit test is included that verifies confirmed and unconfirmed balances are both correct after mining a block to self and then sending 5 coins to another wallet.   It further verifies that the unconfirmed balance changes to match confirmed balance after the mempool is cleared.

This PR adds rpc `synced_balance_unconfirmed()` and neptune-cli command `synced-balance-unconfirmed`.