### PR TITLE
Improve mempool tx update handling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,6 @@ use tarpc::tokio_serde::formats::*;
 use tokio::net::TcpListener;
 use tokio::sync::broadcast;
 use tokio::sync::mpsc;
-use tokio::sync::watch;
 use tokio::time::Instant;
 use tracing::info;
 use tracing::trace;
@@ -85,7 +84,7 @@ use crate::rpc_server::RPC;
 pub const MAGIC_STRING_REQUEST: &[u8] = b"EDE8991A9C599BE908A759B6BF3279CD";
 pub const MAGIC_STRING_RESPONSE: &[u8] = b"Hello Neptune!\n";
 const PEER_CHANNEL_CAPACITY: usize = 1000;
-const MINER_CHANNEL_CAPACITY: usize = 3;
+const MINER_CHANNEL_CAPACITY: usize = 10;
 const RPC_CHANNEL_CAPACITY: usize = 1000;
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -222,7 +221,7 @@ pub async fn initialize(cli_args: cli_args::Args) -> Result<()> {
 
     // Start mining tasks if requested
     let (miner_to_main_tx, miner_to_main_rx) = mpsc::channel::<MinerToMain>(MINER_CHANNEL_CAPACITY);
-    let (main_to_miner_tx, main_to_miner_rx) = watch::channel::<MainToMiner>(MainToMiner::Empty);
+    let (main_to_miner_tx, main_to_miner_rx) = mpsc::channel::<MainToMiner>(MINER_CHANNEL_CAPACITY);
     let miner_state_lock = global_state_lock.clone(); // bump arc refcount.
     if global_state_lock.cli().mine() {
         let miner_join_handle = tokio::task::Builder::new()

--- a/src/main_loop/proof_upgrader.rs
+++ b/src/main_loop/proof_upgrader.rs
@@ -67,6 +67,22 @@ pub struct UpdateMutatorSetDataJob {
     mutator_set_update: MutatorSetUpdate,
 }
 
+impl UpdateMutatorSetDataJob {
+    pub(crate) fn new(
+        old_kernel: TransactionKernel,
+        old_single_proof: Proof,
+        old_mutator_set: MutatorSetAccumulator,
+        mutator_set_update: MutatorSetUpdate,
+    ) -> Self {
+        Self {
+            old_kernel,
+            old_single_proof,
+            old_mutator_set,
+            mutator_set_update,
+        }
+    }
+}
+
 impl UpgradeJob {
     /// Create an upgrade job from a primitive witness, for upgrading proof-
     /// support for a transaction that this client has initiated.

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -163,14 +163,18 @@ fn guess_worker(
     let hash = block.hash();
     let hex = hash.to_hex();
     let height = block.kernel.header.height;
+    let num_inputs = block.body().transaction_kernel.inputs.len();
+    let num_outputs = block.body().transaction_kernel.outputs.len();
     info!(
         r#"Newly mined block details:
               Height: {height}
-              Time:   {timestamp_standard} ({timestamp})
+              Time  : {timestamp_standard} ({timestamp})
         Digest (Hex): {hex}
         Digest (Raw): {hash}
 Difficulty threshold: {threshold}
           Difficulty: {prev_difficulty}
+          #inputs   : {num_inputs}
+          #outputs  : {num_outputs}
 "#
     );
 

--- a/src/models/channel.rs
+++ b/src/models/channel.rs
@@ -14,13 +14,16 @@ use super::proof_abstractions::mast_hash::MastHash;
 use super::state::wallet::expected_utxo::ExpectedUtxo;
 
 #[derive(Clone, Debug)]
-pub enum MainToMiner {
-    Empty,
+pub(crate) enum MainToMiner {
     NewBlock(Box<Block>),
     Shutdown,
 
     /// Communicates to miner that it should work on a new block proposal
     NewBlockProposal,
+
+    /// Main has received a new block or block proposal, and the miner should
+    /// stop all work until it receives a [MainToMiner::Continue] message.
+    WaitForContinue,
 
     /// Used to communicate that main loop has received the block or block
     /// proposal from the miner, and that miner can start a new task.

--- a/src/models/channel.rs
+++ b/src/models/channel.rs
@@ -34,6 +34,22 @@ pub enum MainToMiner {
     // SetCoinbasePubkey,
 }
 
+impl MainToMiner {
+    pub(crate) fn get_type(&self) -> &str {
+        match self {
+            MainToMiner::NewBlock(_) => "new block",
+            MainToMiner::Shutdown => "shutdown",
+            MainToMiner::NewBlockProposal => "new block proposal",
+            MainToMiner::WaitForContinue => "wait for continue",
+            MainToMiner::Continue => "continue",
+            MainToMiner::StopMining => "stop mining",
+            MainToMiner::StartMining => "start mining",
+            MainToMiner::StartSyncing => "start syncing",
+            MainToMiner::StopSyncing => "stop syncing",
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct NewBlockFound {
     pub block: Box<Block>,

--- a/src/models/peer/transaction_notification.rs
+++ b/src/models/peer/transaction_notification.rs
@@ -38,7 +38,6 @@ impl TryFrom<&Transaction> for TransactionNotification {
 
     fn try_from(transaction: &Transaction) -> Result<Self> {
         let proof_quality = match &transaction.proof {
-            TransactionProof::Invalid => bail!("Cannot share invalid transaction proof"),
             TransactionProof::Witness(_) => bail!(
                 "Cannot share primitive witness-backed transaction, as this would leak secret keys"
             ),

--- a/src/models/peer/transfer_transaction.rs
+++ b/src/models/peer/transfer_transaction.rs
@@ -51,7 +51,6 @@ impl TryFrom<&Transaction> for TransferTransaction {
 
     fn try_from(value: &Transaction) -> Result<Self, Self::Error> {
         let transfer_proof = match &value.proof {
-            TransactionProof::Invalid => bail!("Cannot share invalid transaction with peer"),
             TransactionProof::Witness(_) => {
                 bail!("Cannot share primitive witness-supported transaction, as this would leak secret data")
             }

--- a/src/models/proof_abstractions/tasm/consensus_program_prover_job.rs
+++ b/src/models/proof_abstractions/tasm/consensus_program_prover_job.rs
@@ -10,6 +10,7 @@
 //! program can execute at a time.
 #[cfg(not(test))]
 use std::process::Stdio;
+
 #[cfg(not(test))]
 use tokio::io::AsyncWriteExt;
 

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -346,6 +346,10 @@ impl Mempool {
             } else {
                 // If new transaction has a lower fee density than the one previous seen,
                 // ignore it. Stop execution here.
+                debug!(
+                    "Attempted to insert transaction into mempool but it's \
+                     fee density was eclipsed by another transaction."
+                );
                 return events;
             }
         }

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -322,7 +322,6 @@ impl Mempool {
             conflicts: &[(TransactionKernelId, &Transaction)],
         ) -> bool {
             match &new_tx.proof {
-                TransactionProof::Invalid => panic!("Invalid proofs don't belong in mempool"),
                 TransactionProof::Witness(_) => false,
                 TransactionProof::ProofCollection(_) => conflicts
                     .iter()
@@ -336,7 +335,6 @@ impl Mempool {
         let mut events = vec![];
 
         match new_tx.proof {
-            TransactionProof::Invalid => panic!("cannot insert invalid transaction into mempool"),
             TransactionProof::Witness(_) => {}
             TransactionProof::SingleProof(_) => {}
             TransactionProof::ProofCollection(_) => {}
@@ -667,7 +665,6 @@ impl Mempool {
             let can_upgrade_single_proof =
                 TxProvingCapability::SingleProof == tx_proving_capability;
             let (update_job, can_update) = match &tx.transaction.proof {
-                TransactionProof::Invalid => panic!("Mempool may not contain invalid proofs"),
                 TransactionProof::ProofCollection(_) => {
                     debug!("Failed to update transaction {tx_id}. Because it is only supported by a proof collection.");
 

--- a/src/models/state/mining_status.rs
+++ b/src/models/state/mining_status.rs
@@ -23,10 +23,18 @@ impl Display for MiningStatus {
 
         match self {
             MiningStatus::Guessing(_) => {
-                write!(f, "guessing for {}", elapsed_time.unwrap().as_secs())
+                write!(
+                    f,
+                    "guessing for {} seconds",
+                    elapsed_time.unwrap().as_secs()
+                )
             }
             MiningStatus::Composing(_) => {
-                write!(f, "composing for {}", elapsed_time.unwrap().as_secs())
+                write!(
+                    f,
+                    "composing for {} seconds",
+                    elapsed_time.unwrap().as_secs()
+                )
             }
             MiningStatus::Inactive => write!(f, "inactive"),
         }

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -1472,15 +1472,16 @@ impl GlobalState {
                 )
                 .await?;
 
-            // Update mempool with UTXOs from this block. This is done by removing all transaction
-            // that became invalid/was mined by this block.
+            // Update mempool with UTXOs from this block. This is done by
+            // removing all transaction that became invalid/was mined by this
+            // block.
             myself
                 .mempool
                 .update_with_block_and_predecessor(
                     &new_block,
                     &tip_parent,
                     vm_job_queue,
-                    TritonVmJobPriority::Highest,
+                    myself.net.tx_proving_capability,
                     myself.cli().compose,
                 )
                 .await;

--- a/src/models/state/tx_proving_capability.rs
+++ b/src/models/state/tx_proving_capability.rs
@@ -1,3 +1,4 @@
+use std::fmt::Display;
 use std::str::FromStr;
 
 use clap::error::ErrorKind;
@@ -9,6 +10,21 @@ pub enum TxProvingCapability {
     LockScript,
     ProofCollection,
     SingleProof,
+}
+
+impl Display for TxProvingCapability {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                TxProvingCapability::PrimitiveWitness => "primitive witness",
+                TxProvingCapability::LockScript => "lock script",
+                TxProvingCapability::ProofCollection => "proof collection",
+                TxProvingCapability::SingleProof => "single proof",
+            }
+        )
+    }
 }
 
 impl FromStr for TxProvingCapability {

--- a/src/models/state/wallet/mod.rs
+++ b/src/models/state/wallet/mod.rs
@@ -680,7 +680,6 @@ mod wallet_tests {
         let mut alice =
             mock_genesis_global_state(network, 1, alice_wallet_secret, cli_args::Args::default())
                 .await;
-        let alice_vm_job_queue = alice.vm_job_queue().clone();
         let alice_spending_key = alice
             .lock_guard()
             .await
@@ -729,10 +728,7 @@ mod wallet_tests {
                     UtxoNotifier::OwnMinerComposeBlock,
                 ))
                 .await;
-            alice_mut
-                .set_new_tip(block_1.clone(), &alice_vm_job_queue)
-                .await
-                .unwrap();
+            alice_mut.set_new_tip(block_1.clone()).await.unwrap();
         }
 
         // Verify that the allocater returns a sane amount
@@ -772,10 +768,7 @@ mod wallet_tests {
                         UtxoNotifier::OwnMinerComposeBlock,
                     ))
                     .await;
-                alice
-                    .set_new_tip(next_block_prime.clone(), &alice_vm_job_queue)
-                    .await
-                    .unwrap();
+                alice.set_new_tip(next_block_prime.clone()).await.unwrap();
                 next_block = next_block_prime;
             }
         }
@@ -890,7 +883,6 @@ mod wallet_tests {
         let mut bob_global_lock =
             mock_genesis_global_state(network, 2, bob_wallet.clone(), cli_args::Args::default())
                 .await;
-        let bob_vm_job_queue = bob_global_lock.vm_job_queue().clone();
         let mut bob = bob_global_lock.lock_guard_mut().await;
         let in_seven_months = genesis_block.kernel.header.timestamp + Timestamp::months(7);
 
@@ -945,9 +937,7 @@ mod wallet_tests {
 
         // Notification for Bob's change happens on-chain. No need to ask
         // wallet to expect change UTXO.
-        bob.set_new_tip(block_1.clone(), &bob_vm_job_queue)
-            .await
-            .unwrap();
+        bob.set_new_tip(block_1.clone()).await.unwrap();
 
         assert_eq!(
             bobs_original_balance
@@ -1021,9 +1011,7 @@ mod wallet_tests {
                 .add_expected_utxo(expected_utxo)
                 .await;
             alice.set_new_tip(next_block.clone()).await.unwrap();
-            bob.set_new_tip(next_block.clone(), &bob_vm_job_queue)
-                .await
-                .unwrap();
+            bob.set_new_tip(next_block.clone()).await.unwrap();
         }
 
         let first_block_after_spree = next_block;
@@ -1092,9 +1080,7 @@ mod wallet_tests {
             rng.gen(),
         );
         alice.set_new_tip(block_2_b.clone()).await.unwrap();
-        bob.set_new_tip(block_2_b.clone(), &bob_vm_job_queue)
-            .await
-            .unwrap();
+        bob.set_new_tip(block_2_b.clone()).await.unwrap();
         let alice_monitored_utxos_at_2b: Vec<_> =
             get_monitored_utxos(&alice.lock_guard().await.wallet_state)
                 .await

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -1199,7 +1199,6 @@ mod tests {
             cli_args::Args::default(),
         )
         .await;
-        let alice_vm_job_queue = alice_global_lock.vm_job_queue().clone();
 
         let mut alice = alice_global_lock.global_state_lock.lock_guard_mut().await;
         let launch_timestamp = alice.chain.light_state().header().timestamp;
@@ -1261,7 +1260,6 @@ mod tests {
                     alice_key.privacy_preimage,
                     UtxoNotifier::OwnMinerComposeBlock,
                 )],
-                &alice_vm_job_queue,
             )
             .await
             .unwrap();
@@ -1304,7 +1302,6 @@ mod tests {
         let mut bob_global_lock =
             mock_genesis_global_state(network, 0, bob_wallet_secret, cli_args::Args::default())
                 .await;
-        let bob_vm_job_queue = bob_global_lock.vm_job_queue().clone();
         let mut bob = bob_global_lock.lock_guard_mut().await;
         let genesis_block = Block::genesis_block(network);
         let monitored_utxos_count_init = bob.wallet_state.wallet_db.monitored_utxos().len().await;
@@ -1373,7 +1370,6 @@ mod tests {
                 bob_spending_key.privacy_preimage,
                 UtxoNotifier::OwnMinerComposeBlock,
             )],
-            &bob_vm_job_queue,
         )
         .await
         .unwrap();
@@ -1406,9 +1402,7 @@ mod tests {
         // Fork the blockchain with 3b, with no coinbase for us
         let (block_3b, _block_3b_coinbase_utxo, _block_3b_coinbase_sender_randomness) =
             make_mock_block(&latest_block, None, alice_address, rng.gen());
-        bob.set_new_tip(block_3b.clone(), &bob_vm_job_queue)
-            .await
-            .unwrap();
+        bob.set_new_tip(block_3b.clone()).await.unwrap();
 
         assert!(
             bob
@@ -1433,9 +1427,7 @@ mod tests {
         for _ in 4..=11 {
             let (new_block, _new_block_coinbase_utxo, _new_block_coinbase_sender_randomness) =
                 make_mock_block(&latest_block, None, alice_address, rng.gen());
-            bob.set_new_tip(new_block.clone(), &bob_vm_job_queue)
-                .await
-                .unwrap();
+            bob.set_new_tip(new_block.clone()).await.unwrap();
 
             latest_block = new_block;
         }
@@ -1459,9 +1451,7 @@ mod tests {
 
         // Mine *one* more block. Verify that MUTXO is pruned
         let (block_12, _, _) = make_mock_block(&latest_block, None, alice_address, rng.gen());
-        bob.set_new_tip(block_12.clone(), &bob_vm_job_queue)
-            .await
-            .unwrap();
+        bob.set_new_tip(block_12.clone()).await.unwrap();
 
         assert!(
             bob.wallet_state

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -514,7 +514,7 @@ pub(crate) fn make_mock_transaction_with_mutator_set_hash(
             coinbase: None,
             mutator_set_hash,
         },
-        proof: TransactionProof::Invalid,
+        proof: TransactionProof::invalid(),
     }
 }
 
@@ -562,7 +562,7 @@ pub fn make_mock_transaction_with_wallet(
 
     Transaction {
         kernel,
-        proof: TransactionProof::Invalid,
+        proof: TransactionProof::invalid(),
     }
 }
 
@@ -678,7 +678,7 @@ pub(crate) fn make_mock_block(
     };
     let tx = Transaction {
         kernel: tx_kernel,
-        proof: TransactionProof::Invalid,
+        proof: TransactionProof::invalid(),
     };
 
     let block = Block::block_template_invalid_proof(


### PR DESCRIPTION
When we receive a new block, we might have to generate a Triton VM proof for the `update` program which can take minutes. This task was previously done during `set_new_tip`, specifically  in `Mempool::update_with_block_and_predecessor`. With this commit, we instead return the update jobs that need to be run and then spawn a task in which this expensive computation is performed, after the write-lock on `GlobalState` has been released.

There's one warning left in there intentionally, as I wasn't quite sure how to handle the returned `Vec<MempoolEvent>`. Maybe you, apart from the general architecture, @dan-da, can also see if we're using `Vec<MempoolEvent>` correctly here?