### PR TITLE
feat: Reward peers for good behavior

### DIFF
--- a/src/bin/dashboard_src/peers_screen.rs
+++ b/src/bin/dashboard_src/peers_screen.rs
@@ -177,7 +177,8 @@ impl Widget for PeersScreen {
             "archival",
             "authenticated",
             "alias",
-            "last sanction",
+            "last punishment",
+            "last reward",
         ];
         let matrix = self
             .data
@@ -185,8 +186,14 @@ impl Widget for PeersScreen {
             .unwrap()
             .iter()
             .map(|pi| {
-                let latest_violation: Option<String> =
-                    pi.standing().latest_sanction.map(|x| x.to_string());
+                let latest_punishment: Option<String> = pi
+                    .standing()
+                    .latest_punishment
+                    .map(|(peer_sanction, _timestamp)| peer_sanction.to_string());
+                let latest_reward: Option<String> = pi
+                    .standing()
+                    .latest_reward
+                    .map(|(peer_sanction, _timestamp)| peer_sanction.to_string());
                 let connection_established = pi
                     .connection_established()
                     .duration_since(std::time::UNIX_EPOCH)
@@ -203,7 +210,8 @@ impl Widget for PeersScreen {
                     },
                     "✕".to_string(), // no support for authentication yet
                     "-".to_string(), // no support for aliases yes
-                    latest_violation.unwrap_or_default(),
+                    latest_punishment.unwrap_or_default(),
+                    latest_reward.unwrap_or_default(),
                 ]
             })
             .collect_vec();

