### PR TITLE
feat: Time-Locked Coinbase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3373,14 +3373,13 @@ dependencies = [
 [[package]]
 name = "tasm-lib"
 version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2086093477a23c66dc1cfcbb3b3cd6eb9cbc96ab0b6d0b9f796ea14942760e"
+source = "git+https://github.com/TritonVM/tasm-lib.git?rev=bc50c3320b7ca7527a0066e2b28455f4b4e18003#bc50c3320b7ca7527a0066e2b28455f4b4e18003"
 dependencies = [
  "anyhow",
  "arbitrary",
  "const_format",
  "hex",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "ndarray",
  "num",
  "num-traits",
@@ -3395,8 +3394,7 @@ dependencies = [
 [[package]]
 name = "tasm-object-derive"
 version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "018472cead7ee1ecfdf8114ba9021f857cdf511977e9a9e591ea796bfe7e5f12"
+source = "git+https://github.com/TritonVM/tasm-lib.git?rev=bc50c3320b7ca7527a0066e2b28455f4b4e18003#bc50c3320b7ca7527a0066e2b28455f4b4e18003"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,3 +212,6 @@ harness = false
 [[bench]]
 name = "consensus"
 harness = false
+
+[patch.crates-io]
+tasm-lib = { git = "https://github.com/TritonVM/tasm-lib.git", rev = "bc50c3320b7ca7527a0066e2b28455f4b4e18003" }

--- a/benches/consensus.rs
+++ b/benches/consensus.rs
@@ -27,7 +27,6 @@ mod transaction {
     use neptune_cash::models::proof_abstractions::tasm::program::ConsensusProgram;
     use neptune_cash::models::proof_abstractions::timestamp::Timestamp;
     use neptune_cash::models::proof_abstractions::SecretWitness;
-    use proptest::arbitrary::Arbitrary;
     use proptest::strategy::Strategy;
     use proptest::strategy::ValueTree;
     use proptest::test_runner::TestRunner;
@@ -104,10 +103,11 @@ mod transaction {
     fn removal_records_integrity(args: (usize, usize)) {
         let (num_inputs, num_outputs) = args;
         let mut test_runner = TestRunner::deterministic();
-        let primitive_witness = PrimitiveWitness::arbitrary_with((num_inputs, num_outputs, 2))
-            .new_tree(&mut test_runner)
-            .unwrap()
-            .current();
+        let primitive_witness =
+            PrimitiveWitness::arbitrary_with_size_numbers(num_inputs, num_outputs, 2)
+                .new_tree(&mut test_runner)
+                .unwrap()
+                .current();
         let removal_records_integrity_witness =
             RemovalRecordsIntegrityWitness::from(&primitive_witness);
 
@@ -183,10 +183,11 @@ mod transaction {
     fn collect_lock_scripts(args: (usize, usize)) {
         let (num_inputs, num_outputs) = args;
         let mut test_runner = TestRunner::deterministic();
-        let primitive_witness = PrimitiveWitness::arbitrary_with((num_inputs, num_outputs, 2))
-            .new_tree(&mut test_runner)
-            .unwrap()
-            .current();
+        let primitive_witness =
+            PrimitiveWitness::arbitrary_with_size_numbers(num_inputs, num_outputs, 2)
+                .new_tree(&mut test_runner)
+                .unwrap()
+                .current();
         let collect_lock_scripts_witness = CollectLockScriptsWitness::from(&primitive_witness);
         bench_and_profile_consensus_program(
             CollectLockScripts,
@@ -228,10 +229,11 @@ mod transaction {
     fn kernel_to_outputs(args: (usize, usize)) {
         let (num_inputs, num_outputs) = args;
         let mut test_runner = TestRunner::deterministic();
-        let primitive_witness = PrimitiveWitness::arbitrary_with((num_inputs, num_outputs, 2))
-            .new_tree(&mut test_runner)
-            .unwrap()
-            .current();
+        let primitive_witness =
+            PrimitiveWitness::arbitrary_with_size_numbers(num_inputs, num_outputs, 2)
+                .new_tree(&mut test_runner)
+                .unwrap()
+                .current();
         let kernel_to_outputs_witness = KernelToOutputsWitness::from(&primitive_witness);
         bench_and_profile_consensus_program(
             KernelToOutputs,

--- a/benches/consensus.rs
+++ b/benches/consensus.rs
@@ -104,7 +104,7 @@ mod transaction {
         let (num_inputs, num_outputs) = args;
         let mut test_runner = TestRunner::deterministic();
         let primitive_witness =
-            PrimitiveWitness::arbitrary_with_size_numbers(num_inputs, num_outputs, 2)
+            PrimitiveWitness::arbitrary_with_size_numbers(Some(num_inputs), num_outputs, 2)
                 .new_tree(&mut test_runner)
                 .unwrap()
                 .current();
@@ -184,7 +184,7 @@ mod transaction {
         let (num_inputs, num_outputs) = args;
         let mut test_runner = TestRunner::deterministic();
         let primitive_witness =
-            PrimitiveWitness::arbitrary_with_size_numbers(num_inputs, num_outputs, 2)
+            PrimitiveWitness::arbitrary_with_size_numbers(Some(num_inputs), num_outputs, 2)
                 .new_tree(&mut test_runner)
                 .unwrap()
                 .current();
@@ -230,7 +230,7 @@ mod transaction {
         let (num_inputs, num_outputs) = args;
         let mut test_runner = TestRunner::deterministic();
         let primitive_witness =
-            PrimitiveWitness::arbitrary_with_size_numbers(num_inputs, num_outputs, 2)
+            PrimitiveWitness::arbitrary_with_size_numbers(Some(num_inputs), num_outputs, 2)
                 .new_tree(&mut test_runner)
                 .unwrap()
                 .current();

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -1037,7 +1037,7 @@ pub(crate) mod mine_loop_tests {
             assert_eq!(
             4,
             transaction_non_empty_mempool.kernel.outputs.len(),
-            "Transaction for block with non-empty mempool must contain coinbase outputs, send output, and change output"
+            "Transaction for block with non-empty mempool must contain two coinbase outputs, send output, and change output"
         );
             assert_eq!(1, transaction_non_empty_mempool.kernel.inputs.len(), "Transaction for block with non-empty mempool must contain one input: the genesis UTXO being spent");
 

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -996,9 +996,9 @@ pub(crate) mod mine_loop_tests {
             );
 
             assert_eq!(
-                1,
+                2,
                 transaction_empty_mempool.kernel.outputs.len(),
-                "Coinbase transaction with empty mempool must have exactly one output"
+                "Coinbase transaction with empty mempool must have exactly two outputs"
             );
             assert!(
                 transaction_empty_mempool.kernel.inputs.is_empty(),
@@ -1035,9 +1035,9 @@ pub(crate) mod mine_loop_tests {
                     .unwrap()
             };
             assert_eq!(
-            3,
+            4,
             transaction_non_empty_mempool.kernel.outputs.len(),
-            "Transaction for block with non-empty mempool must contain coinbase output, send output, and change output"
+            "Transaction for block with non-empty mempool must contain coinbase outputs, send output, and change output"
         );
             assert_eq!(1, transaction_non_empty_mempool.kernel.inputs.len(), "Transaction for block with non-empty mempool must contain one input: the genesis UTXO being spent");
 

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -78,6 +78,12 @@ use crate::util_types::mutator_set::mutator_set_accumulator::MutatorSetAccumulat
 /// blocks with many outputs.
 pub(crate) const MAX_BLOCK_SIZE: usize = 250_000;
 
+/// Duration of timelock for half the block subsidy.
+///
+/// Half the block subsidy is liquid immediately. Half of it is locked for this
+/// time period.
+pub(crate) const COINBASE_TIME_LOCK_PERIOD: Timestamp = Timestamp::years(3);
+
 /// All blocks have proofs except the genesis block
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, BFieldCodec, GetSize, Default)]
 pub enum BlockProof {

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -1215,10 +1215,15 @@ mod block_tests {
                 mock_genesis_global_state(network, 0, wallet, cli_args::Args::default()).await;
 
             let guesser_fraction = 0f64;
-            let (block_tx, _expected_utxo) =
-                make_coinbase_transaction(&genesis_block, &genesis_state, guesser_fraction, now)
-                    .await
-                    .unwrap();
+            let (block_tx, _expected_utxo) = make_coinbase_transaction(
+                &genesis_block,
+                &genesis_state,
+                guesser_fraction,
+                now,
+                TxProvingCapability::SingleProof,
+            )
+            .await
+            .unwrap();
             let mut block1 = Block::make_block_template_with_valid_proof(
                 &genesis_block,
                 block_tx,

--- a/src/models/blockchain/block/validity/block_program.rs
+++ b/src/models/blockchain/block/validity/block_program.rs
@@ -234,7 +234,10 @@ pub(crate) mod test {
             .iter()
             .flat_map(|appendix_claim| Tip5::hash(appendix_claim).values().to_vec())
             .collect_vec();
-        assert_eq!(expected_output, tasm_output);
+        assert_eq!(
+            expected_output, tasm_output,
+            "tasm output must equal rust output"
+        );
     }
 
     // TODO: Add test that verifies that double spends *within* one block is

--- a/src/models/blockchain/transaction/primitive_witness.rs
+++ b/src/models/blockchain/transaction/primitive_witness.rs
@@ -377,13 +377,12 @@ impl PrimitiveWitness {
 
         true
     }
-}
 
-impl Arbitrary for PrimitiveWitness {
-    type Parameters = (usize, usize, usize);
-    fn arbitrary_with(parameters: Self::Parameters) -> Self::Strategy {
-        let (num_inputs, num_outputs, num_public_announcements) = parameters;
-
+    pub fn arbitrary_with_size_numbers(
+        num_inputs: usize,
+        num_outputs: usize,
+        num_public_announcements: usize,
+    ) -> BoxedStrategy<Self> {
         // unwrap:
         //  - lock script preimages (inputs)
         //  - amounts (inputs)
@@ -497,10 +496,6 @@ impl Arbitrary for PrimitiveWitness {
             .boxed()
     }
 
-    type Strategy = BoxedStrategy<Self>;
-}
-
-impl PrimitiveWitness {
     pub fn arbitrary_primitive_witness_with(
         input_utxos: &[Utxo],
         input_lock_scripts_and_witnesses: &[LockScriptAndWitness],
@@ -1127,7 +1122,7 @@ mod test {
         #[strategy(1usize..3)] _num_inputs: usize,
         #[strategy(1usize..3)] _num_outputs: usize,
         #[strategy(0usize..3)] _num_public_announcements: usize,
-        #[strategy(PrimitiveWitness::arbitrary_with((#_num_inputs, #_num_outputs, #_num_public_announcements)
+        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(#_num_inputs, #_num_outputs, #_num_public_announcements
         ))]
         transaction_primitive_witness: PrimitiveWitness,
     ) {
@@ -1188,7 +1183,8 @@ mod test {
 
     #[proptest(cases = 5)]
     fn total_amount_is_valid(
-        #[strategy(PrimitiveWitness::arbitrary_with((2,2,2)))] primitive_witness: PrimitiveWitness,
+        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2))]
+        primitive_witness: PrimitiveWitness,
     ) {
         println!("generated primitive witness.");
         let mut total = if let Some(amount) = primitive_witness.kernel.coinbase {

--- a/src/models/blockchain/transaction/transaction_kernel.rs
+++ b/src/models/blockchain/transaction/transaction_kernel.rs
@@ -24,11 +24,11 @@ use crate::util_types::mutator_set::removal_record::RemovalRecord;
 
 /// TransactionKernel is immutable and its hash never changes.
 ///
-/// See [TransactionKernelModifier] for generating modified copies.
+/// See [`TransactionKernelModifier`] for generating modified copies.
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, GetSize, BFieldCodec, TasmObject)]
 #[readonly::make]
 pub struct TransactionKernel {
-    // note: see field descriptions in TransactionKernelProxy
+    // note: see field descriptions in [`TransactionKernelProxy`]
     pub inputs: Vec<RemovalRecord>,
     pub outputs: Vec<AdditionRecord>,
     pub public_announcements: Vec<PublicAnnouncement>,

--- a/src/models/blockchain/transaction/utxo.rs
+++ b/src/models/blockchain/transaction/utxo.rs
@@ -244,7 +244,7 @@ impl<'a> Arbitrary<'a> for Utxo {
     }
 }
 #[cfg(test)]
-mod utxo_tests {
+mod test {
     use proptest::prelude::*;
     use rand::thread_rng;
     use rand::Rng;

--- a/src/models/blockchain/transaction/utxo.rs
+++ b/src/models/blockchain/transaction/utxo.rs
@@ -132,6 +132,12 @@ impl Utxo {
         Self::new(lock_script, vec![Coin::new_native_currency(amount)])
     }
 
+    pub(crate) fn has_native_currency(&self) -> bool {
+        self.coins
+            .iter()
+            .any(|coin| coin.type_script_hash == NativeCurrency.hash())
+    }
+
     /// Get the amount of Neptune coins that are encapsulated in this UTXO,
     /// regardless of which other coins are present. (Even if that makes the
     /// Neptune coins unspendable.)

--- a/src/models/blockchain/transaction/validity/collect_lock_scripts.rs
+++ b/src/models/blockchain/transaction/validity/collect_lock_scripts.rs
@@ -248,7 +248,7 @@ mod test {
 
     #[proptest(cases = 5)]
     fn collect_lock_script_proptest(
-        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2))]
+        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2))]
         primitive_witness: PrimitiveWitness,
     ) {
         prop(primitive_witness)?;
@@ -258,10 +258,11 @@ mod test {
     fn collect_lock_script_unit() {
         let mut test_runner = TestRunner::deterministic();
         for num_inputs in 0..5 {
-            let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(num_inputs, 2, 2)
-                .new_tree(&mut test_runner)
-                .unwrap()
-                .current();
+            let primitive_witness =
+                PrimitiveWitness::arbitrary_with_size_numbers(Some(num_inputs), 2, 2)
+                    .new_tree(&mut test_runner)
+                    .unwrap()
+                    .current();
             prop(primitive_witness).expect("");
         }
     }

--- a/src/models/blockchain/transaction/validity/collect_lock_scripts.rs
+++ b/src/models/blockchain/transaction/validity/collect_lock_scripts.rs
@@ -211,7 +211,6 @@ impl From<&PrimitiveWitness> for CollectLockScriptsWitness {
 
 #[cfg(test)]
 mod test {
-    use proptest::arbitrary::Arbitrary;
     use proptest::prop_assert_eq;
     use proptest::strategy::Strategy;
     use proptest::test_runner::TestCaseError;
@@ -249,7 +248,7 @@ mod test {
 
     #[proptest(cases = 5)]
     fn collect_lock_script_proptest(
-        #[strategy(PrimitiveWitness::arbitrary_with((2, 2, 2)))]
+        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2))]
         primitive_witness: PrimitiveWitness,
     ) {
         prop(primitive_witness)?;
@@ -259,7 +258,7 @@ mod test {
     fn collect_lock_script_unit() {
         let mut test_runner = TestRunner::deterministic();
         for num_inputs in 0..5 {
-            let primitive_witness = PrimitiveWitness::arbitrary_with((num_inputs, 2, 2))
+            let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(num_inputs, 2, 2)
                 .new_tree(&mut test_runner)
                 .unwrap()
                 .current();

--- a/src/models/blockchain/transaction/validity/collect_type_scripts.rs
+++ b/src/models/blockchain/transaction/validity/collect_type_scripts.rs
@@ -439,7 +439,7 @@ mod test {
     fn derived_witness_generates_accepting_program_proptest(
         #[strategy(0usize..5)] _num_outputs: usize,
         #[strategy(0usize..5)] _num_inputs: usize,
-        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(#_num_inputs,#_num_outputs,2))]
+        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(Some(#_num_inputs),#_num_outputs,2))]
         primitive_witness: PrimitiveWitness,
     ) {
         prop(primitive_witness)?;
@@ -459,7 +459,7 @@ mod test {
     #[test]
     fn derived_edge_case_witnesses_generate_accepting_programs_unit() {
         let mut test_runner = TestRunner::deterministic();
-        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(0, 0, 2)
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(0), 0, 2)
             .new_tree(&mut test_runner)
             .unwrap()
             .current();
@@ -484,7 +484,7 @@ mod test {
     #[test]
     fn collect_type_scripts_proof_generation() {
         let mut test_runner = TestRunner::deterministic();
-        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2)
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
             .new_tree(&mut test_runner)
             .unwrap()
             .current();

--- a/src/models/blockchain/transaction/validity/collect_type_scripts.rs
+++ b/src/models/blockchain/transaction/validity/collect_type_scripts.rs
@@ -393,7 +393,6 @@ impl From<&PrimitiveWitness> for CollectTypeScriptsWitness {
 
 #[cfg(test)]
 mod test {
-    use proptest::arbitrary::Arbitrary;
     use proptest::prop_assert_eq;
     use proptest::strategy::Strategy;
     use proptest::strategy::ValueTree;
@@ -440,7 +439,7 @@ mod test {
     fn derived_witness_generates_accepting_program_proptest(
         #[strategy(0usize..5)] _num_outputs: usize,
         #[strategy(0usize..5)] _num_inputs: usize,
-        #[strategy(PrimitiveWitness::arbitrary_with((#_num_inputs,#_num_outputs,2)))]
+        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(#_num_inputs,#_num_outputs,2))]
         primitive_witness: PrimitiveWitness,
     ) {
         prop(primitive_witness)?;
@@ -460,7 +459,7 @@ mod test {
     #[test]
     fn derived_edge_case_witnesses_generate_accepting_programs_unit() {
         let mut test_runner = TestRunner::deterministic();
-        let primitive_witness = PrimitiveWitness::arbitrary_with((0, 0, 2))
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(0, 0, 2)
             .new_tree(&mut test_runner)
             .unwrap()
             .current();
@@ -485,7 +484,7 @@ mod test {
     #[test]
     fn collect_type_scripts_proof_generation() {
         let mut test_runner = TestRunner::deterministic();
-        let primitive_witness = PrimitiveWitness::arbitrary_with((2, 2, 2))
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2)
             .new_tree(&mut test_runner)
             .unwrap()
             .current();

--- a/src/models/blockchain/transaction/validity/kernel_to_outputs.rs
+++ b/src/models/blockchain/transaction/validity/kernel_to_outputs.rs
@@ -346,7 +346,6 @@ impl ConsensusProgram for KernelToOutputs {
 
 #[cfg(test)]
 mod test {
-    use proptest::arbitrary::Arbitrary;
     use proptest::prop_assert_eq;
     use proptest::strategy::Strategy;
     use proptest::test_runner::TestRunner;
@@ -363,7 +362,7 @@ mod test {
         #[strategy(0usize..5)] _num_outputs: usize,
         #[strategy(0usize..5)] _num_inputs: usize,
         #[strategy(0usize..5)] _num_pub_announcements: usize,
-        #[strategy(PrimitiveWitness::arbitrary_with((#_num_inputs,#_num_outputs,#_num_pub_announcements)))]
+        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(#_num_inputs,#_num_outputs,#_num_pub_announcements))]
         primitive_witness: PrimitiveWitness,
     ) {
         let kernel_to_outputs_witness = KernelToOutputsWitness::from(&primitive_witness);
@@ -389,7 +388,7 @@ mod test {
     #[test]
     fn kernel_to_outputs_unittest() {
         let mut test_runner = TestRunner::deterministic();
-        let primitive_witness = PrimitiveWitness::arbitrary_with((2, 2, 2))
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2)
             .new_tree(&mut test_runner)
             .unwrap()
             .current();
@@ -411,7 +410,7 @@ mod test {
     #[test]
     fn kernel_to_outputs_failing_proof() {
         let mut test_runner = TestRunner::deterministic();
-        let primitive_witness = PrimitiveWitness::arbitrary_with((2, 2, 2))
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2)
             .new_tree(&mut test_runner)
             .unwrap()
             .current();

--- a/src/models/blockchain/transaction/validity/kernel_to_outputs.rs
+++ b/src/models/blockchain/transaction/validity/kernel_to_outputs.rs
@@ -362,7 +362,7 @@ mod test {
         #[strategy(0usize..5)] _num_outputs: usize,
         #[strategy(0usize..5)] _num_inputs: usize,
         #[strategy(0usize..5)] _num_pub_announcements: usize,
-        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(#_num_inputs,#_num_outputs,#_num_pub_announcements))]
+        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(Some(#_num_inputs),#_num_outputs,#_num_pub_announcements))]
         primitive_witness: PrimitiveWitness,
     ) {
         let kernel_to_outputs_witness = KernelToOutputsWitness::from(&primitive_witness);
@@ -388,7 +388,7 @@ mod test {
     #[test]
     fn kernel_to_outputs_unittest() {
         let mut test_runner = TestRunner::deterministic();
-        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2)
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
             .new_tree(&mut test_runner)
             .unwrap()
             .current();
@@ -410,7 +410,7 @@ mod test {
     #[test]
     fn kernel_to_outputs_failing_proof() {
         let mut test_runner = TestRunner::deterministic();
-        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2)
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
             .new_tree(&mut test_runner)
             .unwrap()
             .current();

--- a/src/models/blockchain/transaction/validity/proof_collection.rs
+++ b/src/models/blockchain/transaction/validity/proof_collection.rs
@@ -437,7 +437,7 @@ pub mod test {
 
     #[proptest(cases = 5)]
     fn can_produce_valid_collection(
-        #[strategy(PrimitiveWitness::arbitrary_with((2, 2, 2)))]
+        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2))]
         primitive_witness: PrimitiveWitness,
     ) {
         prop_assert!(ProofCollection::can_produce(&primitive_witness));

--- a/src/models/blockchain/transaction/validity/proof_collection.rs
+++ b/src/models/blockchain/transaction/validity/proof_collection.rs
@@ -437,7 +437,7 @@ pub mod test {
 
     #[proptest(cases = 5)]
     fn can_produce_valid_collection(
-        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2))]
+        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2))]
         primitive_witness: PrimitiveWitness,
     ) {
         prop_assert!(ProofCollection::can_produce(&primitive_witness));

--- a/src/models/blockchain/transaction/validity/proof_collection.rs
+++ b/src/models/blockchain/transaction/validity/proof_collection.rs
@@ -11,6 +11,7 @@ use tasm_lib::twenty_first::util_types::algebraic_hasher::AlgebraicHasher;
 use tasm_lib::Digest;
 use tracing::debug;
 use tracing::info;
+use tracing::trace;
 
 use super::collect_type_scripts::CollectTypeScriptsWitness;
 use super::kernel_to_outputs::KernelToOutputsWitness;
@@ -249,7 +250,7 @@ impl ProofCollection {
             Claim::about_program(&RemovalRecordsIntegrity.program())
                 .with_input(self.kernel_mast_hash.reversed().values())
                 .with_output(self.salted_inputs_hash.values().to_vec());
-        debug!(
+        trace!(
             "removal records integrity claim: {:?}",
             removal_records_integrity_claim
         );
@@ -277,6 +278,7 @@ impl ProofCollection {
                     .flat_map(|d| d.values())
                     .collect_vec(),
             );
+        trace!("collect_type_scripts_claim:\n{collect_type_scripts_claim:?}\n\n");
         let lock_script_claims = self
             .lock_script_hashes
             .iter()

--- a/src/models/blockchain/transaction/validity/removal_records_integrity.rs
+++ b/src/models/blockchain/transaction/validity/removal_records_integrity.rs
@@ -1078,7 +1078,6 @@ impl<'a> Arbitrary<'a> for RemovalRecordsIntegrityWitness {
 mod tests {
     use assert2::assert;
     use itertools::Itertools;
-    use proptest::arbitrary::Arbitrary;
     use proptest::prop_assert_eq;
     use proptest::strategy::Strategy;
     use proptest::test_runner::TestCaseResult;
@@ -1119,7 +1118,8 @@ mod tests {
 
     #[proptest(cases = 5)]
     fn removal_records_integrity_proptest(
-        #[strategy(PrimitiveWitness::arbitrary_with((2,2,2)))] primitive_witness: PrimitiveWitness,
+        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2))]
+        primitive_witness: PrimitiveWitness,
     ) {
         let removal_records_integrity_witness =
             RemovalRecordsIntegrityWitness::from(&primitive_witness);
@@ -1129,7 +1129,7 @@ mod tests {
     #[test]
     fn removal_records_integrity_only_rust_shadowing() {
         let mut test_runner = TestRunner::deterministic();
-        let primitive_witness = PrimitiveWitness::arbitrary_with((2, 2, 2))
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2)
             .new_tree(&mut test_runner)
             .unwrap()
             .current();
@@ -1149,7 +1149,7 @@ mod tests {
     #[test]
     fn removal_records_integrity_unit_test() {
         let mut test_runner = TestRunner::deterministic();
-        let primitive_witness = PrimitiveWitness::arbitrary_with((2, 2, 2))
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2)
             .new_tree(&mut test_runner)
             .unwrap()
             .current();
@@ -1163,7 +1163,7 @@ mod tests {
     #[test]
     fn removal_records_fail_on_bad_ms_acc() {
         let mut test_runner = TestRunner::deterministic();
-        let primitive_witness = PrimitiveWitness::arbitrary_with((2, 2, 2))
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2)
             .new_tree(&mut test_runner)
             .unwrap()
             .current();
@@ -1180,7 +1180,7 @@ mod tests {
     #[test]
     fn removal_records_fail_on_bad_mast_path_inputs() {
         let mut test_runner = TestRunner::deterministic();
-        let primitive_witness = PrimitiveWitness::arbitrary_with((2, 2, 2))
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2)
             .new_tree(&mut test_runner)
             .unwrap()
             .current();
@@ -1220,7 +1220,7 @@ mod tests {
     fn removal_record_fail_on_bad_absolute_indices_unit_test() {
         let mut test_runner = TestRunner::deterministic();
         let num_inputs = 2;
-        let primitive_witness = PrimitiveWitness::arbitrary_with((num_inputs, 2, 2))
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(num_inputs, 2, 2)
             .new_tree(&mut test_runner)
             .unwrap()
             .current();
@@ -1247,7 +1247,8 @@ mod tests {
 
     #[proptest(cases = 4)]
     fn removal_records_fail_on_bad_absolute_indices(
-        #[strategy(PrimitiveWitness::arbitrary_with((3, 2, 2)))] mut bad_pw: PrimitiveWitness,
+        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2))]
+        mut bad_pw: PrimitiveWitness,
         #[strategy(0..2usize)] mutated_input: usize,
         #[strategy(0..NUM_TRIALS as usize)] mutated_bloom_filter_index: usize,
     ) {

--- a/src/models/blockchain/transaction/validity/removal_records_integrity.rs
+++ b/src/models/blockchain/transaction/validity/removal_records_integrity.rs
@@ -1118,7 +1118,7 @@ mod tests {
 
     #[proptest(cases = 5)]
     fn removal_records_integrity_proptest(
-        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2))]
+        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2))]
         primitive_witness: PrimitiveWitness,
     ) {
         let removal_records_integrity_witness =
@@ -1129,7 +1129,7 @@ mod tests {
     #[test]
     fn removal_records_integrity_only_rust_shadowing() {
         let mut test_runner = TestRunner::deterministic();
-        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2)
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
             .new_tree(&mut test_runner)
             .unwrap()
             .current();
@@ -1149,7 +1149,7 @@ mod tests {
     #[test]
     fn removal_records_integrity_unit_test() {
         let mut test_runner = TestRunner::deterministic();
-        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2)
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
             .new_tree(&mut test_runner)
             .unwrap()
             .current();
@@ -1163,7 +1163,7 @@ mod tests {
     #[test]
     fn removal_records_fail_on_bad_ms_acc() {
         let mut test_runner = TestRunner::deterministic();
-        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2)
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
             .new_tree(&mut test_runner)
             .unwrap()
             .current();
@@ -1180,7 +1180,7 @@ mod tests {
     #[test]
     fn removal_records_fail_on_bad_mast_path_inputs() {
         let mut test_runner = TestRunner::deterministic();
-        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2)
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
             .new_tree(&mut test_runner)
             .unwrap()
             .current();
@@ -1220,10 +1220,11 @@ mod tests {
     fn removal_record_fail_on_bad_absolute_indices_unit_test() {
         let mut test_runner = TestRunner::deterministic();
         let num_inputs = 2;
-        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(num_inputs, 2, 2)
-            .new_tree(&mut test_runner)
-            .unwrap()
-            .current();
+        let primitive_witness =
+            PrimitiveWitness::arbitrary_with_size_numbers(Some(num_inputs), 2, 2)
+                .new_tree(&mut test_runner)
+                .unwrap()
+                .current();
 
         for i in 0..num_inputs {
             let mut bad_pw = primitive_witness.clone();
@@ -1247,7 +1248,7 @@ mod tests {
 
     #[proptest(cases = 4)]
     fn removal_records_fail_on_bad_absolute_indices(
-        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2))]
+        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2))]
         mut bad_pw: PrimitiveWitness,
         #[strategy(0..2usize)] mutated_input: usize,
         #[strategy(0..NUM_TRIALS as usize)] mutated_bloom_filter_index: usize,

--- a/src/models/blockchain/transaction/validity/single_proof.rs
+++ b/src/models/blockchain/transaction/validity/single_proof.rs
@@ -684,7 +684,6 @@ impl ConsensusProgram for SingleProof {
 #[cfg(test)]
 mod test {
     use assert2::let_assert;
-    use proptest::prelude::Arbitrary;
     use proptest::prelude::Strategy;
     use proptest::strategy::ValueTree;
     use proptest::test_runner::TestRunner;
@@ -699,7 +698,6 @@ mod test {
     use crate::models::blockchain::transaction::validity::tasm::single_proof::merge_branch::test::deterministic_merge_witness;
     use crate::models::blockchain::transaction::validity::tasm::single_proof::update_branch::test::deterministic_update_witness_only_additions;
     use crate::models::blockchain::type_scripts::time_lock::arbitrary_primitive_witness_with_expired_timelocks;
-    use crate::models::proof_abstractions::mast_hash::MastHash;
     use crate::models::proof_abstractions::tasm::program::ConsensusError;
     use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
     use crate::models::proof_abstractions::timestamp::Timestamp;
@@ -738,7 +736,7 @@ mod test {
     #[tokio::test]
     async fn can_verify_via_valid_proof_collection() {
         let mut test_runner = TestRunner::deterministic();
-        let primitive_witness = PrimitiveWitness::arbitrary_with((2, 2, 2))
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2)
             .new_tree(&mut test_runner)
             .unwrap()
             .current();

--- a/src/models/blockchain/transaction/validity/single_proof.rs
+++ b/src/models/blockchain/transaction/validity/single_proof.rs
@@ -736,7 +736,7 @@ mod test {
     #[tokio::test]
     async fn can_verify_via_valid_proof_collection() {
         let mut test_runner = TestRunner::deterministic();
-        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2)
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
             .new_tree(&mut test_runner)
             .unwrap()
             .current();

--- a/src/models/blockchain/transaction/validity/single_proof.rs
+++ b/src/models/blockchain/transaction/validity/single_proof.rs
@@ -689,6 +689,7 @@ mod test {
     use proptest::test_runner::TestRunner;
     use proptest_arbitrary_interop::arb;
     use tasm_lib::triton_vm::prelude::BFieldCodec;
+    use tracing_test::traced_test;
 
     use super::*;
     use crate::job_queue::triton_vm::TritonVmJobPriority;
@@ -778,6 +779,7 @@ mod test {
         );
     }
 
+    #[traced_test]
     #[tokio::test]
     async fn can_verify_via_valid_proof_collection_if_timelocked_expired() {
         let mut test_runner = TestRunner::deterministic();
@@ -800,8 +802,6 @@ mod test {
         .await
         .unwrap();
         assert!(proof_collection.verify(txk_mast_hash));
-
-        println!("Have proof collection. \\o/");
 
         let single_proof_witness = SingleProofWitness::from_collection(proof_collection);
         let txk_mast_hash_as_input_as_public_input =

--- a/src/models/blockchain/transaction/validity/tasm/authenticate_txk_field.rs
+++ b/src/models/blockchain/transaction/validity/tasm/authenticate_txk_field.rs
@@ -257,10 +257,13 @@ mod tests {
             let mut rng: TestRng = TestRng::from_seed(RngAlgorithm::ChaCha, &seed);
             let inputs_ptr: BFieldElement = bfe!(rng.gen_range(0..(1 << 30)));
 
-            let primitive_witness = PrimitiveWitness::arbitrary_with((2, 2, 2))
-                .new_tree(&mut TestRunner::new_with_rng(Default::default(), rng))
-                .unwrap()
-                .current();
+            let primitive_witness: PrimitiveWitness = {
+                let mut test_runner = TestRunner::new_with_rng(Default::default(), rng);
+                PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2)
+                    .new_tree(&mut test_runner)
+                    .unwrap()
+                    .current()
+            };
             self.correct_initial_state(inputs_ptr, primitive_witness)
         }
     }
@@ -278,10 +281,13 @@ mod tests {
         for &field in TransactionKernelField::VARIANTS {
             let snippet = AuthenticateTxkField(field);
             let inputs_ptr: BFieldElement = random();
-            let primitive_witness = PrimitiveWitness::arbitrary_with((2, 2, 2))
-                .new_tree(&mut TestRunner::deterministic())
-                .unwrap()
-                .current();
+            let primitive_witness: PrimitiveWitness = {
+                let mut test_runner = TestRunner::deterministic();
+                PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2)
+                    .new_tree(&mut test_runner)
+                    .unwrap()
+                    .current()
+            };
             let mut bad_auth_path = snippet.correct_initial_state(inputs_ptr, primitive_witness);
             bad_auth_path.nondeterminism.digests[0].0[0].increment();
 

--- a/src/models/blockchain/transaction/validity/tasm/authenticate_txk_field.rs
+++ b/src/models/blockchain/transaction/validity/tasm/authenticate_txk_field.rs
@@ -259,7 +259,7 @@ mod tests {
 
             let primitive_witness: PrimitiveWitness = {
                 let mut test_runner = TestRunner::new_with_rng(Default::default(), rng);
-                PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2)
+                PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
                     .new_tree(&mut test_runner)
                     .unwrap()
                     .current()
@@ -283,7 +283,7 @@ mod tests {
             let inputs_ptr: BFieldElement = random();
             let primitive_witness: PrimitiveWitness = {
                 let mut test_runner = TestRunner::deterministic();
-                PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2)
+                PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
                     .new_tree(&mut test_runner)
                     .unwrap()
                     .current()

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_collect_lock_scripts_claim.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_collect_lock_scripts_claim.rs
@@ -191,10 +191,11 @@ mod tests {
             let mut rng = test_runner.new_rng();
 
             let num_inputs = rng.gen_range(0usize..4);
-            let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(num_inputs, 2, 2)
-                .new_tree(&mut test_runner)
-                .unwrap()
-                .current();
+            let primitive_witness =
+                PrimitiveWitness::arbitrary_with_size_numbers(Some(num_inputs), 2, 2)
+                    .new_tree(&mut test_runner)
+                    .unwrap()
+                    .current();
             let rt = tokio::runtime::Runtime::new().unwrap();
             let _guard = rt.enter();
             let proof_collection = rt

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_collect_lock_scripts_claim.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_collect_lock_scripts_claim.rs
@@ -140,7 +140,6 @@ impl BasicSnippet for GenerateCollectLockScriptsClaim {
 mod tests {
     use std::collections::HashMap;
 
-    use proptest::prelude::Arbitrary;
     use proptest::prelude::Strategy;
     use proptest::test_runner::TestRunner;
     use rand::Rng;
@@ -192,7 +191,7 @@ mod tests {
             let mut rng = test_runner.new_rng();
 
             let num_inputs = rng.gen_range(0usize..4);
-            let primitive_witness = PrimitiveWitness::arbitrary_with((num_inputs, 2, 2))
+            let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(num_inputs, 2, 2)
                 .new_tree(&mut test_runner)
                 .unwrap()
                 .current();

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_collect_type_scripts_claim.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_collect_type_scripts_claim.rs
@@ -226,7 +226,7 @@ mod tests {
 
             let num_inputs = 2;
             let primitive_witness = if rng.gen_bool(0.5) {
-                PrimitiveWitness::arbitrary_with_size_numbers(num_inputs, 2, 2)
+                PrimitiveWitness::arbitrary_with_size_numbers(Some(num_inputs), 2, 2)
                     .new_tree(&mut test_runner)
                     .unwrap()
                     .current()

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_collect_type_scripts_claim.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_collect_type_scripts_claim.rs
@@ -168,7 +168,6 @@ mod tests {
     use std::collections::HashMap;
 
     use itertools::Itertools;
-    use proptest::prelude::Arbitrary;
     use proptest::prelude::Strategy;
     use proptest::strategy::ValueTree;
     use proptest::test_runner::TestRunner;
@@ -227,7 +226,7 @@ mod tests {
 
             let num_inputs = 2;
             let primitive_witness = if rng.gen_bool(0.5) {
-                PrimitiveWitness::arbitrary_with((num_inputs, 2, 2))
+                PrimitiveWitness::arbitrary_with_size_numbers(num_inputs, 2, 2)
                     .new_tree(&mut test_runner)
                     .unwrap()
                     .current()

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_k2o_claim.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_k2o_claim.rs
@@ -122,7 +122,6 @@ mod tests {
     use std::collections::HashMap;
 
     use itertools::Itertools;
-    use proptest::prelude::Arbitrary;
     use proptest::prelude::Strategy;
     use proptest::test_runner::TestRunner;
     use rand::rngs::StdRng;
@@ -194,7 +193,7 @@ mod tests {
             _bench_case: Option<BenchmarkCase>,
         ) -> FunctionInitialState {
             let mut test_runner = TestRunner::deterministic();
-            let primitive_witness = PrimitiveWitness::arbitrary_with((2, 2, 2))
+            let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2)
                 .new_tree(&mut test_runner)
                 .unwrap()
                 .current();

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_k2o_claim.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_k2o_claim.rs
@@ -193,7 +193,7 @@ mod tests {
             _bench_case: Option<BenchmarkCase>,
         ) -> FunctionInitialState {
             let mut test_runner = TestRunner::deterministic();
-            let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2)
+            let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
                 .new_tree(&mut test_runner)
                 .unwrap()
                 .current();

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_lock_script_claim_template.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_lock_script_claim_template.rs
@@ -126,7 +126,7 @@ mod test {
             _bench_case: Option<BenchmarkCase>,
         ) -> FunctionInitialState {
             let mut test_runner = TestRunner::deterministic();
-            let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2)
+            let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
                 .new_tree(&mut test_runner)
                 .unwrap()
                 .current();

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_lock_script_claim_template.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_lock_script_claim_template.rs
@@ -69,7 +69,6 @@ impl BasicSnippet for GenerateLockScriptClaimTemplate {
 mod test {
     use std::collections::HashMap;
 
-    use proptest::arbitrary::Arbitrary;
     use proptest::prelude::Strategy;
     use proptest::test_runner::TestRunner;
     use rand::rngs::StdRng;
@@ -127,7 +126,7 @@ mod test {
             _bench_case: Option<BenchmarkCase>,
         ) -> FunctionInitialState {
             let mut test_runner = TestRunner::deterministic();
-            let primitive_witness = PrimitiveWitness::arbitrary_with((2, 2, 2))
+            let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2)
                 .new_tree(&mut test_runner)
                 .unwrap()
                 .current();

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_rri_claim.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_rri_claim.rs
@@ -122,7 +122,6 @@ mod tests {
     use std::collections::HashMap;
 
     use itertools::Itertools;
-    use proptest::prelude::Arbitrary;
     use proptest::prelude::Strategy;
     use proptest::test_runner::TestRunner;
     use rand::rngs::StdRng;
@@ -194,7 +193,7 @@ mod tests {
             _bench_case: Option<BenchmarkCase>,
         ) -> FunctionInitialState {
             let mut test_runner = TestRunner::deterministic();
-            let primitive_witness = PrimitiveWitness::arbitrary_with((2, 2, 2))
+            let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2)
                 .new_tree(&mut test_runner)
                 .unwrap()
                 .current();

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_rri_claim.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_rri_claim.rs
@@ -193,7 +193,7 @@ mod tests {
             _bench_case: Option<BenchmarkCase>,
         ) -> FunctionInitialState {
             let mut test_runner = TestRunner::deterministic();
-            let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2)
+            let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
                 .new_tree(&mut test_runner)
                 .unwrap()
                 .current();

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_type_script_claim_template.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_type_script_claim_template.rs
@@ -99,7 +99,6 @@ impl BasicSnippet for GenerateTypeScriptClaimTemplate {
 mod test {
     use std::collections::HashMap;
 
-    use proptest::arbitrary::Arbitrary;
     use proptest::prelude::Strategy;
     use proptest::test_runner::TestRunner;
     use rand::rngs::StdRng;
@@ -158,7 +157,7 @@ mod test {
             _bench_case: Option<BenchmarkCase>,
         ) -> FunctionInitialState {
             let mut test_runner = TestRunner::deterministic();
-            let primitive_witness = PrimitiveWitness::arbitrary_with((2, 2, 2))
+            let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2)
                 .new_tree(&mut test_runner)
                 .unwrap()
                 .current();

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_type_script_claim_template.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_type_script_claim_template.rs
@@ -157,7 +157,7 @@ mod test {
             _bench_case: Option<BenchmarkCase>,
         ) -> FunctionInitialState {
             let mut test_runner = TestRunner::deterministic();
-            let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2)
+            let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
                 .new_tree(&mut test_runner)
                 .unwrap()
                 .current();

--- a/src/models/blockchain/transaction/validity/tasm/hash_removal_record_index_sets.rs
+++ b/src/models/blockchain/transaction/validity/tasm/hash_removal_record_index_sets.rs
@@ -164,7 +164,7 @@ mod tests {
             let mut removal_records = vec![];
             for _ in 0..N {
                 let removal_record = PrimitiveWitness::arbitrary_with_size_numbers(
-                    num_inputs,
+                    Some(num_inputs),
                     num_outputs,
                     num_public_announcements,
                 )

--- a/src/models/blockchain/transaction/validity/tasm/hash_removal_record_index_sets.rs
+++ b/src/models/blockchain/transaction/validity/tasm/hash_removal_record_index_sets.rs
@@ -66,7 +66,6 @@ mod tests {
 
     use itertools::Itertools;
     use num_traits::ConstZero;
-    use proptest::prelude::Arbitrary;
     use proptest::prelude::Strategy;
     use proptest::test_runner::RngAlgorithm;
     use proptest::test_runner::TestRng;
@@ -159,17 +158,22 @@ mod tests {
                     rng.gen_range(0..10),
                 ),
             };
+            let (num_inputs, num_outputs, num_public_announcements) = arb_params;
 
             let mut test_runner = TestRunner::new_with_rng(Default::default(), rng);
             let mut removal_records = vec![];
             for _ in 0..N {
-                let removal_record = PrimitiveWitness::arbitrary_with(arb_params)
-                    .new_tree(&mut test_runner)
-                    .unwrap()
-                    .current()
-                    .kernel
-                    .inputs
-                    .clone();
+                let removal_record = PrimitiveWitness::arbitrary_with_size_numbers(
+                    num_inputs,
+                    num_outputs,
+                    num_public_announcements,
+                )
+                .new_tree(&mut test_runner)
+                .unwrap()
+                .current()
+                .kernel
+                .inputs
+                .clone();
                 removal_records.push(removal_record);
             }
             let removal_records = removal_records.try_into().unwrap();

--- a/src/models/blockchain/transaction/validity/tasm/leaf_authentication/authenticate_inputs_against_txk.rs
+++ b/src/models/blockchain/transaction/validity/tasm/leaf_authentication/authenticate_inputs_against_txk.rs
@@ -165,7 +165,7 @@ mod tests {
 
             let primitive_witness: PrimitiveWitness = {
                 let mut test_runner = TestRunner::new_with_rng(Default::default(), rng);
-                PrimitiveWitness::arbitrary_with((2, 2, 2))
+                PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2)
                     .new_tree(&mut test_runner)
                     .unwrap()
                     .current()
@@ -183,10 +183,13 @@ mod tests {
     fn negative_test_bad_auth_path() {
         let snippet = AuthenticateInputsAgainstTxk;
         let inputs_ptr: BFieldElement = random();
-        let primitive_witness = PrimitiveWitness::arbitrary_with((2, 2, 2))
-            .new_tree(&mut TestRunner::deterministic())
-            .unwrap()
-            .current();
+        let primitive_witness: PrimitiveWitness = {
+            let mut test_runner = TestRunner::deterministic();
+            PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2)
+                .new_tree(&mut test_runner)
+                .unwrap()
+                .current()
+        };
         let mut bad_auth_path = snippet.correct_init_state(inputs_ptr, primitive_witness);
         bad_auth_path.nondeterminism.digests[0] =
             bad_auth_path.nondeterminism.digests[0].reversed();

--- a/src/models/blockchain/transaction/validity/tasm/leaf_authentication/authenticate_inputs_against_txk.rs
+++ b/src/models/blockchain/transaction/validity/tasm/leaf_authentication/authenticate_inputs_against_txk.rs
@@ -165,7 +165,7 @@ mod tests {
 
             let primitive_witness: PrimitiveWitness = {
                 let mut test_runner = TestRunner::new_with_rng(Default::default(), rng);
-                PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2)
+                PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
                     .new_tree(&mut test_runner)
                     .unwrap()
                     .current()
@@ -185,7 +185,7 @@ mod tests {
         let inputs_ptr: BFieldElement = random();
         let primitive_witness: PrimitiveWitness = {
             let mut test_runner = TestRunner::deterministic();
-            PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2)
+            PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
                 .new_tree(&mut test_runner)
                 .unwrap()
                 .current()

--- a/src/models/blockchain/transaction/validity/tasm/leaf_authentication/authenticate_msa_against_txk.rs
+++ b/src/models/blockchain/transaction/validity/tasm/leaf_authentication/authenticate_msa_against_txk.rs
@@ -244,7 +244,7 @@ mod tests {
 
             let primitive_witness: PrimitiveWitness = {
                 let mut test_runner = TestRunner::new_with_rng(Default::default(), rng);
-                PrimitiveWitness::arbitrary_with((2, 2, 2))
+                PrimitiveWitness::arbitrary_with_size_numbers(2,2,2)
                     .new_tree(&mut test_runner)
                     .unwrap()
                     .current()

--- a/src/models/blockchain/transaction/validity/tasm/leaf_authentication/authenticate_msa_against_txk.rs
+++ b/src/models/blockchain/transaction/validity/tasm/leaf_authentication/authenticate_msa_against_txk.rs
@@ -244,7 +244,7 @@ mod tests {
 
             let primitive_witness: PrimitiveWitness = {
                 let mut test_runner = TestRunner::new_with_rng(Default::default(), rng);
-                PrimitiveWitness::arbitrary_with_size_numbers(2,2,2)
+                PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
                     .new_tree(&mut test_runner)
                     .unwrap()
                     .current()

--- a/src/models/blockchain/transaction/validity/tasm/single_proof/update_branch.rs
+++ b/src/models/blockchain/transaction/validity/tasm/single_proof/update_branch.rs
@@ -706,7 +706,6 @@ impl BasicSnippet for UpdateBranch {
 #[cfg(test)]
 pub(crate) mod test {
     use itertools::Itertools;
-    use proptest::arbitrary::Arbitrary;
     use proptest::collection::vec;
     use proptest::strategy::Strategy;
     use proptest::strategy::ValueTree;
@@ -799,11 +798,14 @@ pub(crate) mod test {
         // Should also test for removed records in the new mutator set
         // accumulator.
         let mut test_runner = TestRunner::deterministic();
-        let primitive_witness =
-            PrimitiveWitness::arbitrary_with((num_inputs, num_outputs, num_pub_announcements))
-                .new_tree(&mut test_runner)
-                .unwrap()
-                .current();
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(
+            num_inputs,
+            num_outputs,
+            num_pub_announcements,
+        )
+        .new_tree(&mut test_runner)
+        .unwrap()
+        .current();
         let newly_confirmed_records = vec(arb::<Digest>(), 0usize..100)
             .new_tree(&mut test_runner)
             .unwrap()

--- a/src/models/blockchain/transaction/validity/tasm/single_proof/update_branch.rs
+++ b/src/models/blockchain/transaction/validity/tasm/single_proof/update_branch.rs
@@ -799,7 +799,7 @@ pub(crate) mod test {
         // accumulator.
         let mut test_runner = TestRunner::deterministic();
         let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(
-            num_inputs,
+            Some(num_inputs),
             num_outputs,
             num_pub_announcements,
         )

--- a/src/models/blockchain/type_scripts/native_currency.rs
+++ b/src/models/blockchain/type_scripts/native_currency.rs
@@ -809,7 +809,7 @@ pub mod test {
     fn native_currency_derived_witness_generates_accepting_tasm_program_empty_tx() {
         // Generate a tx with coinbase input, no outputs, fee-size is the same
         // as the coinbase, so tx is valid.
-        let primitive_witness = PrimitiveWitness::arbitrary_with((0, 0, 0))
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(0, 0, 0)
             .new_tree(&mut TestRunner::deterministic())
             .unwrap()
             .current();
@@ -823,7 +823,7 @@ pub mod test {
 
     #[test]
     fn native_currency_derived_witness_generates_accepting_tasm_program_unittest() {
-        let primitive_witness = PrimitiveWitness::arbitrary_with((2, 2, 2))
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2)
             .new_tree(&mut TestRunner::deterministic())
             .unwrap()
             .current();
@@ -840,11 +840,7 @@ pub mod test {
         #[strategy(0usize..=3)] _num_inputs: usize,
         #[strategy(0usize..=3)] _num_outputs: usize,
         #[strategy(0usize..=1)] _num_public_announcements: usize,
-        #[strategy(PrimitiveWitness::arbitrary_with((
-            #_num_inputs,
-            #_num_outputs,
-            #_num_public_announcements),
-        ))]
+        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(#_num_inputs, #_num_outputs, #_num_public_announcements))]
         primitive_witness: PrimitiveWitness,
     ) {
         // PrimitiveWitness::arbitrary_with already ensures the transaction is balanced
@@ -953,7 +949,7 @@ pub mod test {
 
     #[tokio::test]
     async fn native_currency_failing_proof() {
-        let primitive_witness = PrimitiveWitness::arbitrary_with((2, 2, 2))
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2)
             .new_tree(&mut TestRunner::deterministic())
             .unwrap()
             .current();

--- a/src/models/blockchain/type_scripts/native_currency.rs
+++ b/src/models/blockchain/type_scripts/native_currency.rs
@@ -25,6 +25,7 @@ use super::neptune_coins::NeptuneCoins;
 use super::TypeScriptWitness;
 use crate::models::blockchain::block::COINBASE_TIME_LOCK_PERIOD;
 use crate::models::blockchain::shared::Hash;
+use crate::models::blockchain::transaction::primitive_witness::PrimitiveWitness;
 use crate::models::blockchain::transaction::primitive_witness::SaltedUtxos;
 use crate::models::blockchain::transaction::transaction_kernel::TransactionKernel;
 use crate::models::blockchain::transaction::transaction_kernel::TransactionKernelField;
@@ -910,6 +911,16 @@ pub struct NativeCurrencyWitness {
     pub kernel: TransactionKernel,
 }
 
+impl From<PrimitiveWitness> for NativeCurrencyWitness {
+    fn from(primitive_witness: PrimitiveWitness) -> Self {
+        NativeCurrencyWitness {
+            salted_input_utxos: primitive_witness.input_utxos,
+            salted_output_utxos: primitive_witness.output_utxos,
+            kernel: primitive_witness.kernel,
+        }
+    }
+}
+
 /// The part of witness data that is read from memory
 ///
 /// Factored out since this makes auditing the preloaded data much cheaper as
@@ -1092,11 +1103,7 @@ pub mod test {
             .new_tree(&mut test_runner)
             .unwrap()
             .current();
-        let native_currency_witness = NativeCurrencyWitness {
-            salted_input_utxos: primitive_witness.input_utxos,
-            salted_output_utxos: primitive_witness.output_utxos,
-            kernel: primitive_witness.kernel,
-        };
+        let native_currency_witness = NativeCurrencyWitness::from(primitive_witness);
         prop_positive(native_currency_witness).unwrap();
     }
 
@@ -1107,11 +1114,7 @@ pub mod test {
             .new_tree(&mut test_runner)
             .unwrap()
             .current();
-        let native_currency_witness = NativeCurrencyWitness {
-            salted_input_utxos: primitive_witness.input_utxos,
-            salted_output_utxos: primitive_witness.output_utxos,
-            kernel: primitive_witness.kernel,
-        };
+        let native_currency_witness = NativeCurrencyWitness::from(primitive_witness);
         prop_positive(native_currency_witness).unwrap();
     }
 
@@ -1124,11 +1127,7 @@ pub mod test {
         primitive_witness: PrimitiveWitness,
     ) {
         // PrimitiveWitness::arbitrary_with already ensures the transaction is balanced
-        let native_currency_witness = NativeCurrencyWitness {
-            salted_input_utxos: primitive_witness.input_utxos,
-            salted_output_utxos: primitive_witness.output_utxos,
-            kernel: primitive_witness.kernel,
-        };
+        let native_currency_witness = NativeCurrencyWitness::from(primitive_witness);
         prop_positive(native_currency_witness)?;
     }
 
@@ -1146,11 +1145,7 @@ pub mod test {
         ))]
         primitive_witness: PrimitiveWitness,
     ) {
-        let native_currency_witness = NativeCurrencyWitness {
-            salted_input_utxos: primitive_witness.input_utxos,
-            salted_output_utxos: primitive_witness.output_utxos,
-            kernel: primitive_witness.kernel,
-        };
+        let native_currency_witness = NativeCurrencyWitness::from(primitive_witness);
 
         // there are inputs so there can be no coinbase and we are testing a
         // regular transaction
@@ -1168,11 +1163,7 @@ pub mod test {
             .new_tree(&mut test_runner)
             .unwrap()
             .current();
-        let native_currency_witness = NativeCurrencyWitness {
-            salted_input_utxos: primitive_witness.input_utxos,
-            salted_output_utxos: primitive_witness.output_utxos,
-            kernel: primitive_witness.kernel,
-        };
+        let native_currency_witness = NativeCurrencyWitness::from(primitive_witness);
 
         prop_positive(native_currency_witness).unwrap();
     }
@@ -1201,11 +1192,7 @@ pub mod test {
         primitive_witness: PrimitiveWitness,
     ) {
         // with high probability the amounts (which are random) do not add up
-        let witness = NativeCurrencyWitness {
-            salted_input_utxos: primitive_witness.input_utxos,
-            salted_output_utxos: primitive_witness.output_utxos,
-            kernel: primitive_witness.kernel,
-        };
+        let witness = NativeCurrencyWitness::from(primitive_witness);
 
         NativeCurrency.test_assertion_failure(
             witness.standard_input(),
@@ -1241,11 +1228,7 @@ pub mod test {
         // with high probability the amounts (which are random) do not add up
         // and since the coinbase is set, the coinbase-timelock test might fail
         // before the no-inflation test.
-        let witness = NativeCurrencyWitness {
-            salted_input_utxos: primitive_witness.input_utxos,
-            salted_output_utxos: primitive_witness.output_utxos,
-            kernel: primitive_witness.kernel,
-        };
+        let witness = NativeCurrencyWitness::from(primitive_witness);
         assert!(witness.kernel.coinbase.is_some(), "coinbase is none");
         NativeCurrency.test_assertion_failure(
             witness.standard_input(),
@@ -1265,11 +1248,7 @@ pub mod test {
         let salted_input_utxos_hash = Hash::hash(&primitive_witness.input_utxos);
         let salted_output_utxos_hash = Hash::hash(&primitive_witness.output_utxos);
 
-        let native_currency_witness = NativeCurrencyWitness {
-            salted_input_utxos: primitive_witness.input_utxos,
-            salted_output_utxos: primitive_witness.output_utxos,
-            kernel: primitive_witness.kernel,
-        };
+        let native_currency_witness = NativeCurrencyWitness::from(primitive_witness);
         let type_script_and_witness = TypeScriptAndWitness::new_with_nondeterminism(
             NativeCurrency.program(),
             native_currency_witness.nondeterminism(),
@@ -1319,11 +1298,7 @@ pub mod test {
         #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(None, 2, 2))]
         primitive_witness: PrimitiveWitness,
     ) {
-        let native_currency_witness = NativeCurrencyWitness {
-            salted_input_utxos: primitive_witness.input_utxos,
-            salted_output_utxos: primitive_witness.output_utxos,
-            kernel: primitive_witness.kernel,
-        };
+        let native_currency_witness = NativeCurrencyWitness::from(primitive_witness);
         prop_positive(native_currency_witness).unwrap();
     }
 
@@ -1334,11 +1309,7 @@ pub mod test {
             .new_tree(&mut test_runner)
             .unwrap()
             .current();
-        let native_currency_witness = NativeCurrencyWitness {
-            salted_input_utxos: primitive_witness.input_utxos,
-            salted_output_utxos: primitive_witness.output_utxos,
-            kernel: primitive_witness.kernel,
-        };
+        let native_currency_witness = NativeCurrencyWitness::from(primitive_witness);
         println!(
             "coinbase amount: {:?}",
             TransactionKernelProxy::from(native_currency_witness.kernel.clone())
@@ -1396,11 +1367,7 @@ pub mod test {
             .current()
             .clone();
             // with high probability the amounts (which are random) do not add up
-            let witness = NativeCurrencyWitness {
-                salted_input_utxos: primitive_witness.input_utxos,
-                salted_output_utxos: primitive_witness.output_utxos,
-                kernel: primitive_witness.kernel,
-            };
+            let witness = NativeCurrencyWitness::from(primitive_witness);
             let result = NativeCurrency.test_assertion_failure(
                 witness.standard_input(),
                 witness.nondeterminism(),
@@ -1424,11 +1391,7 @@ pub mod test {
         // enough coinbase funds are time-locked.
         let kernel_modifier = TransactionKernelModifier::default().coinbase(Some(coinbase + delta));
         primitive_witness.kernel = kernel_modifier.modify(primitive_witness.kernel);
-        let native_currency_witness = NativeCurrencyWitness {
-            salted_input_utxos: primitive_witness.input_utxos,
-            salted_output_utxos: primitive_witness.output_utxos,
-            kernel: primitive_witness.kernel,
-        };
+        let native_currency_witness = NativeCurrencyWitness::from(primitive_witness);
         prop_negative(native_currency_witness);
     }
 
@@ -1443,11 +1406,7 @@ pub mod test {
         let kernel_modifier = TransactionKernelModifier::default()
             .timestamp(primitive_witness.kernel.timestamp + Timestamp::days(1));
         primitive_witness.kernel = kernel_modifier.modify(primitive_witness.kernel);
-        let native_currency_witness = NativeCurrencyWitness {
-            salted_input_utxos: primitive_witness.input_utxos,
-            salted_output_utxos: primitive_witness.output_utxos,
-            kernel: primitive_witness.kernel,
-        };
+        let native_currency_witness = NativeCurrencyWitness::from(primitive_witness);
         prop_negative(native_currency_witness);
     }
 

--- a/src/models/blockchain/type_scripts/native_currency.rs
+++ b/src/models/blockchain/type_scripts/native_currency.rs
@@ -809,8 +809,9 @@ pub mod test {
     fn native_currency_derived_witness_generates_accepting_tasm_program_empty_tx() {
         // Generate a tx with coinbase input, no outputs, fee-size is the same
         // as the coinbase, so tx is valid.
-        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(0, 0, 0)
-            .new_tree(&mut TestRunner::deterministic())
+        let mut test_runner = TestRunner::deterministic();
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(0), 0, 0)
+            .new_tree(&mut test_runner)
             .unwrap()
             .current();
         let native_currency_witness = NativeCurrencyWitness {
@@ -823,8 +824,9 @@ pub mod test {
 
     #[test]
     fn native_currency_derived_witness_generates_accepting_tasm_program_unittest() {
-        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2)
-            .new_tree(&mut TestRunner::deterministic())
+        let mut test_runner = TestRunner::deterministic();
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
+            .new_tree(&mut test_runner)
             .unwrap()
             .current();
         let native_currency_witness = NativeCurrencyWitness {
@@ -840,7 +842,7 @@ pub mod test {
         #[strategy(0usize..=3)] _num_inputs: usize,
         #[strategy(0usize..=3)] _num_outputs: usize,
         #[strategy(0usize..=1)] _num_public_announcements: usize,
-        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(#_num_inputs, #_num_outputs, #_num_public_announcements))]
+        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(Some(#_num_inputs), #_num_outputs, #_num_public_announcements))]
         primitive_witness: PrimitiveWitness,
     ) {
         // PrimitiveWitness::arbitrary_with already ensures the transaction is balanced
@@ -949,8 +951,9 @@ pub mod test {
 
     #[tokio::test]
     async fn native_currency_failing_proof() {
-        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(2, 2, 2)
-            .new_tree(&mut TestRunner::deterministic())
+        let mut test_runner = TestRunner::deterministic();
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
+            .new_tree(&mut test_runner)
             .unwrap()
             .current();
         let txk_mast_hash = primitive_witness.kernel.mast_hash();

--- a/src/models/blockchain/type_scripts/native_currency.rs
+++ b/src/models/blockchain/type_scripts/native_currency.rs
@@ -1410,14 +1410,11 @@ pub mod test {
         }
     }
 
-    #[test]
-    fn coinbase_transaction_with_not_enough_funds_timelocked_is_invalid() {
-        let mut test_runner = TestRunner::deterministic();
-        let mut primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(None, 2, 2)
-            .new_tree(&mut test_runner)
-            .unwrap()
-            .current()
-            .clone();
+    #[proptest]
+    fn coinbase_transaction_with_not_enough_funds_timelocked_is_invalid(
+        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(None, 2, 2))]
+        mut primitive_witness: PrimitiveWitness,
+    ) {
         let delta = NeptuneCoins::from_nau(7.into()).unwrap();
         let coinbase = primitive_witness.kernel.coinbase.unwrap();
 
@@ -1435,15 +1432,11 @@ pub mod test {
         prop_negative(native_currency_witness);
     }
 
-    #[test]
-    fn coinbase_transaction_with_too_early_release_is_invalid() {
-        let mut test_runner = TestRunner::deterministic();
-        let mut primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(None, 2, 2)
-            .new_tree(&mut test_runner)
-            .unwrap()
-            .current()
-            .clone();
-
+    #[proptest]
+    fn coinbase_transaction_with_too_early_release_is_invalid(
+        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(None, 2, 2))]
+        mut primitive_witness: PrimitiveWitness,
+    ) {
         // Modify the kernel's timestamp to push it later in time. As a result,
         // the time-locks embedded in the coinbase UTXOs are less than the
         // coinbase time-lock time.

--- a/src/models/blockchain/type_scripts/native_currency.rs
+++ b/src/models/blockchain/type_scripts/native_currency.rs
@@ -1045,7 +1045,9 @@ pub mod test {
     use crate::models::proof_abstractions::tasm::program::ConsensusError;
     use crate::models::proof_abstractions::timestamp::Timestamp;
 
-    fn prop_positive(native_currency_witness: NativeCurrencyWitness) -> Result<(), TestCaseError> {
+    fn assert_both_rust_and_tasm_halt_gracefully(
+        native_currency_witness: NativeCurrencyWitness,
+    ) -> Result<(), TestCaseError> {
         let rust_result = NativeCurrency
             .run_rust(
                 &native_currency_witness.standard_input(),
@@ -1074,7 +1076,7 @@ pub mod test {
         Ok(())
     }
 
-    fn prop_negative(native_currency_witness: NativeCurrencyWitness) {
+    fn assert_both_rust_and_tasm_fail(native_currency_witness: NativeCurrencyWitness) {
         let rust_result = NativeCurrency.run_rust(
             &native_currency_witness.standard_input(),
             native_currency_witness.nondeterminism(),
@@ -1104,7 +1106,7 @@ pub mod test {
             .unwrap()
             .current();
         let native_currency_witness = NativeCurrencyWitness::from(primitive_witness);
-        prop_positive(native_currency_witness).unwrap();
+        assert_both_rust_and_tasm_halt_gracefully(native_currency_witness).unwrap();
     }
 
     #[test]
@@ -1115,7 +1117,7 @@ pub mod test {
             .unwrap()
             .current();
         let native_currency_witness = NativeCurrencyWitness::from(primitive_witness);
-        prop_positive(native_currency_witness).unwrap();
+        assert_both_rust_and_tasm_halt_gracefully(native_currency_witness).unwrap();
     }
 
     #[proptest(cases = 1)]
@@ -1128,7 +1130,7 @@ pub mod test {
     ) {
         // PrimitiveWitness::arbitrary_with already ensures the transaction is balanced
         let native_currency_witness = NativeCurrencyWitness::from(primitive_witness);
-        prop_positive(native_currency_witness)?;
+        assert_both_rust_and_tasm_halt_gracefully(native_currency_witness)?;
     }
 
     #[proptest(cases = 10)]
@@ -1149,7 +1151,7 @@ pub mod test {
 
         // there are inputs so there can be no coinbase and we are testing a
         // regular transaction
-        prop_positive(native_currency_witness)?;
+        assert_both_rust_and_tasm_halt_gracefully(native_currency_witness)?;
     }
 
     #[test]
@@ -1165,7 +1167,7 @@ pub mod test {
             .current();
         let native_currency_witness = NativeCurrencyWitness::from(primitive_witness);
 
-        prop_positive(native_currency_witness).unwrap();
+        assert_both_rust_and_tasm_halt_gracefully(native_currency_witness).unwrap();
     }
 
     #[proptest(cases = 20)]
@@ -1299,7 +1301,7 @@ pub mod test {
         primitive_witness: PrimitiveWitness,
     ) {
         let native_currency_witness = NativeCurrencyWitness::from(primitive_witness);
-        prop_positive(native_currency_witness).unwrap();
+        assert_both_rust_and_tasm_halt_gracefully(native_currency_witness).unwrap();
     }
 
     #[test]
@@ -1333,7 +1335,7 @@ pub mod test {
                 .sum::<NeptuneCoins>()
         );
 
-        assert!(prop_positive(native_currency_witness).is_ok());
+        assert!(assert_both_rust_and_tasm_halt_gracefully(native_currency_witness).is_ok());
     }
 
     #[test]
@@ -1392,7 +1394,7 @@ pub mod test {
         let kernel_modifier = TransactionKernelModifier::default().coinbase(Some(coinbase + delta));
         primitive_witness.kernel = kernel_modifier.modify(primitive_witness.kernel);
         let native_currency_witness = NativeCurrencyWitness::from(primitive_witness);
-        prop_negative(native_currency_witness);
+        assert_both_rust_and_tasm_fail(native_currency_witness);
     }
 
     #[proptest]
@@ -1407,7 +1409,7 @@ pub mod test {
             .timestamp(primitive_witness.kernel.timestamp + Timestamp::days(1));
         primitive_witness.kernel = kernel_modifier.modify(primitive_witness.kernel);
         let native_currency_witness = NativeCurrencyWitness::from(primitive_witness);
-        prop_negative(native_currency_witness);
+        assert_both_rust_and_tasm_fail(native_currency_witness);
     }
 
     #[test]

--- a/src/models/blockchain/type_scripts/time_lock.rs
+++ b/src/models/blockchain/type_scripts/time_lock.rs
@@ -823,6 +823,7 @@ impl Arbitrary for TimeLockWitness {
                         PrimitiveWitness::valid_tx_outputs_from_amounts_and_address_seeds(
                             &output_amounts,
                             &output_address_seeds,
+                            None,
                         );
 
                     // generate primitive transaction witness and time lock witness from there
@@ -1000,6 +1001,7 @@ fn arbitrary_primitive_witness_with_timelocks(
                     PrimitiveWitness::valid_tx_outputs_from_amounts_and_address_seeds(
                         &output_amounts,
                         &output_address_seeds,
+                        None,
                     );
                 let mut counter = 0usize;
                 for utxo in input_utxos.iter_mut() {

--- a/src/models/blockchain/type_scripts/time_lock.rs
+++ b/src/models/blockchain/type_scripts/time_lock.rs
@@ -716,6 +716,7 @@ impl TypeScriptWitness for TimeLockWitness {
     fn salted_output_utxos(&self) -> SaltedUtxos {
         SaltedUtxos::empty()
     }
+
     fn type_script_and_witness(&self) -> TypeScriptAndWitness {
         TypeScriptAndWitness::new_with_nondeterminism(TimeLock.program(), self.nondeterminism())
     }
@@ -1009,13 +1010,13 @@ fn arbitrary_primitive_witness_with_timelocks(
                     let time_lock = TimeLock::until(release_date);
                     let mut coins = utxo.coins().to_vec();
                     coins.push(time_lock);
-                    *utxo = (utxo.lock_script_hash(), coins).into();
+                    *utxo = Utxo::from((utxo.lock_script_hash(), coins));
                     counter += 1;
                 }
                 for utxo in output_utxos.iter_mut() {
                     let mut coins = utxo.coins().to_vec();
                     coins.push(TimeLock::until(release_dates[counter]));
-                    *utxo = (utxo.lock_script_hash(), coins).into();
+                    *utxo = Utxo::from((utxo.lock_script_hash(), coins));
                     counter += 1;
                 }
                 let release_dates = release_dates.clone();
@@ -1030,13 +1031,6 @@ fn arbitrary_primitive_witness_with_timelocks(
                 )
                 .prop_map(move |primitive_witness_template| {
                     let mut primitive_witness = primitive_witness_template.clone();
-                    let time_lock_witness = TimeLockWitness::from(primitive_witness.clone());
-                    primitive_witness.type_scripts_and_witnesses.push(
-                        TypeScriptAndWitness::new_with_nondeterminism(
-                            TimeLock.program(),
-                            time_lock_witness.nondeterminism(),
-                        ),
-                    );
                     let modified_kernel = TransactionKernelModifier::default()
                         .timestamp(now)
                         .modify(primitive_witness.kernel);

--- a/src/models/state/archival_state.rs
+++ b/src/models/state/archival_state.rs
@@ -1867,6 +1867,7 @@ mod archival_state_tests {
             &genesis,
             guesser_fraction,
             in_seven_months,
+            TxProvingCapability::SingleProof,
         )
         .await
         .unwrap();
@@ -2104,6 +2105,7 @@ mod archival_state_tests {
             &genesis,
             guesser_fraction,
             in_seven_months,
+            TxProvingCapability::SingleProof,
         )
         .await
         .unwrap();

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -1204,6 +1204,7 @@ mod tests {
             &bob,
             guesser_fraction,
             in_eight_months,
+            TxProvingCapability::SingleProof,
         )
         .await
         .unwrap();
@@ -1284,6 +1285,7 @@ mod tests {
             &alice,
             guesser_fraction,
             block_5_timestamp,
+            TxProvingCapability::SingleProof,
         )
         .await
         .unwrap();

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -2320,6 +2320,7 @@ mod global_state_tests {
             &premine_receiver,
             guesser_fraction,
             in_seven_months,
+            TxProvingCapability::SingleProof,
         )
         .await
         .unwrap();
@@ -2612,6 +2613,7 @@ mod global_state_tests {
             &premine_receiver,
             guesser_fraction,
             in_seven_months,
+            TxProvingCapability::SingleProof,
         )
         .await
         .unwrap();
@@ -2667,10 +2669,15 @@ mod global_state_tests {
         let now = genesis_block.kernel.header.timestamp + Timestamp::hours(1);
 
         let guesser_fraction = 0f64;
-        let (cb, _) =
-            make_coinbase_transaction(&genesis_block, &global_state_lock, guesser_fraction, now)
-                .await
-                .unwrap();
+        let (cb, _) = make_coinbase_transaction(
+            &genesis_block,
+            &global_state_lock,
+            guesser_fraction,
+            now,
+            TxProvingCapability::SingleProof,
+        )
+        .await
+        .unwrap();
         let block_1 = Block::compose(
             &genesis_block,
             cb,
@@ -2720,21 +2727,18 @@ mod global_state_tests {
                 global_state_lock,
                 guesser_fraction,
                 timestamp,
+                TxProvingCapability::PrimitiveWitness,
             )
             .await
             .unwrap();
 
-            Block::compose(
+            Block::block_template_invalid_proof(
                 &genesis_block,
                 cb,
                 timestamp,
                 Digest::default(),
                 None,
-                &TritonVmJobQueue::dummy(),
-                TritonVmJobPriority::default().into(),
             )
-            .await
-            .unwrap()
         }
 
         let network = Network::Main;

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -2477,14 +2477,14 @@ mod global_state_tests {
         }
 
         assert_eq!(
-            3,
+            4,
             premine_receiver
                 .lock_guard_mut()
                 .await
                 .wallet_state
                 .wallet_db
                 .monitored_utxos()
-                .len().await, "Genesis receiver must have 3 monitored UTXOs after block 1: change from transaction, coinbase from block 1, and premine UTXO"
+                .len().await, "Premine receiver must have 4 monitored UTXOs after block 1: change from transaction, 2 coinbases from block 1, and premine UTXO"
         );
 
         assert_eq!(
@@ -2601,7 +2601,7 @@ mod global_state_tests {
 
         // Make block_2 with tx that contains:
         // - 4 inputs: 2 from Alice and 2 from Bob
-        // - 6 outputs: 2 from Alice to Genesis, 3 from Bob to Genesis, and 1 coinbase
+        // - 7 outputs: 2 from Alice to Genesis, 3 from Bob to Genesis, and 2 coinbases
         let (coinbase_transaction2, _expected_utxo) = make_coinbase_transaction(
             &premine_receiver
                 .global_state_lock
@@ -2649,7 +2649,7 @@ mod global_state_tests {
         assert!(block_2.is_valid(&block_1, in_eight_months));
 
         assert_eq!(4, block_2.kernel.body.transaction_kernel.inputs.len());
-        assert_eq!(6, block_2.kernel.body.transaction_kernel.outputs.len());
+        assert_eq!(7, block_2.kernel.body.transaction_kernel.outputs.len());
     }
 
     #[traced_test]

--- a/src/models/state/wallet/mod.rs
+++ b/src/models/state/wallet/mod.rs
@@ -1218,6 +1218,7 @@ mod wallet_tests {
             &alice,
             guesser_fraction,
             block_2_b.header().timestamp + MINIMUM_BLOCK_TIME,
+            TxProvingCapability::SingleProof,
         )
         .await
         .unwrap();
@@ -1397,6 +1398,7 @@ mod wallet_tests {
             &bob,
             guesser_fraction,
             in_seven_months,
+            TxProvingCapability::SingleProof,
         )
         .await
         .unwrap();

--- a/src/models/state/wallet/mod.rs
+++ b/src/models/state/wallet/mod.rs
@@ -1295,9 +1295,9 @@ mod wallet_tests {
                 .filter(|x| x.is_synced_to(block_3_b.hash()))
                 .collect();
         assert_eq!(
-            4,
+            5,
             alice_monitored_utxos_3b.len(),
-            "List of monitored and unspent UTXOs have length 4 after receiving two"
+            "List of monitored and unspent UTXOs have length 5 after receiving two"
         );
         assert_eq!(
             0,
@@ -1447,8 +1447,8 @@ mod wallet_tests {
         // be valid in other respects. We don't care about PoW, though.
         assert!(block_1.is_valid(&genesis_block, in_seven_months));
 
-        // 3 outputs: 1 coinbase, 1 for recipient of tx, 1 for change.
-        assert_eq!(3, block_1.body().transaction_kernel.outputs.len());
+        // 4 outputs: 2 coinbases, 1 for recipient of tx, 1 for change.
+        assert_eq!(4, block_1.body().transaction_kernel.outputs.len());
     }
 
     #[tokio::test]

--- a/src/models/state/wallet/transaction_output.rs
+++ b/src/models/state/wallet/transaction_output.rs
@@ -12,6 +12,7 @@ use crate::models::blockchain::shared::Hash;
 use crate::models::blockchain::transaction::utxo::Utxo;
 use crate::models::blockchain::transaction::PublicAnnouncement;
 use crate::models::blockchain::type_scripts::neptune_coins::NeptuneCoins;
+use crate::models::proof_abstractions::timestamp::Timestamp;
 use crate::models::state::wallet::address::ReceivingAddress;
 use crate::models::state::wallet::wallet_state::WalletState;
 use crate::prelude::twenty_first::math::digest::Digest;
@@ -252,6 +253,20 @@ impl TxOutput {
                 ))
             }
             UtxoNotifyMethod::None => None,
+        }
+    }
+
+    /// Adds a time lock coin, if necessary.
+    ///
+    /// Does nothing if there already is a time lock coin whose release date is
+    /// later than the argument.
+    pub(crate) fn with_time_lock(self, release_date: Timestamp) -> Self {
+        Self {
+            utxo: self.utxo.with_time_lock(release_date),
+            sender_randomness: self.sender_randomness,
+            receiver_digest: self.receiver_digest,
+            notification_method: self.notification_method,
+            owned: self.owned,
         }
     }
 }

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -876,9 +876,15 @@ pub(crate) async fn valid_block_for_tests(
     guesser_fraction: f64,
 ) -> Block {
     let current_tip = state_lock.lock_guard().await.chain.light_state().clone();
-    let (cb, _) = make_coinbase_transaction(&current_tip, state_lock, guesser_fraction, timestamp)
-        .await
-        .unwrap();
+    let (cb, _) = make_coinbase_transaction(
+        &current_tip,
+        state_lock,
+        guesser_fraction,
+        timestamp,
+        TxProvingCapability::SingleProof,
+    )
+    .await
+    .unwrap();
     valid_block_from_tx_for_tests(&current_tip, cb, seed).await
 }
 


### PR DESCRIPTION
In Neptune Cash, the coinbase is divided into two parts. The first is liquid immediately; the second is locked for 3 years. This PR applies the latter lock.

Note that the guesser reward is already split in two parts, one liquid immediately and the other locked for 3 years. This commit modifies the `NativeCurrency` type script so as to require that if the transaction has a coinbase, then half of it is locked -- however this amount is distributed across time-locked outputs and guesser fee.