### PR TITLE
fix(mine_loop): Avoid using different blocks in block composition

### DIFF
--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -1210,7 +1210,7 @@ mod block_tests {
 
             let guesser_fraction = 0f64;
             let (block_tx, _expected_utxo) =
-                make_coinbase_transaction(&genesis_state, guesser_fraction, now)
+                make_coinbase_transaction(&genesis_block, &genesis_state, guesser_fraction, now)
                     .await
                     .unwrap();
             let mut block1 = Block::make_block_template_with_valid_proof(

--- a/src/models/state/archival_state.rs
+++ b/src/models/state/archival_state.rs
@@ -1760,10 +1760,20 @@ mod archival_state_tests {
         println!("Generated transaction for Alice and Bob.");
 
         let guesser_fraction = 0f64;
-        let (cbtx, expected_composer_utxos) =
-            make_coinbase_transaction(&genesis, guesser_fraction, in_seven_months)
+        let (cbtx, expected_composer_utxos) = make_coinbase_transaction(
+            &genesis
+                .global_state_lock
+                .lock_guard()
                 .await
-                .unwrap();
+                .chain
+                .light_state()
+                .clone(),
+            &genesis,
+            guesser_fraction,
+            in_seven_months,
+        )
+        .await
+        .unwrap();
 
         let block_tx = cbtx
             .merge_with(
@@ -1984,10 +1994,20 @@ mod archival_state_tests {
         // Make block_2 with tx that contains:
         // - 4 inputs: 2 from Alice and 2 from Bob
         // - 6 outputs: 2 from Alice to Genesis, 3 from Bob to Genesis, and 1 coinbase to Genesis
-        let (cbtx2, expected_composer_utxos2) =
-            make_coinbase_transaction(&genesis, guesser_fraction, in_seven_months)
+        let (cbtx2, expected_composer_utxos2) = make_coinbase_transaction(
+            &genesis
+                .global_state_lock
+                .lock_guard()
                 .await
-                .unwrap();
+                .chain
+                .light_state()
+                .clone(),
+            &genesis,
+            guesser_fraction,
+            in_seven_months,
+        )
+        .await
+        .unwrap();
         let block_tx2 = cbtx2
             .merge_with(
                 tx_from_alice,

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -1194,10 +1194,19 @@ mod tests {
 
         // Create next block which includes Bob's, but not Alice's, transaction.
         let guesser_fraction = 0f64;
-        let (coinbase_transaction, _expected_utxo) =
-            make_coinbase_transaction(&bob, guesser_fraction, in_eight_months)
+        let (coinbase_transaction, _expected_utxo) = make_coinbase_transaction(
+            &bob.global_state_lock
+                .lock_guard()
                 .await
-                .unwrap();
+                .chain
+                .light_state()
+                .clone(),
+            &bob,
+            guesser_fraction,
+            in_eight_months,
+        )
+        .await
+        .unwrap();
         let block_transaction = tx_by_bob
             .merge_with(
                 coinbase_transaction,
@@ -1264,9 +1273,20 @@ mod tests {
 
         tx_by_alice_updated = mempool.get_transactions_for_block(usize::MAX, None, true)[0].clone();
         let block_5_timestamp = previous_block.header().timestamp + Timestamp::hours(1);
-        let (cbtx, _eutxo) = make_coinbase_transaction(&alice, guesser_fraction, block_5_timestamp)
-            .await
-            .unwrap();
+        let (cbtx, _eutxo) = make_coinbase_transaction(
+            &alice
+                .global_state_lock
+                .lock_guard()
+                .await
+                .chain
+                .light_state()
+                .clone(),
+            &alice,
+            guesser_fraction,
+            block_5_timestamp,
+        )
+        .await
+        .unwrap();
         let block_tx_5 = cbtx
             .merge_with(
                 tx_by_alice_updated,

--- a/src/models/state/wallet/mod.rs
+++ b/src/models/state/wallet/mod.rs
@@ -1220,6 +1220,13 @@ mod wallet_tests {
 
         let guesser_fraction = 0f64;
         let (coinbase_tx, expected_composer_utxos) = make_coinbase_transaction(
+            &alice
+                .global_state_lock
+                .lock_guard()
+                .await
+                .chain
+                .light_state()
+                .clone(),
             &alice,
             guesser_fraction,
             block_2_b.header().timestamp + MINIMUM_BLOCK_TIME,
@@ -1392,10 +1399,19 @@ mod wallet_tests {
         let mut rng = StdRng::seed_from_u64(87255549301u64);
 
         let guesser_fraction = 0f64;
-        let (cbtx, _cb_expected) =
-            make_coinbase_transaction(&bob, guesser_fraction, in_seven_months)
+        let (cbtx, _cb_expected) = make_coinbase_transaction(
+            &bob.global_state_lock
+                .lock_guard()
                 .await
-                .unwrap();
+                .chain
+                .light_state()
+                .clone(),
+            &bob,
+            guesser_fraction,
+            in_seven_months,
+        )
+        .await
+        .unwrap();
         let one_money: NeptuneCoins = NeptuneCoins::new(1);
         let anyone_can_spend_utxo =
             Utxo::new_native_currency(LockScript::anyone_can_spend(), one_money);

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -876,7 +876,7 @@ pub(crate) async fn valid_block_for_tests(
     guesser_fraction: f64,
 ) -> Block {
     let current_tip = state_lock.lock_guard().await.chain.light_state().clone();
-    let (cb, _) = make_coinbase_transaction(state_lock, guesser_fraction, timestamp)
+    let (cb, _) = make_coinbase_transaction(&current_tip, state_lock, guesser_fraction, timestamp)
         .await
         .unwrap();
     valid_block_from_tx_for_tests(&current_tip, cb, seed).await


### PR DESCRIPTION
Prior to this fix, a race condition could lead to two different blocks being used in the witness composition for a new block. This happened since one block was input to the function, and inside the function to construct the coinbase transaction, a block was read from global state. With this fix, the block used as input argument is always used.

This closes #266.