### PR TITLE
job_queue: Return joinhandles to caller for graceful shutdown

### DIFF
--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -141,6 +141,7 @@ impl GlobalStateLock {
         cli: cli_args::Args,
         mempool: Mempool,
         mining: bool,
+        vm_job_queue: TritonVmJobQueue,
     ) -> Self {
         let global_state = GlobalState::new(wallet_state, chain, net, cli.clone(), mempool, mining);
         let global_state_lock = sync_tokio::AtomicRw::from((
@@ -151,7 +152,7 @@ impl GlobalStateLock {
         Self {
             global_state_lock,
             cli,
-            vm_job_queue: TritonVmJobQueue::start(),
+            vm_job_queue,
         }
     }
 

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -50,6 +50,7 @@ use crate::config_models::network::Network;
 use crate::database::NeptuneLevelDb;
 use crate::job_queue::triton_vm::TritonVmJobPriority;
 use crate::job_queue::triton_vm::TritonVmJobQueue;
+use crate::job_queue::JobQueue;
 use crate::mine_loop::make_coinbase_transaction;
 use crate::mine_loop::mine_loop_tests::mine_iteration_for_tests;
 use crate::models::blockchain::block::block_appendix::BlockAppendix;
@@ -224,6 +225,7 @@ pub(crate) async fn mock_genesis_global_state(
 
     let wallet_state = mock_genesis_wallet_state(wallet, network).await;
 
+    let (jobqueue, _, _) = JobQueue::start();
     GlobalStateLock::new(
         wallet_state,
         blockchain_state,
@@ -231,6 +233,7 @@ pub(crate) async fn mock_genesis_global_state(
         cli_args.clone(),
         mempool,
         cli_args.mine,
+        jobqueue,
     )
 }
 


### PR DESCRIPTION
Competing implementation to shut down `JobQueue`. This PR would replace functionality introduced in 4a36ec54d6607dbcdce98ec040c737edf86c8442. 

I personally prefer this PR to 4a36ec54d6607dbcdce98ec040c737edf86c8442 since this PR only uses Rust's ownership concept to ensure that only one code path can shut down the job queue. Also: It follows the existing pattern of accumulating `JoinHandle`s in a list and looping over that list in `main_loop`'s graceful shutdown.