### PR TITLE
bug: bootstrapper mode refuses incoming connections

### DIFF
--- a/src/bin/neptune-cli.rs
+++ b/src/bin/neptune-cli.rs
@@ -134,6 +134,9 @@ enum Command {
         /// one of: `genesis, tip, height/<n>, digest/<hex>`
         block_selector: BlockSelector,
     },
+    BlockDigestsByHeight {
+        height: u64,
+    },
     Confirmations,
     PeerInfo,
     AllPunishedPeers,
@@ -452,6 +455,10 @@ async fn main() -> Result<()> {
                 Some(block_info) => println!("{}", block_info),
                 None => println!("Not found"),
             }
+        }
+        Command::BlockDigestsByHeight { height } => {
+            let digests = client.block_digests_by_height(ctx, height.into()).await?;
+            println!("{}", digests.iter().join("\n"));
         }
         Command::Confirmations => {
             let val = client.confirmations(ctx).await?;

--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -1442,7 +1442,6 @@ impl PeerLoopHandler {
         } else if global_state.net.peer_map.len() >= cli_args.max_num_peers as usize {
             bail!("Attempted to connect to more peers than allowed. Aborting connection.");
         }
-        
 
         if global_state.net.peer_map.contains_key(&self.peer_address) {
             // This shouldn't be possible, unless the peer reports a different instance ID than

--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -1433,13 +1433,7 @@ impl PeerLoopHandler {
             bail!("Attempted to connect to already connected peer. Aborting connection.");
         }
 
-        if cli_args.bootstrap
-            && global_state.net.peer_map.len() >= (cli_args.max_num_peers as usize) - 1
-        {
-            self.to_main_tx
-                .send(PeerTaskToMain::DisconnectFromLongestLivedPeer)
-                .await?;
-        } else if global_state.net.peer_map.len() >= cli_args.max_num_peers as usize {
+        if global_state.net.peer_map.len() >= cli_args.max_num_peers as usize {
             bail!("Attempted to connect to more peers than allowed. Aborting connection.");
         }
 

--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -1433,12 +1433,12 @@ impl PeerLoopHandler {
             bail!("Attempted to connect to already connected peer. Aborting connection.");
         }
 
-        if cli_args.bootstrap {
-            if global_state.net.peer_map.len() >= (cli_args.max_num_peers as usize) - 1 {
-                self.to_main_tx
-                    .send(PeerTaskToMain::DisconnectFromLongestLivedPeer)
-                    .await?;
-            }
+        if cli_args.bootstrap
+            && global_state.net.peer_map.len() >= (cli_args.max_num_peers as usize) - 1
+        {
+            self.to_main_tx
+                .send(PeerTaskToMain::DisconnectFromLongestLivedPeer)
+                .await?;
         } else if global_state.net.peer_map.len() >= cli_args.max_num_peers as usize {
             bail!("Attempted to connect to more peers than allowed. Aborting connection.");
         }


### PR DESCRIPTION
This PR fixes the issue of Bootstrapped nodes not able to accept incoming connections by always keeping one spot available by disconnected the longest lived connection. 
It addresses issue #287 