### PR TITLE
Bootstrapper Mode

### DIFF
--- a/src/config_models/cli_args.rs
+++ b/src/config_models/cli_args.rs
@@ -56,7 +56,7 @@ pub struct Args {
     /// Will not prevent outgoing connections made with `--peers`.
     /// Set this value to 0 to refuse all incoming connections.
     #[clap(long, default_value = "10", value_name = "COUNT")]
-    pub max_peers: u16,
+    pub max_num_peers: u16,
 
     /// If this flag is set, the node will refuse to initiate a transaction.
     /// This flag makes sense for machines whose resources are dedicated to
@@ -229,7 +229,7 @@ impl Args {
 
     /// Indicates if all incoming peer connections are disallowed.
     pub(crate) fn disallow_all_incoming_peer_connections(&self) -> bool {
-        self.max_peers.is_zero()
+        self.max_num_peers.is_zero()
     }
 
     /// Return the port that peer can connect on. None if incoming connections
@@ -319,7 +319,7 @@ mod cli_args_tests {
         let default_args = Args::default();
 
         assert_eq!(1000, default_args.peer_tolerance);
-        assert_eq!(10, default_args.max_peers);
+        assert_eq!(10, default_args.max_num_peers);
         assert_eq!(9798, default_args.peer_port);
         assert_eq!(9799, default_args.rpc_port);
         assert_eq!(
@@ -342,7 +342,7 @@ mod cli_args_tests {
     #[test]
     fn max_peers_0_means_no_incoming_connections() {
         let args = Args {
-            max_peers: 0,
+            max_num_peers: 0,
             ..Default::default()
         };
         assert!(args.disallow_all_incoming_peer_connections());

--- a/src/config_models/cli_args.rs
+++ b/src/config_models/cli_args.rs
@@ -58,6 +58,16 @@ pub struct Args {
     #[clap(long, default_value = "10", value_name = "COUNT")]
     pub max_num_peers: u16,
 
+    /// Whether to act as bootstrapper node.
+    ///
+    /// Bootstrapper nodes ensure that the maximum number of peers is never
+    /// reached by disconnecting from existing peers when the maximum is about
+    /// to be reached. As a result, they will respond with high likelihood to
+    /// incoming connection requests -- in contrast to regular nodes, which
+    /// refuse incoming connections when the max is reached.
+    #[clap(long)]
+    pub bootstrap: bool,
+
     /// If this flag is set, the node will refuse to initiate a transaction.
     /// This flag makes sense for machines whose resources are dedicated to
     /// composing, and which must do so in a regular and predictable manner,

--- a/src/connect_to_peers.rs
+++ b/src/connect_to_peers.rs
@@ -134,10 +134,20 @@ async fn check_if_connection_is_allowed(
         return ConnectionStatus::Refused(ConnectionRefusedReason::IncompatibleVersion);
     }
 
+    // If this connection touches the maximum number of peer connections, say
+    // so with special OK code.
+    if cli_arguments.max_num_peers as usize == global_state.net.peer_map.len() + 1 {
+        info!("ConnectionStatus::Accepted, but max # connections is now reached");
+        return ConnectionStatus::AcceptedMaxReached;
+    }
+
     info!("ConnectionStatus::Accepted");
     ConnectionStatus::Accepted
 }
 
+/// Respond to an incoming connection initiation.
+///
+/// Catch and process errors (if any) gracefully.
 pub(crate) async fn answer_peer_wrapper<S>(
     stream: S,
     state_lock: GlobalStateLock,
@@ -206,9 +216,9 @@ where
     > = SymmetricallyFramed::new(length_delimited, SymmetricalBincode::default());
 
     // Complete Neptune handshake
-    let peer_handshake_data: HandshakeData = match peer.try_next().await? {
+    let (peer_handshake_data, acceptance_code) = match peer.try_next().await? {
         Some(PeerMessage::Handshake(payload)) => {
-            let (v, hsd) = *payload;
+            let (v, handshake_data) = *payload;
             if v != crate::MAGIC_STRING_REQUEST {
                 bail!("Expected magic value, got {:?}", v);
             }
@@ -220,11 +230,11 @@ where
             .await?;
 
             // Verify peer network before moving on
-            if hsd.network != own_handshake_data.network {
+            if handshake_data.network != own_handshake_data.network {
                 bail!(
                     "Cannot connect with {}: Peer runs {}, this client runs {}.",
                     peer_address,
-                    hsd.network,
+                    handshake_data.network,
                     own_handshake_data.network,
                 );
             }
@@ -233,28 +243,47 @@ where
             let connection_status = check_if_connection_is_allowed(
                 state.clone(),
                 &own_handshake_data,
-                &hsd,
+                &handshake_data,
                 &peer_address,
             )
             .await;
 
-            peer.send(PeerMessage::ConnectionStatus(connection_status))
-                .await?;
-            if let ConnectionStatus::Refused(refused_reason) = connection_status {
-                warn!("Incoming connection refused: {:?}", refused_reason);
-                bail!("Refusing incoming connection. Reason: {:?}", refused_reason);
+            match connection_status {
+                ConnectionStatus::Refused(refused_reason) => {
+                    peer.send(PeerMessage::ConnectionStatus(ConnectionStatus::Refused(
+                        refused_reason,
+                    )))
+                    .await?;
+                    warn!("Incoming connection refused: {:?}", refused_reason);
+                    bail!("Refusing incoming connection. Reason: {:?}", refused_reason);
+                }
+                ConnectionStatus::AcceptedMaxReached | ConnectionStatus::Accepted => {
+                    peer.send(PeerMessage::ConnectionStatus(ConnectionStatus::Accepted))
+                        .await?;
+                }
             }
 
             debug!("Got correct magic value request!");
-            hsd
+            (handshake_data, connection_status)
         }
         _ => {
             bail!("Didn't get handshake on connection attempt");
         }
     };
 
-    // Whether the incoming connection comes from a peer in bad standing is checked in `get_connection_status`
+    // Whether the incoming connection comes from a peer in bad standing is
+    // checked in `check_if_connection_is_allowed`. So if we get here, we are
+    // good to go.
     info!("Connection accepted from {}", peer_address);
+
+    // If necessary, disconnect from another, existing peer.
+    if acceptance_code == ConnectionStatus::AcceptedMaxReached {
+        info!("Maximum # peers reached, so disconnecting from an existing peer.");
+        peer_task_to_main_tx
+            .send(PeerTaskToMain::DisconnectFromLongestLivedPeer)
+            .await?;
+    }
+
     let peer_distance = 1; // All incoming connections have distance 1
     let mut peer_loop_handler = PeerLoopHandler::new(
         peer_task_to_main_tx,

--- a/src/connect_to_peers.rs
+++ b/src/connect_to_peers.rs
@@ -100,7 +100,7 @@ async fn check_if_connection_is_allowed(
 
     if let Some(status) = {
         // Disallow connection if max number of &peers has been attained
-        if (cli_arguments.max_peers as usize) <= global_state.net.peer_map.len() {
+        if (cli_arguments.max_num_peers as usize) <= global_state.net.peer_map.len() {
             Some(ConnectionStatus::Refused(
                 ConnectionRefusedReason::MaxPeerNumberExceeded,
             ))
@@ -589,7 +589,7 @@ mod connect_tests {
 
         // pretend --max_peers is 1.
         let mut cli = state_lock.cli().clone();
-        cli.max_peers = 1;
+        cli.max_num_peers = 1;
         state_lock.set_cli(cli.clone()).await;
 
         status = check_if_connection_is_allowed(
@@ -606,7 +606,7 @@ mod connect_tests {
         }
 
         // pretend --max-peers is 100
-        cli.max_peers = 100;
+        cli.max_num_peers = 100;
         state_lock.set_cli(cli.clone()).await;
 
         // Attempt to connect to already connected peer
@@ -897,7 +897,7 @@ mod connect_tests {
 
         // set max_peers to 2 to ensure failure on next connection attempt
         let mut cli = state_lock.cli().clone();
-        cli.max_peers = 2;
+        cli.max_num_peers = 2;
         state_lock.set_cli(cli).await;
 
         let answer = answer_peer(

--- a/src/connect_to_peers.rs
+++ b/src/connect_to_peers.rs
@@ -276,7 +276,7 @@ where
     info!("Connection accepted from {}", peer_address);
 
     // If necessary, disconnect from another, existing peer.
-    if acceptance_code == ConnectionStatus::AcceptedMaxReached {
+    if acceptance_code == ConnectionStatus::AcceptedMaxReached && state.cli().bootstrap {
         info!("Maximum # peers reached, so disconnecting from an existing peer.");
         peer_task_to_main_tx
             .send(PeerTaskToMain::DisconnectFromLongestLivedPeer)

--- a/src/connect_to_peers.rs
+++ b/src/connect_to_peers.rs
@@ -411,6 +411,12 @@ where
         bail!("Attempted to connect to peer that was not allowed. This connection attempt should not have been made.");
     }
 
+    // By default, start by asking the peer for its peers. In an adversarial
+    // context, we want the network topology to be as robust as possible.
+    // Blockchain data can be obtained from other peers, if this connection
+    // fails.
+    peer.send(PeerMessage::PeerListRequest).await?;
+
     let mut peer_loop_handler = PeerLoopHandler::new(
         peer_task_to_main_tx,
         state,
@@ -516,6 +522,7 @@ mod connect_tests {
             .read(&to_bytes(&PeerMessage::ConnectionStatus(
                 ConnectionStatus::Accepted,
             ))?)
+            .write(&to_bytes(&PeerMessage::PeerListRequest)?)
             .read(&to_bytes(&PeerMessage::Bye)?)
             .build();
 

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -816,8 +816,9 @@ impl MainLoopHandler {
         Ok(())
     }
 
-    /// Function to perform peer discovery: Finds potential peers from connected peers and attempts
-    /// to establish connections with one of those potential peers.
+    /// Perform peer discovery and (if necessary) reconnect to the peers listed
+    /// as CLI arguments. Peer discovery involves finding potential peers from
+    /// connected peers and attempts to establish connections with one of them.
     ///
     /// Locking:
     ///   * acquires `global_state_lock` for read

--- a/src/models/channel.rs
+++ b/src/models/channel.rs
@@ -135,6 +135,7 @@ pub(crate) enum PeerTaskToMain {
     PeerDiscoveryAnswer((Vec<(SocketAddr, u128)>, SocketAddr, u8)), // ([(peer_listen_address)], reported_by, distance)
     Transaction(Box<PeerTaskToMainTransaction>),
     BlockProposal(Box<Block>),
+    DisconnectFromLongestLivedPeer,
 }
 
 #[derive(Clone, Debug)]
@@ -152,6 +153,7 @@ impl PeerTaskToMain {
             PeerTaskToMain::PeerDiscoveryAnswer(_) => "peer discovery answer",
             PeerTaskToMain::Transaction(_) => "transaction",
             PeerTaskToMain::BlockProposal(_) => "block proposal",
+            PeerTaskToMain::DisconnectFromLongestLivedPeer => "disconnect from longest lived peer",
         }
         .to_string()
     }

--- a/src/models/peer.rs
+++ b/src/models/peer.rs
@@ -115,6 +115,11 @@ impl PeerInfo {
             .port_for_incoming_connections
             .map(|port| SocketAddr::new(self.peer_connection_info.connected_address.ip(), port))
     }
+
+    #[cfg(test)]
+    pub(crate) fn set_connection_established(&mut self, new_timestamp: SystemTime) {
+        self.connection_established = new_timestamp;
+    }
 }
 
 trait Sanction {

--- a/src/models/peer.rs
+++ b/src/models/peer.rs
@@ -583,7 +583,8 @@ impl PeerMessage {
     }
 }
 
-/// `MutablePeerState` contains the part of the peer-loop's state that is mutable
+/// `MutablePeerState` contains information about the peer's blockchain state.
+/// Under normal conditions, this information varies across time.
 #[derive(Clone, Debug)]
 pub struct MutablePeerState {
     pub highest_shared_block_height: BlockHeight,

--- a/src/models/peer.rs
+++ b/src/models/peer.rs
@@ -449,6 +449,7 @@ pub enum ConnectionRefusedReason {
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum ConnectionStatus {
     Refused(ConnectionRefusedReason),
+    AcceptedMaxReached,
     Accepted,
 }
 

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -1649,7 +1649,7 @@ mod global_state_tests {
         )
         .await;
         let no_incoming_connections = cli_args::Args {
-            max_peers: 0,
+            max_num_peers: 0,
             ..Default::default()
         };
         bob.set_cli(no_incoming_connections).await;

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -12,6 +12,7 @@ pub mod tx_proving_capability;
 pub mod wallet;
 
 use std::cmp::max;
+use std::net::SocketAddr;
 use std::ops::Deref;
 use std::ops::DerefMut;
 use std::time::SystemTime;
@@ -1540,6 +1541,11 @@ impl GlobalState {
     #[inline]
     fn cli(&self) -> &cli_args::Args {
         &self.cli
+    }
+
+    /// Return the list of peers that were supplied as CLI arguments.
+    pub(crate) fn cli_peers(&self) -> Vec<SocketAddr> {
+        self.cli().peers.clone()
     }
 
     pub(crate) fn proving_capability(&self) -> TxProvingCapability {

--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -1433,7 +1433,7 @@ impl PeerLoopHandler {
             bail!("Attempted to connect to already connected peer. Aborting connection.");
         }
 
-        if global_state.net.peer_map.len() >= cli_args.max_peers as usize {
+        if global_state.net.peer_map.len() >= cli_args.max_num_peers as usize {
             bail!("Attempted to connect to more peers than allowed. Aborting connection.");
         }
 

--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -198,7 +198,8 @@ impl PeerLoopHandler {
     /// in the batch.
     ///
     /// # Locking
-    ///   * acquires `global_state_lock` for write via Self::punish()
+    ///   * Acquires `global_state_lock` for write via `self.punish(..)` and
+    ///     `self.reward(..)`.
     ///
     /// # Panics
     ///
@@ -309,7 +310,8 @@ impl PeerLoopHandler {
     /// are passed down the pipeline.
     ///
     /// Locking:
-    ///   * acquires `global_state_lock` for write via Self::punish()
+    ///   * Acquires `global_state_lock` for write via `self.punish(..)` and
+    ///     `self.reward(..)`.
     async fn try_ensure_path<S>(
         &mut self,
         received_block: Box<Block>,
@@ -452,8 +454,9 @@ impl PeerLoopHandler {
     /// Otherwise returns OK(false).
     ///
     /// Locking:
-    ///   * acquires `global_state_lock` for read
-    ///   * acquires `global_state_lock` for write via Self::punish()
+    ///   * Acquires `global_state_lock` for read.
+    ///   * Acquires `global_state_lock` for write via `self.punish(..)` and
+    ///     `self.reward(..)`.
     async fn handle_peer_message<S>(
         &mut self,
         msg: PeerMessage,

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -145,7 +145,7 @@ pub(crate) fn get_dummy_peer(address: SocketAddr) -> PeerInfo {
 }
 
 pub fn get_dummy_version() -> String {
-    "0.1.0".to_string()
+    "0.0.10".to_string()
 }
 
 /// Return a handshake object with a randomly set instance ID


### PR DESCRIPTION
We are observing that people would like to participate in the network but can't because the two nodes listed in the README.md refuse connections. They do this because their max number of peers has already been reached.

This PR adds functionality for running a node in "bootstrapper mode", wherein it will drop the longest-lived peer connection whenever the maximum is reached. This mode is activated through a CLI argument. Whenever an incoming connection is established, if this mode is set, and if the max number of peers has been reached, the peer loop will send a  `DisconnectFromLongestLivedPeer` message to the main loop. The main loop iterates over all peers, filters out the peers given as CLI arguments, selects the one with the earliest connection established date, and instructs that peer's peer loop to close the connection.