### PR TITLE
Asz/kill proof queue gracefully

### DIFF
--- a/src/bin/triton-vm.rs
+++ b/src/bin/triton-vm.rs
@@ -1,0 +1,54 @@
+use std::io::BufRead;
+use std::io::Write;
+use std::io::{self};
+use std::time;
+use std::time::Duration;
+
+use neptune_core::models::proof_abstractions::tasm::consensus_program_prover_job::ConsensusProgramProverJobResult;
+use tasm_lib::triton_vm::prelude::Program;
+use tasm_lib::triton_vm::proof::Claim;
+use tasm_lib::triton_vm::prove;
+use tasm_lib::triton_vm::stark::Stark;
+use tasm_lib::triton_vm::vm::NonDeterminism;
+use tracing::info;
+
+fn main() {
+    let stdin = io::stdin();
+    let mut iterator = stdin.lock().lines();
+    let claim: Claim = serde_json::from_str(&iterator.next().unwrap().unwrap()).unwrap();
+    let program: Program = serde_json::from_str(&iterator.next().unwrap().unwrap()).unwrap();
+    let non_determinism: NonDeterminism =
+        serde_json::from_str(&iterator.next().unwrap().unwrap()).unwrap();
+    let default_stark: Stark = Stark::default();
+
+    let proof = prove(default_stark, &claim, &program, non_determinism).unwrap();
+    info!("triton-vm: completed proof");
+    println!("triton-vm: Completed proof");
+
+    let result = ConsensusProgramProverJobResult(proof);
+    let as_bytes = bincode::serialize(&result).unwrap();
+    let mut stdout = std::io::stdout();
+    stdout.write_all(&as_bytes).unwrap();
+    stdout.flush().unwrap();
+
+    std::thread::sleep(time::Duration::from_millis(1000));
+}
+
+#[cfg(test)]
+mod tests {
+    use tasm_lib::triton_vm::isa::triton_asm;
+
+    use super::*;
+
+    #[test]
+    fn halt_program() {
+        let program = triton_asm!(halt);
+        let program = Program::new(&program);
+        let claim = Claim::about_program(&program);
+        let non_determinism = NonDeterminism::default();
+
+        println!("{}", serde_json::to_string(&claim).unwrap());
+        println!("{}", serde_json::to_string(&program).unwrap());
+        println!("{}", serde_json::to_string(&non_determinism).unwrap());
+    }
+}

--- a/src/job_queue/queue.rs
+++ b/src/job_queue/queue.rs
@@ -1,14 +1,10 @@
-use std::collections::VecDeque;
-
 use anyhow::bail;
 use async_priority_channel as mpsc;
 use serde::de::DeserializeOwned;
-use serde::Deserialize;
-use tokio::io::AsyncBufReadExt;
 use tokio::io::AsyncReadExt;
-use tokio::io::BufReader;
 use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
+use tracing::error;
 use tracing::info;
 
 use super::traits::Job;
@@ -20,8 +16,9 @@ use super::traits::Synchronicity;
 /// At present order of jobs with the same priority is undefined.
 type JobResultOneShotChannel = oneshot::Sender<Box<dyn JobResult>>;
 
