### PR TITLE
feat: True claims cache

### DIFF
--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -884,6 +884,7 @@ pub(crate) mod mine_loop_tests {
     use crate::models::blockchain::type_scripts::neptune_coins::NeptuneCoins;
     use crate::models::proof_abstractions::mast_hash::MastHash;
     use crate::models::proof_abstractions::timestamp::Timestamp;
+    use crate::models::proof_abstractions::verifier::verify;
     use crate::models::state::mempool::TransactionOrigin;
     use crate::models::state::wallet::transaction_output::TxOutput;
     use crate::models::state::wallet::utxo_notification::UtxoNotificationMedium;
@@ -891,8 +892,6 @@ pub(crate) mod mine_loop_tests {
     use crate::tests::shared::make_mock_transaction_with_mutator_set_hash;
     use crate::tests::shared::mock_genesis_global_state;
     use crate::tests::shared::random_transaction_kernel;
-    use crate::triton_vm;
-    use crate::triton_vm::stark::Stark;
     use crate::util_types::test_shared::mutator_set::pseudorandom_addition_record;
     use crate::util_types::test_shared::mutator_set::random_mmra;
     use crate::util_types::test_shared::mutator_set::random_mutator_set_accumulator;
@@ -1165,11 +1164,15 @@ pub(crate) mod mine_loop_tests {
             let cb_txkmh = transaction_empty_mempool.kernel.mast_hash();
             let cb_tx_claim = SingleProof::claim(cb_txkmh);
             assert!(
-                triton_vm::verify(
-                    Stark::default(),
-                    &cb_tx_claim,
-                    &transaction_empty_mempool.proof.clone().into_single_proof()
-                ),
+                verify(
+                    cb_tx_claim.clone(),
+                    transaction_empty_mempool
+                        .proof
+                        .clone()
+                        .into_single_proof()
+                        .clone()
+                )
+                .await,
                 "Transaction proof for coinbase transaction must be valid."
             );
 

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -58,13 +58,13 @@ use crate::models::proof_abstractions::mast_hash::MastHash;
 use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
 use crate::models::proof_abstractions::tasm::program::TritonVmProofJobOptions;
 use crate::models::proof_abstractions::timestamp::Timestamp;
+use crate::models::proof_abstractions::verifier::verify;
 use crate::models::proof_abstractions::SecretWitness;
 use crate::models::state::wallet::address::ReceivingAddress;
 use crate::models::state::wallet::expected_utxo::ExpectedUtxo;
 use crate::models::state::wallet::expected_utxo::UtxoNotifier;
 use crate::models::state::wallet::WalletSecret;
 use crate::prelude::twenty_first;
-use crate::triton_vm;
 use crate::util_types::mutator_set::addition_record::AdditionRecord;
 use crate::util_types::mutator_set::commit;
 use crate::util_types::mutator_set::mutator_set_accumulator::MutatorSetAccumulator;
@@ -283,11 +283,11 @@ impl Block {
     ) -> anyhow::Result<Block> {
         let tx_claim = SingleProof::claim(transaction.kernel.mast_hash());
         assert!(
-            triton_vm::verify(
-                Stark::default(),
-                &tx_claim,
-                &transaction.proof.clone().into_single_proof()
-            ),
+            verify(
+                tx_claim.clone(),
+                transaction.proof.clone().into_single_proof().clone()
+            )
+            .await,
             "Transaction proof must be valid to generate a block"
         );
         assert!(

--- a/src/models/blockchain/block/validity/block_program.rs
+++ b/src/models/blockchain/block/validity/block_program.rs
@@ -10,7 +10,6 @@ use tasm_lib::memory::FIRST_NON_DETERMINISTICALLY_INITIALIZED_MEMORY_ADDRESS;
 use tasm_lib::prelude::DataType;
 use tasm_lib::prelude::Digest;
 use tasm_lib::prelude::Library;
-use tasm_lib::triton_vm;
 use tasm_lib::triton_vm::isa::triton_asm;
 use tasm_lib::triton_vm::isa::triton_instr;
 use tasm_lib::triton_vm::prelude::BFieldCodec;
@@ -21,7 +20,6 @@ use tasm_lib::triton_vm::proof::Claim;
 use tasm_lib::triton_vm::proof::Proof;
 use tasm_lib::triton_vm::stark::Stark;
 use tasm_lib::verifier::stark_verify::StarkVerify;
-use tokio::task;
 use tracing::debug;
 
 use super::block_proof_witness::BlockProofWitness;
@@ -35,6 +33,7 @@ use crate::models::proof_abstractions::mast_hash::MastHash;
 use crate::models::proof_abstractions::tasm::builtins as tasmlib;
 use crate::models::proof_abstractions::tasm::builtins::verify_stark;
 use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
+use crate::models::proof_abstractions::verifier::verify;
 
 /// Verifies that all claims listed in the appendix are true.
 ///
@@ -60,10 +59,7 @@ impl BlockProgram {
         let proof_clone = proof.clone();
 
         debug!("** Calling triton_vm::verify to verify block proof ...");
-        let verdict =
-            task::spawn_blocking(move || triton_vm::verify(Stark::default(), &claim, &proof_clone))
-                .await
-                .expect("should be able to verify block proof in new tokio task");
+        let verdict = verify(claim, proof_clone).await;
         debug!("** Call to triton_vm::verify to verify block proof completed; verdict: {verdict}.");
 
         verdict

--- a/src/models/blockchain/block/validity/block_proof_witness.rs
+++ b/src/models/blockchain/block/validity/block_proof_witness.rs
@@ -49,7 +49,7 @@ impl BlockProofWitness {
     }
 
     fn with_claim(mut self, claim: Claim, proof: Proof) -> Self {
-        assert!(triton_vm::verify(Stark::default(), &claim, &proof));
+        debug_assert!(triton_vm::verify(Stark::default(), &claim, &proof));
         self.claims.push(claim);
         self.proofs.push(proof);
 

--- a/src/models/blockchain/transaction/validity/single_proof.rs
+++ b/src/models/blockchain/transaction/validity/single_proof.rs
@@ -859,7 +859,7 @@ mod test {
             )
             .await
             .unwrap();
-            assert!(proof_collection.verify(txk_mast_hash));
+            assert!(proof_collection.verify(txk_mast_hash).await);
 
             let witness = SingleProofWitness::from_collection(proof_collection);
             let claim = witness.claim();
@@ -898,7 +898,7 @@ mod test {
             )
             .await
             .unwrap();
-            assert!(proof_collection.verify(txk_mast_hash));
+            assert!(proof_collection.verify(txk_mast_hash).await);
 
             let witness = SingleProofWitness::from_collection(proof_collection);
             let claim = witness.claim();

--- a/src/models/blockchain/type_scripts/native_currency.rs
+++ b/src/models/blockchain/type_scripts/native_currency.rs
@@ -1205,9 +1205,7 @@ pub mod test {
     use proptest::strategy::ValueTree;
     use proptest::test_runner::TestRunner;
     use proptest_arbitrary_interop::arb;
-    use tasm_lib::triton_vm;
     use tasm_lib::triton_vm::proof::Claim;
-    use tasm_lib::triton_vm::stark::Stark;
     use test_strategy::proptest;
 
     use super::*;
@@ -1224,6 +1222,7 @@ pub mod test {
     use crate::models::proof_abstractions::tasm::program::test::consensus_program_negative_test;
     use crate::models::proof_abstractions::tasm::program::ConsensusError;
     use crate::models::proof_abstractions::timestamp::Timestamp;
+    use crate::models::proof_abstractions::verifier::verify;
 
     fn assert_both_rust_and_tasm_halt_gracefully(
         native_currency_witness: NativeCurrencyWitness,
@@ -1492,10 +1491,7 @@ pub mod test {
             )
             .await
             .unwrap();
-        assert!(
-            triton_vm::verify(Stark::default(), &claim, &proof),
-            "proof fails"
-        );
+        assert!(verify(claim, proof).await, "proof fails");
     }
 
     #[proptest]

--- a/src/models/proof_abstractions/mod.rs
+++ b/src/models/proof_abstractions/mod.rs
@@ -10,6 +10,7 @@ use triton_vm::prelude::PublicInput;
 pub mod mast_hash;
 pub mod tasm;
 pub mod timestamp;
+pub mod verifier;
 
 /// A `SecretWitness` is data that makes a `ConsensusProgram` halt gracefully, but
 /// that should be hidden behind a zero-knowledge proof.

--- a/src/models/proof_abstractions/verifier.rs
+++ b/src/models/proof_abstractions/verifier.rs
@@ -1,0 +1,76 @@
+use tasm_lib::triton_vm;
+use tasm_lib::triton_vm::proof::Claim;
+use tasm_lib::triton_vm::proof::Proof;
+use tasm_lib::triton_vm::stark::Stark;
+use tokio::task;
+
+#[cfg(test)]
+static CLAIMS_CACHE: std::sync::LazyLock<tokio::sync::Mutex<std::collections::HashSet<Claim>>> =
+    std::sync::LazyLock::new(|| tokio::sync::Mutex::new(std::collections::HashSet::new()));
+
+/// Verify a Triton VM (claim,proof) pair for default STARK parameters.
+///
+/// When the test flag is set, this function checks whether the claim is present
+/// in the `CLAIMS_CACHE` and if so returns true early (*i.e.*, without running
+/// the verifier). When the test flag is set and the cache does not contain the
+/// claim and verification succeeds, the claim is added to the cache. The only
+/// other way to populate the cache is through method [`cache_true_claim`].
+pub(crate) async fn verify(claim: Claim, proof: Proof) -> bool {
+    #[cfg(test)]
+    if CLAIMS_CACHE.lock().await.contains(&claim) {
+        return true;
+    }
+
+    let claim_clone = claim.clone();
+    let verdict =
+        task::spawn_blocking(move || triton_vm::verify(Stark::default(), &claim_clone, &proof))
+            .await
+            .expect("should be able to verify proof in new tokio task");
+
+    #[cfg(test)]
+    if verdict {
+        cache_true_claim(claim).await;
+    }
+
+    verdict
+}
+
+/// Add a claim to the `CLAIMS_CACHE`.
+#[cfg(test)]
+pub(crate) async fn cache_true_claim(claim: Claim) {
+    CLAIMS_CACHE.lock().await.insert(claim);
+}
+
+#[cfg(test)]
+pub(crate) mod test {
+    use itertools::Itertools;
+    use rand::{thread_rng, Rng};
+
+    use tasm_lib::prelude::Tip5;
+    use triton_vm::prelude::BFieldCodec;
+
+    use super::*;
+
+    pub(crate) fn bogus_proof(claim: &Claim) -> Proof {
+        Proof(Tip5::hash_varlen(&claim.encode()).values().to_vec())
+    }
+
+    #[tokio::test]
+    async fn test_claims_cache() {
+        // generate random claim and bogus proof
+        let mut rng = thread_rng();
+        let some_claim = Claim::new(rng.gen())
+            .with_input((0..10).map(|_| rng.gen()).collect_vec())
+            .with_output((0..10).map(|_| rng.gen()).collect_vec());
+        let some_proof = bogus_proof(&some_claim);
+
+        // verification must fail
+        assert!(!verify(some_claim.clone(), some_proof.clone()).await);
+
+        // put claim into cache
+        cache_true_claim(some_claim.clone()).await;
+
+        // verification must succeed
+        assert!(verify(some_claim, some_proof).await);
+    }
+}


### PR DESCRIPTION
Wrap calls to `triton_vm::verify` into a function `verify` living in `proof_abstractions`.

If the test flag is disabled, `verify` just:
 - selects the right (*i.e.*, default) `Stark` parameters
 - calls `triton_vm::verify` inside of a `task::spawn_blocking`.

If the test flag is enabled, `verify` also:
 - checks the cache of claims before calling `triton_vm::verify` and even bypasses said call if the claim lives there and instead returns true early
 - populates the cache of claims with claims that pass `triton_vm::verify`.

Furthermore, if the test flag is enabled then there is a new function `cache_true_claim`. This function inserts a claim into the cache.

By using this interface, some tests (in particular, tests pertaining to archival state, wallet state, or peer interactions) can now avoid producing proofs. Instead, they should populate the true claims cache with the correct claim and the proof field with a bogus proof (that now won't be read anyway).

Note that this optimization does not cover all tests: some tests are about verifying that proof production succeeds. It would be improper to avoid producing proofs there.