### PR TITLE
refactor: add 'arbitrary-impl' feature-flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,9 @@ track-lock-location = []
 # not generally useful by itself.
 track-lock-time = []
 
+# implements arbitrary::Arbitrary for various types
+arbitrary-impls = []
+
 [dependencies]
 aead = { version = "0.5", features = ["std"] }
 aes-gcm = "0.10"
@@ -212,6 +215,7 @@ harness = false
 [[bench]]
 name = "consensus"
 harness = false
+required-features = ["arbitrary-impls"]
 
 [patch.crates-io]
 tasm-lib = { git = "https://github.com/TritonVM/tasm-lib.git", rev = "924439307d6c38ecec49568179928f5bb32498b6" }

--- a/benches/consensus.rs
+++ b/benches/consensus.rs
@@ -20,8 +20,8 @@ mod transaction {
     use neptune_cash::models::blockchain::transaction::validity::removal_records_integrity::RemovalRecordsIntegrityWitness;
     use neptune_cash::models::blockchain::type_scripts::native_currency::NativeCurrency;
     use neptune_cash::models::blockchain::type_scripts::native_currency::NativeCurrencyWitness;
-    use neptune_cash::models::blockchain::type_scripts::time_lock::arbitrary_primitive_witness_with_active_timelocks;
-    use neptune_cash::models::blockchain::type_scripts::time_lock::arbitrary_primitive_witness_with_expired_timelocks;
+    use neptune_cash::models::blockchain::type_scripts::time_lock::neptune_arbitrary::arbitrary_primitive_witness_with_active_timelocks;
+    use neptune_cash::models::blockchain::type_scripts::time_lock::neptune_arbitrary::arbitrary_primitive_witness_with_expired_timelocks;
     use neptune_cash::models::blockchain::type_scripts::time_lock::TimeLock;
     use neptune_cash::models::blockchain::type_scripts::time_lock::TimeLockWitness;
     use neptune_cash::models::proof_abstractions::tasm::program::ConsensusProgram;

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -274,6 +274,7 @@ impl GuessNonceResult {
 /// Returns (found: bool, cancelled: bool).
 ///   found is true if a valid block is found
 ///   cancelled is true if the task is terminated.
+#[allow(clippy::too_many_arguments)]
 #[inline]
 fn guess_nonce_iteration(
     block_body_mast_hash_digest: Digest,

--- a/src/models/blockchain/transaction/transaction_kernel.rs
+++ b/src/models/blockchain/transaction/transaction_kernel.rs
@@ -1,8 +1,6 @@
 use std::sync::OnceLock;
 
-use arbitrary::Arbitrary;
 use get_size2::GetSize;
-use itertools::Itertools;
 use serde::Deserialize;
 use serde::Serialize;
 use strum::EnumCount;
@@ -122,37 +120,45 @@ impl MastHash for TransactionKernel {
     }
 }
 
-impl<'a> Arbitrary<'a> for TransactionKernel {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        let num_inputs = u.int_in_range(0..=4)?;
-        let num_outputs = u.int_in_range(0..=4)?;
-        let num_public_announcements = u.int_in_range(0..=2)?;
-        let inputs: Vec<RemovalRecord> = (0..num_inputs)
-            .map(|_| u.arbitrary().unwrap())
-            .collect_vec();
-        let outputs: Vec<AdditionRecord> = (0..num_outputs)
-            .map(|_| u.arbitrary().unwrap())
-            .collect_vec();
-        let public_announcements: Vec<PublicAnnouncement> = (0..num_public_announcements)
-            .map(|_| u.arbitrary().unwrap())
-            .collect_vec();
-        let fee: NeptuneCoins = u.arbitrary()?;
-        let coinbase: Option<NeptuneCoins> = u.arbitrary()?;
-        let timestamp: Timestamp = u.arbitrary()?;
-        let mutator_set_hash: Digest = u.arbitrary()?;
+#[cfg(any(test, feature = "arbitrary-impls"))]
+pub mod neptune_arbitrary {
+    use arbitrary::Arbitrary;
+    use itertools::Itertools;
 
-        let transaction_kernel = TransactionKernelProxy {
-            inputs,
-            outputs,
-            public_announcements,
-            fee,
-            coinbase,
-            timestamp,
-            mutator_set_hash,
+    use super::*;
+
+    impl<'a> Arbitrary<'a> for TransactionKernel {
+        fn arbitrary(u: &mut ::arbitrary::Unstructured<'a>) -> ::arbitrary::Result<Self> {
+            let num_inputs = u.int_in_range(0..=4)?;
+            let num_outputs = u.int_in_range(0..=4)?;
+            let num_public_announcements = u.int_in_range(0..=2)?;
+            let inputs: Vec<RemovalRecord> = (0..num_inputs)
+                .map(|_| u.arbitrary().unwrap())
+                .collect_vec();
+            let outputs: Vec<AdditionRecord> = (0..num_outputs)
+                .map(|_| u.arbitrary().unwrap())
+                .collect_vec();
+            let public_announcements: Vec<PublicAnnouncement> = (0..num_public_announcements)
+                .map(|_| u.arbitrary().unwrap())
+                .collect_vec();
+            let fee: NeptuneCoins = u.arbitrary()?;
+            let coinbase: Option<NeptuneCoins> = u.arbitrary()?;
+            let timestamp: Timestamp = u.arbitrary()?;
+            let mutator_set_hash: Digest = u.arbitrary()?;
+
+            let transaction_kernel = TransactionKernelProxy {
+                inputs,
+                outputs,
+                public_announcements,
+                fee,
+                coinbase,
+                timestamp,
+                mutator_set_hash,
+            }
+            .into_kernel();
+
+            Ok(transaction_kernel)
         }
-        .into_kernel();
-
-        Ok(transaction_kernel)
     }
 }
 
@@ -304,6 +310,7 @@ impl TransactionKernelModifier {
 
 #[cfg(test)]
 pub mod transaction_kernel_tests {
+    use itertools::Itertools;
     use rand::random;
     use rand::rngs::StdRng;
     use rand::thread_rng;

--- a/src/models/blockchain/transaction/validity/collect_type_scripts.rs
+++ b/src/models/blockchain/transaction/validity/collect_type_scripts.rs
@@ -405,7 +405,7 @@ mod test {
     use crate::models::blockchain::transaction::primitive_witness::PrimitiveWitness;
     use crate::models::blockchain::transaction::validity::collect_type_scripts::CollectTypeScripts;
     use crate::models::blockchain::transaction::validity::collect_type_scripts::CollectTypeScriptsWitness;
-    use crate::models::blockchain::type_scripts::time_lock::arbitrary_primitive_witness_with_active_timelocks;
+    use crate::models::blockchain::type_scripts::time_lock::neptune_arbitrary::arbitrary_primitive_witness_with_active_timelocks;
     use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
     use crate::models::proof_abstractions::timestamp::Timestamp;
     use crate::models::proof_abstractions::SecretWitness;

--- a/src/models/blockchain/transaction/validity/single_proof.rs
+++ b/src/models/blockchain/transaction/validity/single_proof.rs
@@ -698,7 +698,7 @@ mod test {
     use crate::models::blockchain::transaction::validity::single_proof::SingleProofWitness;
     use crate::models::blockchain::transaction::validity::tasm::single_proof::merge_branch::test::deterministic_merge_witness;
     use crate::models::blockchain::transaction::validity::tasm::single_proof::update_branch::test::deterministic_update_witness_only_additions;
-    use crate::models::blockchain::type_scripts::time_lock::arbitrary_primitive_witness_with_expired_timelocks;
+    use crate::models::blockchain::type_scripts::time_lock::neptune_arbitrary::arbitrary_primitive_witness_with_expired_timelocks;
     use crate::models::proof_abstractions::tasm::program::ConsensusError;
     use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
     use crate::models::proof_abstractions::timestamp::Timestamp;

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_collect_type_scripts_claim.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_collect_type_scripts_claim.rs
@@ -186,7 +186,7 @@ mod tests {
     use crate::job_queue::triton_vm::TritonVmJobPriority;
     use crate::job_queue::triton_vm::TritonVmJobQueue;
     use crate::models::blockchain::transaction::primitive_witness::PrimitiveWitness;
-    use crate::models::blockchain::type_scripts::time_lock::arbitrary_primitive_witness_with_active_timelocks;
+    use crate::models::blockchain::type_scripts::time_lock::neptune_arbitrary::arbitrary_primitive_witness_with_active_timelocks;
     use crate::models::proof_abstractions::timestamp::Timestamp;
 
     #[test]

--- a/src/models/blockchain/type_scripts/native_currency.rs
+++ b/src/models/blockchain/type_scripts/native_currency.rs
@@ -1221,7 +1221,7 @@ pub mod test {
     use crate::models::blockchain::transaction::utxo::Utxo;
     use crate::models::blockchain::transaction::PublicAnnouncement;
     use crate::models::blockchain::type_scripts::neptune_coins::test::invalid_positive_amount;
-    use crate::models::blockchain::type_scripts::time_lock::arbitrary_primitive_witness_with_active_timelocks;
+    use crate::models::blockchain::type_scripts::time_lock::neptune_arbitrary::arbitrary_primitive_witness_with_active_timelocks;
     use crate::models::blockchain::type_scripts::time_lock::TimeLock;
     use crate::models::proof_abstractions::tasm::program::test::consensus_program_negative_test;
     use crate::models::proof_abstractions::tasm::program::ConsensusError;

--- a/src/models/blockchain/type_scripts/time_lock.rs
+++ b/src/models/blockchain/type_scripts/time_lock.rs
@@ -3,13 +3,7 @@ use std::sync::OnceLock;
 
 use get_size2::GetSize;
 use itertools::Itertools;
-use num_traits::CheckedSub;
 use num_traits::Zero;
-use proptest::arbitrary::Arbitrary;
-use proptest::collection::vec;
-use proptest::strategy::BoxedStrategy;
-use proptest::strategy::Strategy;
-use proptest_arbitrary_interop::arb;
 use serde::Deserialize;
 use serde::Serialize;
 use tasm_lib::memory::encode_to_memory;
@@ -22,16 +16,13 @@ use tasm_lib::twenty_first::math::b_field_element::BFieldElement;
 use tasm_lib::twenty_first::math::bfield_codec::BFieldCodec;
 use tasm_lib::twenty_first::math::tip5::Tip5;
 
-use super::neptune_coins::NeptuneCoins;
 use super::TypeScriptWitness;
 use crate::models::blockchain::transaction::primitive_witness::PrimitiveWitness;
 use crate::models::blockchain::transaction::primitive_witness::SaltedUtxos;
 use crate::models::blockchain::transaction::transaction_kernel::TransactionKernel;
 use crate::models::blockchain::transaction::transaction_kernel::TransactionKernelField;
-use crate::models::blockchain::transaction::transaction_kernel::TransactionKernelModifier;
 use crate::models::blockchain::transaction::utxo::Coin;
 use crate::models::blockchain::transaction::utxo::Utxo;
-use crate::models::blockchain::transaction::PublicAnnouncement;
 use crate::models::blockchain::type_scripts::TypeScriptAndWitness;
 use crate::models::proof_abstractions::mast_hash::MastHash;
 use crate::models::proof_abstractions::tasm::builtins as tasm;
@@ -758,288 +749,306 @@ impl From<PrimitiveWitness> for TimeLockWitness {
     }
 }
 
-impl Arbitrary for TimeLockWitness {
-    /// Parameters are:
-    ///  - release_dates : `Vec<u64>` One release date per input UTXO. 0 if the time lock
-    ///    coin is absent.
-    ///  - num_outputs : usize Number of outputs.
-    ///  - num_public_announcements : usize Number of public announcements.
-    ///  - transaction_timestamp: Timestamp determining when the transaction takes place.
-    type Parameters = (Vec<Timestamp>, usize, usize, Timestamp);
+#[cfg(any(test, feature = "arbitrary-impls"))]
+pub mod neptune_arbitrary {
+    use num_traits::CheckedSub;
+    use proptest::arbitrary::Arbitrary;
+    use proptest::collection::vec;
+    use proptest::strategy::BoxedStrategy;
+    use proptest::strategy::Strategy;
+    use proptest_arbitrary_interop::arb;
 
-    type Strategy = BoxedStrategy<Self>;
+    use super::super::neptune_coins::NeptuneCoins;
+    use super::*;
+    use crate::models::blockchain::transaction::transaction_kernel::TransactionKernelModifier;
+    use crate::models::blockchain::transaction::PublicAnnouncement;
 
-    fn arbitrary_with(parameters: Self::Parameters) -> Self::Strategy {
-        let (release_dates, num_outputs, num_public_announcements, transaction_timestamp) =
-            parameters;
-        let num_inputs = release_dates.len();
+    impl Arbitrary for TimeLockWitness {
+        /// Parameters are:
+        ///  - release_dates : `Vec<u64>` One release date per input UTXO. 0 if the time lock
+        ///    coin is absent.
+        ///  - num_outputs : usize Number of outputs.
+        ///  - num_public_announcements : usize Number of public announcements.
+        ///  - transaction_timestamp: Timestamp determining when the transaction takes place.
+        type Parameters = (Vec<Timestamp>, usize, usize, Timestamp);
+
+        type Strategy = BoxedStrategy<Self>;
+
+        fn arbitrary_with(parameters: Self::Parameters) -> Self::Strategy {
+            let (release_dates, num_outputs, num_public_announcements, transaction_timestamp) =
+                parameters;
+            let num_inputs = release_dates.len();
+            (
+                vec(arb::<Digest>(), num_inputs),
+                vec(NeptuneCoins::arbitrary_non_negative(), num_inputs),
+                vec(arb::<Digest>(), num_outputs),
+                vec(NeptuneCoins::arbitrary_non_negative(), num_outputs),
+                vec(arb::<PublicAnnouncement>(), num_public_announcements),
+                NeptuneCoins::arbitrary_coinbase(),
+                NeptuneCoins::arbitrary_non_negative(),
+            )
+                .prop_flat_map(
+                    move |(
+                        input_address_seeds,
+                        input_amounts,
+                        output_address_seeds,
+                        mut output_amounts,
+                        public_announcements,
+                        maybe_coinbase,
+                        mut fee,
+                    )| {
+                        // generate inputs
+                        let (mut input_utxos, input_lock_scripts_and_witnesses) =
+                            PrimitiveWitness::transaction_inputs_from_address_seeds_and_amounts(
+                                &input_address_seeds,
+                                &input_amounts,
+                            );
+                        let total_inputs = input_amounts.into_iter().sum::<NeptuneCoins>();
+
+                        // add time locks to input UTXOs (changes Utxo hash)
+                        for (utxo, release_date) in input_utxos.iter_mut().zip(release_dates.iter())
+                        {
+                            if !release_date.is_zero() {
+                                let time_lock_coin = TimeLock::until(*release_date);
+                                let mut coins = utxo.coins().to_vec();
+                                coins.push(time_lock_coin);
+                                *utxo = (utxo.lock_script_hash(), coins).into()
+                            }
+                        }
+
+                        // generate valid output amounts
+                        PrimitiveWitness::find_balanced_output_amounts_and_fee(
+                            total_inputs,
+                            maybe_coinbase,
+                            &mut output_amounts,
+                            &mut fee,
+                        );
+
+                        // generate output UTXOs
+                        let output_utxos =
+                            PrimitiveWitness::valid_tx_outputs_from_amounts_and_address_seeds(
+                                &output_amounts,
+                                &output_address_seeds,
+                                None,
+                            );
+
+                        // generate primitive transaction witness and time lock witness from there
+                        PrimitiveWitness::arbitrary_primitive_witness_with(
+                            &input_utxos,
+                            &input_lock_scripts_and_witnesses,
+                            &output_utxos,
+                            &public_announcements,
+                            NeptuneCoins::zero(),
+                            maybe_coinbase,
+                        )
+                        .prop_map(move |mut transaction_primitive_witness| {
+                            let modified_kernel = TransactionKernelModifier::default()
+                                .timestamp(transaction_timestamp)
+                                .modify(transaction_primitive_witness.kernel);
+
+                            transaction_primitive_witness.kernel = modified_kernel;
+                            TimeLockWitness::from(transaction_primitive_witness)
+                        })
+                        .boxed()
+                    },
+                )
+                .boxed()
+        }
+    }
+
+    /// Generate a `Strategy` for a [`PrimitiveWitness`] with the given numbers of
+    /// inputs, outputs, and public announcements, with active timelocks.
+    ///
+    /// The UTXOs are timelocked with a release date set between `now` and six
+    /// months from `now`.
+    pub fn arbitrary_primitive_witness_with_active_timelocks(
+        num_inputs: usize,
+        num_outputs: usize,
+        num_announcements: usize,
+        now: Timestamp,
+    ) -> BoxedStrategy<PrimitiveWitness> {
+        vec(
+            Timestamp::arbitrary_between(now, now + Timestamp::months(6)),
+            num_inputs + num_outputs,
+        )
+        .prop_flat_map(move |release_dates| {
+            arbitrary_primitive_witness_with_timelocks(
+                num_inputs,
+                num_outputs,
+                num_announcements,
+                now,
+                release_dates,
+            )
+        })
+        .boxed()
+    }
+
+    /// Generate a `Strategy` for a [`PrimitiveWitness`] with the given numbers of
+    /// inputs, outputs, and public announcements, with expired timelocks.
+    ///
+    /// The UTXOs are timelocked with a release date set between six months in the
+    /// past relative to `now` and `now`.
+    pub fn arbitrary_primitive_witness_with_expired_timelocks(
+        num_inputs: usize,
+        num_outputs: usize,
+        num_announcements: usize,
+        now: Timestamp,
+    ) -> BoxedStrategy<PrimitiveWitness> {
+        vec(
+            Timestamp::arbitrary_between(now - Timestamp::months(6), now - Timestamp::millis(1)),
+            num_inputs + num_outputs,
+        )
+        .prop_flat_map(move |release_dates| {
+            arbitrary_primitive_witness_with_timelocks(
+                num_inputs,
+                num_outputs,
+                num_announcements,
+                now,
+                release_dates,
+            )
+        })
+        .boxed()
+    }
+
+    #[expect(unused_variables, reason = "under development")]
+    fn arbitrary_primitive_witness_with_timelocks(
+        num_inputs: usize,
+        num_outputs: usize,
+        num_announcements: usize,
+        now: Timestamp,
+        release_dates: Vec<Timestamp>,
+    ) -> BoxedStrategy<PrimitiveWitness> {
         (
-            vec(arb::<Digest>(), num_inputs),
-            vec(NeptuneCoins::arbitrary_non_negative(), num_inputs),
-            vec(arb::<Digest>(), num_outputs),
-            vec(NeptuneCoins::arbitrary_non_negative(), num_outputs),
-            vec(arb::<PublicAnnouncement>(), num_public_announcements),
-            NeptuneCoins::arbitrary_coinbase(),
             NeptuneCoins::arbitrary_non_negative(),
+            vec(arb::<Digest>(), num_inputs),
+            vec(arb::<u64>(), num_inputs),
+            vec(arb::<Digest>(), num_outputs),
+            vec(arb::<u64>(), num_outputs),
+            vec(arb::<PublicAnnouncement>(), num_announcements),
+            arb::<u64>(),
+            arb::<Option<u64>>(),
         )
             .prop_flat_map(
                 move |(
+                    total_amount,
                     input_address_seeds,
-                    input_amounts,
+                    input_dist,
                     output_address_seeds,
-                    mut output_amounts,
+                    output_dist,
                     public_announcements,
-                    maybe_coinbase,
-                    mut fee,
+                    fee_dist,
+                    maybe_coinbase_dist,
                 )| {
-                    // generate inputs
+                    let maybe_coinbase_dist = if num_inputs.is_zero() {
+                        maybe_coinbase_dist
+                    } else {
+                        None
+                    };
+
+                    // distribute total amount across inputs (+ coinbase)
+                    let mut input_denominator = input_dist.iter().map(|u| *u as f64).sum::<f64>();
+                    if let Some(d) = maybe_coinbase_dist {
+                        input_denominator += d as f64;
+                    }
+                    let input_weights = input_dist
+                        .into_iter()
+                        .map(|u| (u as f64) / input_denominator)
+                        .collect_vec();
+                    let mut input_amounts = input_weights
+                        .into_iter()
+                        .map(|w| total_amount.to_nau_f64() * w)
+                        .map(|f| NeptuneCoins::try_from(f).unwrap())
+                        .collect_vec();
+                    let maybe_coinbase = if maybe_coinbase_dist.is_some()
+                        || input_amounts.is_empty()
+                    {
+                        Some(
+                            total_amount
+                                .checked_sub(&input_amounts.iter().cloned().sum::<NeptuneCoins>())
+                                .unwrap(),
+                        )
+                    } else {
+                        let sum_of_all_but_last = input_amounts
+                            .iter()
+                            .rev()
+                            .skip(1)
+                            .cloned()
+                            .sum::<NeptuneCoins>();
+                        *input_amounts.last_mut().unwrap() =
+                            total_amount.checked_sub(&sum_of_all_but_last).unwrap();
+                        None
+                    };
+
+                    // distribute total amount across outputs
+                    let output_denominator =
+                        output_dist.iter().map(|u| *u as f64).sum::<f64>() + (fee_dist as f64);
+                    let output_weights = output_dist
+                        .into_iter()
+                        .map(|u| (u as f64) / output_denominator)
+                        .collect_vec();
+                    let output_amounts = output_weights
+                        .into_iter()
+                        .map(|w| total_amount.to_nau_f64() * w)
+                        .map(|f| NeptuneCoins::try_from(f).unwrap())
+                        .collect_vec();
+                    let total_outputs = output_amounts.iter().cloned().sum::<NeptuneCoins>();
+                    let fee = total_amount.checked_sub(&total_outputs).unwrap();
+
                     let (mut input_utxos, input_lock_scripts_and_witnesses) =
                         PrimitiveWitness::transaction_inputs_from_address_seeds_and_amounts(
                             &input_address_seeds,
                             &input_amounts,
                         );
-                    let total_inputs = input_amounts.into_iter().sum::<NeptuneCoins>();
+                    let total_inputs = input_amounts.iter().copied().sum::<NeptuneCoins>();
 
-                    // add time locks to input UTXOs (changes Utxo hash)
-                    for (utxo, release_date) in input_utxos.iter_mut().zip(release_dates.iter()) {
-                        if !release_date.is_zero() {
-                            let time_lock_coin = TimeLock::until(*release_date);
-                            let mut coins = utxo.coins().to_vec();
-                            coins.push(time_lock_coin);
-                            *utxo = (utxo.lock_script_hash(), coins).into()
-                        }
-                    }
-
-                    // generate valid output amounts
-                    PrimitiveWitness::find_balanced_output_amounts_and_fee(
-                        total_inputs,
-                        maybe_coinbase,
-                        &mut output_amounts,
-                        &mut fee,
+                    assert_eq!(
+                        total_inputs + maybe_coinbase.unwrap_or(NeptuneCoins::new(0)),
+                        total_outputs + fee
                     );
-
-                    // generate output UTXOs
-                    let output_utxos =
+                    let mut output_utxos =
                         PrimitiveWitness::valid_tx_outputs_from_amounts_and_address_seeds(
                             &output_amounts,
                             &output_address_seeds,
                             None,
                         );
-
-                    // generate primitive transaction witness and time lock witness from there
-                    PrimitiveWitness::arbitrary_primitive_witness_with(
+                    let mut counter = 0usize;
+                    for utxo in input_utxos.iter_mut() {
+                        let release_date = release_dates[counter];
+                        let time_lock = TimeLock::until(release_date);
+                        let mut coins = utxo.coins().to_vec();
+                        coins.push(time_lock);
+                        *utxo = Utxo::from((utxo.lock_script_hash(), coins));
+                        counter += 1;
+                    }
+                    for utxo in output_utxos.iter_mut() {
+                        let mut coins = utxo.coins().to_vec();
+                        coins.push(TimeLock::until(release_dates[counter]));
+                        *utxo = Utxo::from((utxo.lock_script_hash(), coins));
+                        counter += 1;
+                    }
+                    let release_dates = release_dates.clone();
+                    PrimitiveWitness::arbitrary_primitive_witness_with_timestamp_and(
                         &input_utxos,
                         &input_lock_scripts_and_witnesses,
                         &output_utxos,
                         &public_announcements,
-                        NeptuneCoins::zero(),
+                        fee,
                         maybe_coinbase,
+                        now,
                     )
-                    .prop_map(move |mut transaction_primitive_witness| {
+                    .prop_map(move |primitive_witness_template| {
+                        let mut primitive_witness = primitive_witness_template.clone();
                         let modified_kernel = TransactionKernelModifier::default()
-                            .timestamp(transaction_timestamp)
-                            .modify(transaction_primitive_witness.kernel);
+                            .timestamp(now)
+                            .modify(primitive_witness.kernel);
 
-                        transaction_primitive_witness.kernel = modified_kernel;
-                        TimeLockWitness::from(transaction_primitive_witness)
+                        primitive_witness.kernel = modified_kernel;
+                        primitive_witness
                     })
-                    .boxed()
                 },
             )
             .boxed()
     }
-}
-
-/// Generate a `Strategy` for a [`PrimitiveWitness`] with the given numbers of
-/// inputs, outputs, and public announcements, with active timelocks.
-///
-/// The UTXOs are timelocked with a release date set between `now` and six
-/// months from `now`.
-pub fn arbitrary_primitive_witness_with_active_timelocks(
-    num_inputs: usize,
-    num_outputs: usize,
-    num_announcements: usize,
-    now: Timestamp,
-) -> BoxedStrategy<PrimitiveWitness> {
-    vec(
-        Timestamp::arbitrary_between(now, now + Timestamp::months(6)),
-        num_inputs + num_outputs,
-    )
-    .prop_flat_map(move |release_dates| {
-        arbitrary_primitive_witness_with_timelocks(
-            num_inputs,
-            num_outputs,
-            num_announcements,
-            now,
-            release_dates,
-        )
-    })
-    .boxed()
-}
-
-/// Generate a `Strategy` for a [`PrimitiveWitness`] with the given numbers of
-/// inputs, outputs, and public announcements, with expired timelocks.
-///
-/// The UTXOs are timelocked with a release date set between six months in the
-/// past relative to `now` and `now`.
-pub fn arbitrary_primitive_witness_with_expired_timelocks(
-    num_inputs: usize,
-    num_outputs: usize,
-    num_announcements: usize,
-    now: Timestamp,
-) -> BoxedStrategy<PrimitiveWitness> {
-    vec(
-        Timestamp::arbitrary_between(now - Timestamp::months(6), now - Timestamp::millis(1)),
-        num_inputs + num_outputs,
-    )
-    .prop_flat_map(move |release_dates| {
-        arbitrary_primitive_witness_with_timelocks(
-            num_inputs,
-            num_outputs,
-            num_announcements,
-            now,
-            release_dates,
-        )
-    })
-    .boxed()
-}
-
-#[expect(unused_variables, reason = "under development")]
-fn arbitrary_primitive_witness_with_timelocks(
-    num_inputs: usize,
-    num_outputs: usize,
-    num_announcements: usize,
-    now: Timestamp,
-    release_dates: Vec<Timestamp>,
-) -> BoxedStrategy<PrimitiveWitness> {
-    (
-        NeptuneCoins::arbitrary_non_negative(),
-        vec(arb::<Digest>(), num_inputs),
-        vec(arb::<u64>(), num_inputs),
-        vec(arb::<Digest>(), num_outputs),
-        vec(arb::<u64>(), num_outputs),
-        vec(arb::<PublicAnnouncement>(), num_announcements),
-        arb::<u64>(),
-        arb::<Option<u64>>(),
-    )
-        .prop_flat_map(
-            move |(
-                total_amount,
-                input_address_seeds,
-                input_dist,
-                output_address_seeds,
-                output_dist,
-                public_announcements,
-                fee_dist,
-                maybe_coinbase_dist,
-            )| {
-                let maybe_coinbase_dist = if num_inputs.is_zero() {
-                    maybe_coinbase_dist
-                } else {
-                    None
-                };
-
-                // distribute total amount across inputs (+ coinbase)
-                let mut input_denominator = input_dist.iter().map(|u| *u as f64).sum::<f64>();
-                if let Some(d) = maybe_coinbase_dist {
-                    input_denominator += d as f64;
-                }
-                let input_weights = input_dist
-                    .into_iter()
-                    .map(|u| (u as f64) / input_denominator)
-                    .collect_vec();
-                let mut input_amounts = input_weights
-                    .into_iter()
-                    .map(|w| total_amount.to_nau_f64() * w)
-                    .map(|f| NeptuneCoins::try_from(f).unwrap())
-                    .collect_vec();
-                let maybe_coinbase = if maybe_coinbase_dist.is_some() || input_amounts.is_empty() {
-                    Some(
-                        total_amount
-                            .checked_sub(&input_amounts.iter().cloned().sum::<NeptuneCoins>())
-                            .unwrap(),
-                    )
-                } else {
-                    let sum_of_all_but_last = input_amounts
-                        .iter()
-                        .rev()
-                        .skip(1)
-                        .cloned()
-                        .sum::<NeptuneCoins>();
-                    *input_amounts.last_mut().unwrap() =
-                        total_amount.checked_sub(&sum_of_all_but_last).unwrap();
-                    None
-                };
-
-                // distribute total amount across outputs
-                let output_denominator =
-                    output_dist.iter().map(|u| *u as f64).sum::<f64>() + (fee_dist as f64);
-                let output_weights = output_dist
-                    .into_iter()
-                    .map(|u| (u as f64) / output_denominator)
-                    .collect_vec();
-                let output_amounts = output_weights
-                    .into_iter()
-                    .map(|w| total_amount.to_nau_f64() * w)
-                    .map(|f| NeptuneCoins::try_from(f).unwrap())
-                    .collect_vec();
-                let total_outputs = output_amounts.iter().cloned().sum::<NeptuneCoins>();
-                let fee = total_amount.checked_sub(&total_outputs).unwrap();
-
-                let (mut input_utxos, input_lock_scripts_and_witnesses) =
-                    PrimitiveWitness::transaction_inputs_from_address_seeds_and_amounts(
-                        &input_address_seeds,
-                        &input_amounts,
-                    );
-                let total_inputs = input_amounts.iter().copied().sum::<NeptuneCoins>();
-
-                assert_eq!(
-                    total_inputs + maybe_coinbase.unwrap_or(NeptuneCoins::new(0)),
-                    total_outputs + fee
-                );
-                let mut output_utxos =
-                    PrimitiveWitness::valid_tx_outputs_from_amounts_and_address_seeds(
-                        &output_amounts,
-                        &output_address_seeds,
-                        None,
-                    );
-                let mut counter = 0usize;
-                for utxo in input_utxos.iter_mut() {
-                    let release_date = release_dates[counter];
-                    let time_lock = TimeLock::until(release_date);
-                    let mut coins = utxo.coins().to_vec();
-                    coins.push(time_lock);
-                    *utxo = Utxo::from((utxo.lock_script_hash(), coins));
-                    counter += 1;
-                }
-                for utxo in output_utxos.iter_mut() {
-                    let mut coins = utxo.coins().to_vec();
-                    coins.push(TimeLock::until(release_dates[counter]));
-                    *utxo = Utxo::from((utxo.lock_script_hash(), coins));
-                    counter += 1;
-                }
-                let release_dates = release_dates.clone();
-                PrimitiveWitness::arbitrary_primitive_witness_with_timestamp_and(
-                    &input_utxos,
-                    &input_lock_scripts_and_witnesses,
-                    &output_utxos,
-                    &public_announcements,
-                    fee,
-                    maybe_coinbase,
-                    now,
-                )
-                .prop_map(move |primitive_witness_template| {
-                    let mut primitive_witness = primitive_witness_template.clone();
-                    let modified_kernel = TransactionKernelModifier::default()
-                        .timestamp(now)
-                        .modify(primitive_witness.kernel);
-
-                    primitive_witness.kernel = modified_kernel;
-                    primitive_witness
-                })
-            },
-        )
-        .boxed()
 }
 
 #[cfg(test)]
@@ -1058,8 +1067,8 @@ mod test {
 
     use super::TimeLockWitness;
     use crate::models::blockchain::transaction::primitive_witness::PrimitiveWitness;
-    use crate::models::blockchain::type_scripts::time_lock::arbitrary_primitive_witness_with_active_timelocks;
-    use crate::models::blockchain::type_scripts::time_lock::arbitrary_primitive_witness_with_expired_timelocks;
+    use crate::models::blockchain::type_scripts::time_lock::neptune_arbitrary::arbitrary_primitive_witness_with_active_timelocks;
+    use crate::models::blockchain::type_scripts::time_lock::neptune_arbitrary::arbitrary_primitive_witness_with_expired_timelocks;
     use crate::models::blockchain::type_scripts::time_lock::TimeLock;
     use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
     use crate::models::proof_abstractions::timestamp::Timestamp;

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -68,7 +68,7 @@ use crate::models::blockchain::transaction::PublicAnnouncement;
 use crate::models::blockchain::transaction::Transaction;
 use crate::models::blockchain::transaction::TransactionProof;
 use crate::models::blockchain::type_scripts::neptune_coins::NeptuneCoins;
-use crate::models::blockchain::type_scripts::time_lock::arbitrary_primitive_witness_with_expired_timelocks;
+use crate::models::blockchain::type_scripts::time_lock::neptune_arbitrary::arbitrary_primitive_witness_with_expired_timelocks;
 use crate::models::channel::MainToPeerTask;
 use crate::models::channel::PeerTaskToMain;
 use crate::models::database::BlockIndexKey;

--- a/src/util_types/mutator_set/mmra_and_membership_proofs.rs
+++ b/src/util_types/mutator_set/mmra_and_membership_proofs.rs
@@ -1,14 +1,5 @@
-use itertools::Itertools;
-use proptest::arbitrary::Arbitrary;
-use proptest::strategy::BoxedStrategy;
-use proptest::strategy::Just;
-use proptest::strategy::Strategy;
-use tasm_lib::prelude::Digest;
 use tasm_lib::twenty_first::util_types::mmr::mmr_accumulator::MmrAccumulator;
 use tasm_lib::twenty_first::util_types::mmr::mmr_membership_proof::MmrMembershipProof;
-use tasm_lib::twenty_first::util_types::mmr::shared_basic::leaf_index_to_mt_index_and_peak_index;
-
-use super::root_and_paths::RootAndPaths;
 
 #[derive(Debug, Clone)]
 pub struct MmraAndMembershipProofs {
@@ -17,133 +8,152 @@ pub struct MmraAndMembershipProofs {
     pub leaf_indices: Vec<u64>,
 }
 
-impl Arbitrary for MmraAndMembershipProofs {
-    type Parameters = (Vec<(u64, Digest)>, u64);
+#[cfg(any(test, feature = "arbitrary-impls"))]
+pub mod neptune_arbitrary {
+    use itertools::Itertools;
+    use proptest::arbitrary::Arbitrary;
+    use proptest::strategy::BoxedStrategy;
+    use proptest::strategy::Just;
+    use proptest::strategy::Strategy;
+    use tasm_lib::prelude::Digest;
+    use tasm_lib::twenty_first::util_types::mmr::shared_basic::leaf_index_to_mt_index_and_peak_index;
 
-    fn arbitrary_with(parameters: Self::Parameters) -> Self::Strategy {
-        let (indices_and_leafs, total_leaf_count) = parameters;
-        let indices = indices_and_leafs.iter().map(|(i, _d)| *i).collect_vec();
-        let leafs = indices_and_leafs.iter().map(|(_i, d)| *d).collect_vec();
-        let num_paths = leafs.len() as u64;
+    use super::super::root_and_paths::RootAndPaths;
+    use super::*;
 
-        let num_peaks = total_leaf_count.count_ones();
-        let mut tree_heights = vec![];
-        for shift in (0..64).rev() {
-            if total_leaf_count & (1u64 << shift) != 0 {
-                tree_heights.push(shift);
+    impl Arbitrary for MmraAndMembershipProofs {
+        type Parameters = (Vec<(u64, Digest)>, u64);
+
+        fn arbitrary_with(parameters: Self::Parameters) -> Self::Strategy {
+            let (indices_and_leafs, total_leaf_count) = parameters;
+            let indices = indices_and_leafs.iter().map(|(i, _d)| *i).collect_vec();
+            let leafs = indices_and_leafs.iter().map(|(_i, d)| *d).collect_vec();
+            let num_paths = leafs.len() as u64;
+
+            let num_peaks = total_leaf_count.count_ones();
+            let mut tree_heights = vec![];
+            for shift in (0..64).rev() {
+                if total_leaf_count & (1u64 << shift) != 0 {
+                    tree_heights.push(shift);
+                }
             }
-        }
 
-        // sample mmr leaf indices and calculate matching derived indices
-        let index_sets = leafs
-            .iter()
-            .enumerate()
-            .map(|(enumeration_index, _leaf)| (enumeration_index, indices[enumeration_index]))
-            .map(|(enumeration_index, mmr_leaf_index)| {
-                let (mt_node_index, peak_index) =
-                    leaf_index_to_mt_index_and_peak_index(mmr_leaf_index, total_leaf_count);
-                (enumeration_index, mt_node_index, mmr_leaf_index, peak_index)
-            })
-            .collect_vec();
-        let leafs_and_indices = leafs
-            .iter()
-            .copied()
-            .zip(index_sets.iter().cloned())
-            .collect_vec();
-
-        // segregate by tree
-        let mut indices_and_leafs_by_tree = vec![];
-        for tree in 0..num_peaks {
-            let local_indices_and_leafs = leafs_and_indices
+            // sample mmr leaf indices and calculate matching derived indices
+            let index_sets = leafs
                 .iter()
-                .filter(
-                    |(_leaf, (_enumeration_index, _mt_node_index, _mmr_leaf_index, peak_index))| {
-                        *peak_index == tree
-                    },
-                )
-                .cloned()
-                .map(
-                    |(leaf, (enumeration_index, mt_node_index, mmr_leaf_index, _peak_index))| {
-                        (enumeration_index, mt_node_index, mmr_leaf_index, leaf)
-                    },
-                )
+                .enumerate()
+                .map(|(enumeration_index, _leaf)| (enumeration_index, indices[enumeration_index]))
+                .map(|(enumeration_index, mmr_leaf_index)| {
+                    let (mt_node_index, peak_index) =
+                        leaf_index_to_mt_index_and_peak_index(mmr_leaf_index, total_leaf_count);
+                    (enumeration_index, mt_node_index, mmr_leaf_index, peak_index)
+                })
+                .collect_vec();
+            let leafs_and_indices = leafs
+                .iter()
+                .copied()
+                .zip(index_sets.iter().cloned())
                 .collect_vec();
 
-            indices_and_leafs_by_tree.push(local_indices_and_leafs);
-        }
-
-        // for each tree generate root and paths
-        let mut root_and_paths_strategies = vec![];
-        for (tree, local_indices_and_leafs) in indices_and_leafs_by_tree.iter().enumerate() {
-            let tree_height = tree_heights[tree];
-            let root_and_paths_strategy = RootAndPaths::arbitrary_with((
-                tree_height,
-                local_indices_and_leafs
+            // segregate by tree
+            let mut indices_and_leafs_by_tree = vec![];
+            for tree in 0..num_peaks {
+                let local_indices_and_leafs = leafs_and_indices
                     .iter()
-                    .copied()
-                    .map(|(_ei, mtni, _mmri, leaf)| (mtni ^ (1 << tree_height), leaf))
-                    .collect_vec(),
-            ));
-            root_and_paths_strategies.push(root_and_paths_strategy);
-        }
-
-        // unwrap vector of roots and pathses
-        (root_and_paths_strategies, Just(indices_and_leafs_by_tree))
-            .prop_map(move |(roots_and_pathses, indices_and_leafs_by_tree_)| {
-                // extract peaks
-                let peaks = roots_and_pathses
-                    .iter()
-                    .map(|root_and_paths| root_and_paths.root)
+                    .filter(
+                        |(
+                            _leaf,
+                            (_enumeration_index, _mt_node_index, _mmr_leaf_index, peak_index),
+                        )| { *peak_index == tree },
+                    )
+                    .cloned()
+                    .map(
+                        |(
+                            leaf,
+                            (enumeration_index, mt_node_index, mmr_leaf_index, _peak_index),
+                        )| {
+                            (enumeration_index, mt_node_index, mmr_leaf_index, leaf)
+                        },
+                    )
                     .collect_vec();
 
-                // prepare to extract membership proofs
-                let mut membership_proofs = vec![
-                    MmrMembershipProof {
-                        authentication_path: vec![],
-                    };
-                    num_paths as usize
-                ];
-                let mut leaf_indices = vec![0; num_paths as usize];
+                indices_and_leafs_by_tree.push(local_indices_and_leafs);
+            }
 
-                // loop over all leaf indices and look up membership proof
-                for (root_and_paths, indices_and_leafs_) in roots_and_pathses
-                    .into_iter()
-                    .zip(indices_and_leafs_by_tree_.iter())
-                {
-                    let paths = root_and_paths.paths;
-                    for (path, &(enumeration_index, _merkle_tree_index, mmr_index, _leaf)) in
-                        paths.into_iter().zip(indices_and_leafs_.iter())
+            // for each tree generate root and paths
+            let mut root_and_paths_strategies = vec![];
+            for (tree, local_indices_and_leafs) in indices_and_leafs_by_tree.iter().enumerate() {
+                let tree_height = tree_heights[tree];
+                let root_and_paths_strategy = RootAndPaths::arbitrary_with((
+                    tree_height,
+                    local_indices_and_leafs
+                        .iter()
+                        .copied()
+                        .map(|(_ei, mtni, _mmri, leaf)| (mtni ^ (1 << tree_height), leaf))
+                        .collect_vec(),
+                ));
+                root_and_paths_strategies.push(root_and_paths_strategy);
+            }
+
+            // unwrap vector of roots and pathses
+            (root_and_paths_strategies, Just(indices_and_leafs_by_tree))
+                .prop_map(move |(roots_and_pathses, indices_and_leafs_by_tree_)| {
+                    // extract peaks
+                    let peaks = roots_and_pathses
+                        .iter()
+                        .map(|root_and_paths| root_and_paths.root)
+                        .collect_vec();
+
+                    // prepare to extract membership proofs
+                    let mut membership_proofs = vec![
+                        MmrMembershipProof {
+                            authentication_path: vec![],
+                        };
+                        num_paths as usize
+                    ];
+                    let mut leaf_indices = vec![0; num_paths as usize];
+
+                    // loop over all leaf indices and look up membership proof
+                    for (root_and_paths, indices_and_leafs_) in roots_and_pathses
+                        .into_iter()
+                        .zip(indices_and_leafs_by_tree_.iter())
                     {
-                        membership_proofs[enumeration_index].authentication_path = path;
-                        leaf_indices[enumeration_index] = mmr_index;
+                        let paths = root_and_paths.paths;
+                        for (path, &(enumeration_index, _merkle_tree_index, mmr_index, _leaf)) in
+                            paths.into_iter().zip(indices_and_leafs_.iter())
+                        {
+                            membership_proofs[enumeration_index].authentication_path = path;
+                            leaf_indices[enumeration_index] = mmr_index;
+                        }
                     }
-                }
 
-                // sanity check
-                for ((mmr_mp, leaf), leaf_index) in membership_proofs
-                    .iter()
-                    .zip(leafs.iter())
-                    .zip(leaf_indices.iter())
-                {
-                    let (_mti, _pi) =
-                        leaf_index_to_mt_index_and_peak_index(*leaf_index, total_leaf_count);
-                    assert!(mmr_mp.verify(*leaf_index, *leaf, &peaks, total_leaf_count));
-                }
+                    // sanity check
+                    for ((mmr_mp, leaf), leaf_index) in membership_proofs
+                        .iter()
+                        .zip(leafs.iter())
+                        .zip(leaf_indices.iter())
+                    {
+                        let (_mti, _pi) =
+                            leaf_index_to_mt_index_and_peak_index(*leaf_index, total_leaf_count);
+                        assert!(mmr_mp.verify(*leaf_index, *leaf, &peaks, total_leaf_count));
+                    }
 
-                MmraAndMembershipProofs {
-                    mmra: MmrAccumulator::init(peaks, total_leaf_count),
-                    membership_proofs,
-                    leaf_indices,
-                }
-            })
-            .boxed()
+                    MmraAndMembershipProofs {
+                        mmra: MmrAccumulator::init(peaks, total_leaf_count),
+                        membership_proofs,
+                        leaf_indices,
+                    }
+                })
+                .boxed()
+        }
+
+        type Strategy = BoxedStrategy<Self>;
     }
-
-    type Strategy = BoxedStrategy<Self>;
 }
 
 #[cfg(test)]
 mod test {
+    use itertools::Itertools;
     use proptest::collection::vec;
     use proptest::prelude::*;
     use proptest_arbitrary_interop::arb;

--- a/src/util_types/mutator_set/msa_and_records.rs
+++ b/src/util_types/mutator_set/msa_and_records.rs
@@ -1,28 +1,9 @@
-use std::collections::HashMap;
-
 use itertools::Itertools;
-use proptest::arbitrary::Arbitrary;
-use proptest::collection::vec;
-use proptest::strategy::BoxedStrategy;
-use proptest::strategy::Strategy;
-use proptest_arbitrary_interop::arb;
 use tasm_lib::prelude::Digest;
-use tasm_lib::twenty_first::util_types::mmr::mmr_membership_proof::MmrMembershipProof;
-use tasm_lib::twenty_first::util_types::mmr::mmr_trait::Mmr;
 
-use super::active_window::ActiveWindow;
-use super::chunk::Chunk;
-use super::chunk_dictionary::ChunkDictionary;
-use super::get_swbf_indices;
-use super::mmra_and_membership_proofs::MmraAndMembershipProofs;
 use super::ms_membership_proof::MsMembershipProof;
 use super::mutator_set_accumulator::MutatorSetAccumulator;
-use super::removal_record::AbsoluteIndexSet;
 use super::removal_record::RemovalRecord;
-use super::shared::BATCH_SIZE;
-use super::shared::CHUNK_SIZE;
-use crate::util_types::mutator_set::commit;
-use crate::Hash;
 
 #[derive(Debug, Clone, Default)]
 pub struct MsaAndRecords {
@@ -54,223 +35,248 @@ impl MsaAndRecords {
     }
 }
 
-impl Arbitrary for MsaAndRecords {
-    /// Parameters:
-    ///  - removables : Vec<(Digest, Digest, Digest)> where each triple contains:
-    ///     - an item
-    ///     - sender randomness
-    ///     - receiver preimage
-    ///  - aocl_size : u64 which counts the total number of items added to the mutator
-    ///    set.
-    type Parameters = (Vec<(Digest, Digest, Digest)>, u64);
-    type Strategy = BoxedStrategy<Self>;
+#[cfg(any(test, feature = "arbitrary-impls"))]
+pub mod neptune_arbitrary {
+    use std::collections::HashMap;
 
-    fn arbitrary_with(parameters: Self::Parameters) -> Self::Strategy {
-        let (removables, aocl_size) = parameters;
+    use proptest::arbitrary::Arbitrary;
+    use proptest::collection::vec;
+    use proptest::strategy::BoxedStrategy;
+    use proptest::strategy::Strategy;
+    use proptest_arbitrary_interop::arb;
+    use tasm_lib::twenty_first::util_types::mmr::mmr_membership_proof::MmrMembershipProof;
+    use tasm_lib::twenty_first::util_types::mmr::mmr_trait::Mmr;
 
-        // compute the canonical commitments that were added to the aocl at some prior,
-        // as this is information needed to produce membership proofs for the items that
-        // are going to be removed
-        let removable_commitments = removables
-            .iter()
-            .map(|(item, sender_randomness, receiver_preimage)| {
-                commit(*item, *sender_randomness, receiver_preimage.hash())
-            })
-            .collect_vec();
+    use super::super::active_window::ActiveWindow;
+    use super::super::chunk::Chunk;
+    use super::super::chunk_dictionary::ChunkDictionary;
+    use super::super::get_swbf_indices;
+    use super::super::mmra_and_membership_proofs::MmraAndMembershipProofs;
+    use super::super::removal_record::AbsoluteIndexSet;
+    use super::super::shared::BATCH_SIZE;
+    use super::super::shared::CHUNK_SIZE;
+    use super::*;
+    use crate::util_types::mutator_set::commit;
+    use crate::Hash;
 
-        let removable_commitments = removable_commitments.clone();
+    impl Arbitrary for MsaAndRecords {
+        /// Parameters:
+        ///  - removables : Vec<(Digest, Digest, Digest)> where each triple contains:
+        ///     - an item
+        ///     - sender randomness
+        ///     - receiver preimage
+        ///  - aocl_size : u64 which counts the total number of items added to the mutator
+        ///    set.
+        type Parameters = (Vec<(Digest, Digest, Digest)>, u64);
+        type Strategy = BoxedStrategy<Self>;
 
-        // sample random aocl indices
-        vec(0u64..aocl_size, removables.len())
-            .prop_flat_map(move |removed_aocl_indices| {
+        fn arbitrary_with(parameters: Self::Parameters) -> Self::Strategy {
+            let (removables, aocl_size) = parameters;
 
-            // prepare unwrap
-            let removables = removables.clone();
+            // compute the canonical commitments that were added to the aocl at some prior,
+            // as this is information needed to produce membership proofs for the items that
+            // are going to be removed
+            let removable_commitments = removables
+                .iter()
+                .map(|(item, sender_randomness, receiver_preimage)| {
+                    commit(*item, *sender_randomness, receiver_preimage.hash())
+                })
+                .collect_vec();
 
-            // bundle all indices and leafs for pseudorandom aocl
-            let all_aocl_indices_and_leafs = removed_aocl_indices.into_iter().zip(removable_commitments.iter().map(|ar|ar.canonical_commitment)).collect_vec();
+            let removable_commitments = removable_commitments.clone();
 
-            // unwrap random aocl mmr with membership proofs
-            MmraAndMembershipProofs::arbitrary_with((all_aocl_indices_and_leafs, aocl_size))
-            .prop_flat_map(move |aocl_mmra_and_membership_proofs| {
-                let aocl_mmra = aocl_mmra_and_membership_proofs.mmra;
-                let aocl_membership_proofs = aocl_mmra_and_membership_proofs.membership_proofs;
-                let aocl_leaf_indices = aocl_mmra_and_membership_proofs.leaf_indices;
+            // sample random aocl indices
+            vec(0u64..aocl_size, removables.len())
+                .prop_flat_map(move |removed_aocl_indices| {
 
-                // assemble all indices of all removal records
-                let all_index_sets = removables
-                    .iter()
-                    .zip(aocl_leaf_indices.iter())
-                    .map(
-                        |((item, sender_randomness, receiver_preimage), aocl_leaf_index)| {
-                            get_swbf_indices(
-                                *item,
-                                *sender_randomness,
-                                *receiver_preimage,
-                                *aocl_leaf_index,
-                            )
-                        },
-                    )
-                    .collect_vec();
-                let mut all_bloom_indices = all_index_sets.iter().flatten().cloned().collect_vec();
-                all_bloom_indices.sort();
-
-                // assemble all chunk indices
-                let mut all_chunk_indices = all_bloom_indices
-                    .iter()
-                    .map(|index| *index / (CHUNK_SIZE as u128))
-                    .map(|index| index as u64)
-                    .collect_vec();
-                all_chunk_indices.sort();
-                all_chunk_indices.dedup();
-
-                // filter by swbf mmr size
-                let swbf_mmr_size = aocl_mmra.num_leafs() / (BATCH_SIZE as u64);
-                let mmr_chunk_indices = all_chunk_indices
-                    .iter()
-                    .cloned()
-                    .filter(|ci| *ci < swbf_mmr_size)
-                    .collect_vec();
-
-                // prepare to unwrap
-                let aocl_mmra = aocl_mmra.clone();
-                let swbf_chunk_indices = mmr_chunk_indices.clone();
-                let all_index_sets = all_index_sets.clone();
-                let aocl_membership_proofs = aocl_membership_proofs.clone();
+                // prepare unwrap
                 let removables = removables.clone();
 
-                // unwrap random swbf chunks
-                swbf_chunk_indices.iter()
-                    .map(|_| arb::<Chunk>())
-                    .collect_vec()
-                    .prop_flat_map(move |swbf_chunks| {
-                        // prepare input to pseudorandom mmr generator
-                        let swbf_leafs = swbf_chunks.iter().map(Hash::hash).collect_vec();
-                        let swbf_indices_and_leafs = swbf_chunk_indices.iter().copied().zip(swbf_leafs.iter().copied()).collect_vec();
+                // bundle all indices and leafs for pseudorandom aocl
+                let all_aocl_indices_and_leafs = removed_aocl_indices.into_iter().zip(removable_commitments.iter().map(|ar|ar.canonical_commitment)).collect_vec();
 
-                        // prepare to unwrap
-                        let aocl_mmra = aocl_mmra.clone();
-                        let swbf_chunk_indices = swbf_chunk_indices.clone();
-                        let all_index_sets = all_index_sets.clone();
-                        let aocl_membership_proofs = aocl_membership_proofs.clone();
-                        let removables = removables.clone();
-                        let swbf_mmr_leaf_count = (aocl_mmra.num_leafs() / (BATCH_SIZE as u64)).saturating_sub(1);
-                        let aocl_leaf_indices = aocl_leaf_indices.clone();
+                // unwrap random aocl mmr with membership proofs
+                MmraAndMembershipProofs::arbitrary_with((all_aocl_indices_and_leafs, aocl_size))
+                .prop_flat_map(move |aocl_mmra_and_membership_proofs| {
+                    let aocl_mmra = aocl_mmra_and_membership_proofs.mmra;
+                    let aocl_membership_proofs = aocl_mmra_and_membership_proofs.membership_proofs;
+                    let aocl_leaf_indices = aocl_mmra_and_membership_proofs.leaf_indices;
 
-                        // unwrap random swbf mmra and membership proofs
-                        MmraAndMembershipProofs::arbitrary_with((
-                            swbf_indices_and_leafs, swbf_mmr_leaf_count
-                        )).prop_flat_map(move |swbf_mmr_and_paths| {
-                                let swbf_mmra = swbf_mmr_and_paths.mmra;
-                                let swbf_membership_proofs = swbf_mmr_and_paths.membership_proofs;
+                    // assemble all indices of all removal records
+                    let all_index_sets = removables
+                        .iter()
+                        .zip(aocl_leaf_indices.iter())
+                        .map(
+                            |((item, sender_randomness, receiver_preimage), aocl_leaf_index)| {
+                                get_swbf_indices(
+                                    *item,
+                                    *sender_randomness,
+                                    *receiver_preimage,
+                                    *aocl_leaf_index,
+                                )
+                            },
+                        )
+                        .collect_vec();
+                    let mut all_bloom_indices = all_index_sets.iter().flatten().cloned().collect_vec();
+                    all_bloom_indices.sort();
 
-                                let universal_chunk_dictionary: HashMap<u64, (MmrMembershipProof, Chunk)> =
-                                    swbf_chunk_indices
-                                        .iter()
-                                        .cloned()
-                                        .zip(
-                                            swbf_membership_proofs
-                                                .into_iter()
-                                                .zip(swbf_chunks.iter().cloned())
-                                            )
-                                        .collect();
-                                let personalized_chunk_dictionaries = all_index_sets
-                                    .iter()
-                                    .map(|index_set| {
-                                        let mut is = index_set
+                    // assemble all chunk indices
+                    let mut all_chunk_indices = all_bloom_indices
+                        .iter()
+                        .map(|index| *index / (CHUNK_SIZE as u128))
+                        .map(|index| index as u64)
+                        .collect_vec();
+                    all_chunk_indices.sort();
+                    all_chunk_indices.dedup();
+
+                    // filter by swbf mmr size
+                    let swbf_mmr_size = aocl_mmra.num_leafs() / (BATCH_SIZE as u64);
+                    let mmr_chunk_indices = all_chunk_indices
+                        .iter()
+                        .cloned()
+                        .filter(|ci| *ci < swbf_mmr_size)
+                        .collect_vec();
+
+                    // prepare to unwrap
+                    let aocl_mmra = aocl_mmra.clone();
+                    let swbf_chunk_indices = mmr_chunk_indices.clone();
+                    let all_index_sets = all_index_sets.clone();
+                    let aocl_membership_proofs = aocl_membership_proofs.clone();
+                    let removables = removables.clone();
+
+                    // unwrap random swbf chunks
+                    swbf_chunk_indices.iter()
+                        .map(|_| arb::<Chunk>())
+                        .collect_vec()
+                        .prop_flat_map(move |swbf_chunks| {
+                            // prepare input to pseudorandom mmr generator
+                            let swbf_leafs = swbf_chunks.iter().map(Hash::hash).collect_vec();
+                            let swbf_indices_and_leafs = swbf_chunk_indices.iter().copied().zip(swbf_leafs.iter().copied()).collect_vec();
+
+                            // prepare to unwrap
+                            let aocl_mmra = aocl_mmra.clone();
+                            let swbf_chunk_indices = swbf_chunk_indices.clone();
+                            let all_index_sets = all_index_sets.clone();
+                            let aocl_membership_proofs = aocl_membership_proofs.clone();
+                            let removables = removables.clone();
+                            let swbf_mmr_leaf_count = (aocl_mmra.num_leafs() / (BATCH_SIZE as u64)).saturating_sub(1);
+                            let aocl_leaf_indices = aocl_leaf_indices.clone();
+
+                            // unwrap random swbf mmra and membership proofs
+                            MmraAndMembershipProofs::arbitrary_with((
+                                swbf_indices_and_leafs, swbf_mmr_leaf_count
+                            )).prop_flat_map(move |swbf_mmr_and_paths| {
+                                    let swbf_mmra = swbf_mmr_and_paths.mmra;
+                                    let swbf_membership_proofs = swbf_mmr_and_paths.membership_proofs;
+
+                                    let universal_chunk_dictionary: HashMap<u64, (MmrMembershipProof, Chunk)> =
+                                        swbf_chunk_indices
                                             .iter()
-                                            .map(|index| *index / (CHUNK_SIZE as u128))
-                                            .map(|index| index as u64)
-                                            .collect_vec();
-                                        is.sort();
-                                        is.dedup();
-                                        is
-                                    })
-                                    .map(|chunk_indices| {
-                                        ChunkDictionary::new(
-                                            chunk_indices
-                                            .iter()
-                                            .filter(|chunk_index| **chunk_index < swbf_mmr_size)
-                                            .map(|chunk_index| {
-                                                (
-                                                    chunk_index,
-                                                    universal_chunk_dictionary
-                                                        .get(
-                                                            chunk_index,
-                                                        ).unwrap_or_else(|| panic!("Could not find chunk index {chunk_index} in universal chunk dictionary"))
+                                            .cloned()
+                                            .zip(
+                                                swbf_membership_proofs
+                                                    .into_iter()
+                                                    .zip(swbf_chunks.iter().cloned())
                                                 )
-                                            })
-                                            .map(|(chunk_index, (membership_proof, chunk))| (*chunk_index, (membership_proof.clone(), chunk.clone())))
-                                            .collect(),
+                                            .collect();
+                                    let personalized_chunk_dictionaries = all_index_sets
+                                        .iter()
+                                        .map(|index_set| {
+                                            let mut is = index_set
+                                                .iter()
+                                                .map(|index| *index / (CHUNK_SIZE as u128))
+                                                .map(|index| index as u64)
+                                                .collect_vec();
+                                            is.sort();
+                                            is.dedup();
+                                            is
+                                        })
+                                        .map(|chunk_indices| {
+                                            ChunkDictionary::new(
+                                                chunk_indices
+                                                .iter()
+                                                .filter(|chunk_index| **chunk_index < swbf_mmr_size)
+                                                .map(|chunk_index| {
+                                                    (
+                                                        chunk_index,
+                                                        universal_chunk_dictionary
+                                                            .get(
+                                                                chunk_index,
+                                                            ).unwrap_or_else(|| panic!("Could not find chunk index {chunk_index} in universal chunk dictionary"))
+                                                    )
+                                                })
+                                                .map(|(chunk_index, (membership_proof, chunk))| (*chunk_index, (membership_proof.clone(), chunk.clone())))
+                                                .collect(),
+                                            )
+                                        })
+                                        .collect_vec();
+                                    let membership_proofs = removables
+                                        .clone()
+                                        .iter()
+                                        .zip(aocl_membership_proofs.iter())
+                                        .zip(personalized_chunk_dictionaries.iter())
+                                        .zip(aocl_leaf_indices.iter())
+                                        .map(|((((item, sender_randomness, receiver_preimage), aocl_auth_path), target_chunks), aocl_leaf_index)| {
+                                            let leaf = commit(*item, *sender_randomness, receiver_preimage.hash()).canonical_commitment;
+                                            assert!(aocl_auth_path.verify(*aocl_leaf_index, leaf, &aocl_mmra.peaks(), aocl_mmra.num_leafs()));
+                                            (sender_randomness, receiver_preimage, aocl_auth_path, target_chunks, aocl_leaf_index)
+                                        })
+                                        .map(
+                                            |
+                                                (sender_randomness, receiver_preimage, aocl_auth_path,
+                                                target_chunks, aocl_leaf_index)
+                                            | {
+                                                MsMembershipProof {
+                                                    sender_randomness: *sender_randomness,
+                                                    receiver_preimage: *receiver_preimage,
+                                                    auth_path_aocl: aocl_auth_path.clone(),
+                                                    target_chunks: target_chunks.clone(),
+                                                    aocl_leaf_index: *aocl_leaf_index,
+                                                }
+                                            },
                                         )
-                                    })
-                                    .collect_vec();
-                                let membership_proofs = removables
-                                    .clone()
-                                    .iter()
-                                    .zip(aocl_membership_proofs.iter())
-                                    .zip(personalized_chunk_dictionaries.iter())
-                                    .zip(aocl_leaf_indices.iter())
-                                    .map(|((((item, sender_randomness, receiver_preimage), aocl_auth_path), target_chunks), aocl_leaf_index)| {
-                                        let leaf = commit(*item, *sender_randomness, receiver_preimage.hash()).canonical_commitment;
-                                        assert!(aocl_auth_path.verify(*aocl_leaf_index, leaf, &aocl_mmra.peaks(), aocl_mmra.num_leafs()));
-                                        (sender_randomness, receiver_preimage, aocl_auth_path, target_chunks, aocl_leaf_index)
-                                    })
-                                    .map(
-                                        |
-                                            (sender_randomness, receiver_preimage, aocl_auth_path,
-                                            target_chunks, aocl_leaf_index)
-                                        | {
-                                            MsMembershipProof {
-                                                sender_randomness: *sender_randomness,
-                                                receiver_preimage: *receiver_preimage,
-                                                auth_path_aocl: aocl_auth_path.clone(),
-                                                target_chunks: target_chunks.clone(),
-                                                aocl_leaf_index: *aocl_leaf_index,
+                                        .collect_vec();
+
+                                    let removal_records = all_index_sets
+                                        .iter()
+                                        .zip(personalized_chunk_dictionaries.iter())
+                                        .map(|(index_set, target_chunks)| RemovalRecord {
+                                            absolute_indices: AbsoluteIndexSet::new(index_set),
+                                            target_chunks: target_chunks.clone(),
+                                        })
+                                        .collect_vec();
+
+                                    // prepare to unwrap
+                                    let aocl_mmra = aocl_mmra.clone();
+                                    let swbf_mmra = swbf_mmra.clone();
+                                    let removal_records = removal_records.clone();
+                                    let membership_proofs = membership_proofs.clone();
+
+                                    // unwrap random active window
+                                    arb::<ActiveWindow>()
+                                        .prop_map(move |active_window| {
+                                            let mutator_set_accumulator = MutatorSetAccumulator {
+                                                    aocl: aocl_mmra.clone(),
+                                                    swbf_inactive: swbf_mmra.clone(),
+                                                    swbf_active: active_window,
+                                            };
+
+                                            MsaAndRecords {
+                                                mutator_set_accumulator,
+                                                removal_records: removal_records.clone(),
+                                                membership_proofs: membership_proofs.clone(),
                                             }
-                                        },
-                                    )
-                                    .collect_vec();
-
-                                let removal_records = all_index_sets
-                                    .iter()
-                                    .zip(personalized_chunk_dictionaries.iter())
-                                    .map(|(index_set, target_chunks)| RemovalRecord {
-                                        absolute_indices: AbsoluteIndexSet::new(index_set),
-                                        target_chunks: target_chunks.clone(),
-                                    })
-                                    .collect_vec();
-
-                                // prepare to unwrap
-                                let aocl_mmra = aocl_mmra.clone();
-                                let swbf_mmra = swbf_mmra.clone();
-                                let removal_records = removal_records.clone();
-                                let membership_proofs = membership_proofs.clone();
-
-                                // unwrap random active window
-                                arb::<ActiveWindow>()
-                                    .prop_map(move |active_window| {
-                                        let mutator_set_accumulator = MutatorSetAccumulator {
-                                                aocl: aocl_mmra.clone(),
-                                                swbf_inactive: swbf_mmra.clone(),
-                                                swbf_active: active_window,
-                                        };
-
-                                        MsaAndRecords {
-                                            mutator_set_accumulator,
-                                            removal_records: removal_records.clone(),
-                                            membership_proofs: membership_proofs.clone(),
-                                        }
-                                    })
-                                    .boxed()
-                            })
-                            .boxed()
-                    })
-                    .boxed()
+                                        })
+                                        .boxed()
+                                })
+                                .boxed()
+                        })
+                        .boxed()
+                })
+                .boxed()
             })
             .boxed()
-        })
-        .boxed()
+        }
     }
 }
 

--- a/src/util_types/mutator_set/root_and_paths.rs
+++ b/src/util_types/mutator_set/root_and_paths.rs
@@ -1,16 +1,4 @@
-use std::collections::hash_map::Entry;
-use std::collections::HashMap;
-
-use itertools::Itertools;
-use proptest::arbitrary::Arbitrary;
-use proptest::collection::vec;
-use proptest::strategy::BoxedStrategy;
-use proptest::strategy::Just;
-use proptest::strategy::Strategy;
-use proptest_arbitrary_interop::arb;
 use tasm_lib::prelude::Digest;
-
-use crate::models::blockchain::shared::Hash;
 
 #[derive(Debug, Clone, Default)]
 pub struct RootAndPaths {
@@ -18,109 +6,129 @@ pub struct RootAndPaths {
     pub paths: Vec<Vec<Digest>>,
 }
 
-impl Arbitrary for RootAndPaths {
-    type Parameters = (usize, Vec<(u64, Digest)>);
-    type Strategy = BoxedStrategy<Self>;
+#[cfg(any(test, feature = "arbitrary-impls"))]
+pub mod neptune_arbitrary {
+    use std::collections::hash_map::Entry;
+    use std::collections::HashMap;
 
-    fn arbitrary_with(parameters: Self::Parameters) -> Self::Strategy {
-        let (tree_height_proper, indices_and_leafs_proper) = parameters;
-        assert!(
-            indices_and_leafs_proper
-                .iter()
-                .map(|(idx, _)| idx)
-                .all_unique(),
-            "indices are not all unique"
-        );
-        assert!(
-            indices_and_leafs_proper
-                .iter()
-                .all(|(i, _l)| (*i as u128) < 1u128 << tree_height_proper),
-            "some or all indices are too large; don't fit in a tree of height {tree_height_proper}"
-        );
-        let upper_bound_num_digests = tree_height_proper * indices_and_leafs_proper.len() + 1;
+    use itertools::Itertools;
+    use proptest::arbitrary::Arbitrary;
+    use proptest::collection::vec;
+    use proptest::strategy::BoxedStrategy;
+    use proptest::strategy::Just;
+    use proptest::strategy::Strategy;
+    use proptest_arbitrary_interop::arb;
 
-        let tree_height_strategy = Just(tree_height_proper);
-        let indices_and_leafs_strategy = Just(indices_and_leafs_proper);
-        let vec_digest_strategy = vec(arb::<Digest>(), upper_bound_num_digests);
-        (
-            tree_height_strategy,
-            indices_and_leafs_strategy,
-            vec_digest_strategy,
-        )
-            .prop_map(|(tree_height, indices_and_leafs, mut digests)| {
-                assert!(indices_and_leafs.iter().all(|(i, _l)| (*i as u128) < (1u128 << tree_height)), "indices too large for tree of height: {}", tree_height);
-                // populate nodes dictionary with leafs
-                let mut nodes = HashMap::new();
-                for &(index, leaf) in &indices_and_leafs {
-                    let node_index = (index as u128) + (1u128 << tree_height);
-                    nodes.insert(node_index, leaf);
-                }
+    use super::*;
+    use crate::models::blockchain::shared::Hash;
 
-                let by_layer = |index: u128, layer: usize| {
-                    let sub_tree_height = tree_height - layer;
-                    let layer_start = 1u128 << sub_tree_height;
-                    let layer_stop = 1u128 << (sub_tree_height + 1);
-                    index >= layer_start && index < layer_stop
-                };
+    impl Arbitrary for RootAndPaths {
+        type Parameters = (usize, Vec<(u64, Digest)>);
+        type Strategy = BoxedStrategy<Self>;
 
-                // walk up tree layer by layer
-                // when we need nodes not already present, sample at random
-                for layer in 0..tree_height {
-                    let mut working_indices = nodes
-                        .keys()
-                        .copied()
-                        .filter(|&i| by_layer(i, layer))
-                        .collect_vec();
-                    working_indices.sort();
-                    working_indices.dedup();
-                    for wi in working_indices {
-                        let wi_odd = wi | 1;
-                        if let Entry::Vacant(entry) = nodes.entry(wi_odd) {
-                            entry.insert(digests.pop().unwrap());
-                        }
-                        let wi_even = wi_odd ^ 1;
-                        if let Entry::Vacant(entry) = nodes.entry(wi_even) {
-                            entry.insert(digests.pop().unwrap());
-                        }
-                        let hash = Hash::hash_pair(nodes[&wi_even], nodes[&wi_odd]);
-                        nodes.insert(wi >> 1, hash);
-                    }
-                }
-
-                // read out root, even if no paths were traversed
-                let root = *nodes.get(&1).unwrap_or(&digests.pop().unwrap());
-
-                // read out paths
-                let paths = indices_and_leafs
+        fn arbitrary_with(parameters: Self::Parameters) -> Self::Strategy {
+            let (tree_height_proper, indices_and_leafs_proper) = parameters;
+            assert!(
+                indices_and_leafs_proper
                     .iter()
-                    .map(|(leaf_idx, _)| (*leaf_idx as u128) + (1u128 << tree_height))
-                    .map(|node_idx| {
-                        (0..tree_height)
-                            .map(|layer_idx| {
-                                nodes
-                                    .get(&((node_idx >> layer_idx) ^ 1u128))
-                                    .unwrap_or_else(|| {
-                                        panic!(
-                                            "node index \n{} \nnot present in node dictionary!\ndo have indices:\n{}",
-                                            (node_idx >> layer_idx) ^ 1,
-                                            nodes.keys().join("\n")
-                                        )
-                                    })
-                            })
-                            .copied()
-                            .collect_vec()
-                    })
-                    .collect_vec();
+                    .map(|(idx, _)| idx)
+                    .all_unique(),
+                "indices are not all unique"
+            );
+            assert!(
+                indices_and_leafs_proper
+                    .iter()
+                    .all(|(i, _l)| (*i as u128) < 1u128 << tree_height_proper),
+                "some or all indices are too large; don't fit in a tree of height {tree_height_proper}"
+            );
+            let upper_bound_num_digests = tree_height_proper * indices_and_leafs_proper.len() + 1;
 
-                RootAndPaths { root, paths }
-            })
-            .boxed()
+            let tree_height_strategy = Just(tree_height_proper);
+            let indices_and_leafs_strategy = Just(indices_and_leafs_proper);
+            let vec_digest_strategy = vec(arb::<Digest>(), upper_bound_num_digests);
+            (
+                tree_height_strategy,
+                indices_and_leafs_strategy,
+                vec_digest_strategy,
+            )
+                .prop_map(|(tree_height, indices_and_leafs, mut digests)| {
+                    assert!(indices_and_leafs.iter().all(|(i, _l)| (*i as u128) < (1u128 << tree_height)), "indices too large for tree of height: {}", tree_height);
+                    // populate nodes dictionary with leafs
+                    let mut nodes = HashMap::new();
+                    for &(index, leaf) in &indices_and_leafs {
+                        let node_index = (index as u128) + (1u128 << tree_height);
+                        nodes.insert(node_index, leaf);
+                    }
+
+                    let by_layer = |index: u128, layer: usize| {
+                        let sub_tree_height = tree_height - layer;
+                        let layer_start = 1u128 << sub_tree_height;
+                        let layer_stop = 1u128 << (sub_tree_height + 1);
+                        index >= layer_start && index < layer_stop
+                    };
+
+                    // walk up tree layer by layer
+                    // when we need nodes not already present, sample at random
+                    for layer in 0..tree_height {
+                        let mut working_indices = nodes
+                            .keys()
+                            .copied()
+                            .filter(|&i| by_layer(i, layer))
+                            .collect_vec();
+                        working_indices.sort();
+                        working_indices.dedup();
+                        for wi in working_indices {
+                            let wi_odd = wi | 1;
+                            if let Entry::Vacant(entry) = nodes.entry(wi_odd) {
+                                entry.insert(digests.pop().unwrap());
+                            }
+                            let wi_even = wi_odd ^ 1;
+                            if let Entry::Vacant(entry) = nodes.entry(wi_even) {
+                                entry.insert(digests.pop().unwrap());
+                            }
+                            let hash = Hash::hash_pair(nodes[&wi_even], nodes[&wi_odd]);
+                            nodes.insert(wi >> 1, hash);
+                        }
+                    }
+
+                    // read out root, even if no paths were traversed
+                    let root = *nodes.get(&1).unwrap_or(&digests.pop().unwrap());
+
+                    // read out paths
+                    let paths = indices_and_leafs
+                        .iter()
+                        .map(|(leaf_idx, _)| (*leaf_idx as u128) + (1u128 << tree_height))
+                        .map(|node_idx| {
+                            (0..tree_height)
+                                .map(|layer_idx| {
+                                    nodes
+                                        .get(&((node_idx >> layer_idx) ^ 1u128))
+                                        .unwrap_or_else(|| {
+                                            panic!(
+                                                "node index \n{} \nnot present in node dictionary!\ndo have indices:\n{}",
+                                                (node_idx >> layer_idx) ^ 1,
+                                                nodes.keys().join("\n")
+                                            )
+                                        })
+                                })
+                                .copied()
+                                .collect_vec()
+                        })
+                        .collect_vec();
+
+                    RootAndPaths { root, paths }
+                })
+                .boxed()
+        }
     }
 }
 
 #[cfg(test)]
 mod test {
+    use itertools::Itertools;
+    use proptest::collection::vec;
     use proptest::prelude::*;
+    use proptest_arbitrary_interop::arb;
     use tasm_lib::twenty_first::util_types::merkle_tree::MerkleTreeInclusionProof;
     use test_strategy::proptest;
 


### PR DESCRIPTION
Closes #199.

This moves all 'impl Arbitrary' and related functions into module 'neptune_arbitrary', which is built
if either:
  1) --features arbitrary-impl
  2) --tests
  3) --test &lt;x>
  4) --benches
  5) --bench &lt;x>

It is necessary to include for tests because some unit tests require this functionality.

This modularization cleanly separates code that is only needed for arbitrary/testing from that which is necessary for debug/release builds.

I verified that both of these give no warnings or errors:

```
$ cargo clippy --all-features
$ cargo +nightly clippy --all-features --all-targets
```