### PR TITLE
refactor(`Block`): Distinguish MSA: in-between versus after-block

### DIFF
--- a/src/main_loop/proof_upgrader.rs
+++ b/src/main_loop/proof_upgrader.rs
@@ -200,7 +200,7 @@ impl UpgradeJob {
                     != global_state
                         .chain
                         .light_state()
-                        .mutator_set_accumulator()
+                        .mutator_set_accumulator_after()
                         .hash();
 
                 if !transaction_is_deprecated {
@@ -374,7 +374,7 @@ pub(super) fn get_upgrade_task_from_mempool(
         let upgrade_decision = UpgradeJob::ProofCollectionToSingleProof {
             kernel: kernel.to_owned(),
             proof: proof.to_owned(),
-            mutator_set: tip.mutator_set_accumulator().to_owned(),
+            mutator_set: tip.mutator_set_accumulator_after().to_owned(),
         };
 
         if upgrade_decision.mutator_set().hash() != kernel.mutator_set_hash {
@@ -398,7 +398,7 @@ pub(super) fn get_upgrade_task_from_mempool(
             right_kernel: right_kernel.to_owned(),
             single_proof_right: right_single_proof.to_owned(),
             shuffle_seed: rng.gen(),
-            mutator_set: tip.mutator_set_accumulator().to_owned(),
+            mutator_set: tip.mutator_set_accumulator_after().to_owned(),
         };
 
         if left_kernel.mutator_set_hash != right_kernel.mutator_set_hash

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -272,7 +272,7 @@ pub(crate) async fn make_coinbase_transaction(
         .chain
         .light_state()
         .clone();
-    let mutator_set_accumulator = latest_block.mutator_set_accumulator().clone();
+    let mutator_set_accumulator = latest_block.mutator_set_accumulator_after().clone();
     let next_block_height: BlockHeight = latest_block.header().height.next();
 
     #[allow(clippy::manual_range_contains)]
@@ -372,7 +372,7 @@ pub(crate) async fn create_block_transaction(
 
     debug!(
         "Creating block transaction with mutator set hash: {}",
-        predecessor_block.mutator_set_accumulator().hash()
+        predecessor_block.mutator_set_accumulator_after().hash()
     );
 
     let mut rng: StdRng =
@@ -702,7 +702,7 @@ pub(crate) mod mine_loop_tests {
                 make_mock_transaction_with_mutator_set_hash(
                     vec![],
                     vec![],
-                    previous_block.mutator_set_accumulator().hash(),
+                    previous_block.mutator_set_accumulator_after().hash(),
                 ),
                 dummy_expected_utxo(),
             )
@@ -1152,7 +1152,7 @@ pub(crate) mod mine_loop_tests {
                     make_mock_transaction_with_mutator_set_hash(
                         vec![],
                         vec![],
-                        prev_block.mutator_set_accumulator().hash(),
+                        prev_block.mutator_set_accumulator_after().hash(),
                     ),
                     vec![dummy_expected_utxo()],
                 )

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -639,7 +639,6 @@ pub(crate) mod mine_loop_tests {
     use block_body::BlockBody;
     use block_header::block_header_tests::random_block_header;
     use difficulty_control::Difficulty;
-    use mutator_set_update::MutatorSetUpdate;
     use num_bigint::BigUint;
     use num_traits::Pow;
     use num_traits::Zero;
@@ -1302,92 +1301,5 @@ pub(crate) mod mine_loop_tests {
                 "number of hash trials before finding valid pow exceeds statistical limit"
             )
         }
-    }
-
-    #[traced_test]
-    #[tokio::test]
-    async fn guesser_fees_are_added_to_mutator_set() {
-        // Mine two blocks on top of the genesis block. Verify that the guesser
-        // fee for the 1st block was added to the mutator set. The genesis
-        // block awards no guesser fee.
-
-        let mut rng = thread_rng();
-        let network = Network::Main;
-        let genesis_block = Block::genesis_block(network);
-        assert!(
-            genesis_block.guesser_fee_addition_records().is_empty(),
-            "Genesis block has no guesser fee UTXOs"
-        );
-
-        let launch_date = genesis_block.header().timestamp;
-        let in_seven_months = launch_date + Timestamp::months(7);
-        let in_eight_months = launch_date + Timestamp::months(8);
-        let alice_wallet = WalletSecret::devnet_wallet();
-        let alice_key = alice_wallet.nth_generation_spending_key(0);
-        let alice_address = alice_key.to_address();
-        let mut alice =
-            mock_genesis_global_state(network, 0, alice_wallet, cli_args::Args::default()).await;
-
-        let output = TxOutput::offchain_native_currency(
-            NeptuneCoins::new(4),
-            rng.gen(),
-            alice_address.into(),
-        );
-        let fee = NeptuneCoins::new(1);
-        let (tx1, _) = alice
-            .lock_guard()
-            .await
-            .create_transaction_with_prover_capability(
-                vec![output.clone()].into(),
-                alice_key.into(),
-                UtxoNotificationMedium::OnChain,
-                fee,
-                in_seven_months,
-                TxProvingCapability::PrimitiveWitness,
-                &TritonVmJobQueue::dummy(),
-            )
-            .await
-            .unwrap();
-
-        let block1 = Block::block_template_invalid_proof(
-            &genesis_block,
-            tx1,
-            in_seven_months,
-            Digest::default(),
-            None,
-        );
-        alice.set_new_tip(block1.clone()).await.unwrap();
-
-        let (tx2, _) = alice
-            .lock_guard()
-            .await
-            .create_transaction_with_prover_capability(
-                vec![output].into(),
-                alice_key.into(),
-                UtxoNotificationMedium::OnChain,
-                fee,
-                in_eight_months,
-                TxProvingCapability::PrimitiveWitness,
-                &TritonVmJobQueue::dummy(),
-            )
-            .await
-            .unwrap();
-
-        let block2 =
-            Block::block_template_invalid_proof(&block1, tx2, in_eight_months, rng.gen(), None);
-
-        let new_addition_records = [
-            block1.guesser_fee_addition_records(),
-            block2.body().transaction_kernel.outputs.clone(),
-        ]
-        .concat();
-        let mut ms = block1.mutator_set_accumulator().clone();
-        let mutator_set_update = MutatorSetUpdate::new(
-            block2.body().transaction_kernel.inputs.clone(),
-            new_addition_records,
-        );
-        mutator_set_update.apply_to_accumulator(&mut ms).expect("applying mutator set update derived from block 2 to mutator set from block 1 should work");
-
-        assert_eq!(ms.hash(), block2.mutator_set_accumulator().hash());
     }
 }

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -932,20 +932,8 @@ impl Block {
             self.body().transaction_kernel.outputs.clone(),
         );
 
-        let mut mutator_set_accumulator = self.kernel.body.mutator_set_accumulator.clone();
-
         let extra_addition_records = self.guesser_fee_addition_records();
-
-        for addition in &extra_addition_records {
-            RemovalRecord::batch_update_from_addition(
-                &mut mutator_set_update.removals.iter_mut().collect_vec(),
-                &mutator_set_accumulator,
-            );
-            mutator_set_accumulator.add(addition);
-        }
-
         mutator_set_update.additions.extend(extra_addition_records);
-
         mutator_set_update
     }
 }
@@ -1155,9 +1143,8 @@ mod block_tests {
     }
 
     mod block_is_valid {
-        use crate::config_models::cli_args;
-
         use super::*;
+        use crate::config_models::cli_args;
 
         #[traced_test]
         #[tokio::test]

--- a/src/models/blockchain/block/mutator_set_update.rs
+++ b/src/models/blockchain/block/mutator_set_update.rs
@@ -1,5 +1,3 @@
-use std::ops::Add;
-
 use anyhow::bail;
 use anyhow::Result;
 use serde::Deserialize;
@@ -77,73 +75,6 @@ impl MutatorSetUpdate {
             ms_accumulator.remove(applied_removal_record);
         }
 
-        Ok(())
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
-pub struct MutatorSetUpdateSequence {
-    sequence: Vec<MutatorSetUpdate>,
-}
-
-impl From<MutatorSetUpdate> for MutatorSetUpdateSequence {
-    fn from(value: MutatorSetUpdate) -> Self {
-        Self {
-            sequence: vec![value],
-        }
-    }
-}
-
-impl<T: Into<MutatorSetUpdateSequence>> Add<T> for MutatorSetUpdateSequence {
-    type Output = MutatorSetUpdateSequence;
-
-    fn add(self, rhs: T) -> Self::Output {
-        Self {
-            sequence: [self.sequence, rhs.into().sequence].concat(),
-        }
-    }
-}
-
-impl Add<MutatorSetUpdate> for MutatorSetUpdate {
-    type Output = MutatorSetUpdateSequence;
-
-    fn add(self, rhs: MutatorSetUpdate) -> Self::Output {
-        Self::Output {
-            sequence: vec![self, rhs],
-        }
-    }
-}
-
-impl MutatorSetUpdateSequence {
-    /// Apply a sequence of mutator-set-updates to a mutator-set-accumulator.
-    ///
-    /// # Return Value
-    ///
-    /// Returns an error if some removal record could not be removed.
-    pub(crate) fn apply_to_accumulator(
-        &self,
-        mutator_set_accumulator: &mut MutatorSetAccumulator,
-    ) -> Result<()> {
-        for update in self.sequence.iter() {
-            update.apply_to_accumulator(mutator_set_accumulator)?;
-        }
-        Ok(())
-    }
-
-    /// Apply a sequence of mutator-set-updates to a mutator-set-accumulator and
-    /// a bunch of removal records.
-    ///
-    /// # Return Value
-    ///
-    /// Returns an error if some removal record could not be removed.
-    pub(crate) fn apply_to_accumulator_and_records(
-        &self,
-        mutator_set_accumulator: &mut MutatorSetAccumulator,
-        removal_records: &mut [&mut RemovalRecord],
-    ) -> Result<()> {
-        for update in self.sequence.iter() {
-            update.apply_to_accumulator_and_records(mutator_set_accumulator, removal_records)?;
-        }
         Ok(())
     }
 }

--- a/src/models/blockchain/block/validity/block_primitive_witness.rs
+++ b/src/models/blockchain/block/validity/block_primitive_witness.rs
@@ -52,21 +52,19 @@ impl BlockPrimitiveWitness {
 
     pub(crate) fn body(&self) -> &BlockBody {
         self.maybe_body.get_or_init(||{
-
-            
             assert_eq!(
-                self.predecessor_block.mutator_set_accumulator().hash(),
+                self.predecessor_block.mutator_set_accumulator_after().hash(),
                 self.transaction.kernel.mutator_set_hash,
-                "Mutator sets must agree in transaction and predecessor block."
+                "Mutator set of transaction must agree with mutator set after previous block."
             );
-            
-            let mut mutator_set = self.predecessor_block.mutator_set_accumulator();
+
+            let mut mutator_set = self.predecessor_block.mutator_set_accumulator_after();
             let mutator_set_update = MutatorSetUpdate::new(self.transaction.kernel.inputs.clone(), self.transaction.kernel.outputs.clone());
-            
+
             mutator_set_update.apply_to_accumulator(&mut mutator_set).unwrap_or_else(|e| {
                 panic!("attempting to produce a block body from a transaction whose mutator set update is incompatible: {e:?}");
             });
-            
+
             let predecessor_body = self.predecessor_block.body();
             let lock_free_mmr = predecessor_body.lock_free_mmr_accumulator.clone();
             let mut block_mmr = predecessor_body.block_mmr_accumulator.clone();
@@ -86,10 +84,18 @@ impl BlockPrimitiveWitness {
 pub(crate) mod test {
     use std::sync::OnceLock;
 
+    use itertools::izip;
+    use itertools::Itertools;
+    use num_traits::CheckedSub;
+    use proptest::collection::vec;
+    use proptest::prelude::Arbitrary;
     use proptest::prelude::BoxedStrategy;
     use proptest::strategy::Strategy;
     use proptest::test_runner::TestRunner;
     use proptest_arbitrary_interop::arb;
+    use tasm_lib::triton_vm::prelude::Tip5;
+    use tasm_lib::twenty_first::prelude::AlgebraicHasher;
+    use tasm_lib::Digest;
 
     use super::BlockPrimitiveWitness;
     use crate::job_queue::triton_vm::TritonVmJobPriority;
@@ -100,27 +106,42 @@ pub(crate) mod test {
     use crate::models::blockchain::block::block_kernel::BlockKernel;
     use crate::models::blockchain::block::Block;
     use crate::models::blockchain::block::BlockProof;
+    use crate::models::blockchain::block::TARGET_BLOCK_INTERVAL;
+    use crate::models::blockchain::transaction::lock_script::LockScript;
+    use crate::models::blockchain::transaction::lock_script::LockScriptAndWitness;
     use crate::models::blockchain::transaction::primitive_witness::PrimitiveWitness;
+    use crate::models::blockchain::transaction::utxo::Utxo;
     use crate::models::blockchain::transaction::validity::single_proof::SingleProof;
     use crate::models::blockchain::transaction::Transaction;
     use crate::models::blockchain::transaction::TransactionProof;
-    use crate::util_types::mutator_set::mutator_set_accumulator::MutatorSetAccumulator;
+    use crate::models::blockchain::type_scripts::neptune_coins::NeptuneCoins;
+    use crate::models::proof_abstractions::timestamp::Timestamp;
+    use crate::util_types::mutator_set::ms_membership_proof::MsMembershipProof;
+    use crate::util_types::mutator_set::msa_and_records::MsaAndRecords;
+    use crate::util_types::mutator_set::removal_record::RemovalRecord;
 
-    fn arbitrary_block_transaction_with_mutator_set(
-        num_inputs: usize,
+    fn arbitrary_block_transaction_from_msa_and_records(
         num_outputs: usize,
         num_announcements: usize,
-    ) -> BoxedStrategy<(Transaction, MutatorSetAccumulator)> {
+        msa_and_records: MsaAndRecords,
+        input_utxos: Vec<Utxo>,
+        lock_scripts_and_witnesses: Vec<LockScriptAndWitness>,
+        coinbase_amount: NeptuneCoins,
+        timestamp: Timestamp,
+    ) -> BoxedStrategy<Transaction> {
         (
-            PrimitiveWitness::arbitrary_pair_with_inputs_and_coinbase_respectively(
-                num_inputs,
+            PrimitiveWitness::arbitrary_pair_with_inputs_and_coinbase_respectively_from_msa_and_records(
                 num_outputs,
                 num_announcements,
+                msa_and_records,
+                input_utxos,
+                lock_scripts_and_witnesses,
+                coinbase_amount,
+                timestamp
             ),
             arb::<[u8; 32]>(),
         )
-            .prop_map(|((primwit_inputs, primwit_coinbase), shuffle_seed)| {
-                let mutator_set_accumulator = primwit_inputs.mutator_set_accumulator.clone();
+            .prop_map(move |((primwit_inputs, primwit_coinbase), shuffle_seed)| {
                 let rt = tokio::runtime::Runtime::new().unwrap();
                 let _guard = rt.enter();
 
@@ -148,16 +169,13 @@ pub(crate) mod test {
                     proof: TransactionProof::SingleProof(single_proof_coinbase),
                 };
 
-                (
-                    rt.block_on(tx_inputs.merge_with(
-                        tx_coinbase,
-                        shuffle_seed,
-                        &TritonVmJobQueue::dummy(),
-                        TritonVmJobPriority::default(),
-                    ))
-                    .unwrap(),
-                    mutator_set_accumulator,
-                )
+                rt.block_on(tx_inputs.merge_with(
+                    tx_coinbase,
+                    shuffle_seed,
+                    &TritonVmJobQueue::dummy(),
+                    TritonVmJobPriority::default(),
+                ))
+                .unwrap()
             })
             .boxed()
     }
@@ -173,31 +191,141 @@ pub(crate) mod test {
 
     impl BlockPrimitiveWitness {
         pub(crate) fn arbitrary() -> BoxedStrategy<BlockPrimitiveWitness> {
-            let parent_header = arb::<BlockHeader>();
-            let parent_appendix = arb::<BlockAppendix>();
-            let block_transaction_with_mutator_set =
-                arbitrary_block_transaction_with_mutator_set(2, 2, 2);
+            const NUM_INPUTS: usize = 2;
             (
-                parent_header,
-                parent_appendix,
-                block_transaction_with_mutator_set,
+                arb::<NeptuneCoins>(),
+                vec(0f64..1f64, NUM_INPUTS - 1),
+                vec(arb::<Digest>(), NUM_INPUTS),
+                vec(arb::<Digest>(), NUM_INPUTS),
+                vec(arb::<Digest>(), NUM_INPUTS),
+                0..u64::MAX,
             )
                 .prop_flat_map(
-                    move |(header, appendix, (block_tx, mutator_set_accumulator))| {
-                        BlockBody::arbitrary_with_mutator_set_accumulator(mutator_set_accumulator)
-                            .prop_map(move |body| {
-                                let parent_kernel = BlockKernel {
-                                    header: header.clone(),
-                                    body,
-                                    appendix: appendix.clone(),
-                                };
-                                let parent = Block {
-                                    kernel: parent_kernel,
-                                    proof: BlockProof::Invalid,
-                                    digest: OnceLock::new(),
-                                };
+                    |(
+                        total_input,
+                        input_distribution,
+                        hash_lock_keys,
+                        sender_randomnesses,
+                        receiver_preimages,
+                        aocl_size,
+                    )| {
+                        let mut input_amounts = input_distribution
+                            .into_iter()
+                            .map(|fraction| total_input.lossy_f64_fraction_mul(fraction).unwrap())
+                            .collect_vec();
+                        input_amounts.push(
+                            total_input
+                                .checked_sub(&input_amounts.iter().cloned().sum::<NeptuneCoins>())
+                                .unwrap(),
+                        );
+                        let lock_scripts_and_witnesses = hash_lock_keys
+                            .iter()
+                            .copied()
+                            .map(LockScriptAndWitness::hash_lock)
+                            .collect_vec();
+                        let lock_script_hashes = lock_scripts_and_witnesses
+                            .iter()
+                            .map(|lsaw| LockScript::from(lsaw).hash())
+                            .collect_vec();
+                        let input_utxos = input_amounts
+                            .into_iter()
+                            .zip(lock_script_hashes)
+                            .map(|(amount, hash)| Utxo {
+                                lock_script_hash: hash,
+                                coins: amount.to_native_coins(),
+                            })
+                            .collect_vec();
+                        let own_items = input_utxos.iter().map(Tip5::hash).collect_vec();
+                        let removables = izip!(
+                            own_items.iter().copied(),
+                            sender_randomnesses.iter().copied(),
+                            receiver_preimages.iter().copied()
+                        )
+                        .collect_vec();
+                        MsaAndRecords::arbitrary_with((removables.clone(), aocl_size))
+                            .prop_flat_map(move |msa_and_records| {
+                                let removal_records = msa_and_records.removal_records;
+                                let membership_proofs = msa_and_records.membership_proofs;
+                                let intermediate_mutator_set_accumulator =
+                                    msa_and_records.mutator_set_accumulator;
 
-                                BlockPrimitiveWitness::new(parent, block_tx.clone())
+                                let input_utxos = input_utxos.clone();
+                                let own_items = own_items.clone();
+                                let lock_scripts_and_witnesses = lock_scripts_and_witnesses.clone();
+
+                                let parent_header = arb::<BlockHeader>();
+                                let parent_appendix = arb::<BlockAppendix>();
+                                let parent_body = BlockBody::arbitrary_with_mutator_set_accumulator(
+                                    intermediate_mutator_set_accumulator.clone(),
+                                );
+                                (parent_header, parent_body, parent_appendix).prop_flat_map(
+                                    move |(header, body, appendix)| {
+                                        let parent_kernel = BlockKernel {
+                                            header: header.clone(),
+                                            body: body.clone(),
+                                            appendix: appendix.clone(),
+                                        };
+                                        let predecessor_block = Block {
+                                            kernel: parent_kernel,
+                                            proof: BlockProof::Invalid,
+                                            digest: OnceLock::new(),
+                                        };
+
+                                        let coinbase_amount = Block::block_subsidy(
+                                            predecessor_block.header().height.next(),
+                                        );
+                                        let timestamp = predecessor_block.header().timestamp
+                                            + TARGET_BLOCK_INTERVAL;
+
+                                        let miner_fee_records =
+                                            predecessor_block.guesser_fee_addition_records();
+
+                                        let mut mutator_set_accumulator_after_block =
+                                            intermediate_mutator_set_accumulator.clone();
+                                        let mut membership_proofs = membership_proofs.clone();
+                                        let mut removal_records = removal_records.clone();
+
+                                        for addition_record in &miner_fee_records {
+                                            MsMembershipProof::batch_update_from_addition(
+                                                &mut membership_proofs.iter_mut().collect_vec(),
+                                                &own_items.clone(),
+                                                &mutator_set_accumulator_after_block,
+                                                addition_record,
+                                            )
+                                            .expect("update from addition should always work");
+                                            RemovalRecord::batch_update_from_addition(
+                                                &mut removal_records.iter_mut().collect_vec(),
+                                                &mutator_set_accumulator_after_block,
+                                            );
+                                            mutator_set_accumulator_after_block
+                                                .add(addition_record);
+                                        }
+
+                                        let msa_and_records_after_block = MsaAndRecords {
+                                            mutator_set_accumulator:
+                                                mutator_set_accumulator_after_block,
+                                            removal_records,
+                                            membership_proofs,
+                                        };
+                                        arbitrary_block_transaction_from_msa_and_records(
+                                            2,
+                                            2,
+                                            msa_and_records_after_block,
+                                            input_utxos.clone(),
+                                            lock_scripts_and_witnesses.clone(),
+                                            coinbase_amount,
+                                            timestamp,
+                                        )
+                                        .prop_map(
+                                            move |block_tx| {
+                                                BlockPrimitiveWitness::new(
+                                                    predecessor_block.clone(),
+                                                    block_tx.clone(),
+                                                )
+                                            },
+                                        )
+                                    },
+                                )
                             })
                     },
                 )

--- a/src/models/blockchain/block/validity/block_primitive_witness.rs
+++ b/src/models/blockchain/block/validity/block_primitive_witness.rs
@@ -3,6 +3,7 @@ use std::sync::OnceLock;
 use tasm_lib::twenty_first::prelude::Mmr;
 
 use crate::models::blockchain::block::block_body::BlockBody;
+use crate::models::blockchain::block::mutator_set_update::MutatorSetUpdate;
 use crate::models::blockchain::block::Block;
 use crate::models::blockchain::transaction::Transaction;
 
@@ -18,14 +19,14 @@ use crate::models::blockchain::transaction::Transaction;
 ///                                                             |
 ///                                                             |---> BlockBody ----}-.
 ///                                                             |                     |
-/// TransactionIsValid : BlockConsensusProgram <-- conversion --+-> }                 |
-///  |               ? : BlockConsensusProgram <-- conversion --+-> } Appendix -----}-|
-///  | ......        ? : BlockConsensusProgram <-- conversion --'-> }                 |
-/// prove                                                                             |
-///  | prove                                                                          |
-///  |  | prove                                                                       |
-///  |  |  |                                                                          |-> Block
-///  v  v  v                                                                          |
+///        SingleProof : BlockConsensusProgram <-- conversion --+-> }                 |
+///         |        ? : BlockConsensusProgram <-- conversion --+-> } Appendix -----}-|
+///         | ...... ? : BlockConsensusProgram <-- conversion --'-> }                 |
+///        prove                                                                      |
+///         | prove                                                                   |
+///         |  | prove                                                                |
+///         |  |  |                                                                   |-> Block
+///         v  v  v                                                                   |
 /// AppendixWitness ---------------  produce  ----------------------> BlockProof ---}-|
 ///                                                                               |   |
 ///                                                                   mining -----'   |
@@ -52,27 +53,22 @@ impl BlockPrimitiveWitness {
     pub(crate) fn body(&self) -> &BlockBody {
         self.maybe_body.get_or_init(||{
 
-            let predecessor_body = self.predecessor_block.body();
-
+            
             assert_eq!(
-                predecessor_body.mutator_set_accumulator.hash(),
+                self.predecessor_block.mutator_set_accumulator().hash(),
                 self.transaction.kernel.mutator_set_hash,
                 "Mutator sets must agree in transaction and predecessor block."
             );
-
-
-            // All but two of the addition records stem from the transaction's
-            // outputs. The two remaining are the guesser-rewards from the
-            // previous block.
-            let mut mutator_set = predecessor_body.mutator_set_accumulator.clone();
-            let mutator_set_update = Block::ms_update_from_predecessor_and_new_tx_kernel(&self.predecessor_block, &self.transaction.kernel);
-
+            
+            let mut mutator_set = self.predecessor_block.mutator_set_accumulator();
+            let mutator_set_update = MutatorSetUpdate::new(self.transaction.kernel.inputs.clone(), self.transaction.kernel.outputs.clone());
+            
             mutator_set_update.apply_to_accumulator(&mut mutator_set).unwrap_or_else(|e| {
                 panic!("attempting to produce a block body from a transaction whose mutator set update is incompatible: {e:?}");
             });
-
+            
+            let predecessor_body = self.predecessor_block.body();
             let lock_free_mmr = predecessor_body.lock_free_mmr_accumulator.clone();
-
             let mut block_mmr = predecessor_body.block_mmr_accumulator.clone();
             block_mmr.append(self.predecessor_block.hash());
 

--- a/src/models/proof_abstractions/tasm/consensus_program_prover_job.rs
+++ b/src/models/proof_abstractions/tasm/consensus_program_prover_job.rs
@@ -83,6 +83,9 @@ impl ConsensusProgramProverJob {
                 self.nondeterminism.clone(),
             )
         };
+        if let Err(e) = vm_output {
+            panic!("VM run prior to proving should halt gracefully.\n{e}");
+        }
         assert!(vm_output.is_ok());
         assert_eq!(self.claim.program_digest, self.program.hash());
         assert_eq!(self.claim.output, vm_output?);

--- a/src/models/state/archival_state.rs
+++ b/src/models/state/archival_state.rs
@@ -917,18 +917,13 @@ impl ArchivalState {
                     .standard_format()
             );
 
-            // Apply the addition and removal records mimicking how they are
-            // applied to blocks: first tx addition records (while Updating
-            // removal records), then tx removal records, then guesser fee
-            // addition records.
-            let mut additions = apply_forward_block
-                .body()
-                .transaction_kernel
-                .outputs
-                .clone();
-            let mut removals = apply_forward_block.body().transaction_kernel.inputs.clone();
+            let MutatorSetUpdate {
+                mut additions,
+                mut removals,
+            } = apply_forward_block.mutator_set_update();
             additions.reverse();
             removals.reverse();
+
             let mut removals_mutable = removals.iter_mut().collect::<Vec<_>>();
 
             // Add items, thus adding the output UTXOs to the mutator set
@@ -955,15 +950,6 @@ impl ArchivalState {
                 self.archival_mutator_set
                     .ams_mut()
                     .remove(removal_record)
-                    .await;
-            }
-
-            // Add guesser fee addition records to the mutator set
-            for addition_record in apply_forward_block.guesser_fee_addition_records() {
-                // Add the element to the mutator set
-                self.archival_mutator_set
-                    .ams_mut()
-                    .add(&addition_record)
                     .await;
             }
         }

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -604,8 +604,7 @@ impl Mempool {
         let mut events = self.retain(keep);
 
         // Prepare a mutator set update to be applied to all retained items
-        let mutator_set_update =
-            Block::mutator_set_update_from_consecutive_pair(predecessor_block, new_block);
+        let mutator_set_update = new_block.mutator_set_update();
 
         // Update policy:
         // We update transaction if either of these conditions are true:
@@ -1146,7 +1145,7 @@ mod tests {
         let mut tx_by_alice_updated: Transaction =
             mempool.get_transactions_for_block(usize::MAX, None, true)[0].clone();
         assert!(
-            tx_by_alice_updated.is_confirmable_relative_to(block_2.mutator_set_accumulator()),
+            tx_by_alice_updated.is_confirmable_relative_to(&block_2.mutator_set_accumulator()),
             "Block with tx with updated mutator set data must be confirmable wrt. block_2"
         );
 
@@ -1386,7 +1385,7 @@ mod tests {
                 "The inserted tx must stay in the mempool"
             );
             assert!(
-                mempool_txs[0].is_confirmable_relative_to(next_block.mutator_set_accumulator()),
+                mempool_txs[0].is_confirmable_relative_to(&next_block.mutator_set_accumulator()),
                 "Mempool tx must stay confirmable after each new block has been applied"
             );
             assert!(mempool_txs[0].is_valid().await, "Tx should be valid.");
@@ -1417,7 +1416,7 @@ mod tests {
                 .mempool
                 .get_transactions_for_block(usize::MAX, None, false)
                 .iter()
-                .all(|tx| tx.is_confirmable_relative_to(block_1b.mutator_set_accumulator())),
+                .all(|tx| tx.is_confirmable_relative_to(&block_1b.mutator_set_accumulator())),
             "All retained txs in the mempool must be confirmable relative to the new block.
              Or the mempool must be empty."
         );

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -552,7 +552,8 @@ impl Mempool {
         priority: TritonVmJobPriority,
         composing: bool,
     ) -> Vec<MempoolEvent> {
-        let previous_mutator_set_accumulator = predecessor_block.mutator_set_accumulator().clone();
+        let previous_mutator_set_accumulator =
+            predecessor_block.mutator_set_accumulator_after().clone();
 
         // If we discover a reorganization, we currently just clear the mempool,
         // as we don't have the ability to roll transaction removal record integrity
@@ -1145,7 +1146,8 @@ mod tests {
         let mut tx_by_alice_updated: Transaction =
             mempool.get_transactions_for_block(usize::MAX, None, true)[0].clone();
         assert!(
-            tx_by_alice_updated.is_confirmable_relative_to(&block_2.mutator_set_accumulator()),
+            tx_by_alice_updated
+                .is_confirmable_relative_to(&block_2.mutator_set_accumulator_after()),
             "Block with tx with updated mutator set data must be confirmable wrt. block_2"
         );
 
@@ -1385,7 +1387,8 @@ mod tests {
                 "The inserted tx must stay in the mempool"
             );
             assert!(
-                mempool_txs[0].is_confirmable_relative_to(&next_block.mutator_set_accumulator()),
+                mempool_txs[0]
+                    .is_confirmable_relative_to(&next_block.mutator_set_accumulator_after()),
                 "Mempool tx must stay confirmable after each new block has been applied"
             );
             assert!(mempool_txs[0].is_valid().await, "Tx should be valid.");
@@ -1416,7 +1419,7 @@ mod tests {
                 .mempool
                 .get_transactions_for_block(usize::MAX, None, false)
                 .iter()
-                .all(|tx| tx.is_confirmable_relative_to(&block_1b.mutator_set_accumulator())),
+                .all(|tx| tx.is_confirmable_relative_to(&block_1b.mutator_set_accumulator_after())),
             "All retained txs in the mempool must be confirmable relative to the new block.
              Or the mempool must be empty."
         );

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -1459,11 +1459,7 @@ impl GlobalState {
             // update wallet state with relevant UTXOs from this block
             myself
                 .wallet_state
-                .update_wallet_state_with_new_block(
-                    &previous_ms_accumulator,
-                    tip_parent.guesser_fee_addition_records(),
-                    &new_block,
-                )
+                .update_wallet_state_with_new_block(&previous_ms_accumulator, &new_block)
                 .await?;
 
             // Update mempool with UTXOs from this block. This is done by removing all transaction

--- a/src/models/state/wallet/mod.rs
+++ b/src/models/state/wallet/mod.rs
@@ -505,7 +505,7 @@ mod wallet_tests {
                 next_block = nb;
                 alice
                     .update_wallet_state_with_new_block(
-                        &previous_block.mutator_set_accumulator(),
+                        &previous_block.mutator_set_accumulator_after(),
                         previous_block.guesser_fee_addition_records(),
                         &next_block,
                     )
@@ -526,7 +526,7 @@ mod wallet_tests {
                 .unwrap();
             assert!(
                 next_block
-                    .mutator_set_accumulator()
+                    .mutator_set_accumulator_after()
                     .verify(Hash::hash(&genesis_block_utxo), &ms_membership_proof),
                 "Membership proof must be valid after updating wallet state with generated blocks"
             );
@@ -572,7 +572,7 @@ mod wallet_tests {
         );
         alice_wallet
             .update_wallet_state_with_new_block(
-                &genesis_block.mutator_set_accumulator(),
+                &genesis_block.mutator_set_accumulator_after(),
                 vec![],
                 &block_1,
             )
@@ -605,7 +605,7 @@ mod wallet_tests {
             .get_membership_proof_for_block(block_1.hash())
             .unwrap();
         assert!(block_1
-            .mutator_set_accumulator()
+            .mutator_set_accumulator_after()
             .verify(alice_block_1_cb_item, &ms_membership_proof_block1));
 
         // Create new blocks, verify that the membership proofs are *not* valid
@@ -624,7 +624,7 @@ mod wallet_tests {
             // path having a length of zero).
             assert!(
                 !block_3
-                    .mutator_set_accumulator()
+                    .mutator_set_accumulator_after()
                     .verify(alice_block_1_cb_item, &ms_membership_proof_block1),
                 "membership proof must be invalid before updating wallet state"
             );
@@ -633,7 +633,7 @@ mod wallet_tests {
         // Verify that the membership proof is valid *after* running the updater
         alice_wallet
             .update_wallet_state_with_new_block(
-                &block_1.mutator_set_accumulator(),
+                &block_1.mutator_set_accumulator_after(),
                 block_1.guesser_fee_addition_records(),
                 &block_2,
             )
@@ -641,7 +641,7 @@ mod wallet_tests {
             .unwrap();
         alice_wallet
             .update_wallet_state_with_new_block(
-                &block_2.mutator_set_accumulator(),
+                &block_2.mutator_set_accumulator_after(),
                 block_2.guesser_fee_addition_records(),
                 &block_3,
             )
@@ -656,7 +656,7 @@ mod wallet_tests {
                 .get_membership_proof_for_block(block_3.hash())
                 .unwrap();
             let membership_proof_is_valid = block_3
-                .mutator_set_accumulator()
+                .mutator_set_accumulator_after()
                 .verify(alice_block_1_cb_item, &ms_membership_proof_block3);
             assert!(
                 membership_proof_is_valid,
@@ -820,7 +820,7 @@ mod wallet_tests {
         );
 
         // This block throws away two UTXOs. So the new balance becomes 2000.
-        let msa_tip_previous = next_block.mutator_set_accumulator().clone();
+        let msa_tip_previous = next_block.mutator_set_accumulator_after().clone();
         let output_utxo =
             Utxo::new_native_currency(LockScript::anyone_can_spend(), NeptuneCoins::new(200));
         let tx_outputs: TxOutputList =
@@ -834,7 +834,7 @@ mod wallet_tests {
         let tx = make_mock_transaction_with_mutator_set_hash(
             removal_records,
             addition_records,
-            next_block.mutator_set_accumulator().hash(),
+            next_block.mutator_set_accumulator_after().hash(),
         );
 
         let next_block = Block::block_template_invalid_proof(
@@ -985,7 +985,7 @@ mod wallet_tests {
         // Verify that all monitored UTXOs have valid membership proofs
         for monitored_utxo in alice_monitored_utxos {
             assert!(
-                block_1.mutator_set_accumulator().verify(
+                block_1.mutator_set_accumulator_after().verify(
                     Hash::hash(&monitored_utxo.utxo),
                     &monitored_utxo
                         .get_membership_proof_for_block(block_1.hash())
@@ -1035,12 +1035,14 @@ mod wallet_tests {
         );
         for monitored_utxo in alice_monitored_utxos {
             assert!(
-                first_block_after_spree.mutator_set_accumulator().verify(
-                    Hash::hash(&monitored_utxo.utxo),
-                    &monitored_utxo
-                        .get_membership_proof_for_block(first_block_after_spree.hash())
-                        .unwrap()
-                ),
+                first_block_after_spree
+                    .mutator_set_accumulator_after()
+                    .verify(
+                        Hash::hash(&monitored_utxo.utxo),
+                        &monitored_utxo
+                            .get_membership_proof_for_block(first_block_after_spree.hash())
+                            .unwrap()
+                    ),
                 "All membership proofs must be valid after this block"
             )
         }
@@ -1110,7 +1112,7 @@ mod wallet_tests {
         // Verify that all monitored UTXOs (with synced MPs) have valid membership proofs
         for monitored_utxo in alice_monitored_utxos_at_2b.iter() {
             assert!(
-                block_2_b.mutator_set_accumulator().verify(
+                block_2_b.mutator_set_accumulator_after().verify(
                     Hash::hash(&monitored_utxo.utxo),
                     &monitored_utxo
                         .get_membership_proof_for_block(block_2_b.hash())
@@ -1133,7 +1135,7 @@ mod wallet_tests {
             .await
             .wallet_state
             .update_wallet_state_with_new_block(
-                &first_block_after_spree.mutator_set_accumulator(),
+                &first_block_after_spree.mutator_set_accumulator_after(),
                 first_block_after_spree.guesser_fee_addition_records(),
                 &first_block_continuing_spree,
             )
@@ -1158,7 +1160,7 @@ mod wallet_tests {
         for monitored_utxo in alice_monitored_utxos_after_continued_spree.iter() {
             assert!(
                 first_block_continuing_spree
-                    .mutator_set_accumulator()
+                    .mutator_set_accumulator_after()
                     .verify(
                         Hash::hash(&monitored_utxo.utxo),
                         &monitored_utxo
@@ -1258,7 +1260,7 @@ mod wallet_tests {
             .await
             .wallet_state
             .update_wallet_state_with_new_block(
-                &block_2_b.mutator_set_accumulator(),
+                &block_2_b.mutator_set_accumulator_after(),
                 block_2_b.guesser_fee_addition_records(),
                 &block_3_b,
             )
@@ -1289,7 +1291,7 @@ mod wallet_tests {
         for monitored_utxo in alice_monitored_utxos_3b {
             assert!(
                 monitored_utxo.spent_in_block.is_some()
-                    || block_3_b.mutator_set_accumulator().verify(
+                    || block_3_b.mutator_set_accumulator_after().verify(
                         Hash::hash(&monitored_utxo.utxo),
                         &monitored_utxo
                             .get_membership_proof_for_block(block_3_b.hash())
@@ -1311,7 +1313,7 @@ mod wallet_tests {
             .await
             .wallet_state
             .update_wallet_state_with_new_block(
-                &first_block_continuing_spree.mutator_set_accumulator(),
+                &first_block_continuing_spree.mutator_set_accumulator_after(),
                 first_block_continuing_spree.guesser_fee_addition_records(),
                 &second_block_continuing_spree,
             )
@@ -1335,7 +1337,7 @@ mod wallet_tests {
             assert!(
                 monitored_utxo.spent_in_block.is_some()
                     || second_block_continuing_spree
-                        .mutator_set_accumulator()
+                        .mutator_set_accumulator_after()
                         .verify(
                             Hash::hash(&monitored_utxo.utxo),
                             &monitored_utxo

--- a/src/models/state/wallet/mod.rs
+++ b/src/models/state/wallet/mod.rs
@@ -505,7 +505,7 @@ mod wallet_tests {
                 next_block = nb;
                 alice
                     .update_wallet_state_with_new_block(
-                        previous_block.mutator_set_accumulator(),
+                        &previous_block.mutator_set_accumulator(),
                         previous_block.guesser_fee_addition_records(),
                         &next_block,
                     )
@@ -572,7 +572,7 @@ mod wallet_tests {
         );
         alice_wallet
             .update_wallet_state_with_new_block(
-                genesis_block.mutator_set_accumulator(),
+                &genesis_block.mutator_set_accumulator(),
                 vec![],
                 &block_1,
             )
@@ -633,7 +633,7 @@ mod wallet_tests {
         // Verify that the membership proof is valid *after* running the updater
         alice_wallet
             .update_wallet_state_with_new_block(
-                block_1.mutator_set_accumulator(),
+                &block_1.mutator_set_accumulator(),
                 block_1.guesser_fee_addition_records(),
                 &block_2,
             )
@@ -641,7 +641,7 @@ mod wallet_tests {
             .unwrap();
         alice_wallet
             .update_wallet_state_with_new_block(
-                block_2.mutator_set_accumulator(),
+                &block_2.mutator_set_accumulator(),
                 block_2.guesser_fee_addition_records(),
                 &block_3,
             )
@@ -1133,7 +1133,7 @@ mod wallet_tests {
             .await
             .wallet_state
             .update_wallet_state_with_new_block(
-                first_block_after_spree.mutator_set_accumulator(),
+                &first_block_after_spree.mutator_set_accumulator(),
                 first_block_after_spree.guesser_fee_addition_records(),
                 &first_block_continuing_spree,
             )
@@ -1258,7 +1258,7 @@ mod wallet_tests {
             .await
             .wallet_state
             .update_wallet_state_with_new_block(
-                block_2_b.mutator_set_accumulator(),
+                &block_2_b.mutator_set_accumulator(),
                 block_2_b.guesser_fee_addition_records(),
                 &block_3_b,
             )
@@ -1311,7 +1311,7 @@ mod wallet_tests {
             .await
             .wallet_state
             .update_wallet_state_with_new_block(
-                first_block_continuing_spree.mutator_set_accumulator(),
+                &first_block_continuing_spree.mutator_set_accumulator(),
                 first_block_continuing_spree.guesser_fee_addition_records(),
                 &second_block_continuing_spree,
             )

--- a/src/models/state/wallet/mod.rs
+++ b/src/models/state/wallet/mod.rs
@@ -506,7 +506,6 @@ mod wallet_tests {
                 alice
                     .update_wallet_state_with_new_block(
                         &previous_block.mutator_set_accumulator_after(),
-                        previous_block.guesser_fee_addition_records(),
                         &next_block,
                     )
                     .await
@@ -573,7 +572,6 @@ mod wallet_tests {
         alice_wallet
             .update_wallet_state_with_new_block(
                 &genesis_block.mutator_set_accumulator_after(),
-                vec![],
                 &block_1,
             )
             .await
@@ -632,19 +630,11 @@ mod wallet_tests {
 
         // Verify that the membership proof is valid *after* running the updater
         alice_wallet
-            .update_wallet_state_with_new_block(
-                &block_1.mutator_set_accumulator_after(),
-                block_1.guesser_fee_addition_records(),
-                &block_2,
-            )
+            .update_wallet_state_with_new_block(&block_1.mutator_set_accumulator_after(), &block_2)
             .await
             .unwrap();
         alice_wallet
-            .update_wallet_state_with_new_block(
-                &block_2.mutator_set_accumulator_after(),
-                block_2.guesser_fee_addition_records(),
-                &block_3,
-            )
+            .update_wallet_state_with_new_block(&block_2.mutator_set_accumulator_after(), &block_3)
             .await
             .unwrap();
 
@@ -1136,7 +1126,6 @@ mod wallet_tests {
             .wallet_state
             .update_wallet_state_with_new_block(
                 &first_block_after_spree.mutator_set_accumulator_after(),
-                first_block_after_spree.guesser_fee_addition_records(),
                 &first_block_continuing_spree,
             )
             .await
@@ -1261,7 +1250,6 @@ mod wallet_tests {
             .wallet_state
             .update_wallet_state_with_new_block(
                 &block_2_b.mutator_set_accumulator_after(),
-                block_2_b.guesser_fee_addition_records(),
                 &block_3_b,
             )
             .await
@@ -1314,7 +1302,6 @@ mod wallet_tests {
             .wallet_state
             .update_wallet_state_with_new_block(
                 &first_block_continuing_spree.mutator_set_accumulator_after(),
-                first_block_continuing_spree.guesser_fee_addition_records(),
                 &second_block_continuing_spree,
             )
             .await

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -946,10 +946,10 @@ impl WalletState {
 
         // Sanity check that `msa_state` agrees with the mutator set from the applied block
         assert_eq!(
-            new_block.mutator_set_accumulator().clone().hash(),
+            new_block.mutator_set_accumulator_after().clone().hash(),
             msa_state.hash(),
             "\n\nMutator set in applied block:\n{}\n\nmust agree with that in wallet handler:\n{}\n\n",
-            new_block.mutator_set_accumulator().clone().hash(),
+            new_block.mutator_set_accumulator_after().clone().hash(),
             msa_state.hash(),
         );
 
@@ -1327,7 +1327,7 @@ mod tests {
                 make_mock_block(&latest_block, None, alice_address, rng.gen());
             bob.wallet_state
                 .update_wallet_state_with_new_block(
-                    &latest_block.mutator_set_accumulator(),
+                    &latest_block.mutator_set_accumulator_after(),
                     latest_block.guesser_fee_addition_records(),
                     &new_block,
                 )
@@ -1531,7 +1531,7 @@ mod tests {
                 .1
                 .clone();
             assert!(genesis_block
-                .mutator_set_accumulator()
+                .mutator_set_accumulator_after()
                 .verify(Hash::hash(&utxo), &ms_membership_proof));
         }
     }

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -45,6 +45,7 @@ use crate::database::storage::storage_schema::DbtVec;
 use crate::database::storage::storage_vec::traits::*;
 use crate::database::storage::storage_vec::Index;
 use crate::database::NeptuneLevelDb;
+use crate::models::blockchain::block::mutator_set_update::MutatorSetUpdate;
 use crate::models::blockchain::block::Block;
 use crate::models::blockchain::transaction::transaction_kernel::TransactionKernel;
 use crate::models::blockchain::transaction::transaction_output::TxOutputList;
@@ -721,11 +722,10 @@ impl WalletState {
 
         let onchain_received_outputs = self.scan_for_announced_utxos(&tx_kernel);
 
-        let addition_records = [
-            guesser_fee_records,
-            new_block.kernel.body.transaction_kernel.outputs.clone(),
-        ]
-        .concat();
+        let MutatorSetUpdate {
+            additions: addition_records,
+            removals: _removal_records,
+        } = new_block.mutator_set_update();
 
         let offchain_received_outputs = self
             .scan_addition_records_for_expected_utxos(&addition_records)
@@ -1327,7 +1327,7 @@ mod tests {
                 make_mock_block(&latest_block, None, alice_address, rng.gen());
             bob.wallet_state
                 .update_wallet_state_with_new_block(
-                    latest_block.mutator_set_accumulator(),
+                    &latest_block.mutator_set_accumulator(),
                     latest_block.guesser_fee_addition_records(),
                     &new_block,
                 )

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -240,7 +240,6 @@ impl WalletState {
             wallet_state
                 .update_wallet_state_with_new_block(
                     &MutatorSetAccumulator::default(),
-                    vec![],
                     &Block::genesis_block(cli_args.network),
                 )
                 .await
@@ -635,7 +634,6 @@ impl WalletState {
     pub async fn update_wallet_state_with_new_block(
         &mut self,
         previous_mutator_set_accumulator: &MutatorSetAccumulator,
-        guesser_fee_records: Vec<AdditionRecord>,
         new_block: &Block,
     ) -> Result<()> {
         /// Preprocess all own monitored UTXOs prior to processing of the block.
@@ -1328,7 +1326,6 @@ mod tests {
             bob.wallet_state
                 .update_wallet_state_with_new_block(
                     &latest_block.mutator_set_accumulator_after(),
-                    latest_block.guesser_fee_addition_records(),
                     &new_block,
                 )
                 .await

--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -937,7 +937,7 @@ impl PeerLoopHandler {
                     .await
                     .chain
                     .light_state()
-                    .mutator_set_accumulator();
+                    .mutator_set_accumulator_after();
                 let confirmable =
                     transaction.is_confirmable_relative_to(&mutator_set_accumulator_after);
                 if !confirmable {
@@ -1003,7 +1003,11 @@ impl PeerLoopHandler {
 
                 // Only accept transactions that do not require executing
                 // `update`.
-                if state.chain.light_state().mutator_set_accumulator().hash()
+                if state
+                    .chain
+                    .light_state()
+                    .mutator_set_accumulator_after()
+                    .hash()
                     != tx_notification.mutator_set_hash
                 {
                     debug!("transaction refers to non-canonical mutator set state");

--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -931,14 +931,15 @@ impl PeerLoopHandler {
                 }
 
                 // 4 if transaction is not confirmable, punish.
-                let confirmable = transaction.is_confirmable_relative_to(
-                    self.global_state_lock
-                        .lock_guard()
-                        .await
-                        .chain
-                        .light_state()
-                        .mutator_set_accumulator(),
-                );
+                let mutator_set_accumulator_after = self
+                    .global_state_lock
+                    .lock_guard()
+                    .await
+                    .chain
+                    .light_state()
+                    .mutator_set_accumulator();
+                let confirmable =
+                    transaction.is_confirmable_relative_to(&mutator_set_accumulator_after);
                 if !confirmable {
                     warn!("Received unconfirmable tx");
                     self.punish(PeerSanctionReason::UnconfirmableTransaction)

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -622,8 +622,10 @@ pub(crate) fn invalid_block_with_transaction(
     let mut block_mmr = previous_block.kernel.body.block_mmr_accumulator.clone();
     block_mmr.append(previous_block.hash());
 
-    let ms_update =
-        Block::ms_update_from_predecessor_and_new_tx_kernel(previous_block, &transaction.kernel);
+    let ms_update = MutatorSetUpdate::new(
+        transaction.kernel.inputs.clone(),
+        transaction.kernel.outputs.clone(),
+    );
     ms_update
         .apply_to_accumulator(&mut next_mutator_set)
         .unwrap();

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -207,7 +207,7 @@ pub(crate) async fn mock_genesis_global_state(
     let light_state: LightState = LightState::from(genesis_block.to_owned());
     println!(
         "Genesis light state MSA hash: {}",
-        light_state.mutator_set_accumulator().hash()
+        light_state.mutator_set_accumulator_after().hash()
     );
     let blockchain_state = BlockchainState::Archival(BlockchainArchivalState {
         light_state,
@@ -618,7 +618,7 @@ pub(crate) fn invalid_block_with_transaction(
         difficulty: previous_block.header().difficulty,
     };
 
-    let mut next_mutator_set = previous_block.mutator_set_accumulator().clone();
+    let mut next_mutator_set = previous_block.mutator_set_accumulator_after().clone();
     let mut block_mmr = previous_block.kernel.body.block_mmr_accumulator.clone();
     block_mmr.append(previous_block.hash());
 
@@ -676,7 +676,7 @@ pub(crate) fn make_mock_block(
         fee: NeptuneCoins::zero(),
         timestamp: block_timestamp,
         coinbase: Some(coinbase_amount),
-        mutator_set_hash: previous_block.mutator_set_accumulator().hash(),
+        mutator_set_hash: previous_block.mutator_set_accumulator_after().hash(),
     };
     let tx = Transaction {
         kernel: tx_kernel,
@@ -802,7 +802,7 @@ pub(crate) fn invalid_empty_block(predecessor: &Block) -> Block {
     let tx = make_mock_transaction_with_mutator_set_hash(
         vec![],
         vec![],
-        predecessor.mutator_set_accumulator().hash(),
+        predecessor.mutator_set_accumulator_after().hash(),
     );
     let timestamp = predecessor.header().timestamp + Timestamp::hours(1);
     Block::block_template_invalid_proof(predecessor, tx, timestamp, Digest::default(), None)
@@ -845,7 +845,7 @@ pub(crate) async fn valid_successor_for_tests(
         TxOutputList::default(),
         NeptuneCoins::zero(),
         timestamp,
-        predecessor.mutator_set_accumulator().clone(),
+        predecessor.mutator_set_accumulator_after().clone(),
     )
     .unwrap();
     let tx = GlobalState::create_raw_transaction(

--- a/src/util_types/mutator_set/ms_membership_proof.rs
+++ b/src/util_types/mutator_set/ms_membership_proof.rs
@@ -1442,6 +1442,8 @@ mod ms_proof_tests {
             mutator_set_accumulator.prove(own_item, sender_randomness, receiver_preimage);
         mutator_set_accumulator.add(&own_addition_record);
 
+        // aocl leaf count is now 42966841942012424_u64
+
         let other_addition_record = AdditionRecord::new(rng.gen::<Digest>());
 
         msmp.update_from_addition(own_item, &mutator_set_accumulator, &other_addition_record)

--- a/src/util_types/mutator_set/msa_and_records.rs
+++ b/src/util_types/mutator_set/msa_and_records.rs
@@ -155,7 +155,7 @@ impl Arbitrary for MsaAndRecords {
                         let all_index_sets = all_index_sets.clone();
                         let aocl_membership_proofs = aocl_membership_proofs.clone();
                         let removables = removables.clone();
-                        let swbf_mmr_leaf_count = aocl_mmra.num_leafs() / (BATCH_SIZE as u64);
+                        let swbf_mmr_leaf_count = (aocl_mmra.num_leafs() / (BATCH_SIZE as u64)).saturating_sub(1);
                         let aocl_leaf_indices = aocl_leaf_indices.clone();
 
                         // unwrap random swbf mmra and membership proofs


### PR DESCRIPTION
This PR makes a distinction between the mutator set as presented in the block body, which is in an in-between state; and the mutator set implicitly defined by the block, which includes the guesser fee UTXOs and cannot be inferred from the block transaction alone. The `Arbitrary` implementation for `BlockPrimitiveWitness` takes the new dependency graph into account.

I cannot run all tests in a feasible amount of time because of the requirement to produce proofs. At this point I think all tests probably will pass.