--- a/src/bin/dashboard_src/peers_screen.rs
+++ b/src/bin/dashboard_src/peers_screen.rs
@@ -186,17 +186,17 @@ impl Widget for PeersScreen {
             .iter()
             .map(|pi| {
                 let latest_violation: Option<String> =
-                    pi.standing.latest_sanction.map(|x| x.to_string());
+                    pi.standing().latest_sanction.map(|x| x.to_string());
                 let connection_established = pi
-                    .connection_established
+                    .connection_established()
                     .duration_since(std::time::UNIX_EPOCH)
                     .unwrap();
                 vec![
-                    pi.connected_address.to_string(),
+                    pi.connected_address().to_string(),
                     neptune_core::utc_timestamp_to_localtime(connection_established.as_millis())
                         .to_string(),
-                    pi.standing.standing.to_string(),
-                    if pi.is_archival_node {
+                    pi.standing().to_string(),
+                    if pi.is_archival_node() {
                         "✓".to_string()
                     } else {
                         "".to_string()

--- a/src/bin/neptune-cli.rs
+++ b/src/bin/neptune-cli.rs
@@ -374,8 +374,8 @@ async fn main() -> Result<()> {
             let peer_sanctions = client.all_sanctioned_peers(ctx).await?;
             for (ip, sanction) in peer_sanctions {
                 let standing = sanction.standing;
-                let latest_sanction_str = match sanction.latest_sanction {
-                    Some(sanction) => sanction.to_string(),
+                let latest_sanction_str = match sanction.latest_punishment {
+                    Some((sanction, _timestamp)) => sanction.to_string(),
                     None => String::default(),
                 };
                 println!(

--- a/src/config_models/cli_args.rs
+++ b/src/config_models/cli_args.rs
@@ -43,6 +43,7 @@ pub struct Args {
     /// Refuse connection if peer is in bad standing.
     ///
     /// This sets the threshold for when a peer should be automatically refused.
+    /// The default is set to 1000.
     ///
     /// For a list of reasons that cause bad standing, see [PeerSanctionReason](crate::models::peer::PeerSanctionReason).
     #[clap(long, default_value = "1000", value_name = "VALUE")]

--- a/src/models/peer.rs
+++ b/src/models/peer.rs
@@ -149,8 +149,11 @@ pub enum PeerSanctionReason {
     NoStandingFoundMaybeCrash,
 
     // positive sanctions (standing-improving)
+    // We only reward events that are unlikely to occur more frequently than the
+    // target block frequency. This should make it impossible for an attacker
+    // to quickly ramp up their standing with peers, provided that they are on
+    // the global tip.
     ValidBlocks(usize),
-    ValidNewTransaction,
     NewBlockProposal,
 }
 
@@ -186,7 +189,6 @@ impl Display for PeerSanctionReason {
             PeerSanctionReason::NonFavorableBlockProposal => "non-favorable block proposal",
 
             PeerSanctionReason::ValidBlocks(_) => "valid blocks",
-            PeerSanctionReason::ValidNewTransaction => "valid transaction",
             PeerSanctionReason::NewBlockProposal => "new block proposal",
         };
         write!(f, "{string}")
@@ -246,7 +248,6 @@ impl PeerSanctionReason {
                 .try_into()
                 .map(|n: i32| n.saturating_mul(10))
                 .unwrap_or(i32::MAX),
-            PeerSanctionReason::ValidNewTransaction => 3,
             PeerSanctionReason::NewBlockProposal => 7,
         }
     }

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -1275,7 +1275,7 @@ impl GlobalState {
     ///
     /// Locking:
     ///  * acquires `monitored_utxos` lock for write
-    pub async fn prune_abandoned_monitored_utxos<'a>(
+    pub async fn prune_abandoned_monitored_utxos(
         &mut self,
         block_depth_threshhold: usize,
     ) -> Result<usize> {

--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -820,9 +820,6 @@ impl PeerLoopHandler {
                     }
                 }
 
-                // We can't reward a peer for notifying us of a block without
-                // knowing that that block is valid.
-
                 Ok(KEEP_CONNECTION_ALIVE)
             }
             PeerMessage::BlockRequestByHash(block_digest) => {
@@ -1032,9 +1029,6 @@ impl PeerLoopHandler {
                     .send(PeerTaskToMain::Transaction(Box::new(pt2m_transaction)))
                     .await?;
 
-                // Valuable, hard-to-produce, new information. So reward peer.
-                self.reward(PeerSanctionReason::ValidNewTransaction).await?;
-
                 Ok(KEEP_CONNECTION_ALIVE)
             }
             PeerMessage::TransactionNotification(tx_notification) => {
@@ -1072,9 +1066,6 @@ impl PeerLoopHandler {
                 debug!("requesting transaction from peer");
                 peer.send(PeerMessage::TransactionRequest(tx_notification.txid))
                     .await?;
-
-                // We cannot reward the peer for notifying us of a transaction
-                // without knowing whether the transaction is valid.
 
                 Ok(KEEP_CONNECTION_ALIVE)
             }
@@ -1125,9 +1116,6 @@ impl PeerLoopHandler {
                         self.peer_address
                     );
                 }
-
-                // We cannot reward the peer for notifying us of a new block
-                // proposal without knowing if it is valid.
 
                 Ok(KEEP_CONNECTION_ALIVE)
             }

--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -516,8 +516,8 @@ impl RPC for NeptuneRPCServer {
 
         // Get all connected peers
         for (socket_address, peer_info) in global_state.net.peer_map.iter() {
-            if peer_info.standing.is_negative() {
-                sanctions_in_memory.insert(socket_address.ip(), peer_info.standing);
+            if peer_info.standing().is_negative() {
+                sanctions_in_memory.insert(socket_address.ip(), peer_info.standing());
             }
         }
 
@@ -1155,9 +1155,9 @@ mod rpc_server_tests {
         let rpc_request_context = context::current();
         let global_state = state_lock.lock_guard().await;
         let peer_address_0 =
-            global_state.net.peer_map.values().collect::<Vec<_>>()[0].connected_address;
+            global_state.net.peer_map.values().collect::<Vec<_>>()[0].connected_address();
         let peer_address_1 =
-            global_state.net.peer_map.values().collect::<Vec<_>>()[1].connected_address;
+            global_state.net.peer_map.values().collect::<Vec<_>>()[1].connected_address();
         drop(global_state);
 
         // Verify that sanctions list is empty
@@ -1179,14 +1179,18 @@ mod rpc_server_tests {
                 .peer_map
                 .entry(peer_address_0)
                 .and_modify(|p| {
-                    p.standing.sanction(PeerSanctionReason::DifferentGenesis);
+                    p.standing
+                        .sanction(PeerSanctionReason::DifferentGenesis)
+                        .unwrap();
                 });
             global_state_mut
                 .net
                 .peer_map
                 .entry(peer_address_1)
                 .and_modify(|p| {
-                    p.standing.sanction(PeerSanctionReason::DifferentGenesis);
+                    p.standing
+                        .sanction(PeerSanctionReason::DifferentGenesis)
+                        .unwrap();
                 });
             let standing_0 = global_state_mut.net.peer_map[&peer_address_0].standing;
             let standing_1 = global_state_mut.net.peer_map[&peer_address_1].standing;
@@ -1301,16 +1305,20 @@ mod rpc_server_tests {
         )
         .await;
         let mut state = state_lock.lock_guard_mut().await;
-        let peer_address_0 = state.net.peer_map.values().collect::<Vec<_>>()[0].connected_address;
-        let peer_address_1 = state.net.peer_map.values().collect::<Vec<_>>()[1].connected_address;
+        let peer_address_0 = state.net.peer_map.values().collect::<Vec<_>>()[0].connected_address();
+        let peer_address_1 = state.net.peer_map.values().collect::<Vec<_>>()[1].connected_address();
 
         // sanction both peers
         let (standing_0, standing_1) = {
             state.net.peer_map.entry(peer_address_0).and_modify(|p| {
-                p.standing.sanction(PeerSanctionReason::DifferentGenesis);
+                p.standing
+                    .sanction(PeerSanctionReason::DifferentGenesis)
+                    .unwrap();
             });
             state.net.peer_map.entry(peer_address_1).and_modify(|p| {
-                p.standing.sanction(PeerSanctionReason::DifferentGenesis);
+                p.standing
+                    .sanction(PeerSanctionReason::DifferentGenesis)
+                    .unwrap();
             });
             let standing_0 = state.net.peer_map[&peer_address_0].standing;
             let standing_1 = state.net.peer_map[&peer_address_1].standing;

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -76,9 +76,9 @@ use crate::models::database::BlockIndexKey;
 use crate::models::database::BlockIndexValue;
 use crate::models::database::PeerDatabases;
 use crate::models::peer::HandshakeData;
+use crate::models::peer::PeerConnectionInfo;
 use crate::models::peer::PeerInfo;
 use crate::models::peer::PeerMessage;
-use crate::models::peer::PeerStanding;
 use crate::models::proof_abstractions::timestamp::Timestamp;
 use crate::models::state::archival_state::ArchivalState;
 use crate::models::state::blockchain_state::BlockchainArchivalState;
@@ -132,16 +132,15 @@ pub fn get_dummy_socket_address(count: u8) -> SocketAddr {
 
 /// Get a dummy-peer representing an outgoing connection.
 pub(crate) fn get_dummy_peer(address: SocketAddr) -> PeerInfo {
-    PeerInfo {
-        connected_address: address,
-        inbound: false,
-        instance_id: rand::random(),
-        connection_established: SystemTime::now(),
-        standing: PeerStanding::default(),
-        version: get_dummy_version(),
-        port_for_incoming_connections: Some(8080),
-        is_archival_node: true,
-    }
+    let peer_connection_info = PeerConnectionInfo::new(Some(8080), address, false);
+    PeerInfo::new(
+        peer_connection_info,
+        rand::random(),
+        SystemTime::now(),
+        get_dummy_version(),
+        true,
+        cli_args::Args::default().peer_tolerance,
+    )
 }
 
 pub fn get_dummy_version() -> String {


### PR DESCRIPTION
This commit adds a `reward` function on `PeerLoopHandler` that improves peers' standings when they
 - send valid blocks
 - send a valid block proposal
 - send a valid transaction.

Notifications should not be rewarded because the thing they inform the recipient of might not be valid.

This commit also refactors `PeerInfo` and `PeerStanding` to better encapsulate logic and data and present the outside world with a smaller, abstract interface.