### PR TITLE
Offchain notifications

### DIFF
--- a/scripts/linux/testnet-premine-receiver-no-mine-from-genesis-faked-time.sh
+++ b/scripts/linux/testnet-premine-receiver-no-mine-from-genesis-faked-time.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Run one instance without mining, with a faked time such that the premine UTXO
+# can be spent immediately.
+
+set -e # Exit on first error.
+
+export RUST_LOG=debug;
+
+# Build before proceeding
+cargo build
+
+NC_LOCAL_STATE_DIR="$HOME/.local/share/neptune-integration-test-from-genesis"
+rm -rf $NC_LOCAL_STATE_DIR
+
+NC_DATA_DIRECTORY="$NC_LOCAL_STATE_DIR/0"
+NC_WALLET_DIRECTORY="$NC_DATA_DIRECTORY/neptune/testnet/wallet"
+mkdir -p "$NC_WALLET_DIRECTORY"
+echo '{"name":"standard_wallet","secret_seed":{"coefficients":[12063201067205522823,1529663126377206632,2090171368883726200]},"version":0}' > $NC_WALLET_DIRECTORY/wallet.dat
+
+# Fake that time locked UTXOs from premine are no longer timelocked
+export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/faketime/libfaketime.so.1
+export FAKETIME="+200d"
+
+# LD_PRELOAD=/usr/lib/x86_64-linux-gnu/faketime/libfaketime.so.1 FAKETIME="+200d" RUST_BACKTRACE=1 XDG_DATA_HOME="$NC_DATA_DIRECTORY" nice -n 1 --  cargo run -- --network testnet --tx-proving-capability=proofcollection --peer-port 29790 --rpc-port 19790  2>&1 | tee integration_test.log | sed 's/(.*)/\0 \[I0\]/g'  &
+XDG_DATA_HOME="$NC_LOCAL_STATE_DIR/0/" cargo run -- --network testnet --tx-proving-capability=proofcollection --peer-port 29790 --rpc-port 19790 --max-peers=1 2>&1 | tee integration_test0.log | sed 's/(.*)/\0 \[I0\]/g'  &
+pid[0]=$!
+sleep 2s;
+
+XDG_DATA_HOME="$NC_LOCAL_STATE_DIR/1/" cargo run -- --network testnet --tx-proving-capability=proofcollection --peer-port 29791 --rpc-port 19791 --max-peers=1 --peers 127.0.0.1:29790 2>&1 | tee integration_test1.log | sed 's/(.*)/\0 \[I1\]/g'  &
+pid[0]=$!
+sleep 2s;
+
+# Inspired by https://stackoverflow.com/a/52033580/2574407
+trap 'kill -0 ${pid[0]}; exit 0' SIGINT
+wait

--- a/src/bin/dashboard_src/send_screen.rs
+++ b/src/bin/dashboard_src/send_screen.rs
@@ -142,6 +142,7 @@ impl SendScreen {
                 valid_amount,
                 valid_address,
                 UtxoNotificationMedium::OnChain,
+                UtxoNotificationMedium::OnChain,
                 fee,
             )
             .await

--- a/src/config_models/data_directory.rs
+++ b/src/config_models/data_directory.rs
@@ -17,6 +17,8 @@ use crate::models::state::wallet::WALLET_DB_NAME;
 use crate::models::state::wallet::WALLET_DIRECTORY;
 use crate::models::state::wallet::WALLET_OUTPUT_COUNT_DB_NAME;
 
