### PR TITLE
ArchivalMutatorSet: Fix get_mutator_set_update_to_tip

### DIFF
--- a/src/database/storage/storage_schema/dbtvec.rs
+++ b/src/database/storage/storage_schema/dbtvec.rs
@@ -24,7 +24,7 @@ pub struct DbtVec<V> {
 
 impl<V> DbtVec<V>
 where
-    V: Clone + Serialize,
+    V: Clone + Serialize + DeserializeOwned,
 {
     // DbtVec cannot be instantiated directly outside of storage_schema module
     // use [Schema::new_vec()]
@@ -38,6 +38,11 @@ where
         let vec = DbtVecPrivate::<V>::new(pending_writes, reader, key_prefix, name).await;
 
         Self { inner: vec }
+    }
+
+    #[inline]
+    pub(crate) async fn delete_cache(&mut self) {
+        self.inner.delete_cache().await;
     }
 }
 

--- a/src/database/storage/storage_schema/dbtvec_private.rs
+++ b/src/database/storage/storage_schema/dbtvec_private.rs
@@ -320,6 +320,12 @@ where
         }
     }
 
+    /// Delete the non-persisted values, without persisting to disk.
+    pub(super) async fn delete_cache(&mut self) {
+        self.cache.clear();
+        self.current_length = self.persisted_length().await;
+    }
+
     #[inline]
     pub(super) async fn pop(&mut self) -> Option<V> {
         // If vector is empty, return None

--- a/src/database/storage/storage_schema/simple_rusty_storage.rs
+++ b/src/database/storage/storage_schema/simple_rusty_storage.rs
@@ -40,6 +40,15 @@ impl StorageWriter for SimpleRustyStorage {
 
         self.db.batch_write(write_ops).await
     }
+
+    async fn drop_unpersisted(&mut self) {
+        self.schema
+            .pending_writes
+            .lock_guard_mut()
+            .await
+            .write_ops
+            .clear();
+    }
 }
 
 impl SimpleRustyStorage {

--- a/src/database/storage/storage_schema/traits.rs
+++ b/src/database/storage/storage_schema/traits.rs
@@ -33,4 +33,7 @@ pub trait StorageReader {
 pub trait StorageWriter {
     /// Write data to storage
     async fn persist(&mut self);
+
+    /// Delete all changes that were not persisted.
+    async fn drop_unpersisted(&mut self);
 }

--- a/src/main_loop/proof_upgrader.rs
+++ b/src/main_loop/proof_upgrader.rs
@@ -230,7 +230,7 @@ impl UpgradeJob {
 
                 let Some(ms_update) = global_state
                     .chain
-                    .archival_state()
+                    .archival_state_mut()
                     .get_mutator_set_update_to_tip(
                         &mutator_set_for_tx,
                         SEARCH_DEPTH_FOR_BLOCKS_FOR_MS_UPDATE_PROOF,

--- a/src/models/state/wallet/rusty_wallet_database.rs
+++ b/src/models/state/wallet/rusty_wallet_database.rs
@@ -99,4 +99,8 @@ impl StorageWriter for RustyWalletDatabase {
     async fn persist(&mut self) {
         self.storage.persist().await
     }
+
+    async fn drop_unpersisted(&mut self) {
+        unimplemented!("wallet does not need it")
+    }
 }

--- a/src/util_types/mutator_set/archival_mmr.rs
+++ b/src/util_types/mutator_set/archival_mmr.rs
@@ -13,6 +13,7 @@ use twenty_first::util_types::mmr::mmr_trait::Mmr;
 use twenty_first::util_types::mmr::shared_advanced;
 use twenty_first::util_types::shared::bag_peaks;
 
+use crate::database::storage::storage_schema::DbtVec;
 use crate::database::storage::storage_vec::traits::*;
 use crate::models::blockchain::shared::Hash;
 use crate::prelude::twenty_first;
@@ -231,6 +232,15 @@ impl<Storage: StorageVec<Digest>> ArchivalMmr<Storage> {
         }
 
         Some(ret)
+    }
+}
+
+impl ArchivalMmr<DbtVec<Digest>> {
+    /// Delete ephemeral (cache) values, without persisting them.
+    ///
+    /// Can be used to roll-back ephemeral values to a persisted state.
+    pub(crate) async fn delete_cache(&mut self) {
+        self.digests.delete_cache().await;
     }
 }
 

--- a/src/util_types/mutator_set/chunk_dictionary.rs
+++ b/src/util_types/mutator_set/chunk_dictionary.rs
@@ -80,6 +80,12 @@ impl ChunkDictionary {
             .collect_vec()
     }
 
+    pub fn chunk_indices_and_membership_proofs_and_leafs_iter_mut(
+        &mut self,
+    ) -> std::slice::IterMut<'_, (u64, (MmrMembershipProof, Chunk))> {
+        self.dictionary.iter_mut()
+    }
+
     pub fn authentication_paths(&self) -> Vec<MmrMembershipProof> {
         self.dictionary
             .iter()

--- a/src/util_types/mutator_set/rusty_archival_mutator_set.rs
+++ b/src/util_types/mutator_set/rusty_archival_mutator_set.rs
@@ -93,6 +93,14 @@ impl StorageWriter for RustyArchivalMutatorSet {
 
         self.storage.persist().await;
     }
+
+    async fn drop_unpersisted(&mut self) {
+        self.ams_mut().swbf_active.sbf = self.active_window_storage.get().await;
+        self.storage.drop_unpersisted().await;
+        self.ams_mut().aocl.delete_cache().await;
+        self.ams_mut().swbf_inactive.delete_cache().await;
+        self.ams_mut().chunks.delete_cache().await;
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fix a problem in get_mutator_set_update_to_tip where the wrong removal records were returned.

The function attempts to find a `MutatorSetUpdate` that transforms the mutator set from a state B to a later state A where B and A can be separated by an arbitrary number of blocks. The problem was the the removal records were collecting from all blocks between B and A. But the MutatorSetUpdate data structure needs the removal records valid for block B.

To fix this, we make ephemeral changes to the archival mutator set to assemble the required information. And then roll those ephemeral changes back once the information is gathered.

This closes #225.

A solution where a "snapshot" of the archival mutator set was returned -- an archival mutator set that could read from the databases but only write to cache, not databases -- would be a more elegant and robust solution, I think. But that seems like a rather big rewrite. 

Since a write-lock is held over the `ArchivalMutatorSet` throughout this operation, I believe that the operation is safe and should not lead to data corruption.

Prior to this commit, the test `models::state::archival_state::archival_state_tests::update_mutator_set_rollback_many_blocks_multiple_inputs_outputs_test` was flaky. With this commit, that is no longer the case.