### PR TITLE
triton-vm serialized job queue, with job priorities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-priority-channel"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acde96f444d31031f760c5c43dc786b97d3e1cb2ee49dd06898383fe9a999758"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,6 +595,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "condtype"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -961,6 +979,17 @@ checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1818,6 +1847,7 @@ dependencies = [
  "aes-gcm",
  "anyhow",
  "arbitrary",
+ "async-priority-channel",
  "async-stream",
  "async-trait",
  "bech32",
@@ -2124,6 +2154,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ readonly = "0.2.12"
 thiserror = "1.0.65"
 systemstat = "0.2.3"
 sysinfo = "0.31.4"
+async-priority-channel = "0.2.0"
 
 [dev-dependencies]
 blake3 = "1.5.4"

--- a/benchmarks/neptune_transaction_hash_removal_record_index_sets_2.json
+++ b/benchmarks/neptune_transaction_hash_removal_record_index_sets_2.json
@@ -15,7 +15,7 @@
     "benchmark_result": {
       "clock_cycle_count": 13237,
       "hash_table_height": 5056,
-      "u32_table_height": 1186,
+      "u32_table_height": 826,
       "op_stack_table_height": 9807,
       "ram_table_height": 7605
     },

--- a/src/job_queue/mod.rs
+++ b/src/job_queue/mod.rs
@@ -1,0 +1,33 @@
+//! This module implements a prioritized, heterogenous job queue that sends
+//! completed job results to the initiator/caller.
+//!
+//! This is intended for running heavy multi-threaded jobs that should be run
+//! one at a time to avoid resource contention.  By using this queue, multiple
+//! (async) tasks can initiate these tasks and wait for results without need
+//! of any other synchronization.
+//!
+//! note: Other rust job queues I found either did not support waiting for job
+//! results or else were overly complicated, requiring backend database, etc.
+//!
+//! Both blocking and non-blocking (async) jobs are supported.  Non-blocking jobs
+//! are called inside spawn_blocking() in order to execute on tokio's blocking
+//! thread-pool.  Async jobs are simply awaited.
+//!
+//! An async_priority_channel::unbounded is used for queueing the jobs.
+//! This is much like tokio::sync::mpsc::unbounded except:
+//!  1. it supports prioritizing channel events (jobs)
+//!  2. order of events with same priority is undefined.
+//!     see: https://github.com/rmcgibbo/async-priority-channel/issues/75
+//!
+//! Using an unbounded channel means that there is no backpressure and no
+//! upper limit on the number of jobs. (except RAM).
+//!
+//! A nice feature is that jobs may be of mixed (heterogenous) types
+//! in a single JobQueue instance.  Any type that implements the Job trait
+//! may be a job.
+
+mod queue;
+pub mod traits;
+pub mod triton_vm;
+
+pub use queue::JobQueue;

--- a/src/job_queue/queue.rs
+++ b/src/job_queue/queue.rs
@@ -1,0 +1,175 @@
+use async_priority_channel as mpsc;
+use tokio::sync::oneshot;
+
+use super::traits::Job;
+use super::traits::JobResult;
+
+/// implements a prioritized job queue that sends result of each job to a listener.
+/// At present order of jobs with the same priority is undefined.
+/// todo: fix it so that jobs with same priority execute FIFO.
+
+type JobResultOneShotChannel = oneshot::Sender<Box<dyn JobResult>>;
+
+pub struct JobQueue<P: Ord> {
+    tx: mpsc::Sender<(Box<dyn Job>, JobResultOneShotChannel), P>,
+}
+
+impl<P: Ord> std::fmt::Debug for JobQueue<P> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("JobQueue")
+            .field("tx", &"mpsc::Sender")
+            .finish()
+    }
+}
+
+impl<P: Ord> Clone for JobQueue<P> {
+    fn clone(&self) -> Self {
+        Self {
+            tx: self.tx.clone(),
+        }
+    }
+}
+
+impl<P: Ord + Send + Sync + 'static> JobQueue<P> {
+    // creates job queue and starts it processing.  returns immediately.
+    pub fn start() -> Self {
+        let (tx, rx) = mpsc::unbounded::<(Box<dyn Job>, JobResultOneShotChannel), P>();
+
+        // spawns background task that processes job-queue and runs jobs.
+        tokio::spawn(async move {
+            while let Ok(r) = rx.recv().await {
+                let (job, otx) = r.0;
+
+                let result = match job.is_async() {
+                    true => job.run_async().await,
+                    false => tokio::task::spawn_blocking(move || job.run())
+                        .await
+                        .unwrap(),
+                };
+                let _ = otx.send(result);
+            }
+        });
+
+        Self { tx }
+    }
+
+    // alias of Self::start().
+    // here for two reasons:
+    //  1. backwards compat with existing tests
+    //  2. if tests call dummy() instead of start(), then it is easier
+    //     to find where start() is called for real.
+    #[cfg(test)]
+    pub fn dummy() -> Self {
+        Self::start()
+    }
+
+    // adds job to job-queue and returns immediately.
+    pub async fn add_job(
+        &self,
+        job: Box<dyn Job>,
+        priority: P,
+    ) -> anyhow::Result<oneshot::Receiver<Box<dyn JobResult>>> {
+        let (otx, orx) = oneshot::channel();
+        self.tx.send((job, otx), priority).await?;
+        Ok(orx)
+    }
+
+    // adds job to job-queue, waits for job completion, and returns job result.
+    pub async fn add_and_await_job(
+        &self,
+        job: Box<dyn Job>,
+        priority: P,
+    ) -> anyhow::Result<Box<dyn JobResult>> {
+        let (otx, orx) = oneshot::channel();
+        self.tx.send((job, otx), priority).await?;
+        Ok(orx.await?)
+    }
+
+    #[cfg(test)]
+    pub async fn wait_until_queue_empty(&self) {
+        loop {
+            if self.tx.is_empty() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::any::Any;
+
+    #[derive(PartialEq, Debug)]
+    struct DoubleJobResult(u64, u64);
+    impl JobResult for DoubleJobResult {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+    }
+
+    // a job that doubles the input value.  implements Job.
+    struct DoubleJob {
+        data: u64,
+    }
+
+    impl Job for DoubleJob {
+        fn is_async(&self) -> bool {
+            false
+        }
+
+        fn run(&self) -> Box<dyn JobResult> {
+            let r = DoubleJobResult(self.data, self.data * 2);
+
+            println!("{} * 2 = {}", r.0, r.1);
+            Box::new(r)
+        }
+    }
+
+    // todo: make test(s) for async jobs.
+
+    /// todo: this should verify the priority order of jobs.
+    ///       presently each job just prints result and
+    ///       human can manually verify output.
+    #[tokio::test]
+    async fn run_jobs_by_priority() -> anyhow::Result<()> {
+        // create a job queue
+        let job_queue = JobQueue::<u8>::start();
+
+        // create 10 jobs
+        for i in 0..10 {
+            let job1 = Box::new(DoubleJob { data: i });
+            let job2 = Box::new(DoubleJob { data: i * 100 });
+            let job3 = Box::new(DoubleJob { data: i * 1000 });
+
+            // process job and print results.
+            job_queue.add_job(job1, 1).await?;
+            job_queue.add_job(job2, 2).await?;
+            job_queue.add_job(job3, 3).await?;
+        }
+
+        job_queue.wait_until_queue_empty().await;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn get_result() -> anyhow::Result<()> {
+        // create a job queue
+        let job_queue = JobQueue::<u8>::start();
+
+        // create 10 jobs
+        for i in 0..10 {
+            let job = Box::new(DoubleJob { data: i });
+
+            let result = job_queue.add_and_await_job(job, 1).await?;
+            assert_eq!(
+                Some(&DoubleJobResult(i, i * 2)),
+                result.as_any().downcast_ref::<DoubleJobResult>()
+            );
+        }
+
+        Ok(())
+    }
+}

--- a/src/job_queue/traits.rs
+++ b/src/job_queue/traits.rs
@@ -1,0 +1,24 @@
+use std::any::Any;
+
+pub trait JobResult: Any + Send + Sync + std::fmt::Debug {
+    fn as_any(&self) -> &dyn Any;
+}
+
+// represents any kind of job
+#[async_trait::async_trait]
+pub trait Job: Send + Sync {
+    fn is_async(&self) -> bool;
+
+    // note: we provide unimplemented default methods for
+    // run and run_async.  This is so that implementing types
+    // only need to impl the appropriate method.
+
+    fn run(&self) -> Box<dyn JobResult> {
+        unimplemented!()
+    }
+
+    // fn run_async(&self) ->  std::future::Future<Output = Box<dyn JobResult>> + Send;
+    async fn run_async(&self) -> Box<dyn JobResult> {
+        unimplemented!()
+    }
+}

--- a/src/job_queue/triton_vm/mod.rs
+++ b/src/job_queue/triton_vm/mod.rs
@@ -1,0 +1,4 @@
+mod triton_vm_job_queue;
+
+pub use triton_vm_job_queue::TritonVmJobPriority;
+pub use triton_vm_job_queue::TritonVmJobQueue;

--- a/src/job_queue/triton_vm/triton_vm_job_queue.rs
+++ b/src/job_queue/triton_vm/triton_vm_job_queue.rs
@@ -1,0 +1,16 @@
+use super::super::JobQueue;
+
+// todo: maybe we want to have more levels or just make it an integer eg u8.
+// or maybe name the levels by type/usage of job/proof.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub enum TritonVmJobPriority {
+    Lowest = 1,
+    Low = 2,
+    #[default]
+    Normal = 3,
+    High = 4,
+    Highest = 5,
+}
+
+/// provides type safety and clarity in case we implement multiple job queues.
+pub type TritonVmJobQueue = JobQueue<TritonVmJobPriority>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod config_models;
 pub mod connect_to_peers;
 pub mod database;
+pub mod job_queue;
 pub mod locks;
 pub mod macros;
 pub mod main_loop;

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -33,7 +33,6 @@ use serde::Serialize;
 use tasm_lib::triton_vm::prelude::*;
 use tasm_lib::twenty_first::util_types::mmr::mmr_accumulator::MmrAccumulator;
 use tasm_lib::twenty_first::util_types::mmr::mmr_trait::Mmr;
-use tokio::sync::TryLockError;
 use tracing::debug;
 use tracing::warn;
 use twenty_first::math::b_field_element::BFieldElement;
@@ -50,11 +49,12 @@ use super::transaction::Transaction;
 use super::type_scripts::neptune_coins::NeptuneCoins;
 use super::type_scripts::time_lock::TimeLock;
 use crate::config_models::network::Network;
+use crate::job_queue::triton_vm::TritonVmJobPriority;
+use crate::job_queue::triton_vm::TritonVmJobQueue;
 use crate::models::blockchain::block::difficulty_control::difficulty_control;
 use crate::models::blockchain::shared::Hash;
 use crate::models::proof_abstractions::mast_hash::MastHash;
 use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
-use crate::models::proof_abstractions::tasm::program::TritonProverSync;
 use crate::models::proof_abstractions::timestamp::Timestamp;
 use crate::models::proof_abstractions::SecretWitness;
 use crate::models::state::wallet::address::ReceivingAddress;
@@ -216,17 +216,24 @@ impl Block {
         transaction: Transaction,
         block_timestamp: Timestamp,
         target_block_interval: Option<Timestamp>,
-        sync_device: &TritonProverSync,
-    ) -> Result<Block, TryLockError> {
+        triton_vm_job_queue: &TritonVmJobQueue,
+        priority: TritonVmJobPriority,
+    ) -> anyhow::Result<Block> {
         let primitive_witness = BlockPrimitiveWitness::new(predecessor.to_owned(), transaction);
         let body = primitive_witness.body().to_owned();
         let header = Self::template_header(predecessor, block_timestamp, target_block_interval);
         let (appendix, proof) = {
-            let appendix_witness = AppendixWitness::produce(primitive_witness, sync_device).await?;
+            let appendix_witness =
+                AppendixWitness::produce(primitive_witness, triton_vm_job_queue).await?;
             let appendix = appendix_witness.appendix();
             let claim = BlockProgram::claim(&body, &appendix);
             let proof = BlockProgram
-                .prove(&claim, appendix_witness.nondeterminism(), sync_device)
+                .prove(
+                    &claim,
+                    appendix_witness.nondeterminism(),
+                    triton_vm_job_queue,
+                    priority,
+                )
                 .await?;
             (appendix, BlockProof::SingleProof(proof))
         };
@@ -240,14 +247,16 @@ impl Block {
         transaction: Transaction,
         block_timestamp: Timestamp,
         target_block_interval: Option<Timestamp>,
-        sync_device: &TritonProverSync,
-    ) -> Result<Block, TryLockError> {
+        triton_vm_job_queue: &TritonVmJobQueue,
+        priority: TritonVmJobPriority,
+    ) -> anyhow::Result<Block> {
         Self::make_block_template_with_valid_proof(
             predecessor,
             transaction,
             block_timestamp,
             target_block_interval,
-            sync_device,
+            triton_vm_job_queue,
+            priority,
         )
         .await
     }
@@ -1021,7 +1030,8 @@ mod block_tests {
                 block_tx,
                 now,
                 None,
-                &TritonProverSync::dummy(),
+                &TritonVmJobQueue::dummy(),
+                TritonVmJobPriority::default(),
             )
             .await
             .unwrap();

--- a/src/models/blockchain/block/validity/appendix_witness.rs
+++ b/src/models/blockchain/block/validity/appendix_witness.rs
@@ -16,17 +16,16 @@ use tasm_lib::triton_vm::vm::NonDeterminism;
 use tasm_lib::triton_vm::vm::PublicInput;
 use tasm_lib::verifier::stark_verify::StarkVerify;
 use tasm_lib::Digest;
-use tokio::sync::TryLockError;
 
 use super::block_primitive_witness::BlockPrimitiveWitness;
 use super::block_program::BlockProgram;
+use crate::job_queue::triton_vm::TritonVmJobQueue;
 use crate::models::blockchain::block::block_body::BlockBody;
 use crate::models::blockchain::block::BlockAppendix;
 use crate::models::blockchain::transaction::validity::single_proof::SingleProof;
 use crate::models::blockchain::transaction::TransactionProof;
 use crate::models::proof_abstractions::mast_hash::MastHash;
 use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
-use crate::models::proof_abstractions::tasm::program::TritonProverSync;
 use crate::models::proof_abstractions::SecretWitness;
 
 /// All information necessary to efficiently produce a proof for a block.
@@ -66,8 +65,8 @@ impl AppendixWitness {
 
     pub(crate) async fn produce(
         block_primitive_witness: BlockPrimitiveWitness,
-        _sync_device: &TritonProverSync,
-    ) -> Result<AppendixWitness, TryLockError> {
+        _triton_vm_job_queue: &TritonVmJobQueue,
+    ) -> anyhow::Result<AppendixWitness> {
         let txk_mast_hash = block_primitive_witness
             .body()
             .transaction_kernel

--- a/src/models/blockchain/block/validity/block_primitive_witness.rs
+++ b/src/models/blockchain/block/validity/block_primitive_witness.rs
@@ -84,6 +84,8 @@ pub(crate) mod test {
     use proptest_arbitrary_interop::arb;
 
     use super::BlockPrimitiveWitness;
+    use crate::job_queue::triton_vm::TritonVmJobPriority;
+    use crate::job_queue::triton_vm::TritonVmJobQueue;
     use crate::models::blockchain::block::block_appendix::BlockAppendix;
     use crate::models::blockchain::block::block_body::BlockBody;
     use crate::models::blockchain::block::block_header::BlockHeader;
@@ -94,7 +96,6 @@ pub(crate) mod test {
     use crate::models::blockchain::transaction::validity::single_proof::SingleProof;
     use crate::models::blockchain::transaction::Transaction;
     use crate::models::blockchain::transaction::TransactionProof;
-    use crate::models::proof_abstractions::tasm::program::TritonProverSync;
     use crate::util_types::mutator_set::mutator_set_accumulator::MutatorSetAccumulator;
 
     fn arbitrary_block_transaction_with_mutator_set(
@@ -114,7 +115,8 @@ pub(crate) mod test {
                 let mutator_set_accumulator = primwit_inputs.mutator_set_accumulator.clone();
                 let single_proof_inputs = futures::executor::block_on(SingleProof::produce(
                     &primwit_inputs,
-                    &TritonProverSync::dummy(),
+                    &TritonVmJobQueue::dummy(),
+                    TritonVmJobPriority::default(),
                 ))
                 .unwrap();
 
@@ -124,7 +126,8 @@ pub(crate) mod test {
                 };
                 let single_proof_coinbase = futures::executor::block_on(SingleProof::produce(
                     &primwit_coinbase,
-                    &TritonProverSync::dummy(),
+                    &TritonVmJobQueue::dummy(),
+                    TritonVmJobPriority::default(),
                 ))
                 .unwrap();
                 let tx_coinbase = Transaction {
@@ -136,7 +139,8 @@ pub(crate) mod test {
                     futures::executor::block_on(tx_inputs.merge_with(
                         tx_coinbase,
                         shuffle_seed,
-                        &TritonProverSync::dummy(),
+                        &TritonVmJobQueue::dummy(),
+                        TritonVmJobPriority::default(),
                     ))
                     .unwrap(),
                     mutator_set_accumulator,

--- a/src/models/blockchain/block/validity/block_program.rs
+++ b/src/models/blockchain/block/validity/block_program.rs
@@ -172,9 +172,9 @@ pub(crate) mod test {
     use tracing_test::traced_test;
 
     use super::*;
+    use crate::job_queue::triton_vm::TritonVmJobQueue;
     use crate::models::blockchain::block::validity::block_primitive_witness::test::deterministic_block_primitive_witness;
     use crate::models::proof_abstractions::mast_hash::MastHash;
-    use crate::models::proof_abstractions::tasm::program::TritonProverSync;
     use crate::models::proof_abstractions::SecretWitness;
 
     #[traced_test]
@@ -191,7 +191,7 @@ pub(crate) mod test {
         );
 
         let appendix_witness =
-            AppendixWitness::produce(block_primitive_witness, &TritonProverSync::dummy())
+            AppendixWitness::produce(block_primitive_witness, &TritonVmJobQueue::dummy())
                 .await
                 .unwrap();
         let block_program_nondeterminism = appendix_witness.nondeterminism();

--- a/src/models/blockchain/transaction/mod.rs
+++ b/src/models/blockchain/transaction/mod.rs
@@ -1,8 +1,9 @@
+use crate::job_queue::triton_vm::TritonVmJobPriority;
+use crate::job_queue::triton_vm::TritonVmJobQueue;
 use crate::models::blockchain::block::mutator_set_update::MutatorSetUpdate;
 use crate::models::peer::transfer_transaction::TransactionProofQuality;
 use crate::models::proof_abstractions::mast_hash::MastHash;
 use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
-use crate::models::proof_abstractions::tasm::program::TritonProverSync;
 use crate::models::proof_abstractions::SecretWitness;
 use crate::models::state::wallet::expected_utxo::ExpectedUtxo;
 use crate::prelude::twenty_first;
@@ -31,7 +32,6 @@ use tasm_lib::triton_vm;
 use tasm_lib::triton_vm::stark::Stark;
 use tasm_lib::twenty_first::util_types::mmr::mmr_successor_proof::MmrSuccessorProof;
 use tasm_lib::Digest;
-use tokio::sync::TryLockError;
 use tracing::info;
 use twenty_first::math::b_field_element::BFieldElement;
 use twenty_first::math::bfield_codec::BFieldCodec;
@@ -307,8 +307,9 @@ impl Transaction {
         previous_mutator_set_accumulator: &MutatorSetAccumulator,
         mutator_set_update: MutatorSetUpdate,
         old_single_proof: Proof,
-        sync_device: &TritonProverSync,
-    ) -> Result<Transaction, TryLockError> {
+        triton_vm_job_queue: &TritonVmJobQueue,
+        priority: TritonVmJobPriority,
+    ) -> anyhow::Result<Transaction> {
         // apply mutator set update to get new mutator set accumulator
         let addition_records = mutator_set_update.additions.clone();
         let mut calculated_new_mutator_set = previous_mutator_set_accumulator.clone();
@@ -346,7 +347,12 @@ impl Transaction {
         let update_nondeterminism = update_witness.nondeterminism();
         info!("updating transaction; starting update proof ...");
         let update_proof = Update
-            .prove(&update_claim, update_nondeterminism, sync_device)
+            .prove(
+                &update_claim,
+                update_nondeterminism,
+                triton_vm_job_queue,
+                priority,
+            )
             .await?;
         info!("done.");
 
@@ -358,7 +364,8 @@ impl Transaction {
             .prove(
                 &new_single_proof_claim,
                 new_single_proof_witness.nondeterminism(),
-                sync_device,
+                triton_vm_job_queue,
+                priority,
             )
             .await?;
         info!("done.");
@@ -376,7 +383,8 @@ impl Transaction {
         self,
         previous_mutator_set_accumulator: &MutatorSetAccumulator,
         block: &Block,
-        sync_device: &TritonProverSync,
+        triton_vm_job_queue: &TritonVmJobQueue,
+        priority: TritonVmJobPriority,
     ) -> Result<Transaction, TransactionProofError> {
         match self.proof {
             TransactionProof::Witness(primitive_witness) => Ok(
@@ -394,7 +402,8 @@ impl Transaction {
                     previous_mutator_set_accumulator,
                     ms_update,
                     proof,
-                    sync_device,
+                    triton_vm_job_queue,
+                    priority,
                 )
                 .await
                 .map_err(|_| TransactionProofError::ProverLockWasTaken)
@@ -424,8 +433,9 @@ impl Transaction {
         self,
         other: Transaction,
         shuffle_seed: [u8; 32],
-        sync_device: &TritonProverSync,
-    ) -> Result<Transaction, TryLockError> {
+        triton_vm_job_queue: &TritonVmJobQueue,
+        priority: TritonVmJobPriority,
+    ) -> Result<Transaction> {
         assert_eq!(
             self.kernel.mutator_set_hash, other.kernel.mutator_set_hash,
             "Mutator sets must be equal for transaction merger."
@@ -462,7 +472,12 @@ impl Transaction {
         info!("Start: creating merge proof");
         let merge_claim = merge_witness.claim();
         let merge_proof = Merge
-            .prove(&merge_claim, merge_witness.nondeterminism(), sync_device)
+            .prove(
+                &merge_claim,
+                merge_witness.nondeterminism(),
+                triton_vm_job_queue,
+                priority,
+            )
             .await?;
         info!("Done: creating merge proof");
         let new_single_proof_witness =
@@ -473,7 +488,8 @@ impl Transaction {
             .prove(
                 &new_single_proof_claim,
                 new_single_proof_witness.nondeterminism(),
-                sync_device,
+                triton_vm_job_queue,
+                priority,
             )
             .await?;
         info!("Done: creating new single proof");
@@ -597,9 +613,13 @@ mod transaction_tests {
     #[allow(clippy::needless_return)]
     async fn update_single_proof_works() {
         async fn prop(to_be_updated: PrimitiveWitness, mined: PrimitiveWitness) {
-            let as_single_proof = SingleProof::produce(&to_be_updated, &TritonProverSync::dummy())
-                .await
-                .unwrap();
+            let as_single_proof = SingleProof::produce(
+                &to_be_updated,
+                &TritonVmJobQueue::dummy(),
+                TritonVmJobPriority::default(),
+            )
+            .await
+            .unwrap();
             let original_tx = Transaction {
                 kernel: to_be_updated.kernel,
                 proof: TransactionProof::SingleProof(as_single_proof),
@@ -615,7 +635,8 @@ mod transaction_tests {
                 .new_with_updated_mutator_set_records(
                     &to_be_updated.mutator_set_accumulator,
                     &block,
-                    &TritonProverSync::dummy(),
+                    &TritonVmJobQueue::dummy(),
+                    TritonVmJobPriority::default(),
                 )
                 .await
                 .unwrap();

--- a/src/models/blockchain/transaction/validity/merge.rs
+++ b/src/models/blockchain/transaction/validity/merge.rs
@@ -945,12 +945,13 @@ pub(crate) mod test {
     use tasm_lib::triton_vm::prelude::PublicInput;
 
     use super::MergeWitness;
+    use crate::job_queue::triton_vm::TritonVmJobPriority;
+    use crate::job_queue::triton_vm::TritonVmJobQueue;
     use crate::models::blockchain::transaction::validity::merge::Merge;
     use crate::models::blockchain::transaction::validity::single_proof::SingleProof;
     use crate::models::blockchain::transaction::PrimitiveWitness;
     use crate::models::proof_abstractions::mast_hash::MastHash;
     use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
-    use crate::models::proof_abstractions::tasm::program::TritonProverSync;
     use crate::models::proof_abstractions::SecretWitness;
     use crate::triton_vm::prelude::Digest;
 
@@ -993,12 +994,20 @@ pub(crate) mod test {
             .unwrap()
             .current();
 
-        let single_proof_1 = SingleProof::produce(&primitive_witness_1, &TritonProverSync::dummy())
-            .await
-            .unwrap();
-        let single_proof_2 = SingleProof::produce(&primitive_witness_2, &TritonProverSync::dummy())
-            .await
-            .unwrap();
+        let single_proof_1 = SingleProof::produce(
+            &primitive_witness_1,
+            &TritonVmJobQueue::dummy(),
+            TritonVmJobPriority::default(),
+        )
+        .await
+        .unwrap();
+        let single_proof_2 = SingleProof::produce(
+            &primitive_witness_2,
+            &TritonVmJobQueue::dummy(),
+            TritonVmJobPriority::default(),
+        )
+        .await
+        .unwrap();
 
         MergeWitness::from_transactions(
             primitive_witness_1.kernel,

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_collect_lock_scripts_claim.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_collect_lock_scripts_claim.rs
@@ -213,8 +213,9 @@ mod tests {
     use tasm_lib::traits::rust_shadow::RustShadow;
 
     use super::*;
+    use crate::job_queue::triton_vm::TritonVmJobPriority;
+    use crate::job_queue::triton_vm::TritonVmJobQueue;
     use crate::models::blockchain::transaction::primitive_witness::PrimitiveWitness;
-    use crate::models::proof_abstractions::tasm::program::TritonProverSync;
 
     #[test]
     fn unit_test() {
@@ -262,10 +263,12 @@ mod tests {
                 .unwrap()
                 .current();
             let rt = tokio::runtime::Runtime::new().unwrap();
+            let _guard = rt.enter();
             let proof_collection = rt
                 .block_on(ProofCollection::produce(
                     &primitive_witness,
-                    &TritonProverSync::dummy(),
+                    &TritonVmJobQueue::dummy(),
+                    TritonVmJobPriority::default(),
                 ))
                 .unwrap();
 

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_collect_type_scripts_claim.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_collect_type_scripts_claim.rs
@@ -232,9 +232,10 @@ mod tests {
     use tasm_lib::traits::rust_shadow::RustShadow;
 
     use super::*;
+    use crate::job_queue::triton_vm::TritonVmJobPriority;
+    use crate::job_queue::triton_vm::TritonVmJobQueue;
     use crate::models::blockchain::transaction::primitive_witness::PrimitiveWitness;
     use crate::models::blockchain::type_scripts::time_lock::arbitrary_primitive_witness_with_active_timelocks;
-    use crate::models::proof_abstractions::tasm::program::TritonProverSync;
     use crate::models::proof_abstractions::timestamp::Timestamp;
 
     #[test]
@@ -307,10 +308,12 @@ mod tests {
                 .current()
             };
             let rt = tokio::runtime::Runtime::new().unwrap();
+            let _guard = rt.enter();
             let proof_collection = rt
                 .block_on(ProofCollection::produce(
                     &primitive_witness,
-                    &TritonProverSync::dummy(),
+                    &TritonVmJobQueue::dummy(),
+                    TritonVmJobPriority::default(),
                 ))
                 .unwrap();
 

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_k2o_claim.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_k2o_claim.rs
@@ -138,8 +138,9 @@ mod tests {
     use tasm_lib::traits::rust_shadow::RustShadow;
 
     use super::*;
+    use crate::job_queue::triton_vm::TritonVmJobPriority;
+    use crate::job_queue::triton_vm::TritonVmJobQueue;
     use crate::models::blockchain::transaction::primitive_witness::PrimitiveWitness;
-    use crate::models::proof_abstractions::tasm::program::TritonProverSync;
 
     #[test]
     fn unit_test() {
@@ -198,10 +199,12 @@ mod tests {
                 .unwrap()
                 .current();
             let rt = tokio::runtime::Runtime::new().unwrap();
+            let _guard = rt.enter();
             let proof_collection = rt
                 .block_on(ProofCollection::produce(
                     &primitive_witness,
-                    &TritonProverSync::dummy(),
+                    &TritonVmJobQueue::dummy(),
+                    TritonVmJobPriority::default(),
                 ))
                 .unwrap();
 

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_lock_script_claim_template.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_lock_script_claim_template.rs
@@ -92,9 +92,10 @@ mod test {
     use tasm_lib::Digest;
 
     use super::GenerateLockScriptClaimTemplate;
+    use crate::job_queue::triton_vm::TritonVmJobPriority;
+    use crate::job_queue::triton_vm::TritonVmJobQueue;
     use crate::models::blockchain::transaction::primitive_witness::PrimitiveWitness;
     use crate::models::blockchain::transaction::validity::proof_collection::ProofCollection;
-    use crate::models::proof_abstractions::tasm::program::TritonProverSync;
 
     impl Function for GenerateLockScriptClaimTemplate {
         fn rust_shadow(
@@ -153,10 +154,12 @@ mod test {
                 .unwrap()
                 .current();
             let rt = tokio::runtime::Runtime::new().unwrap();
+            let _guard = rt.enter();
             let proof_collection = rt
                 .block_on(ProofCollection::produce(
                     &primitive_witness,
-                    &TritonProverSync::dummy(),
+                    &TritonVmJobQueue::dummy(),
+                    TritonVmJobPriority::default(),
                 ))
                 .unwrap();
 

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_rri_claim.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_rri_claim.rs
@@ -138,8 +138,9 @@ mod tests {
     use tasm_lib::traits::rust_shadow::RustShadow;
 
     use super::*;
+    use crate::job_queue::triton_vm::TritonVmJobPriority;
+    use crate::job_queue::triton_vm::TritonVmJobQueue;
     use crate::models::blockchain::transaction::primitive_witness::PrimitiveWitness;
-    use crate::models::proof_abstractions::tasm::program::TritonProverSync;
 
     #[test]
     fn unit_test() {
@@ -198,10 +199,12 @@ mod tests {
                 .unwrap()
                 .current();
             let rt = tokio::runtime::Runtime::new().unwrap();
+            let _guard = rt.enter();
             let proof_collection = rt
                 .block_on(ProofCollection::produce(
                     &primitive_witness,
-                    &TritonProverSync::dummy(),
+                    &TritonVmJobQueue::dummy(),
+                    TritonVmJobPriority::default(),
                 ))
                 .unwrap();
 

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_type_script_claim_template.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_type_script_claim_template.rs
@@ -138,9 +138,10 @@ mod test {
     use tasm_lib::Digest;
 
     use super::GenerateTypeScriptClaimTemplate;
+    use crate::job_queue::triton_vm::TritonVmJobPriority;
+    use crate::job_queue::triton_vm::TritonVmJobQueue;
     use crate::models::blockchain::transaction::primitive_witness::PrimitiveWitness;
     use crate::models::blockchain::transaction::validity::proof_collection::ProofCollection;
-    use crate::models::proof_abstractions::tasm::program::TritonProverSync;
 
     impl Function for GenerateTypeScriptClaimTemplate {
         fn rust_shadow(
@@ -190,10 +191,12 @@ mod test {
                 .unwrap()
                 .current();
             let rt = tokio::runtime::Runtime::new().unwrap();
+            let _guard = rt.enter();
             let proof_collection = rt
                 .block_on(ProofCollection::produce(
                     &primitive_witness,
-                    &TritonProverSync::dummy(),
+                    &TritonVmJobQueue::dummy(),
+                    TritonVmJobPriority::default(),
                 ))
                 .unwrap();
 

--- a/src/models/blockchain/transaction/validity/update.rs
+++ b/src/models/blockchain/transaction/validity/update.rs
@@ -712,13 +712,14 @@ pub(crate) mod test {
     use tasm_lib::Digest;
 
     use super::*;
+    use crate::job_queue::triton_vm::TritonVmJobPriority;
+    use crate::job_queue::triton_vm::TritonVmJobQueue;
     use crate::models::blockchain::transaction::validity::single_proof::SingleProof;
     use crate::models::blockchain::transaction::validity::update::Update;
     use crate::models::blockchain::transaction::PrimitiveWitness;
     use crate::models::blockchain::transaction::Transaction;
     use crate::models::proof_abstractions::tasm::program::test::consensus_program_negative_test;
     use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
-    use crate::models::proof_abstractions::tasm::program::TritonProverSync;
     use crate::models::proof_abstractions::timestamp::Timestamp;
     use crate::models::proof_abstractions::SecretWitness;
     use crate::util_types::mutator_set::addition_record::AdditionRecord;
@@ -766,9 +767,13 @@ pub(crate) mod test {
             mined.kernel.inputs,
         );
 
-        let old_proof = SingleProof::produce(&old_pw, &TritonProverSync::dummy())
-            .await
-            .unwrap();
+        let old_proof = SingleProof::produce(
+            &old_pw,
+            &TritonVmJobQueue::dummy(),
+            TritonVmJobPriority::default(),
+        )
+        .await
+        .unwrap();
         let num_seconds = (0u64..=10).new_tree(&mut test_runner).unwrap().current();
         updated.kernel.timestamp = updated.kernel.timestamp + Timestamp::seconds(num_seconds);
 
@@ -821,9 +826,13 @@ pub(crate) mod test {
             &primitive_witness.mutator_set_accumulator.aocl,
             &newly_confirmed_records,
         );
-        let old_proof = SingleProof::produce(&primitive_witness, &TritonProverSync::dummy())
-            .await
-            .unwrap();
+        let old_proof = SingleProof::produce(
+            &primitive_witness,
+            &TritonVmJobQueue::dummy(),
+            TritonVmJobPriority::default(),
+        )
+        .await
+        .unwrap();
 
         UpdateWitness::from_old_transaction(
             primitive_witness.kernel,

--- a/src/models/blockchain/type_scripts/native_currency.rs
+++ b/src/models/blockchain/type_scripts/native_currency.rs
@@ -685,13 +685,14 @@ pub mod test {
     use test_strategy::proptest;
 
     use super::*;
+    use crate::job_queue::triton_vm::TritonVmJobPriority;
+    use crate::job_queue::triton_vm::TritonVmJobQueue;
     use crate::models::blockchain::transaction::lock_script::LockScriptAndWitness;
     use crate::models::blockchain::transaction::primitive_witness::PrimitiveWitness;
     use crate::models::blockchain::transaction::utxo::Utxo;
     use crate::models::blockchain::transaction::PublicAnnouncement;
     use crate::models::blockchain::type_scripts::time_lock::arbitrary_primitive_witness_with_active_timelocks;
     use crate::models::proof_abstractions::tasm::program::ConsensusError;
-    use crate::models::proof_abstractions::tasm::program::TritonProverSync;
     use crate::models::proof_abstractions::timestamp::Timestamp;
     use crate::triton_vm::prelude::InstructionError;
 
@@ -899,7 +900,8 @@ pub mod test {
                 txk_mast_hash,
                 salted_input_utxos_hash,
                 salted_output_utxos_hash,
-                &TritonProverSync::dummy(),
+                &TritonVmJobQueue::dummy(),
+                TritonVmJobPriority::default(),
             )
             .await
             .unwrap();

--- a/src/models/proof_abstractions/tasm/consensus_program_prover_job.rs
+++ b/src/models/proof_abstractions/tasm/consensus_program_prover_job.rs
@@ -1,0 +1,100 @@
+//! implements a triton-vm-job-queue job for proving
+//! consensus programs.
+//!
+//! These proofs take a lot of time, cpu, and memory to
+//! create. As such, only one should execute at a time
+//! or even the beefiest of today's hardware might run out
+//! of resources.
+//!
+//! The queue is used to ensure that only one triton-vm
+//! program can execute at a time.
+
+use crate::job_queue::traits::Job;
+use crate::job_queue::traits::JobResult;
+use crate::models::proof_abstractions::Claim;
+use crate::models::proof_abstractions::NonDeterminism;
+use crate::models::proof_abstractions::Program;
+use crate::tasm_lib::maybe_write_debuggable_program_to_disk;
+use crate::triton_vm::proof::Proof;
+use crate::triton_vm::vm::VMState;
+use crate::triton_vm::vm::VM;
+
+#[cfg(test)]
+use crate::models::proof_abstractions::tasm::program::test;
+
+#[derive(Debug)]
+pub struct ConsensusProgramProverJobResult(pub Proof);
+impl JobResult for ConsensusProgramProverJobResult {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+impl From<&ConsensusProgramProverJobResult> for Proof {
+    fn from(v: &ConsensusProgramProverJobResult) -> Self {
+        v.0.to_owned()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ConsensusProgramProverJob {
+    pub program: Program,
+    pub claim: Claim,
+    pub nondeterminism: NonDeterminism,
+}
+
+impl ConsensusProgramProverJob {
+    /// Run the program and generate a proof for it, assuming the Triton VM run
+    /// halts gracefully.
+    ///
+    /// If we are in a test environment, try reading it from disk. If it is not
+    /// there, generate it and store it to disk.
+    fn prove(&self) -> Proof {
+        assert_eq!(self.program.hash(), self.claim.program_digest);
+
+        let init_vm_state = VMState::new(
+            &self.program,
+            self.claim.input.clone().into(),
+            self.nondeterminism.clone(),
+        );
+        maybe_write_debuggable_program_to_disk(&self.program, &init_vm_state);
+
+        let vm_output = VM::run(
+            &self.program,
+            self.claim.input.clone().into(),
+            self.nondeterminism.clone(),
+        );
+        assert!(vm_output.is_ok());
+        assert_eq!(self.claim.program_digest, self.program.hash());
+        assert_eq!(self.claim.output, vm_output.unwrap());
+
+        #[cfg(test)]
+        {
+            test::load_proof_or_produce_and_save(
+                &self.claim,
+                self.program.clone(),
+                self.nondeterminism.clone(),
+            )
+        }
+        #[cfg(not(test))]
+        {
+            tasm_lib::triton_vm::prove(
+                tasm_lib::triton_vm::stark::Stark::default(),
+                &self.claim,
+                &self.program,
+                self.nondeterminism.clone(),
+            )
+            .unwrap()
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Job for ConsensusProgramProverJob {
+    fn is_async(&self) -> bool {
+        false
+    }
+
+    fn run(&self) -> Box<dyn JobResult> {
+        Box::new(ConsensusProgramProverJobResult(self.prove()))
+    }
+}

--- a/src/models/proof_abstractions/tasm/mod.rs
+++ b/src/models/proof_abstractions/tasm/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod audit_vm_end_state;
 pub mod builtins;
+mod consensus_program_prover_job;
 mod environment;
 pub mod program;

--- a/src/models/state/archival_state.rs
+++ b/src/models/state/archival_state.rs
@@ -936,6 +936,8 @@ mod archival_state_tests {
     use crate::config_models::data_directory::DataDirectory;
     use crate::config_models::network::Network;
     use crate::database::storage::storage_vec::traits::*;
+    use crate::job_queue::triton_vm::TritonVmJobPriority;
+    use crate::job_queue::triton_vm::TritonVmJobQueue;
     use crate::mine_loop::make_coinbase_transaction;
     use crate::models::blockchain::block::block_header::MINIMUM_BLOCK_TIME;
     use crate::models::blockchain::transaction::lock_script::LockScript;
@@ -944,7 +946,6 @@ mod archival_state_tests {
     use crate::models::blockchain::transaction::transaction_output::UtxoNotificationMedium;
     use crate::models::blockchain::transaction::utxo::Utxo;
     use crate::models::blockchain::type_scripts::neptune_coins::NeptuneCoins;
-    use crate::models::proof_abstractions::tasm::program::TritonProverSync;
     use crate::models::proof_abstractions::timestamp::Timestamp;
     use crate::models::state::archival_state::ArchivalState;
     use crate::models::state::tx_proving_capability::TxProvingCapability;
@@ -1151,7 +1152,7 @@ mod archival_state_tests {
                 NeptuneCoins::new(2),
                 in_seven_months,
                 TxProvingCapability::SingleProof,
-                &TritonProverSync::dummy(),
+                &TritonVmJobQueue::dummy(),
             )
             .await
             .unwrap();
@@ -1516,7 +1517,7 @@ mod archival_state_tests {
                 fee,
                 in_seven_months,
                 TxProvingCapability::SingleProof,
-                &TritonProverSync::dummy(),
+                &TritonVmJobQueue::dummy(),
             )
             .await
             .unwrap();
@@ -1531,7 +1532,8 @@ mod archival_state_tests {
             .merge_with(
                 tx_to_alice_and_bob,
                 Default::default(),
-                &TritonProverSync::dummy(),
+                &TritonVmJobQueue::dummy(),
+                TritonVmJobPriority::default(),
             )
             .await
             .unwrap();
@@ -1542,7 +1544,8 @@ mod archival_state_tests {
             block_tx,
             in_seven_months,
             None,
-            &TritonProverSync::dummy(),
+            &TritonVmJobQueue::dummy(),
+            TritonVmJobPriority::default(),
         )
         .await
         .unwrap();
@@ -1681,7 +1684,7 @@ mod archival_state_tests {
                 NeptuneCoins::new(1),
                 in_seven_months,
                 TxProvingCapability::SingleProof,
-                &TritonProverSync::dummy(),
+                &TritonVmJobQueue::dummy(),
             )
             .await
             .unwrap();
@@ -1724,7 +1727,7 @@ mod archival_state_tests {
                 NeptuneCoins::new(1),
                 in_seven_months,
                 TxProvingCapability::SingleProof,
-                &TritonProverSync::dummy(),
+                &TritonVmJobQueue::dummy(),
             )
             .await
             .unwrap();
@@ -1746,11 +1749,17 @@ mod archival_state_tests {
             .merge_with(
                 tx_from_alice,
                 Default::default(),
-                &TritonProverSync::dummy(),
+                &TritonVmJobQueue::dummy(),
+                TritonVmJobPriority::default(),
             )
             .await
             .unwrap()
-            .merge_with(tx_from_bob, Default::default(), &TritonProverSync::dummy())
+            .merge_with(
+                tx_from_bob,
+                Default::default(),
+                &TritonVmJobQueue::dummy(),
+                TritonVmJobPriority::default(),
+            )
             .await
             .unwrap();
         let block_2 = Block::make_block_template(
@@ -1758,7 +1767,8 @@ mod archival_state_tests {
             block_tx2,
             in_seven_months + MINIMUM_BLOCK_TIME,
             None,
-            &TritonProverSync::dummy(),
+            &TritonVmJobQueue::dummy(),
+            TritonVmJobPriority::default(),
         )
         .await
         .unwrap();

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -1176,10 +1176,11 @@ mod tests {
         // <https://github.com/Neptune-Crypto/neptune-core/issues/207>.
 
         let network = Network::Main;
-        let mut alice = mock_genesis_global_state(network, 0, WalletSecret::devnet_wallet()).await;
+        let mut alice_global_lock =
+            mock_genesis_global_state(network, 0, WalletSecret::devnet_wallet()).await;
+        let alice_vm_job_queue = alice_global_lock.vm_job_queue().clone();
 
-        let alice_proving_lock = alice.proving_lock.clone();
-        let mut alice = alice.global_state_lock.lock_guard_mut().await;
+        let mut alice = alice_global_lock.global_state_lock.lock_guard_mut().await;
         let launch_timestamp = alice.chain.light_state().header().timestamp;
         let released_timestamp = launch_timestamp + Timestamp::months(12);
         let genesis = alice.chain.light_state();
@@ -1239,7 +1240,7 @@ mod tests {
                     alice_key.privacy_preimage,
                     UtxoNotifier::OwnMiner,
                 ),
-                &alice_proving_lock,
+                &alice_vm_job_queue,
             )
             .await
             .unwrap();
@@ -1279,9 +1280,9 @@ mod tests {
         let network = Network::RegTest;
         let bob_wallet_secret = WalletSecret::new_random();
         let bob_spending_key = bob_wallet_secret.nth_generation_spending_key_for_tests(0);
-        let mut bob = mock_genesis_global_state(network, 0, bob_wallet_secret).await;
-        let bob_proving_lock = bob.proving_lock.clone();
-        let mut bob = bob.lock_guard_mut().await;
+        let mut bob_global_lock = mock_genesis_global_state(network, 0, bob_wallet_secret).await;
+        let bob_vm_job_queue = bob_global_lock.vm_job_queue().clone();
+        let mut bob = bob_global_lock.lock_guard_mut().await;
         let genesis_block = Block::genesis_block(network);
         let monitored_utxos_count_init = bob.wallet_state.wallet_db.monitored_utxos().len().await;
         let mut mutator_set_accumulator = genesis_block.kernel.body.mutator_set_accumulator.clone();
@@ -1347,7 +1348,7 @@ mod tests {
                 bob_spending_key.privacy_preimage,
                 UtxoNotifier::OwnMiner,
             ),
-            &bob_proving_lock,
+            &bob_vm_job_queue,
         )
         .await
         .unwrap();
@@ -1380,7 +1381,7 @@ mod tests {
         // Fork the blockchain with 3b, with no coinbase for us
         let (block_3b, _block_3b_coinbase_utxo, _block_3b_coinbase_sender_randomness) =
             make_mock_block(&latest_block, None, alice_address, rng.gen());
-        bob.set_new_tip(block_3b.clone(), &bob_proving_lock)
+        bob.set_new_tip(block_3b.clone(), &bob_vm_job_queue)
             .await
             .unwrap();
 
@@ -1407,7 +1408,7 @@ mod tests {
         for _ in 4..=11 {
             let (new_block, _new_block_coinbase_utxo, _new_block_coinbase_sender_randomness) =
                 make_mock_block(&latest_block, None, alice_address, rng.gen());
-            bob.set_new_tip(new_block.clone(), &bob_proving_lock)
+            bob.set_new_tip(new_block.clone(), &bob_vm_job_queue)
                 .await
                 .unwrap();
 
@@ -1433,7 +1434,7 @@ mod tests {
 
         // Mine *one* more block. Verify that MUTXO is pruned
         let (block_12, _, _) = make_mock_block(&latest_block, None, alice_address, rng.gen());
-        bob.set_new_tip(block_12.clone(), &bob_proving_lock)
+        bob.set_new_tip(block_12.clone(), &bob_vm_job_queue)
             .await
             .unwrap();
 
@@ -1517,8 +1518,8 @@ mod tests {
         use rand::SeedableRng;
 
         use super::*;
+        use crate::job_queue::triton_vm::TritonVmJobQueue;
         use crate::models::blockchain::transaction::transaction_output::UtxoNotificationMedium;
-        use crate::models::proof_abstractions::tasm::program::TritonProverSync;
         use crate::models::state::tx_proving_capability::TxProvingCapability;
         use crate::models::state::wallet::address::ReceivingAddress;
         use crate::tests::shared::mine_block_to_wallet_invalid_block_proof;
@@ -1589,7 +1590,7 @@ mod tests {
                         NeptuneCoins::zero(),
                         timestamp,
                         TxProvingCapability::SingleProof,
-                        &TritonProverSync::dummy(),
+                        &TritonVmJobQueue::dummy(),
                     )
                     .await?;
                 tx

--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -1292,10 +1292,10 @@ mod peer_loop_tests {
 
     use super::*;
     use crate::config_models::network::Network;
+    use crate::job_queue::triton_vm::TritonVmJobQueue;
     use crate::models::blockchain::transaction::transaction_output::UtxoNotificationMedium;
     use crate::models::blockchain::type_scripts::neptune_coins::NeptuneCoins;
     use crate::models::peer::transaction_notification::TransactionNotification;
-    use crate::models::proof_abstractions::tasm::program::TritonProverSync;
     use crate::models::state::tx_proving_capability::TxProvingCapability;
     use crate::models::state::wallet::WalletSecret;
     use crate::tests::shared::get_dummy_peer_connection_data_genesis;
@@ -2490,7 +2490,7 @@ mod peer_loop_tests {
                 NeptuneCoins::new(0),
                 now,
                 TxProvingCapability::ProofCollection,
-                &TritonProverSync::dummy(),
+                &TritonVmJobQueue::dummy(),
             )
             .await
             .unwrap();
@@ -2571,7 +2571,7 @@ mod peer_loop_tests {
                 NeptuneCoins::new(0),
                 now,
                 TxProvingCapability::ProofCollection,
-                &TritonProverSync::dummy(),
+                &TritonVmJobQueue::dummy(),
             )
             .await
             .unwrap();
@@ -2653,7 +2653,7 @@ mod peer_loop_tests {
                     NeptuneCoins::new(1),
                     in_seven_months,
                     prover_capability,
-                    &TritonProverSync::dummy(),
+                    &TritonVmJobQueue::dummy(),
                 )
                 .await
                 .unwrap()

--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -318,7 +318,7 @@ impl NeptuneRPCServer {
                 fee,
                 now,
                 tx_proving_capability,
-                &self.state.wait_if_busy(),
+                self.state.vm_job_queue(),
             )
             .await
         {
@@ -1517,10 +1517,7 @@ mod rpc_server_tests {
         };
 
         // --- Init.  append the block to blockchain ---
-        let prover_lock = state_lock.proving_lock.clone();
         state_lock
-            .lock_guard_mut()
-            .await
             .set_new_self_mined_tip(
                 block_1.clone(),
                 ExpectedUtxo::new(
@@ -1529,7 +1526,6 @@ mod rpc_server_tests {
                     wallet_spending_key.privacy_preimage(),
                     UtxoNotifier::OwnMiner,
                 ),
-                &prover_lock,
             )
             .await?;
 

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -121,10 +121,8 @@ pub async fn unit_test_databases(
 )> {
     let data_dir: DataDirectory = unit_test_data_directory(network)?;
 
-    // The returned future is not `Send` without block_on().
-    use futures::executor::block_on;
-    let block_db = block_on(ArchivalState::initialize_block_index_database(&data_dir))?;
-    let peer_db = block_on(NetworkingState::initialize_peer_databases(&data_dir))?;
+    let block_db = ArchivalState::initialize_block_index_database(&data_dir).await?;
+    let peer_db = NetworkingState::initialize_peer_databases(&data_dir).await?;
 
     Ok((block_db, peer_db, data_dir))
 }


### PR DESCRIPTION
quickstart for reviewers the most interesting files are:
    src/job_queue/*
    src/models/proof_abstractions/tasm/program.rs
    src/models/proof_abstractions/tasm/consensus_program_prover_job.rs
    src/models/state/mod.rs
    src/main_loop/proof_upgrader.rs

-----

mile high view:  This PR implements a serialized job queue system with priorities so that triton-vm jobs (ie proving) can run in serial fashion (one-at-a-time) without competing for hardware resources.  This is necessary because these jobs use huge amounts of cpu and especially ram.

-----

Job Queue description:

First, I will describe the general-purpose core of the system.

By general-purpose I mean that the core could be used by any application, for pretty much any types of jobs.  It could also be used by neptune-core for
more than one type of queue, eg a queue for triton-vm jobs and another for p2p jobs, etc.

note: I built it to be general purpose for two reasons:
1. the design is fully encapsulated and self-contained so it is easy to understand, audit, maintain as its own component without any app logic.
2. at the beginning I was (and still remain) uncertain of exactly what job types might be needed both now and in the future.  There could be additional triton-vm jobs we wish to serialize and/or the functionality could be useful for other purposes.

There is a JobQueue<Priority: Ord> which is built around two types of channels.  The first is an mpsc-like channel that also supports priority levels.  This is for adding jobs to the queue.  The second is a one-shot channel for returning results back to the job initiator.  There are several unique-ish features to this JobQueue:

 1. It supports heterogenous job types.  Any type that implements the trait Job can be a job.
 3. It supports prioritizing jobs.  Each JobQueue instance can define its own priority levels.  They could be an integer or an enum... anything that impl Ord.
 4. It supports both blocking and async jobs.  Blocking jobs are automatically run inside spawn_blocking().
 5. It supports both add-job-and-forget and add-job-and-await-results.

Most other rust job-queues I found did not support any of the above, except perhaps job priorities and they often required database backends.

In particular the ability for the caller to easily await results is a nice usability improvement that makes using the queue very similar to just calling a regular async function and awaiting it.

Limitation:  Presently the execution order of jobs at the same priority is undefined.  This is a known/reported issue for the `async-priority-channel` crate I'm using.  Hopefully it will be fixed soon, else I could possibly fork the crate to fix it, or abandon that crate and impl a priority-queue myself.  In the meantime, a possible workaround would be to use a unique priority for each job.

There is a Job trait.  It defines methods is_async(), run(), and run_async().  The latter two have default impls, so an implementor only needs to impl the appropriate method that matches is_async().

There is also a JobResult trait.  This is so that each job-type can return whatever result-type it needs to.

JobQueue uses trait objects `Box<dyn Job>` and `Box<dyn JobResult>` to enable heterogenous job types in a single queue.  This was hard to get working. The benefit of it is flexibility. We can add future job types to an existing queue.

-----

Now I will describe integration into neptune-core, thus far.

There is a type alias TritonVmJobQueue = JobQueue<TritonVmJobPriority> where:

```
#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
pub enum TritonVmJobPriority {
    Lowest = 1,
    Low = 2,
    Normal = 3,
    High = 4,
    Highest = 5,
}
```

This TritonVmJobPriority is basically a place-holder until we figure out what makes the most sense.  I'm open to suggestions on that.  Again, it can be anything that implements the Ord trait.  I'm kind of partial to an enum with named variants for readability, but it doesn't have to be.

There is a ConsensusProgramProverJob and a ConsensusProgramProverJobResult.  The job consists of the code that previously existed in prove_consensus_program().  That function now simply creates a job, adds it to the queue, and awaits it, then returns the result as before.  The prove_consensus_program() fn now accepts a param `priority: TritonVmJobPriority`, so callers must specify the priority which gets passed down the callstack from highest levels.

Initially the chosen job priorities are:

GlobalState::set_new_tip_internal()::mempool::update_with_block() --> Highest
main_loop::BroadcastTx::UpgradeJob::from_primitive_witness --> High
mine_loop::create_raw_transaction --> High
mine_loop::merge_with --> High
mine_loop::make_block_template --> High
GlobalState::create_transaction_with_prover_capability()::create_raw_transaction() --> High
main_loop::proof_upgrader()::handle_upgrade() --> Low

note: upon review, I notice that:
1. nothing is using priority Normal (except tests).
2. does not distinguish between owned/unowned mempool upgrades.
3. not fully in sync with this advice I received:

```
            // If you're mining, you probably want to prioritize this task
            // the highest.
            Miner => u8::MAX,
            Cli => 3,
            MempoolUpgrader => owned_transaction as u8,
```

So I will make some further adjustments.

Previously there was a ProvingLock in GlobalStateLock and a TritonVmJobQueue that wrapped the ProvingLock and was passed down through all the methods until it finally reached prove_consensus_program(), where it was used to serialize execution of proofs.

The TritonVmJobQueue serves the same purpose of serializing proof execution.  As such it replaces both ProvingLock and TritonVmJobQueue.  For now, I have placed it in GlobalStateLock as well, and it is passed down through all the methods in the same fashion.  It would be possible to move it into a static OnceLock instead as a Singleton, so that it could easily be accessed anywhere in the code. That would make method parameters cleaner but at the cost of less of a "trail" when trying to follow the code paths.  Anyway its an area we may wish to revisit at some point.

Initially I made two separate job types.  The other type was for UpgradeJob.  But then I realized (following the code path) that all the prove() calls in UpgradeJob ultimately call prove_consensus_program(), so it was pretty much redundant, and I could just leave the existing UpgradeJob code unchanged.

Not yet implemented / Todo:

[X] Need to figure out how to prioritize the proving jobs inside prove_consensus_program().   (done)

[ ] adjust per-job priorities, as per above.

[ ] There may be other types of triton-vm jobs to add.  In particular, I'm aware of a distinction between transaction-proofs and block-proofs.  I'm uncertain if both are processed by prove_consensus_program() or not.

note: I accidentally based my branch on master from Oct 14, which did not have the block-proof stuff.  I see work has been done in this area since, so I need to review that.

----

Other changes:

1. I made UpgradeJob::handle_upgrade() into a loop to handle the case where a block is received while a tx is proving.  I'm not too familiar with this code, so it's quite possibly wrong.  That change should be reviewed very carefully by @Sword-Smith and the loop can be reverted without affecting anything to do with this job-queue.
6. I made a fix for tests changing futures::executor::block_on() calls to tokio block_on(), which was breaking (halting execution) with the async job queue.
