### PR TITLE
test(SingleProof): verify set `merge_bit` in PC->SP path disallowed

### DIFF
--- a/src/models/blockchain/transaction/mod.rs
+++ b/src/models/blockchain/transaction/mod.rs
@@ -161,7 +161,8 @@ impl TransactionProof {
     pub async fn verify(&self, kernel_mast_hash: Digest) -> bool {
         match self {
             TransactionProof::Witness(primitive_witness) => {
-                primitive_witness.validate().await
+                !primitive_witness.kernel.merge_bit
+                    && primitive_witness.validate().await
                     && primitive_witness.kernel.mast_hash() == kernel_mast_hash
             }
             TransactionProof::SingleProof(single_proof) => {

--- a/src/models/blockchain/transaction/validity/collect_lock_scripts.rs
+++ b/src/models/blockchain/transaction/validity/collect_lock_scripts.rs
@@ -247,7 +247,7 @@ mod test {
 
     #[proptest(cases = 5)]
     fn collect_lock_script_proptest(
-        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2))]
+        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2, false))]
         primitive_witness: PrimitiveWitness,
     ) {
         prop(primitive_witness)?;
@@ -258,7 +258,7 @@ mod test {
         let mut test_runner = TestRunner::deterministic();
         for num_inputs in 0..5 {
             let primitive_witness =
-                PrimitiveWitness::arbitrary_with_size_numbers(Some(num_inputs), 2, 2)
+                PrimitiveWitness::arbitrary_with_size_numbers(Some(num_inputs), 2, 2, false)
                     .new_tree(&mut test_runner)
                     .unwrap()
                     .current();

--- a/src/models/blockchain/transaction/validity/collect_type_scripts.rs
+++ b/src/models/blockchain/transaction/validity/collect_type_scripts.rs
@@ -438,7 +438,7 @@ mod test {
     fn derived_witness_generates_accepting_program_proptest(
         #[strategy(0usize..5)] _num_outputs: usize,
         #[strategy(0usize..5)] _num_inputs: usize,
-        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(Some(#_num_inputs),#_num_outputs,2))]
+        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(Some(#_num_inputs),#_num_outputs,2, false))]
         primitive_witness: PrimitiveWitness,
     ) {
         prop(primitive_witness)?;
@@ -458,7 +458,7 @@ mod test {
     #[test]
     fn derived_edge_case_witnesses_generate_accepting_programs_unit() {
         let mut test_runner = TestRunner::deterministic();
-        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(0), 0, 2)
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(0), 0, 2, false)
             .new_tree(&mut test_runner)
             .unwrap()
             .current();
@@ -483,7 +483,7 @@ mod test {
     #[test]
     fn collect_type_scripts_proof_generation() {
         let mut test_runner = TestRunner::deterministic();
-        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2, false)
             .new_tree(&mut test_runner)
             .unwrap()
             .current();

--- a/src/models/blockchain/transaction/validity/kernel_to_outputs.rs
+++ b/src/models/blockchain/transaction/validity/kernel_to_outputs.rs
@@ -361,7 +361,7 @@ mod test {
         #[strategy(0usize..5)] _num_outputs: usize,
         #[strategy(0usize..5)] _num_inputs: usize,
         #[strategy(0usize..5)] _num_pub_announcements: usize,
-        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(Some(#_num_inputs),#_num_outputs,#_num_pub_announcements))]
+        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(Some(#_num_inputs),#_num_outputs,#_num_pub_announcements, false))]
         primitive_witness: PrimitiveWitness,
     ) {
         let kernel_to_outputs_witness = KernelToOutputsWitness::from(&primitive_witness);
@@ -387,7 +387,7 @@ mod test {
     #[test]
     fn kernel_to_outputs_unittest() {
         let mut test_runner = TestRunner::deterministic();
-        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2, false)
             .new_tree(&mut test_runner)
             .unwrap()
             .current();
@@ -409,7 +409,7 @@ mod test {
     #[test]
     fn kernel_to_outputs_failing_proof() {
         let mut test_runner = TestRunner::deterministic();
-        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2, false)
             .new_tree(&mut test_runner)
             .unwrap()
             .current();

--- a/src/models/blockchain/transaction/validity/proof_collection.rs
+++ b/src/models/blockchain/transaction/validity/proof_collection.rs
@@ -80,6 +80,7 @@ impl ProofCollection {
             collect_type_scripts_witness,
         )
     }
+
     pub fn can_produce(primitive_witness: &PrimitiveWitness) -> bool {
         fn witness_halts_gracefully(
             program: impl ConsensusProgram,
@@ -454,7 +455,7 @@ pub mod test {
 
     #[proptest(cases = 5)]
     fn can_produce_valid_collection(
-        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2))]
+        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2, false))]
         primitive_witness: PrimitiveWitness,
     ) {
         prop_assert!(ProofCollection::can_produce(&primitive_witness));

--- a/src/models/blockchain/transaction/validity/removal_records_integrity.rs
+++ b/src/models/blockchain/transaction/validity/removal_records_integrity.rs
@@ -1117,7 +1117,7 @@ mod tests {
 
     #[proptest(cases = 5)]
     fn removal_records_integrity_proptest(
-        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2))]
+        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2, false))]
         primitive_witness: PrimitiveWitness,
     ) {
         let removal_records_integrity_witness =
@@ -1128,7 +1128,7 @@ mod tests {
     #[test]
     fn removal_records_integrity_only_rust_shadowing() {
         let mut test_runner = TestRunner::deterministic();
-        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2, false)
             .new_tree(&mut test_runner)
             .unwrap()
             .current();
@@ -1148,7 +1148,7 @@ mod tests {
     #[test]
     fn removal_records_integrity_unit_test() {
         let mut test_runner = TestRunner::deterministic();
-        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2, false)
             .new_tree(&mut test_runner)
             .unwrap()
             .current();
@@ -1162,7 +1162,7 @@ mod tests {
     #[test]
     fn removal_records_fail_on_bad_ms_acc() {
         let mut test_runner = TestRunner::deterministic();
-        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2, false)
             .new_tree(&mut test_runner)
             .unwrap()
             .current();
@@ -1179,7 +1179,7 @@ mod tests {
     #[test]
     fn removal_records_fail_on_bad_mast_path_inputs() {
         let mut test_runner = TestRunner::deterministic();
-        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2, false)
             .new_tree(&mut test_runner)
             .unwrap()
             .current();
@@ -1220,7 +1220,7 @@ mod tests {
         let mut test_runner = TestRunner::deterministic();
         let num_inputs = 2;
         let primitive_witness =
-            PrimitiveWitness::arbitrary_with_size_numbers(Some(num_inputs), 2, 2)
+            PrimitiveWitness::arbitrary_with_size_numbers(Some(num_inputs), 2, 2, false)
                 .new_tree(&mut test_runner)
                 .unwrap()
                 .current();
@@ -1247,7 +1247,7 @@ mod tests {
 
     #[proptest(cases = 4)]
     fn removal_records_fail_on_bad_absolute_indices(
-        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2))]
+        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2, false))]
         mut bad_pw: PrimitiveWitness,
         #[strategy(0..2usize)] mutated_input: usize,
         #[strategy(0..NUM_TRIALS as usize)] mutated_bloom_filter_index: usize,

--- a/src/models/blockchain/transaction/validity/tasm/authenticate_txk_field.rs
+++ b/src/models/blockchain/transaction/validity/tasm/authenticate_txk_field.rs
@@ -259,7 +259,7 @@ mod tests {
 
             let primitive_witness: PrimitiveWitness = {
                 let mut test_runner = TestRunner::new_with_rng(Default::default(), rng);
-                PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
+                PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2, false)
                     .new_tree(&mut test_runner)
                     .unwrap()
                     .current()
@@ -283,7 +283,7 @@ mod tests {
             let inputs_ptr: BFieldElement = random();
             let primitive_witness: PrimitiveWitness = {
                 let mut test_runner = TestRunner::deterministic();
-                PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
+                PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2, false)
                     .new_tree(&mut test_runner)
                     .unwrap()
                     .current()

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_collect_lock_scripts_claim.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_collect_lock_scripts_claim.rs
@@ -192,7 +192,7 @@ mod tests {
 
             let num_inputs = rng.gen_range(0usize..4);
             let primitive_witness =
-                PrimitiveWitness::arbitrary_with_size_numbers(Some(num_inputs), 2, 2)
+                PrimitiveWitness::arbitrary_with_size_numbers(Some(num_inputs), 2, 2, false)
                     .new_tree(&mut test_runner)
                     .unwrap()
                     .current();

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_collect_type_scripts_claim.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_collect_type_scripts_claim.rs
@@ -226,7 +226,7 @@ mod tests {
 
             let num_inputs = 2;
             let primitive_witness = if rng.gen_bool(0.5) {
-                PrimitiveWitness::arbitrary_with_size_numbers(Some(num_inputs), 2, 2)
+                PrimitiveWitness::arbitrary_with_size_numbers(Some(num_inputs), 2, 2, false)
                     .new_tree(&mut test_runner)
                     .unwrap()
                     .current()

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_k2o_claim.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_k2o_claim.rs
@@ -193,10 +193,11 @@ mod tests {
             _bench_case: Option<BenchmarkCase>,
         ) -> FunctionInitialState {
             let mut test_runner = TestRunner::deterministic();
-            let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
-                .new_tree(&mut test_runner)
-                .unwrap()
-                .current();
+            let primitive_witness =
+                PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2, false)
+                    .new_tree(&mut test_runner)
+                    .unwrap()
+                    .current();
             let rt = tokio::runtime::Runtime::new().unwrap();
             let _guard = rt.enter();
             let proof_collection = rt

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_lock_script_claim_template.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_lock_script_claim_template.rs
@@ -126,10 +126,11 @@ mod test {
             _bench_case: Option<BenchmarkCase>,
         ) -> FunctionInitialState {
             let mut test_runner = TestRunner::deterministic();
-            let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
-                .new_tree(&mut test_runner)
-                .unwrap()
-                .current();
+            let primitive_witness =
+                PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2, false)
+                    .new_tree(&mut test_runner)
+                    .unwrap()
+                    .current();
             let rt = tokio::runtime::Runtime::new().unwrap();
             let _guard = rt.enter();
             let proof_collection = rt

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_rri_claim.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_rri_claim.rs
@@ -193,10 +193,11 @@ mod tests {
             _bench_case: Option<BenchmarkCase>,
         ) -> FunctionInitialState {
             let mut test_runner = TestRunner::deterministic();
-            let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
-                .new_tree(&mut test_runner)
-                .unwrap()
-                .current();
+            let primitive_witness =
+                PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2, false)
+                    .new_tree(&mut test_runner)
+                    .unwrap()
+                    .current();
             let rt = tokio::runtime::Runtime::new().unwrap();
             let _guard = rt.enter();
             let proof_collection = rt

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_type_script_claim_template.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_type_script_claim_template.rs
@@ -157,10 +157,11 @@ mod test {
             _bench_case: Option<BenchmarkCase>,
         ) -> FunctionInitialState {
             let mut test_runner = TestRunner::deterministic();
-            let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
-                .new_tree(&mut test_runner)
-                .unwrap()
-                .current();
+            let primitive_witness =
+                PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2, false)
+                    .new_tree(&mut test_runner)
+                    .unwrap()
+                    .current();
             let rt = tokio::runtime::Runtime::new().unwrap();
             let _guard = rt.enter();
             let proof_collection = rt

--- a/src/models/blockchain/transaction/validity/tasm/hash_removal_record_index_sets.rs
+++ b/src/models/blockchain/transaction/validity/tasm/hash_removal_record_index_sets.rs
@@ -166,6 +166,7 @@ mod tests {
                     Some(num_inputs),
                     num_outputs,
                     num_public_announcements,
+                    false,
                 )
                 .new_tree(&mut test_runner)
                 .unwrap()

--- a/src/models/blockchain/transaction/validity/tasm/leaf_authentication/authenticate_inputs_against_txk.rs
+++ b/src/models/blockchain/transaction/validity/tasm/leaf_authentication/authenticate_inputs_against_txk.rs
@@ -164,7 +164,7 @@ mod tests {
 
             let primitive_witness: PrimitiveWitness = {
                 let mut test_runner = TestRunner::new_with_rng(Default::default(), rng);
-                PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
+                PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2, false)
                     .new_tree(&mut test_runner)
                     .unwrap()
                     .current()
@@ -184,7 +184,7 @@ mod tests {
         let inputs_ptr: BFieldElement = random();
         let primitive_witness: PrimitiveWitness = {
             let mut test_runner = TestRunner::deterministic();
-            PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
+            PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2, false)
                 .new_tree(&mut test_runner)
                 .unwrap()
                 .current()

--- a/src/models/blockchain/transaction/validity/tasm/leaf_authentication/authenticate_msa_against_txk.rs
+++ b/src/models/blockchain/transaction/validity/tasm/leaf_authentication/authenticate_msa_against_txk.rs
@@ -243,7 +243,7 @@ mod tests {
 
             let primitive_witness: PrimitiveWitness = {
                 let mut test_runner = TestRunner::new_with_rng(Default::default(), rng);
-                PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
+                PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2, false)
                     .new_tree(&mut test_runner)
                     .unwrap()
                     .current()

--- a/src/models/blockchain/transaction/validity/tasm/single_proof/update_branch.rs
+++ b/src/models/blockchain/transaction/validity/tasm/single_proof/update_branch.rs
@@ -801,6 +801,7 @@ pub(crate) mod test {
             Some(num_inputs),
             num_outputs,
             num_pub_announcements,
+            false,
         )
         .new_tree(&mut test_runner)
         .unwrap()

--- a/src/models/blockchain/type_scripts/native_currency.rs
+++ b/src/models/blockchain/type_scripts/native_currency.rs
@@ -1272,7 +1272,7 @@ pub mod test {
         // Generate a tx with coinbase input, no outputs, fee-size is the same
         // as the coinbase, so tx is valid.
         let mut test_runner = TestRunner::deterministic();
-        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(0), 0, 0)
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(0), 0, 0, false)
             .new_tree(&mut test_runner)
             .unwrap()
             .current();
@@ -1283,7 +1283,7 @@ pub mod test {
     #[test]
     fn native_currency_derived_witness_generates_accepting_tasm_program_unittest() {
         let mut test_runner = TestRunner::deterministic();
-        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2, false)
             .new_tree(&mut test_runner)
             .unwrap()
             .current();
@@ -1296,7 +1296,7 @@ pub mod test {
         #[strategy(0usize..=3)] _num_inputs: usize,
         #[strategy(0usize..=3)] _num_outputs: usize,
         #[strategy(0usize..=1)] _num_public_announcements: usize,
-        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(Some(#_num_inputs), #_num_outputs, #_num_public_announcements))]
+        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(Some(#_num_inputs), #_num_outputs, #_num_public_announcements, false))]
         primitive_witness: PrimitiveWitness,
     ) {
         // PrimitiveWitness::arbitrary_with already ensures the transaction is balanced
@@ -1461,7 +1461,7 @@ pub mod test {
     #[tokio::test]
     async fn native_currency_failing_proof() {
         let mut test_runner = TestRunner::deterministic();
-        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2)
+        let primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(Some(2), 2, 2, false)
             .new_tree(&mut test_runner)
             .unwrap()
             .current();
@@ -1502,7 +1502,7 @@ pub mod test {
 
     #[proptest]
     fn transaction_with_timelocked_coinbase_is_valid(
-        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(None, 2, 2))]
+        #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(None, 2, 2, false))]
         #[filter(!#primitive_witness.kernel.fee.is_negative())]
         primitive_witness: PrimitiveWitness,
     ) {
@@ -1513,12 +1513,13 @@ pub mod test {
     #[test]
     fn transaction_with_timelocked_coinbase_is_valid_deterministic() {
         let mut test_runner = TestRunner::deterministic();
-        let mut primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(None, 2, 2)
-            .new_tree(&mut test_runner)
-            .unwrap()
-            .current();
+        let mut primitive_witness =
+            PrimitiveWitness::arbitrary_with_size_numbers(None, 2, 2, false)
+                .new_tree(&mut test_runner)
+                .unwrap()
+                .current();
         while primitive_witness.kernel.fee.is_negative() {
-            primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(None, 2, 2)
+            primitive_witness = PrimitiveWitness::arbitrary_with_size_numbers(None, 2, 2, false)
                 .new_tree(&mut test_runner)
                 .unwrap()
                 .current();
@@ -1578,7 +1579,8 @@ pub mod test {
         #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(
             None,
             #_num_outputs,
-            #_num_public_announcements
+            #_num_public_announcements,
+            false
         ))]
         mut primitive_witness: PrimitiveWitness,
         #[strategy(arb())]
@@ -1603,7 +1605,8 @@ pub mod test {
         #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(
             None,
             #_num_outputs,
-            #_num_public_announcements
+            #_num_public_announcements,
+            false
         ))]
         mut primitive_witness: PrimitiveWitness,
     ) {
@@ -1625,7 +1628,8 @@ pub mod test {
         #[strategy(PrimitiveWitness::arbitrary_with_size_numbers(
             None,
             #_num_outputs,
-            #_num_public_announcements
+            #_num_public_announcements,
+            false
         ))]
         mut primitive_witness: PrimitiveWitness,
         #[strategy(arb())]

--- a/src/models/blockchain/type_scripts/time_lock.rs
+++ b/src/models/blockchain/type_scripts/time_lock.rs
@@ -1019,6 +1019,8 @@ fn arbitrary_primitive_witness_with_timelocks(
                     counter += 1;
                 }
                 let release_dates = release_dates.clone();
+
+                let merge_bit = false;
                 PrimitiveWitness::arbitrary_primitive_witness_with_timestamp_and(
                     &input_utxos,
                     &input_lock_scripts_and_witnesses,
@@ -1027,6 +1029,7 @@ fn arbitrary_primitive_witness_with_timelocks(
                     fee,
                     maybe_coinbase,
                     now,
+                    merge_bit,
                 )
                 .prop_map(move |primitive_witness_template| {
                     let mut primitive_witness = primitive_witness_template.clone();


### PR DESCRIPTION
Verify that the merge_bit must be set to false in the `ProofCollection` -> `SingleProof` branch in `SingleProof`.

Required generalization of a test-case generator which I think will come in handy later.

This PR was opened because of the change to the test-case generators which are @aszepieniec's  brain child. He should have a say here.