### PR TITLE
RemovalRecordIntegrity: Disallow coinbase when tx has inputs

### DIFF
--- a/src/models/blockchain/type_scripts/time_lock.rs
+++ b/src/models/blockchain/type_scripts/time_lock.rs
@@ -902,6 +902,12 @@ fn arbitrary_primitive_witness_with_timelocks(
                 fee_dist,
                 maybe_coinbase_dist,
             )| {
+                let maybe_coinbase_dist = if num_inputs.is_zero() {
+                    maybe_coinbase_dist
+                } else {
+                    None
+                };
+
                 // distribute total amount across inputs (+ coinbase)
                 let mut input_denominator = input_dist.iter().map(|u| *u as f64).sum::<f64>();
                 if let Some(d) = maybe_coinbase_dist {


### PR DESCRIPTION
Assert that a coinbase transaction has no inputs. This, combined with a potential future softfork requiring each block to have at least one input in its transaction, forces the miner to prove at least one execution of a `Merge` which removes any incentive to mine empty blocks. Mining empty blocks could otherwise be beneficial since it allows the miner to complete the proofs faster and get to the guessing part as soon as possible, to the detriment of the network.