### PR TITLE
Add archival block mmr to state

### DIFF
--- a/src/config_models/data_directory.rs
+++ b/src/config_models/data_directory.rs
@@ -7,6 +7,7 @@ use directories::ProjectDirs;
 
 use crate::config_models::network::Network;
 use crate::models::database::DATABASE_DIRECTORY_ROOT_NAME;
+use crate::models::state::archival_state::ARCHIVAL_BLOCK_MMR_DIRECTORY_NAME;
 use crate::models::state::archival_state::BLOCK_INDEX_DB_NAME;
 use crate::models::state::archival_state::MUTATOR_SET_DIRECTORY_NAME;
 use crate::models::state::networking_state::BANNED_IPS_DB_NAME;
@@ -135,6 +136,16 @@ impl DataDirectory {
     pub fn mutator_set_database_dir_path(&self) -> PathBuf {
         self.database_dir_path()
             .join(Path::new(MUTATOR_SET_DIRECTORY_NAME))
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    ///
+    /// The archival block MMR database director path
+    ///
+    /// This directory lives within `DataDirectory::database_dir_path()`.
+    pub fn archival_block_mmr_dir_path(&self) -> PathBuf {
+        self.database_dir_path()
+            .join(Path::new(ARCHIVAL_BLOCK_MMR_DIRECTORY_NAME))
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,10 +116,14 @@ pub async fn initialize(cli_args: cli_args::Args) -> Result<i32> {
     let archival_mutator_set = ArchivalState::initialize_mutator_set(&data_dir).await?;
     info!("Got archival mutator set");
 
+    let archival_block_mmr = ArchivalState::initialize_archival_block_mmr(&data_dir).await?;
+    info!("Got archival block MMR");
+
     let archival_state = ArchivalState::new(
         data_dir,
         block_index_db,
         archival_mutator_set,
+        archival_block_mmr,
         cli_args.network,
     )
     .await;

--- a/src/models/blockchain/block/block_selector.rs
+++ b/src/models/blockchain/block/block_selector.rs
@@ -113,7 +113,7 @@ impl BlockSelector {
                 state
                     .chain
                     .archival_state()
-                    .block_height_to_canonical_block_digest(*h, state.chain.light_state().hash())
+                    .block_height_to_canonical_block_digest(*h)
                     .await
             }
             BlockSelector::Tip => Some(state.chain.light_state().hash()),

--- a/src/models/state/wallet/monitored_utxo.rs
+++ b/src/models/state/wallet/monitored_utxo.rs
@@ -123,11 +123,11 @@ impl MonitoredUtxo {
     }
 
     /// Returns true if the MUTXO was abandoned
-    pub async fn was_abandoned(&self, tip_digest: Digest, archival_state: &ArchivalState) -> bool {
+    pub async fn was_abandoned(&self, archival_state: &ArchivalState) -> bool {
         match self.confirmed_in_block {
             Some((confirm_block_digest, _, _)) => {
                 !archival_state
-                    .block_belongs_to_canonical_chain(confirm_block_digest, tip_digest)
+                    .block_belongs_to_canonical_chain(confirm_block_digest)
                     .await
             }
             None => false,

--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -834,7 +834,7 @@ impl RPC for NeptuneRPCServer {
 
         let block = archival_state.get_block(digest).await.unwrap()?;
         let is_canonical = archival_state
-            .block_belongs_to_canonical_chain(digest, tip_digest)
+            .block_belongs_to_canonical_chain(digest)
             .await;
 
         // sibling blocks are those at the same height, with different digest
@@ -2144,7 +2144,7 @@ mod rpc_server_tests {
             global_state
                 .chain
                 .archival_state()
-                .block_belongs_to_canonical_chain(genesis_hash, tip_hash)
+                .block_belongs_to_canonical_chain(genesis_hash)
                 .await,
         );
 
@@ -2156,7 +2156,7 @@ mod rpc_server_tests {
             global_state
                 .chain
                 .archival_state()
-                .block_belongs_to_canonical_chain(tip_hash, tip_hash)
+                .block_belongs_to_canonical_chain(tip_hash)
                 .await,
         );
 

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -270,6 +270,7 @@ pub(crate) async fn get_test_genesis_setup(
     ))
 }
 
+/// Set a new block as tip
 pub(crate) async fn add_block_to_archival_state(
     archival_state: &mut ArchivalState,
     new_block: Block,
@@ -277,6 +278,8 @@ pub(crate) async fn add_block_to_archival_state(
     archival_state.write_block_as_tip(&new_block).await?;
 
     archival_state.update_mutator_set(&new_block).await.unwrap();
+
+    archival_state.add_to_archival_block_mmr(&new_block).await;
 
     Ok(())
 }
@@ -765,7 +768,18 @@ pub async fn mock_genesis_archival_state(
         .await
         .unwrap();
 
-    let archival_state = ArchivalState::new(data_dir.clone(), block_index_db, ams, network).await;
+    let archival_block_mmr = ArchivalState::initialize_archival_block_mmr(&data_dir)
+        .await
+        .unwrap();
+
+    let archival_state = ArchivalState::new(
+        data_dir.clone(),
+        block_index_db,
+        ams,
+        archival_block_mmr,
+        network,
+    )
+    .await;
 
     (archival_state, peer_db, data_dir)
 }


### PR DESCRIPTION
feat(archival_state): Add archival block MMR

Add a new field to the archival state, `archival_block_mmr` which is an archival MMR of all block digests in the canonical chain. This allows the client to instantly check if a block belongs to the canonical chain, and thus to faster prune abandoned monitored UTXOs, which is the motivation for this addition.I n the future, this data structure will allow archival nodes to prove the canonicity of a block relative to a tip such that light nodes (that only see the current tip) can verify that any received blocks belong to the canonical chain.

Uses this new field to faster determine whether a block belongs to the canonical chain or not.