### PR TITLE
Block: Add test that double-spending blocks are rejected

### DIFF
--- a/src/bin/dashboard_src/send_screen.rs
+++ b/src/bin/dashboard_src/send_screen.rs
@@ -144,7 +144,7 @@ impl SendScreen {
                 *reset_me.lock().await = ResetType::Form;
             }
             Err(e) => {
-                *notice_arc.lock().await = format!("send error.  {}", e.to_string());
+                *notice_arc.lock().await = format!("send error.  {e}");
                 *reset_me.lock().await = ResetType::Notice;
             }
         }


### PR DESCRIPTION
@aszepieniec Let me know if these small rewrites conflict with your current work.

TODO (for future commits, not for this PR): Block's `is_valid` function should return an error code indicating why the block was rejected. That would make negative tests of block validity much more robust. I'll add an issue to that effect.

Includes a rewrite of helper function for constructing a new block that makes it easier to create a new block from a BlockPrimitiveWitness. Specifically, a new function `block_template_from_primitive_witness` is added which is used in this test as well as in the call graph for creating a new block from a transaction and a predecessor.

Also adds an "unsafe" version of MutatorSetUpdate's "apply" function that allows the caller to calculate a new MS accumulator which ignores double spends. This was needed to allow the BlockPrimitiveWitness constructor to complete the construction of a block with a double- spending transaction.