### PR TITLE
Faster guessing

### DIFF
--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -884,6 +884,7 @@ pub(crate) mod mine_loop_tests {
     use crate::config_models::cli_args;
     use crate::config_models::network::Network;
     use crate::job_queue::triton_vm::TritonVmJobQueue;
+    use crate::models::blockchain::block::validity::block_primitive_witness::test::deterministic_block_primitive_witness;
     use crate::models::blockchain::transaction::validity::single_proof::SingleProof;
     use crate::models::blockchain::type_scripts::neptune_coins::NeptuneCoins;
     use crate::models::proof_abstractions::mast_hash::MastHash;
@@ -1629,6 +1630,17 @@ pub(crate) mod mine_loop_tests {
         assert!((actual_duration as f64) < max_duration);
 
         Ok(())
+    }
+
+    #[test]
+    fn fast_kernel_mast_hash_agrees_with_mast_hash_function() {
+        let block_primitive_witness = deterministic_block_primitive_witness();
+        let a_block = block_primitive_witness.predecessor_block();
+        let (kernel_auth_path, header_auth_path) = precalculate_block_auth_paths(&a_block);
+        assert_eq!(
+            a_block.kernel.mast_hash(),
+            fast_kernel_mast_hash(kernel_auth_path, header_auth_path, a_block.header().nonce)
+        );
     }
 
     #[traced_test]

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -1629,7 +1629,7 @@ pub(crate) mod mine_loop_tests {
     fn fast_kernel_mast_hash_agrees_with_mast_hash_function() {
         let block_primitive_witness = deterministic_block_primitive_witness();
         let a_block = block_primitive_witness.predecessor_block();
-        let (kernel_auth_path, header_auth_path) = precalculate_block_auth_paths(&a_block);
+        let (kernel_auth_path, header_auth_path) = precalculate_block_auth_paths(a_block);
         assert_eq!(
             a_block.kernel.mast_hash(),
             fast_kernel_mast_hash(kernel_auth_path, header_auth_path, a_block.header().nonce)

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -1034,7 +1034,7 @@ pub(crate) mod mine_loop_tests {
         let tick = std::time::SystemTime::now();
         let (kernel_auth_path, header_auth_path) = precalculate_block_auth_paths(&block);
 
-        let (worker_task_tx, _) = oneshot::channel::<NewBlockFound>();
+        let (worker_task_tx, worker_task_rx) = oneshot::channel::<NewBlockFound>();
         let num_iterations_run =
             rayon::iter::IntoParallelIterator::into_par_iter(0..num_iterations_launched)
                 .map_init(rand::thread_rng, |prng, _i| {
@@ -1048,6 +1048,7 @@ pub(crate) mod mine_loop_tests {
                     );
                 })
                 .count();
+        drop(worker_task_rx);
 
         let time_spent_mining = tick.elapsed().unwrap();
 

--- a/src/models/blockchain/block/validity/block_primitive_witness.rs
+++ b/src/models/blockchain/block/validity/block_primitive_witness.rs
@@ -225,6 +225,10 @@ pub(crate) mod test {
     }
 
     impl BlockPrimitiveWitness {
+        pub(crate) fn predecessor_block(&self) -> Block {
+            self.predecessor_block.to_owned()
+        }
+
         pub(crate) fn arbitrary() -> BoxedStrategy<BlockPrimitiveWitness> {
             const NUM_INPUTS: usize = 2;
             (

--- a/src/models/blockchain/block/validity/block_primitive_witness.rs
+++ b/src/models/blockchain/block/validity/block_primitive_witness.rs
@@ -225,8 +225,8 @@ pub(crate) mod test {
     }
 
     impl BlockPrimitiveWitness {
-        pub(crate) fn predecessor_block(&self) -> Block {
-            self.predecessor_block.to_owned()
+        pub(crate) fn predecessor_block(&self) -> &Block {
+            &self.predecessor_block
         }
 
         pub(crate) fn arbitrary() -> BoxedStrategy<BlockPrimitiveWitness> {


### PR DESCRIPTION
This PR makes PoW guessing faster ~3x faster, and apparently resolves the issue of the flakyness of the `hash_rate_independent_of_tx_size` test (when the test is run in isolation, it's still flaky when run in parallel with other tests but that is to be expected).

Running in test mode (opt-level 0), my machine goes from a hash rate of ~2'400 prior to this PR to a hash rate of ~7'800.

The solution is two-fold:
- Implement algorithm for optimal block-kernel MAST hash calculation, without updating timestamp and difficulty with each guess
- Restart guesser every N (currently set to 20) seconds to update timestamp and difficulty calculation, cf #149.

Complication:
- Notice that the `guess_restart_timer` is *never* allowed to resolve if the guesser is not running, as its resolution stops the composer. My solution for preventing this resolution is not the most elegant.

Testing:
- All tests pass
- Added test verifying that the fast calculating of the block-kernel MAST hash matches the naive, standard, calculation.
- I started three connected nodes on RegTest with a node both composing and guessing and another node only guessing. The guessing was set to `--sleepy-guessing` as the PoW solution would otherwise have been found too fast to test this 
guesser-restart mechanics.  Expected behavior verified. See next comment for this test's log output verifying this.