+const UTXO_TRANSFER_DIRECTORY: &str = "utxo-transfer";
+
 // TODO: Add `rusty_leveldb::Options` and `fs::OpenOptions` here too, since they keep being repeated.
 #[derive(Debug, Clone)]
 pub struct DataDirectory {
@@ -89,6 +91,18 @@ impl DataDirectory {
     /// This directory lives within `DataDirectory::database_dir_path()`.
     pub fn banned_ips_database_dir_path(&self) -> PathBuf {
         self.database_dir_path().join(Path::new(BANNED_IPS_DB_NAME))
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    ///
+    /// utxo-transfer path
+    ///
+    /// for storing off-chain serialized transfer files.
+    ///
+    /// note: this is not used by neptune-core, but is used/shared by
+    ///       neptune-cli, neptune-dashboard
+    pub fn utxo_transfer_directory_path(&self) -> PathBuf {
+        self.data_dir.join(Path::new(UTXO_TRANSFER_DIRECTORY))
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,7 +265,6 @@ pub async fn initialize(cli_args: cli_args::Args) -> Result<()> {
             // the generated RPC trait.
             .map(move |channel| {
                 let server = rpc_server::NeptuneRPCServer {
-                    socket_address: channel.transport().peer_addr().unwrap(),
                     state: rpc_state_lock.clone(),
                     rpc_server_to_main_tx: rpc_server_to_main_tx.clone(),
                 };

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -324,10 +324,12 @@ pub(crate) async fn make_coinbase_transaction(
         .generate_sender_randomness(next_block_height, receiving_address.privacy_digest);
 
     // TODO: Produce two outputs here, one timelocked and one not.
+    let owned = true;
     let coinbase_output = TxOutput::offchain_native_currency(
         amount_to_prover,
         sender_randomness,
         receiving_address.into(),
+        owned,
     );
 
     let transaction_details = TransactionDetails::new_with_coinbase(
@@ -859,6 +861,7 @@ pub(crate) mod mine_loop_tests {
             NeptuneCoins::new(4),
             rng.gen(),
             alice_key.to_address().into(),
+            false,
         );
         let (tx_from_alice, _maybe_change_output) = alice
             .lock_guard()

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -1359,6 +1359,7 @@ mod block_tests {
             NeptuneCoins::new(4),
             rng.gen(),
             alice_address.into(),
+            true,
         );
         let fee = NeptuneCoins::new(1);
         let (tx1, _) = alice

--- a/src/models/channel.rs
+++ b/src/models/channel.rs
@@ -12,6 +12,7 @@ use super::blockchain::type_scripts::neptune_coins::NeptuneCoins;
 use super::peer::transaction_notification::TransactionNotification;
 use super::proof_abstractions::mast_hash::MastHash;
 use super::state::wallet::expected_utxo::ExpectedUtxo;
+use super::state::wallet::monitored_utxo::MonitoredUtxo;
 
 #[derive(Clone, Debug)]
 pub(crate) enum MainToMiner {
@@ -156,21 +157,21 @@ impl PeerTaskToMain {
     }
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct ClaimUtxoData {
+    /// Some(mutxo) if UTXO has already been mined. Otherwise None.
+    pub(crate) prepared_monitored_utxo: Option<MonitoredUtxo>,
+
+    /// Indicates if wallet already expects this UTXO.
+    pub(crate) has_expected_utxo: bool,
+
+    pub(crate) expected_utxo: ExpectedUtxo,
+}
+
 #[derive(Clone, Debug)]
-pub enum RPCServerToMain {
+pub(crate) enum RPCServerToMain {
     BroadcastTx(Box<Transaction>),
     Shutdown,
     PauseMiner,
     RestartMiner,
-}
-
-impl RPCServerToMain {
-    pub fn get_type(&self) -> String {
-        match self {
-            RPCServerToMain::BroadcastTx(_) => "broadcast transaction".to_string(),
-            RPCServerToMain::Shutdown => "shutdown".to_string(),
-            RPCServerToMain::PauseMiner => "pause miner".to_owned(),
-            RPCServerToMain::RestartMiner => "restart miner".to_owned(),
-        }
-    }
 }

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -1113,6 +1113,7 @@ mod tests {
                 amount,
                 rng.gen(),
                 bob_address.into(),
+                true,
             ));
         }
 
@@ -1158,6 +1159,7 @@ mod tests {
             NeptuneCoins::new(68),
             rng.gen(),
             alice_address.into(),
+            true,
         )];
         let (tx_from_alice_original, _maybe_change_output) = alice
             .lock_guard()
@@ -1423,8 +1425,12 @@ mod tests {
             .nth_generation_spending_key_for_tests(0)
             .to_address();
 
-        let tx_receiver_data =
-            TxOutput::onchain_native_currency(NeptuneCoins::new(1), rng.gen(), bob_address.into());
+        let tx_receiver_data = TxOutput::onchain_native_currency(
+            NeptuneCoins::new(1),
+            rng.gen(),
+            bob_address.into(),
+            false,
+        );
 
         let genesis_block = alice
             .lock_guard()
@@ -1544,6 +1550,7 @@ mod tests {
                     NeptuneCoins::new(1),
                     sender_randomness,
                     premine_address.into(),
+                    false,
                 );
                 let tx_outputs: TxOutputList = vec![receiver_data.clone()].into();
                 let (tx, _maybe_change_output) = preminer_clone

--- a/src/models/state/wallet/address.rs
+++ b/src/models/state/wallet/address.rs
@@ -1,6 +1,7 @@
 mod address_type;
 mod common;
 
+pub mod encrypted_utxo_notification;
 pub mod generation_address;
 pub mod symmetric_key;
 

--- a/src/models/state/wallet/address/common.rs
+++ b/src/models/state/wallet/address/common.rs
@@ -8,10 +8,20 @@ use twenty_first::math::b_field_element::BFieldElement;
 use twenty_first::math::tip5::Digest;
 use twenty_first::util_types::algebraic_hasher::AlgebraicHasher;
 
+use crate::config_models::network::Network;
 use crate::models::blockchain::shared::Hash;
 use crate::models::blockchain::transaction::PublicAnnouncement;
 use crate::models::state::wallet::transaction_output::UtxoNotificationPayload;
 use crate::prelude::twenty_first;
+
+/// returns human-readable-prefix for the given network
+pub(crate) fn network_hrp_char(network: Network) -> char {
+    match network {
+        Network::Alpha | Network::Beta | Network::Main => 'm',
+        Network::Testnet => 't',
+        Network::RegTest => 'r',
+    }
+}
 
 /// Derive a receiver id from a seed.
 pub fn derive_receiver_id(seed: Digest) -> BFieldElement {

--- a/src/models/state/wallet/address/encrypted_utxo_notification.rs
+++ b/src/models/state/wallet/address/encrypted_utxo_notification.rs
@@ -1,7 +1,18 @@
+use anyhow::bail;
+use anyhow::Result;
+use bech32::FromBase32;
+use bech32::ToBase32;
 use get_size::GetSize;
 use serde::Deserialize;
 use serde::Serialize;
+use tasm_lib::triton_vm::prelude::BFieldCodec;
 use tasm_lib::triton_vm::prelude::BFieldElement;
+
+use super::SpendingKey;
+use crate::config_models::network::Network;
+use crate::models::blockchain::transaction::PublicAnnouncement;
+use crate::models::state::wallet::address::common::network_hrp_char;
+use crate::models::state::wallet::transaction_output::UtxoNotificationPayload;
 
 /// an encrypted wrapper for UTXO notifications.
 ///
@@ -13,11 +24,177 @@ use tasm_lib::triton_vm::prelude::BFieldElement;
 ///
 /// the receiver_identifier enables the receiver to find the matching
 /// `SpendingKey` in their wallet.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, GetSize, Serialize, Deserialize)]
-pub(crate) struct EncryptedNotification {
-    /// Encrypted UTXO notification.
-    pub ciphertext: Vec<BFieldElement>,
+#[derive(Clone, Debug, PartialEq, Eq, Hash, GetSize, Serialize, Deserialize, BFieldCodec)]
+pub(crate) struct EncryptedUtxoNotification {
+    /// Describes the type of encoding used here
+    pub(crate) flag: BFieldElement,
 
     /// enables the receiver to find the matching `SpendingKey` in their wallet.
-    pub receiver_identifier: BFieldElement,
+    pub(crate) receiver_identifier: BFieldElement,
+
+    /// Encrypted UTXO notification payload.
+    pub(crate) ciphertext: Vec<BFieldElement>,
+}
+
+#[derive(Debug, Copy, Clone, strum::Display)]
+pub(crate) enum ConversionFromMessageError {
+    // length must be at least 2
+    MessageTooShort(usize),
+}
+
+impl EncryptedUtxoNotification {
+    fn into_message(self) -> Vec<BFieldElement> {
+        [vec![self.flag, self.receiver_identifier], self.ciphertext].concat()
+    }
+
+    fn from_message(message: Vec<BFieldElement>) -> Result<Self, ConversionFromMessageError> {
+        if message.len() < 2 {
+            Err(ConversionFromMessageError::MessageTooShort(message.len()))
+        } else {
+            Ok(Self {
+                flag: message[0],
+                receiver_identifier: message[1],
+                ciphertext: message[2..].to_vec(),
+            })
+        }
+    }
+
+    /// Convert an encrypted UTXO notification to a public announcement. Leaks
+    /// privacy in the form of `receiver_identifier` is addresses are reused.
+    /// Never leaks actual UTXO info such as amount transferred.
+    pub(crate) fn into_public_announcement(self) -> PublicAnnouncement {
+        // We could use `BfieldCodec` encode here. But it might be a bit faster
+        // to filter out irrelevant public announcement if we don't have to
+        // attempt a decoding to a specific data type first but can instead just
+        // read out b-field elements and skip items based on that.
+        PublicAnnouncement::new(self.into_message())
+    }
+
+    pub(crate) fn into_bech32m(self, network: Network) -> String {
+        let hrp = Self::get_hrp(network);
+        let message = self.into_message();
+        let payload = bincode::serialize(&message)
+            .expect("Serialization shouldn't fail. Message was: {message:?}");
+        let payload = payload.to_base32();
+        let variant = bech32::Variant::Bech32m;
+        bech32::encode(&hrp, payload, variant).expect(
+            "bech32 encoding shouldn't fail. Arguments were:\n\n{hrp}\n\n{payload:?}\n\n{variant:?}",
+        )
+    }
+
+    /// decodes from a bech32m string and verifies it matches `network`
+    pub(crate) fn from_bech32m(encoded: &str, network: Network) -> Result<Self> {
+        let (hrp, data, variant) = bech32::decode(encoded)?;
+
+        if variant != bech32::Variant::Bech32m {
+            bail!("Can only decode bech32m addresses.");
+        }
+
+        if hrp != *Self::get_hrp(network) {
+            bail!("Could not decode bech32m address because of invalid prefix");
+        }
+
+        let payload = Vec::<u8>::from_base32(&data)?;
+
+        let message: Vec<BFieldElement> = match bincode::deserialize(&payload) {
+            Ok(ra) => ra,
+            Err(e) => {
+                bail!("Could not decode bech32m because of error: {e}")
+            }
+        };
+
+        let encrypted_utxo_notification = match Self::from_message(message) {
+            Ok(eun) => eun,
+            Err(e) => {
+                bail!("conversion from bech32m failed: {e}")
+            }
+        };
+
+        Ok(encrypted_utxo_notification)
+    }
+
+    /// returns human readable prefix (hrp) of a utxo-transfer-encrypted, specific to `network`
+    pub(crate) fn get_hrp(network: Network) -> String {
+        format!("utxo{}", network_hrp_char(network))
+    }
+
+    pub fn decrypt_with_spending_key(
+        &self,
+        spending_key: &SpendingKey,
+    ) -> anyhow::Result<UtxoNotificationPayload> {
+        let (utxo, sender_randomness) = spending_key.decrypt(&self.ciphertext)?;
+
+        Ok(UtxoNotificationPayload {
+            utxo,
+            sender_randomness,
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use arbitrary::Arbitrary;
+    use arbitrary::Unstructured;
+    use bech32::FromBase32;
+    use bech32::ToBase32;
+    use proptest::collection::vec;
+    use proptest::prop_assert;
+    use proptest::prop_assert_eq;
+    use proptest_arbitrary_interop::arb;
+    use tasm_lib::triton_vm::prelude::BFieldElement;
+    use tasm_lib::twenty_first::bfe;
+    use test_strategy::proptest;
+
+    use crate::config_models::network::Network;
+
+    use super::EncryptedUtxoNotification;
+
+    impl<'a> Arbitrary<'a> for EncryptedUtxoNotification {
+        fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+            let object = Self {
+                flag: BFieldElement::arbitrary(u)?,
+                receiver_identifier: BFieldElement::arbitrary(u)?,
+                ciphertext: Vec::<BFieldElement>::arbitrary(u)?,
+            };
+            Ok(object)
+        }
+    }
+
+    #[proptest]
+    fn base32_encoding(#[strategy(vec(arb::<u8>(), 0..1000))] bytes: Vec<u8>) {
+        let base32 = bytes.to_base32();
+        let bytes_again = Vec::<u8>::from_base32(&base32).unwrap();
+        prop_assert_eq!(bytes, bytes_again);
+    }
+
+    #[proptest]
+    fn encrypted_utxo_notification_to_and_fro_bech32m(
+        #[strategy(arb())] encrypted_utxo_notification: EncryptedUtxoNotification,
+    ) {
+        prop_assert!(bech32m_conversion_succeeds(encrypted_utxo_notification));
+    }
+
+    #[test]
+    fn empty_encutxo_encoding() {
+        let object = EncryptedUtxoNotification {
+            flag: bfe!(0),
+            receiver_identifier: bfe!(0),
+            ciphertext: vec![],
+        };
+        assert!(bech32m_conversion_succeeds(object));
+    }
+
+    /// tests bech32m serialize, deserialize for [`EncryptedUtxoNotification`]
+    pub fn bech32m_conversion_succeeds(
+        encrypted_utxo_notification: EncryptedUtxoNotification,
+    ) -> bool {
+        let encoded = encrypted_utxo_notification
+            .clone()
+            .into_bech32m(Network::Testnet);
+
+        let encrypted_utxo_notification_again =
+            EncryptedUtxoNotification::from_bech32m(&encoded, Network::Testnet).unwrap();
+
+        encrypted_utxo_notification == encrypted_utxo_notification_again
+    }
 }

--- a/src/models/state/wallet/address/encrypted_utxo_notification.rs
+++ b/src/models/state/wallet/address/encrypted_utxo_notification.rs
@@ -145,9 +145,8 @@ mod test {
     use tasm_lib::twenty_first::bfe;
     use test_strategy::proptest;
 
-    use crate::config_models::network::Network;
-
     use super::EncryptedUtxoNotification;
+    use crate::config_models::network::Network;
 
     impl<'a> Arbitrary<'a> for EncryptedUtxoNotification {
         fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {

--- a/src/models/state/wallet/expected_utxo.rs
+++ b/src/models/state/wallet/expected_utxo.rs
@@ -44,7 +44,7 @@ use crate::util_types::mutator_set::commit;
 /// <https://github.com/Neptune-Crypto/neptune-core/issues/176>
 ///
 /// see [AnnouncedUtxo](crate::models::blockchain::transaction::AnnouncedUtxo), [UtxoNotification](crate::models::blockchain::transaction::UtxoNotification)
-#[derive(Clone, Debug, PartialEq, Eq, Hash, GetSize, Serialize, Deserialize)]
+#[derive(Clone, Debug, Hash, GetSize, Serialize, Deserialize)]
 pub struct ExpectedUtxo {
     pub utxo: Utxo,
     pub addition_record: AdditionRecord,
@@ -56,7 +56,7 @@ pub struct ExpectedUtxo {
 }
 
 impl ExpectedUtxo {
-    pub fn new(
+    pub(crate) fn new(
         utxo: Utxo,
         sender_randomness: Digest,
         receiver_preimage: Digest,

--- a/src/models/state/wallet/mod.rs
+++ b/src/models/state/wallet/mod.rs
@@ -826,8 +826,13 @@ mod wallet_tests {
         let msa_tip_previous = next_block.mutator_set_accumulator_after().clone();
         let output_utxo =
             Utxo::new_native_currency(LockScript::anyone_can_spend(), NeptuneCoins::new(200));
-        let tx_outputs: TxOutputList =
-            vec![TxOutput::no_notification(output_utxo, random(), random())].into();
+        let tx_outputs: TxOutputList = vec![TxOutput::no_notification(
+            output_utxo,
+            random(),
+            random(),
+            false,
+        )]
+        .into();
 
         let removal_records = tx_inputs_two_utxos
             .iter()
@@ -944,11 +949,13 @@ mod wallet_tests {
             NeptuneCoins::new(12),
             bob_sender_randomness,
             alice_address.into(),
+            false,
         );
         let receiver_data_1_to_alice = TxOutput::offchain_native_currency(
             NeptuneCoins::new(1),
             bob_sender_randomness,
             alice_address.into(),
+            false,
         );
 
         let receiver_data_to_alice: TxOutputList =
@@ -1203,6 +1210,7 @@ mod wallet_tests {
             NeptuneCoins::new(1),
             rng.gen(),
             alice_address.into(),
+            false,
         );
 
         let (tx_from_bob, _maybe_change_output) = bob
@@ -1399,7 +1407,8 @@ mod wallet_tests {
         let one_money: NeptuneCoins = NeptuneCoins::new(1);
         let anyone_can_spend_utxo =
             Utxo::new_native_currency(LockScript::anyone_can_spend(), one_money);
-        let tx_output = TxOutput::no_notification(anyone_can_spend_utxo, rng.gen(), rng.gen());
+        let tx_output =
+            TxOutput::no_notification(anyone_can_spend_utxo, rng.gen(), rng.gen(), false);
         let change_key = WalletSecret::devnet_wallet().nth_symmetric_key_for_tests(0);
         let (sender_tx, _change_output) = bob
             .lock_guard()

--- a/src/models/state/wallet/monitored_utxo.rs
+++ b/src/models/state/wallet/monitored_utxo.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 use twenty_first::math::tip5::Digest;
 
 use crate::models::blockchain::block::block_height::BlockHeight;
+use crate::models::blockchain::block::Block;
 use crate::models::blockchain::transaction::utxo::Utxo;
 use crate::models::proof_abstractions::timestamp::Timestamp;
 use crate::models::state::archival_state::ArchivalState;
@@ -69,6 +70,14 @@ impl MonitoredUtxo {
             .iter()
             .find(|x| x.0 == block_digest)
             .map(|x| x.1.clone())
+    }
+
+    pub(crate) fn mark_as_spent(&mut self, spending_block: &Block) {
+        self.spent_in_block = Some((
+            spending_block.hash(),
+            spending_block.kernel.header.timestamp,
+            spending_block.kernel.header.height,
+        ));
     }
 
     /// Get the most recent (block hash, membership proof) entry in the database,

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -1059,11 +1059,7 @@ impl WalletState {
                     );
 
                     let mut spent_mutxo = monitored_utxos.get(*mutxo_list_index).await;
-                    spent_mutxo.spent_in_block = Some((
-                        new_block.hash(),
-                        new_block.kernel.header.timestamp,
-                        new_block.kernel.header.height,
-                    ));
+                    spent_mutxo.mark_as_spent(new_block);
                     monitored_utxos.set(*mutxo_list_index, spent_mutxo).await;
                 }
             }

--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -613,7 +613,7 @@ impl NeptuneRPCServer {
         // search for matching monitored utxo and return early if found.
         if state
             .wallet_state
-            .find_monitored_utxo(&utxo_notification.utxo)
+            .find_monitored_utxo(&utxo_notification.utxo, utxo_notification.sender_randomness)
             .await
             .is_some()
         {


### PR DESCRIPTION
Implementation is very close to that of #185. But the derivation of the mutator set membership proofs is significantly simpler here.

Had to replace a `stream_many` with a `get_many` in `ArchivalMutatorSet` because of a rustc type limitation. I prefer this approach though, as the sequence in question is only 45 elements long.

