### PR TITLE
ConsensusProgram: cache all used program hashes

### DIFF
--- a/src/models/blockchain/block/validity/block_program.rs
+++ b/src/models/blockchain/block/validity/block_program.rs
@@ -42,6 +42,12 @@ impl BlockProgram {
 }
 
 impl ConsensusProgram for BlockProgram {
+    fn hash(&self) -> Digest {
+        static PROGRAM_HASH: std::sync::LazyLock<Digest> =
+            std::sync::LazyLock::new(|| BlockProgram.program().hash());
+        *PROGRAM_HASH
+    }
+
     fn source(&self) {
         let _block_body_digest: Digest = tasmlib::tasmlib_io_read_stdin___digest();
         let start_address: BFieldElement = FIRST_NON_DETERMINISTICALLY_INITIALIZED_MEMORY_ADDRESS;

--- a/src/models/blockchain/transaction/validity/collect_lock_scripts.rs
+++ b/src/models/blockchain/transaction/validity/collect_lock_scripts.rs
@@ -74,6 +74,12 @@ impl SecretWitness for CollectLockScriptsWitness {
 pub struct CollectLockScripts;
 
 impl ConsensusProgram for CollectLockScripts {
+    fn hash(&self) -> Digest {
+        static PROGRAM_HASH: std::sync::LazyLock<Digest> =
+            std::sync::LazyLock::new(|| CollectLockScripts.program().hash());
+        *PROGRAM_HASH
+    }
+
     fn source(&self) {
         let siu_digest: Digest = tasmlib::tasmlib_io_read_stdin___digest();
         let start_address: BFieldElement = FIRST_NON_DETERMINISTICALLY_INITIALIZED_MEMORY_ADDRESS;

--- a/src/models/blockchain/transaction/validity/collect_type_scripts.rs
+++ b/src/models/blockchain/transaction/validity/collect_type_scripts.rs
@@ -90,6 +90,12 @@ impl SecretWitness for CollectTypeScriptsWitness {
 pub struct CollectTypeScripts;
 
 impl ConsensusProgram for CollectTypeScripts {
+    fn hash(&self) -> Digest {
+        static PROGRAM_HASH: std::sync::LazyLock<Digest> =
+            std::sync::LazyLock::new(|| CollectTypeScripts.program().hash());
+        *PROGRAM_HASH
+    }
+
     fn source(&self) {
         let siu_digest: Digest = tasmlib::tasmlib_io_read_stdin___digest();
         let sou_digest: Digest = tasmlib::tasmlib_io_read_stdin___digest();

--- a/src/models/blockchain/transaction/validity/kernel_to_outputs.rs
+++ b/src/models/blockchain/transaction/validity/kernel_to_outputs.rs
@@ -113,6 +113,12 @@ impl SecretWitness for KernelToOutputsWitness {
 pub struct KernelToOutputs;
 
 impl ConsensusProgram for KernelToOutputs {
+    fn hash(&self) -> Digest {
+        static PROGRAM_HASH: std::sync::LazyLock<Digest> =
+            std::sync::LazyLock::new(|| KernelToOutputs.program().hash());
+        *PROGRAM_HASH
+    }
+
     fn source(&self) {
         let txk_digest: Digest = tasmlib::tasmlib_io_read_stdin___digest();
         let start_address: BFieldElement = FIRST_NON_DETERMINISTICALLY_INITIALIZED_MEMORY_ADDRESS;

--- a/src/models/blockchain/transaction/validity/merge.rs
+++ b/src/models/blockchain/transaction/validity/merge.rs
@@ -210,6 +210,12 @@ impl SecretWitness for MergeWitness {
 pub struct Merge;
 
 impl ConsensusProgram for Merge {
+    fn hash(&self) -> Digest {
+        static PROGRAM_HASH: std::sync::LazyLock<Digest> =
+            std::sync::LazyLock::new(|| Merge.program().hash());
+        *PROGRAM_HASH
+    }
+
     fn source(&self) {
         // read the kernel of the transaction that this proof applies to
         let new_txk_digest = tasmlib::tasmlib_io_read_stdin___digest();

--- a/src/models/blockchain/transaction/validity/removal_records_integrity.rs
+++ b/src/models/blockchain/transaction/validity/removal_records_integrity.rs
@@ -366,6 +366,12 @@ impl RemovalRecordsIntegrityWitness {
 }
 
 impl ConsensusProgram for RemovalRecordsIntegrity {
+    fn hash(&self) -> Digest {
+        static PROGRAM_HASH: std::sync::LazyLock<Digest> =
+            std::sync::LazyLock::new(|| RemovalRecordsIntegrity.program().hash());
+        *PROGRAM_HASH
+    }
+
     fn source(&self) {
         let txk_digest: Digest = tasmlib::tasmlib_io_read_stdin___digest();
 

--- a/src/models/blockchain/transaction/validity/single_proof.rs
+++ b/src/models/blockchain/transaction/validity/single_proof.rs
@@ -306,6 +306,12 @@ impl SingleProof {
 }
 
 impl ConsensusProgram for SingleProof {
+    fn hash(&self) -> Digest {
+        static PROGRAM_HASH: std::sync::LazyLock<Digest> =
+            std::sync::LazyLock::new(|| SingleProof.program().hash());
+        *PROGRAM_HASH
+    }
+
     fn source(&self) {
         let stark: Stark = Stark::default();
         let own_program_digest: Digest = tasmlib::own_program_digest();

--- a/src/models/blockchain/transaction/validity/update.rs
+++ b/src/models/blockchain/transaction/validity/update.rs
@@ -180,6 +180,12 @@ impl SecretWitness for UpdateWitness {
 pub struct Update;
 
 impl ConsensusProgram for Update {
+    fn hash(&self) -> Digest {
+        static PROGRAM_HASH: std::sync::LazyLock<Digest> =
+            std::sync::LazyLock::new(|| Update.program().hash());
+        *PROGRAM_HASH
+    }
+
     fn source(&self) {
         // read the kernel of the transaction that this proof applies to
         let new_txk_digest: Digest = tasmlib::tasmlib_io_read_stdin___digest();

--- a/src/models/blockchain/type_scripts/native_currency.rs
+++ b/src/models/blockchain/type_scripts/native_currency.rs
@@ -49,6 +49,12 @@ use crate::models::proof_abstractions::SecretWitness;
 pub struct NativeCurrency;
 
 impl ConsensusProgram for NativeCurrency {
+    fn hash(&self) -> Digest {
+        static PROGRAM_HASH: std::sync::LazyLock<Digest> =
+            std::sync::LazyLock::new(|| NativeCurrency.program().hash());
+        *PROGRAM_HASH
+    }
+
     #[allow(clippy::needless_return)]
     fn source(&self) {
         // get in the current program's hash digest

--- a/src/models/blockchain/type_scripts/time_lock.rs
+++ b/src/models/blockchain/type_scripts/time_lock.rs
@@ -74,6 +74,12 @@ impl TimeLock {
 }
 
 impl ConsensusProgram for TimeLock {
+    fn hash(&self) -> Digest {
+        static PROGRAM_HASH: std::sync::LazyLock<Digest> =
+            std::sync::LazyLock::new(|| TimeLock.program().hash());
+        *PROGRAM_HASH
+    }
+
     #[allow(clippy::needless_return)]
     fn source(&self) {
         // get in the current program's hash digest


### PR DESCRIPTION
The program hashes stay constant for all the `ConsensusProgram` implemenations that we are using, as the implementing structures don't take any arguments. So for each of those implementations we only need to calculate the program hash once. This commit introduces caching to that effect.

Opening this as a PR since it contains a bit of repeated code and @dan-da might have a better approach, or opinions on style.

This addresses #244 and improves the situation considerably, I think. But I don't think it closes it, as I still see some warnings of exceeded fn thresholds in the log when I ran the client with this commit.