### PR TITLE
fix(`mine_loop`): Segregate rayon threadpool for guessing

### DIFF
--- a/src/config_models/cli_args.rs
+++ b/src/config_models/cli_args.rs
@@ -113,6 +113,11 @@ pub struct Args {
     #[clap(long)]
     pub sleepy_guessing: bool,
 
+    /// Set the number of threads to use while guessing. When no value is set,
+    /// the number is set to the number of available cores.
+    #[clap(long)]
+    pub guesser_threads: Option<usize>,
+
     /// Determines the fraction of the transaction fee consumed by this node as
     /// a reward either for upgrading a `ProofCollection` to `SingleProof`, or
     /// for merging two `SingleProof`s.

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -1,6 +1,5 @@
 pub(crate) mod composer_parameters;
 
-use std::cmp;
 use std::cmp::max;
 use std::time::Duration;
 
@@ -174,12 +173,8 @@ fn guess_worker(
     let block_header_template = block.header().to_owned();
     let (block_body_mast_hash_digest, appendix_digest) = precalculate_mast_leafs(&block);
     let rayon_threads_available = rayon::current_num_threads();
-    if rayon_threads_available < 2 {
-        error!("Cannot guess when less than two threads are available to rayon");
-        return;
-    }
 
-    let threads_to_use = cmp::max(1, rayon_threads_available.saturating_sub(2));
+    let threads_to_use = rayon_threads_available;
     let pool = ThreadPoolBuilder::new()
         .num_threads(threads_to_use)
         .build()

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -174,6 +174,11 @@ fn guess_worker(
     let block_header_template = block.header().to_owned();
     let (block_body_mast_hash_digest, appendix_digest) = precalculate_mast_leafs(&block);
     let rayon_threads_available = rayon::current_num_threads();
+    if rayon_threads_available < 2 {
+        error!("Cannot guess when less than two threads are available to rayon");
+        return;
+    }
+
     let threads_to_use = cmp::max(1, rayon_threads_available.saturating_sub(2));
     let pool = ThreadPoolBuilder::new()
         .num_threads(threads_to_use)


### PR DESCRIPTION
Fixes #282.

The issue was caused by interference between rayon parallelism in disparate tokio tasks. On the one hand, the guesser spawned the max number of rayon threads using `repeat`. On the other hand, the peer loop task spawned rayon threads in the course of `triton_vm::verify` using `par_iter`. But since the the rayon threadpool was already occupied and since tokio tasks do not know how to coordinate about rayon's thread pool, the second task ended up stalling.

This PR fixes the problem by managing the rayon parallelism for guessing in a segregated rayon threadpool. It has already been experimentally verified to solve the problem. The [documentation](https://docs.rs/rayon/latest/rayon/struct.ThreadPool.html) for `ThreadPool` explains why:

> If the current thread is part of a different thread pool, it will try to keep busy while the op completes in its target pool, similar to calling [ThreadPool::yield_now()](https://docs.rs/rayon/latest/rayon/struct.ThreadPool.html#method.yield_now) in a loop. Therefore, it may potentially schedule other tasks to run on the current thread in the meantime.

