### PR TITLE
fix: Spawn task for block proof verification (#288)

### DIFF
--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -698,7 +698,7 @@ pub(crate) async fn mine(
                     continue;
                 }
 
-                if !new_block_found.block.is_valid(&latest_block, Timestamp::now()) {
+                if !new_block_found.block.is_valid(&latest_block, Timestamp::now()).await {
                     // Block could be invalid if for instance the proof and proof-of-work
                     // took less time than the minimum block time.
                     error!("Found block with valid proof-of-work but block is invalid.");
@@ -971,7 +971,7 @@ pub(crate) mod mine_loop_tests {
             .await
             .unwrap();
             assert!(
-                block_1_empty_mempool.is_valid(&genesis_block, now),
+                block_1_empty_mempool.is_valid(&genesis_block, now).await,
                 "Block template created by miner with empty mempool must be valid"
             );
 
@@ -1009,7 +1009,9 @@ pub(crate) mod mine_loop_tests {
             .await
             .unwrap();
             assert!(
-                block_1_nonempty_mempool.is_valid(&genesis_block, now + Timestamp::seconds(2)),
+                block_1_nonempty_mempool
+                    .is_valid(&genesis_block, now + Timestamp::seconds(2))
+                    .await,
                 "Block template created by miner with non-empty mempool must be valid"
             );
 
@@ -1041,7 +1043,7 @@ pub(crate) mod mine_loop_tests {
             .await
             .unwrap();
         let (block_1, _) = receiver_1.await.unwrap();
-        assert!(block_1.is_valid(&genesis_block, mocked_now));
+        assert!(block_1.is_valid(&genesis_block, mocked_now).await);
         alice.set_new_tip(block_1.clone()).await.unwrap();
 
         let (sender_2, receiver_2) = oneshot::channel();
@@ -1049,7 +1051,7 @@ pub(crate) mod mine_loop_tests {
             .await
             .unwrap();
         let (block_2, _) = receiver_2.await.unwrap();
-        assert!(block_2.is_valid(&block_1, mocked_now));
+        assert!(block_2.is_valid(&block_1, mocked_now).await);
     }
 
     /// This test mines a single block at height 1 on the main network

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -2419,7 +2419,7 @@ mod global_state_tests {
         .await
         .unwrap();
 
-        assert!(block_1.is_valid(&genesis_block, in_seven_months));
+        assert!(block_1.is_valid(&genesis_block, in_seven_months).await);
 
         println!("Accumulated transaction into block_1.");
         println!(
@@ -2643,7 +2643,7 @@ mod global_state_tests {
         )
         .await
         .unwrap();
-        assert!(block_2.is_valid(&block_1, in_eight_months));
+        assert!(block_2.is_valid(&block_1, in_eight_months).await);
 
         assert_eq!(4, block_2.kernel.body.transaction_kernel.inputs.len());
         assert_eq!(6, block_2.kernel.body.transaction_kernel.outputs.len());
@@ -2690,7 +2690,8 @@ mod global_state_tests {
                 .await
                 .chain
                 .light_state()
-                .is_valid(&genesis_block, now),
+                .is_valid(&genesis_block, now)
+                .await,
             "light state tip must be a valid block"
         );
         assert!(
@@ -2701,7 +2702,8 @@ mod global_state_tests {
                 .archival_state()
                 .get_tip()
                 .await
-                .is_valid(&genesis_block, now),
+                .is_valid(&genesis_block, now)
+                .await,
             "archival state tip must be a valid block"
         );
     }

--- a/src/models/state/wallet/mod.rs
+++ b/src/models/state/wallet/mod.rs
@@ -1255,7 +1255,7 @@ mod wallet_tests {
         .await
         .unwrap();
         assert!(
-            block_3_b.is_valid(&block_2_b, in_seven_months),
+            block_3_b.is_valid(&block_2_b, in_seven_months).await,
             "Block must be valid after accumulating txs"
         );
         let expected_utxos_for_alice_cb = expected_composer_utxos
@@ -1455,7 +1455,7 @@ mod wallet_tests {
 
         // The entire block must be valid, i.e., have a valid block proof, and
         // be valid in other respects. We don't care about PoW, though.
-        assert!(block_1.is_valid(&genesis_block, in_seven_months));
+        assert!(block_1.is_valid(&genesis_block, in_seven_months).await);
 
         // 3 outputs: 1 coinbase, 1 for recipient of tx, 1 for change.
         assert_eq!(3, block_1.body().transaction_kernel.outputs.len());

--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -224,7 +224,7 @@ impl PeerLoopHandler {
         for new_block in received_blocks.iter() {
             let new_block_has_proof_of_work = new_block.has_proof_of_work(previous_block);
             debug!("new block has proof of work? {new_block_has_proof_of_work}");
-            let new_block_is_valid = new_block.is_valid(previous_block, now);
+            let new_block_is_valid = new_block.is_valid(previous_block, now).await;
             debug!("new block is valid? {new_block_is_valid}");
             if !new_block_has_proof_of_work {
                 warn!(
@@ -331,15 +331,14 @@ impl PeerLoopHandler {
         <S as TryStream>::Error: std::error::Error,
     {
         let parent_digest = received_block.kernel.header.prev_block_digest;
-        debug!("Fetching parent block");
-        let parent_block = self
-            .global_state_lock
-            .lock_guard()
-            .await
+        debug!("Try ensure path: fetching parent block");
+        let global_state = self.global_state_lock.lock_guard().await;
+        let parent_block = global_state
             .chain
             .archival_state()
             .get_block(parent_digest)
             .await?;
+        drop(global_state);
         debug!(
             "Completed parent block fetching from DB: {}",
             if parent_block.is_some() {
@@ -1159,7 +1158,7 @@ impl PeerLoopHandler {
                     .chain
                     .light_state()
                     .to_owned();
-                if !block.is_valid(&tip, self.now()) {
+                if !block.is_valid(&tip, self.now()).await {
                     self.punish(NegativePeerSanction::InvalidBlockProposal)
                         .await?;
 
@@ -1802,7 +1801,7 @@ mod peer_loop_tests {
         let block_1 =
             valid_block_for_tests(&alice, now, StdRng::seed_from_u64(5550001).gen(), 0.0).await;
         assert!(
-            block_1.is_valid(&genesis_block, now),
+            block_1.is_valid(&genesis_block, now).await,
             "Block must be valid for this test to make sense"
         );
         alice.set_new_tip(block_1.clone()).await?;


### PR DESCRIPTION
 - Wrap call to `triton_vm::verify` in `spawn_blocking`.
 - Make function `async` and percolate `async` markers.
 - Sandwich relevant call between debug messages.

All observations point to this change eliminating issue #282. However, we do not have a mechanical explanation as to what causes the apparent fix.