-pub struct JobQueue<P: Ord, T: DeserializeOwned + Send> {
-    tx: mpsc::Sender<(Box<dyn Job<ResultType = T>>, JobResultOneShotChannel), P>,
+pub struct JobQueue<Priority: Ord, Result: DeserializeOwned + Send> {
+    tx: mpsc::Sender<(Box<dyn Job<ResultType = Result>>, JobResultOneShotChannel), Priority>,
+    cancel: CancellationToken,
 }
 
 impl<P: Ord, T: DeserializeOwned + Send> std::fmt::Debug for JobQueue<P, T> {
@@ -36,87 +33,101 @@ impl<P: Ord, T: DeserializeOwned + Send> Clone for JobQueue<P, T> {
     fn clone(&self) -> Self {
         Self {
             tx: self.tx.clone(),
+            cancel: self.cancel.clone(),
         }
     }
 }
 
-impl<P: Ord + Send + Sync + 'static, T: DeserializeOwned + Send> JobQueue<P, T> {
+impl<Priority: Ord + Send + Sync + 'static, ResultType: DeserializeOwned + Send + JobResult>
+    JobQueue<Priority, ResultType>
+{
     // creates job queue and starts it processing.  returns immediately.
     pub fn start() -> Self {
-        let (tx, rx) =
-            mpsc::unbounded::<(Box<dyn Job<ResultType = T>>, JobResultOneShotChannel), P>();
+        let (tx, rx) = mpsc::unbounded::<
+            (
+                Box<dyn Job<ResultType = ResultType>>,
+                JobResultOneShotChannel,
+            ),
+            Priority,
+        >();
+        let cancel = CancellationToken::new();
 
-        let mut thread_handles = VecDeque::new();
         // spawns background task that processes job-queue and runs jobs.
-        let task_handle = tokio::spawn(async move {
+        // TODO: Should `task_handle` be returned here?
+
+        let cancel_clone = cancel.clone();
+        let _task_handle = tokio::spawn(async move {
             while let Ok(r) = rx.recv().await {
                 let (job, otx) = r.0;
-
                 let result = match job.synchronicity() {
-                    Synchronicity::Blocking => job.run_async().await,
-                    Synchronicity::Async => tokio::task::spawn_blocking(move || job.run())
+                    Synchronicity::Blocking => tokio::task::spawn_blocking(move || job.run())
                         .await
                         .unwrap(),
-
+                    Synchronicity::Async => job.run_async().await,
                     Synchronicity::Process => {
-                        let token = CancellationToken::new();
-                        let cloned_token = token.clone();
-                        let process_handle = job.process();
+                        let cloned_token = cancel_clone.clone();
+                        let mut process_handle = job.process().await;
                         let jobresult = tokio::spawn(async move {
-                            let mut buffer = Vec::new();
                             let mut stdout = process_handle.stdout.take().unwrap();
+                            let mut buffer = Vec::new();
                             loop {
                                 tokio::select! {
-                                    _ = token.cancelled() => {
+                                    _ = cloned_token.cancelled() => {
                                         process_handle.kill().await.expect("Could not kill proof queue task");
                                         break;
                                     }
                                     result = process_handle.wait() => {
                                         match result { // make into exit code
                                             Ok(status) => info!("Child process exited with status: {}", status),
-                                            Err(e) => eprintln!("Error waiting for child process: {}", e),
+                                            Err(e) => error!("Error waiting for child process: {}", e),
                                         }
                                     }
                                     result = stdout.read_to_end(&mut buffer) => {
                                         match result {
                                             Ok(n) => {
+                                                println!("Buffer length: {}", buffer.len());
                                                 if n == 0 {
                                                     // End of output
+                                                    error!("Empty output. Buffer length was: {}", buffer.len());
                                                     break;
                                                 }
                                                 // Process the output
-                                                let jobresult : T = match bincode::deserialize(&buffer) {
+                                                let jobresult: ResultType = match bincode::deserialize(&buffer) {
                                                     Ok(tee) => tee,
                                                     Err(e) => {
                                                         bail!("Proof queue job failed: {e:?}");
                                                     }
                                                 };
                                                 buffer.clear(); // Clear the buffer for the next read
-                                                return Some(jobresult);
+                                                return Ok(jobresult);
                                             }
                                             Err(e) => {
-                                                eprintln!("Error reading process output: {}", e);
+                                                error!("Error reading process output: {}", e);
                                                 break;
                                             }
                                         }
                                     }
                                 }
                             }
-                            return None;
+
+                            bail!("Failed to read process result");
                         });
-                        // thread_handles.push_back(thread_handle);
-                        let rest = jobresult.await.unwrap();
-                        // let worker_handle = tokio::task::spawn(move || job.run());
-                        // worker_handle.await
-                    } // false => tokio::task::spawn_blocking(move || job.run())
-                      //     .await
-                      //     .unwrap(),
+
+                        let res = jobresult.await.unwrap().unwrap();
+
+                        Box::new(res)
+                    }
                 };
                 let _ = otx.send(result);
             }
         });
 
-        Self { tx }
+        Self { tx, cancel }
+    }
+
+    pub(crate) fn terminate(&self) {
+        info!("Cancelling any spawned prover processes");
+        self.cancel.cancel();
     }
 
     // alias of Self::start().
@@ -132,8 +143,8 @@ impl<P: Ord + Send + Sync + 'static, T: DeserializeOwned + Send> JobQueue<P, T> 
     // adds job to job-queue and returns immediately.
     pub async fn add_job(
         &self,
-        job: Box<dyn Job>,
-        priority: P,
+        job: Box<dyn Job<ResultType = ResultType>>,
+        priority: Priority,
     ) -> anyhow::Result<oneshot::Receiver<Box<dyn JobResult>>> {
         let (otx, orx) = oneshot::channel();
         self.tx.send((job, otx), priority).await?;
@@ -143,8 +154,8 @@ impl<P: Ord + Send + Sync + 'static, T: DeserializeOwned + Send> JobQueue<P, T> 
     // adds job to job-queue, waits for job completion, and returns job result.
     pub async fn add_and_await_job(
         &self,
-        job: Box<dyn Job>,
-        priority: P,
+        job: Box<dyn Job<ResultType = ResultType>>,
+        priority: Priority,
     ) -> anyhow::Result<Box<dyn JobResult>> {
         let (otx, orx) = oneshot::channel();
         self.tx.send((job, otx), priority).await?;
@@ -166,9 +177,11 @@ impl<P: Ord + Send + Sync + 'static, T: DeserializeOwned + Send> JobQueue<P, T> 
 mod tests {
     use std::any::Any;
 
+    use serde::Deserialize;
+
     use super::*;
 
-    #[derive(PartialEq, Debug)]
+    #[derive(PartialEq, Debug, Deserialize)]
     struct DoubleJobResult(u64, u64);
     impl JobResult for DoubleJobResult {
         fn as_any(&self) -> &dyn Any {
@@ -182,8 +195,8 @@ mod tests {
     }
 
     impl Job for DoubleJob {
-        fn synchronicity(&self) -> bool {
-            false
+        fn synchronicity(&self) -> Synchronicity {
+            Synchronicity::Blocking
         }
 
         fn run(&self) -> Box<dyn JobResult> {
@@ -204,7 +217,7 @@ mod tests {
     #[tokio::test]
     async fn run_jobs_by_priority() -> anyhow::Result<()> {
         // create a job queue
-        let job_queue = JobQueue::<u8>::start();
+        let job_queue = JobQueue::<u8, _>::start();
 
         // create 10 jobs
         for i in 0..10 {
@@ -226,7 +239,7 @@ mod tests {
     #[tokio::test]
     async fn get_result() -> anyhow::Result<()> {
         // create a job queue
-        let job_queue = JobQueue::<u8>::start();
+        let job_queue = JobQueue::<u8, _>::start();
 
         // create 10 jobs
         for i in 0..10 {

--- a/src/job_queue/traits.rs
+++ b/src/job_queue/traits.rs
@@ -1,13 +1,23 @@
 use std::any::Any;
 
+use serde::de::DeserializeOwned;
+
 pub trait JobResult: Any + Send + Sync + std::fmt::Debug {
     fn as_any(&self) -> &dyn Any;
+}
+
+pub(crate) enum Synchronicity {
+    Blocking,
+    Async,
+    Process,
 }
 
 // represents any kind of job
 #[async_trait::async_trait]
 pub trait Job: Send + Sync {
-    fn is_async(&self) -> bool;
+    type ResultType: DeserializeOwned + Send;
+
+    fn synchronicity(&self) -> Synchronicity;
 
     // note: we provide unimplemented default methods for
     // run and run_async.  This is so that implementing types
@@ -20,5 +30,14 @@ pub trait Job: Send + Sync {
     // fn run_async(&self) ->  std::future::Future<Output = Box<dyn JobResult>> + Send;
     async fn run_async(&self) -> Box<dyn JobResult> {
         unimplemented!()
+    }
+
+    /// Implement if synchronicity is set to `Process`
+    fn process(&self) -> tokio::process::Child {
+        unimplemented!()
+    }
+
+    fn deserialize_result(&self, string: &str) -> serde_json::Result<Self::ResultType> {
+        serde_json::from_str(string)
     }
 }

--- a/src/job_queue/traits.rs
+++ b/src/job_queue/traits.rs
@@ -1,6 +1,7 @@
 use std::any::Any;
 
 use serde::de::DeserializeOwned;
+use tasm_lib::triton_vm::proof::Proof;
 
 pub trait JobResult: Any + Send + Sync + std::fmt::Debug {
     fn as_any(&self) -> &dyn Any;
@@ -15,7 +16,7 @@ pub(crate) enum Synchronicity {
 // represents any kind of job
 #[async_trait::async_trait]
 pub trait Job: Send + Sync {
-    type ResultType: DeserializeOwned + Send;
+    type ResultType: DeserializeOwned + Send + JobResult;
 
     fn synchronicity(&self) -> Synchronicity;
 
@@ -33,7 +34,7 @@ pub trait Job: Send + Sync {
     }
 
     /// Implement if synchronicity is set to `Process`
-    fn process(&self) -> tokio::process::Child {
+    async fn process(&self) -> tokio::process::Child {
         unimplemented!()
     }
 

--- a/src/job_queue/triton_vm/triton_vm_job_queue.rs
+++ b/src/job_queue/triton_vm/triton_vm_job_queue.rs
@@ -1,4 +1,5 @@
 use super::super::JobQueue;
+use crate::models::proof_abstractions::tasm::consensus_program_prover_job::ConsensusProgramProverJobResult;
 
 // todo: maybe we want to have more levels or just make it an integer eg u8.
 // or maybe name the levels by type/usage of job/proof.
@@ -13,4 +14,4 @@ pub enum TritonVmJobPriority {
 }
 
 /// provides type safety and clarity in case we implement multiple job queues.
-pub type TritonVmJobQueue = JobQueue<TritonVmJobPriority>;
+pub type TritonVmJobQueue = JobQueue<TritonVmJobPriority, ConsensusProgramProverJobResult>;

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -1257,7 +1257,18 @@ impl MainLoopHandler {
                             .await
                     })?;
 
-                    // main_loop_state.proof_upgrader_task = Some(proof_upgrader_task);
+                    // Do not keep track of `_proof_upgrader_task` join handle.
+                    // Why not?
+                    //  - Store handle where? This point could be solved in
+                    //    principle but let's not find a solution for a problem
+                    //    that doesn't exist.
+                    //  - The task itself takes care of communication with the
+                    //    proof queue and broadcasting the transaction when
+                    //    ready.
+                    //  - In case of graceful shutdown, the proof queue is shut
+                    //    through its handle; all the other steps in this task
+                    //    are negligible and will terminate promptly.
+
                     // If transaction could not be shared immediately because
                     // it contains secret data, upgrade its proof-type.
                 }

--- a/src/models/proof_abstractions/tasm/consensus_program_prover_job.rs
+++ b/src/models/proof_abstractions/tasm/consensus_program_prover_job.rs
@@ -89,7 +89,7 @@ impl ConsensusProgramProverJob {
 
 #[async_trait::async_trait]
 impl Job for ConsensusProgramProverJob {
-    fn is_async(&self) -> bool {
+    fn synchronicity(&self) -> bool {
         false
     }
 

--- a/src/models/proof_abstractions/tasm/mod.rs
+++ b/src/models/proof_abstractions/tasm/mod.rs
@@ -1,5 +1,5 @@
 pub(crate) mod audit_vm_end_state;
 pub mod builtins;
-mod consensus_program_prover_job;
+pub mod consensus_program_prover_job;
 mod environment;
 pub mod program;


### PR DESCRIPTION
A template for how to kill runs of triton-vm's `prove`. Uses a spawned process and communicates via JSON/bincode. If a more lightweight solution exists, then that's probably preferable.