### PR TITLE
test: Add test for sync challenge phase

### DIFF
--- a/scripts/linux/provoke-block-syncing-mode.sh
+++ b/scripts/linux/provoke-block-syncing-mode.sh
@@ -28,7 +28,7 @@ echo "Sleeping for $SLEEP_TIME seconds before starting 2nd instance"
 RUST_BACKTRACE=1 XDG_DATA_HOME=~/.local/share/neptune-integration-test/0/ nice -n 0 --  cargo run -- --network regtest --peer-port 29790 --rpc-port 19790 --compose --guess 2>&1 | tee -a integration_test.log | sed 's/(.*)/\0 \[I1\]/g'  &
 pid[0]=$!
 sleep "$SLEEP_TIME"s;
-RUST_BACKTRACE=1 XDG_DATA_HOME=~/.local/share/neptune-integration-test/1/ nice -n 0 --  cargo run -- --network regtest --peer-port 29791 --rpc-port 19791 --peers 127.0.0.1:29790 --max-number-of-blocks-before-syncing 2 2>&1 | tee -a integration_test.log | sed 's/(.*)/\0 \[I1\]/g'  &
+RUST_BACKTRACE=1 XDG_DATA_HOME=~/.local/share/neptune-integration-test/1/ nice -n 0 --  cargo run -- --network regtest --peer-port 29791 --rpc-port 19791 --peers 127.0.0.1:29790 --sync-mode-threshold 2 2>&1 | tee -a integration_test.log | sed 's/(.*)/\0 \[I1\]/g'  &
 pid[1]=$!
 
 # Inspired by https://stackoverflow.com/a/52033580/2574407

--- a/scripts/linux/run-multiple-instances-advanced.sh
+++ b/scripts/linux/run-multiple-instances-advanced.sh
@@ -50,10 +50,10 @@ sleep 2s;
 RUST_BACKTRACE=1 XDG_DATA_HOME=~/.local/share/neptune-integration-test/5/ nice -n 18 --  cargo run -- --network regtest --peer-port 29795 --rpc-port 19795 --peers 127.0.0.1:29794  2>&1 | tee -a advanced_integration_test.log | sed 's/(.*)/\0 \[I5\]/g'  &
 pid[5]=$!
 sleep 2s;
-RUST_BACKTRACE=1 XDG_DATA_HOME=~/.local/share/neptune-integration-test/6/ nice -n 18 --  cargo run -- --network regtest --peer-port 29796 --rpc-port 19796 --peers 127.0.0.1:29795 --max-number-of-blocks-before-syncing 10 2>&1 | tee -a advanced_integration_test.log | sed 's/(.*)/\0 \[I6\]/g'  &
+RUST_BACKTRACE=1 XDG_DATA_HOME=~/.local/share/neptune-integration-test/6/ nice -n 18 --  cargo run -- --network regtest --peer-port 29796 --rpc-port 19796 --peers 127.0.0.1:29795 --sync-mode-threshold 10 2>&1 | tee -a advanced_integration_test.log | sed 's/(.*)/\0 \[I6\]/g'  &
 pid[6]=$!
 sleep 2s;
-RUST_BACKTRACE=1 XDG_DATA_HOME=~/.local/share/neptune-integration-test/7/ nice -n 18 --  cargo run -- --network regtest --peer-port 29797 --rpc-port 19797 --peers 127.0.0.1:29796 --max-number-of-blocks-before-syncing 10 2>&1 | tee -a advanced_integration_test.log | sed 's/(.*)/\0 \[I7\]/g'  &
+RUST_BACKTRACE=1 XDG_DATA_HOME=~/.local/share/neptune-integration-test/7/ nice -n 18 --  cargo run -- --network regtest --peer-port 29797 --rpc-port 19797 --peers 127.0.0.1:29796 --sync-mode-threshold 10 2>&1 | tee -a advanced_integration_test.log | sed 's/(.*)/\0 \[I7\]/g'  &
 pid[7]=$!
 
 # Inspired by https://stackoverflow.com/a/52033580/2574407

--- a/scripts/linux/run-multiple-instances-from-genesis-log-locks.sh
+++ b/scripts/linux/run-multiple-instances-from-genesis-log-locks.sh
@@ -38,7 +38,7 @@ sleep 5s;
 RUST_BACKTRACE=1 XDG_DATA_HOME=$LOCAL_STATE_DIR/1/ nice -n 1 --  cargo $NIGHTLY run $FEATURES -- --network regtest --peer-port 29791 --rpc-port 19791 --peers 127.0.0.1:29790 $EXTRA_ARGS 2>&1 | tee /tmp/integration_test_from_genesis-1.log | sed 's/(.*)/\0 \[I1\]/g'  &
 pid[1]=$!
 sleep 5s;
-RUST_BACKTRACE=1 XDG_DATA_HOME=$LOCAL_STATE_DIR/2/ nice -n 1 --  cargo $NIGHTLY run $FEATURES  -- --network regtest --peer-port 29792 --rpc-port 19792 --peers 127.0.0.1:29791 --max-number-of-blocks-before-syncing 1000 $EXTRA_ARGS 2>&1 | tee /tmp/integration_test_from_genesis-2.log | sed 's/(.*)/\0 \[I2\]/g'  &
+RUST_BACKTRACE=1 XDG_DATA_HOME=$LOCAL_STATE_DIR/2/ nice -n 1 --  cargo $NIGHTLY run $FEATURES  -- --network regtest --peer-port 29792 --rpc-port 19792 --peers 127.0.0.1:29791 --sync-mode-threshold 1000 $EXTRA_ARGS 2>&1 | tee /tmp/integration_test_from_genesis-2.log | sed 's/(.*)/\0 \[I2\]/g'  &
 pid[2]=$!
 
 # Inspired by https://stackoverflow.com/a/52033580/2574407

--- a/scripts/linux/run-multiple-instances-from-genesis.sh
+++ b/scripts/linux/run-multiple-instances-from-genesis.sh
@@ -38,7 +38,7 @@ sleep 5s;
 RUST_BACKTRACE=1 XDG_DATA_HOME=$LOCAL_STATE_DIR/1/ nice -n 1 --  cargo $NIGHTLY run $FEATURES -- --network regtest --peer-port 29791 --rpc-port 19791 --peers 127.0.0.1:29790 $EXTRA_ARGS 2>&1 | tee /tmp/integration_test_from_genesis-1.log | sed 's/(.*)/\0 \[I1\]/g'  &
 pid[1]=$!
 sleep 5s;
-RUST_BACKTRACE=1 XDG_DATA_HOME=$LOCAL_STATE_DIR/2/ nice -n 1 --  cargo $NIGHTLY run $FEATURES  -- --network regtest --peer-port 29792 --rpc-port 19792 --peers 127.0.0.1:29791 --max-number-of-blocks-before-syncing 1000 $EXTRA_ARGS 2>&1 | tee /tmp/integration_test_from_genesis-2.log | sed 's/(.*)/\0 \[I2\]/g'  &
+RUST_BACKTRACE=1 XDG_DATA_HOME=$LOCAL_STATE_DIR/2/ nice -n 1 --  cargo $NIGHTLY run $FEATURES  -- --network regtest --peer-port 29792 --rpc-port 19792 --peers 127.0.0.1:29791 --sync-mode-threshold 1000 $EXTRA_ARGS 2>&1 | tee /tmp/integration_test_from_genesis-2.log | sed 's/(.*)/\0 \[I2\]/g'  &
 pid[2]=$!
 
 # Inspired by https://stackoverflow.com/a/52033580/2574407

--- a/scripts/linux/run-multiple-instances.sh
+++ b/scripts/linux/run-multiple-instances.sh
@@ -30,7 +30,7 @@ sleep 5s;
 RUST_BACKTRACE=1 XDG_DATA_HOME=~/.local/share/neptune-integration-test/1/ nice -n 18 --  cargo run -- --network regtest --peer-port 29791 --rpc-port 19791 --peers 127.0.0.1:29790 2>&1 | tee -a integration_test.log | sed 's/(.*)/\0 \[I1\]/g'  &
 pid[1]=$!
 sleep 5s;
-RUST_BACKTRACE=1 XDG_DATA_HOME=~/.local/share/neptune-integration-test/2/ nice -n 18 --  cargo run -- --network regtest --peer-port 29792 --rpc-port 19792 --guess --peers 127.0.0.1:29791 --max-number-of-blocks-before-syncing 1000 2>&1 | tee -a integration_test.log | sed 's/(.*)/\0 \[I2\]/g'  &
+RUST_BACKTRACE=1 XDG_DATA_HOME=~/.local/share/neptune-integration-test/2/ nice -n 18 --  cargo run -- --network regtest --peer-port 29792 --rpc-port 19792 --guess --peers 127.0.0.1:29791 --sync-mode-threshold 1000 2>&1 | tee -a integration_test.log | sed 's/(.*)/\0 \[I2\]/g'  &
 pid[2]=$!
 
 # Inspired by https://stackoverflow.com/a/52033580/2574407

--- a/src/config_models/cli_args.rs
+++ b/src/config_models/cli_args.rs
@@ -164,7 +164,7 @@ pub struct Args {
     /// The process running this program should have access to at least the number of blocks
     /// in this field multiplied with the max block size amounts of RAM. Probably 1.5 to 2 times
     /// that amount.
-    #[clap(long, default_value = "1000", value_parser(RangedI64ValueParser::<usize>::new().range(2..100000)))]
+    #[clap(long, default_value = "1000", value_parser(RangedI64ValueParser::<usize>::new().range(10..100000)))]
     pub(crate) max_number_of_blocks_before_syncing: usize,
 
     /// IPs of nodes to connect to, e.g.: --peers 8.8.8.8:9798 --peers 8.8.4.4:1337.

--- a/src/config_models/cli_args.rs
+++ b/src/config_models/cli_args.rs
@@ -159,13 +159,17 @@ pub struct Args {
     #[clap(short, long, default_value = "::")]
     pub(crate) listen_addr: IpAddr,
 
-    /// Max number of blocks that the client can catch up to before going into syncing mode.
+    /// Maximum number of blocks that the client can catch up to without going
+    /// into sync mode.
     ///
-    /// The process running this program should have access to at least the number of blocks
-    /// in this field multiplied with the max block size amounts of RAM. Probably 1.5 to 2 times
-    /// that amount.
+    /// Default: 1000.
+    ///
+    /// The process running this program should have access to enough RAM: at
+    /// least the number of blocks set by this argument multiplied with the max
+    /// block size (around 2 MB). Probably 1.5 to 2 times that amount for good
+    /// margin.
     #[clap(long, default_value = "1000", value_parser(RangedI64ValueParser::<usize>::new().range(10..100000)))]
-    pub(crate) max_number_of_blocks_before_syncing: usize,
+    pub(crate) sync_mode_threshold: usize,
 
     /// IPs of nodes to connect to, e.g.: --peers 8.8.8.8:9798 --peers 8.8.4.4:1337.
     #[structopt(long)]

--- a/src/connect_to_peers.rs
+++ b/src/connect_to_peers.rs
@@ -591,7 +591,7 @@ mod connect_tests {
             .build();
 
         let (_peer_broadcast_tx, from_main_rx_clone, to_main_tx, _to_main_rx1, state, _hsd) =
-            get_test_genesis_setup(Network::Alpha, 0).await?;
+            get_test_genesis_setup(Network::Alpha, 0, cli_args::Args::default()).await?;
         call_peer_inner(
             mock,
             state.clone(),
@@ -623,7 +623,7 @@ mod connect_tests {
             _to_main_rx1,
             mut state_lock,
             _hsd,
-        ) = get_test_genesis_setup(network, 1).await?;
+        ) = get_test_genesis_setup(network, 1, cli_args::Args::default()).await?;
 
         // Get an address for a peer that's not already connected
         let (other_handshake, peer_sa) = get_dummy_peer_connection_data_genesis(network, 1).await;
@@ -787,7 +787,7 @@ mod connect_tests {
             .read(&to_bytes(&PeerMessage::Bye)?)
             .build();
         let (_peer_broadcast_tx, from_main_rx_clone, to_main_tx, _to_main_rx1, state_lock, _hsd) =
-            get_test_genesis_setup(network, 0).await?;
+            get_test_genesis_setup(network, 0, cli_args::Args::default()).await?;
         answer_peer_inner(
             mock,
             state_lock.clone(),
@@ -821,7 +821,7 @@ mod connect_tests {
             .build();
 
         let (_peer_broadcast_tx, from_main_rx_clone, to_main_tx, _to_main_rx1, state, _hsd) =
-            get_test_genesis_setup(network, 0).await?;
+            get_test_genesis_setup(network, 0, cli_args::Args::default()).await?;
 
         let answer = answer_peer_inner(
             mock,
@@ -854,7 +854,7 @@ mod connect_tests {
             .build();
 
         let (_peer_broadcast_tx, from_main_rx_clone, to_main_tx, _to_main_rx1, state, _hsd) =
-            get_test_genesis_setup(Network::Alpha, 0).await?;
+            get_test_genesis_setup(Network::Alpha, 0, cli_args::Args::default()).await?;
 
         let answer = answer_peer_inner(
             mock,
@@ -875,7 +875,9 @@ mod connect_tests {
     async fn test_incoming_connection_fail_bad_version() {
         let mut other_handshake = get_dummy_handshake_data_for_genesis(Network::Testnet).await;
         let (_peer_broadcast_tx, from_main_rx_clone, to_main_tx, _to_main_rx1, state_lock, _hsd) =
-            get_test_genesis_setup(Network::Alpha, 0).await.unwrap();
+            get_test_genesis_setup(Network::Alpha, 0, cli_args::Args::default())
+                .await
+                .unwrap();
         let state = state_lock.lock_guard().await;
         let mut own_handshake = state.get_own_handshakedata().await;
 
@@ -959,7 +961,7 @@ mod connect_tests {
             _to_main_rx1,
             mut state_lock,
             _hsd,
-        ) = get_test_genesis_setup(Network::Alpha, 2).await?;
+        ) = get_test_genesis_setup(Network::Alpha, 2, cli_args::Args::default()).await?;
 
         // set max_peers to 2 to ensure failure on next connection attempt
         let mut cli = state_lock.cli().clone();
@@ -1013,6 +1015,7 @@ mod connect_tests {
         ) = get_test_genesis_setup(
             Network::Alpha,
             peer_count_before_incoming_connection_request,
+            cli_args::Args::default(),
         )
         .await?;
         let bad_standing: PeerStanding = PeerStanding::init(

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -692,7 +692,7 @@ impl MainLoopHandler {
                 // mode.
                 let mut global_state_mut = self.global_state_lock.lock_guard_mut().await;
                 if global_state_mut
-                    .should_enter_sync_mode(claimed_max_height, claimed_max_accumulative_pow)
+                    .sync_mode_criterion(claimed_max_height, claimed_max_accumulative_pow)
                 {
                     info!(
                     "Entering synchronization mode due to peer {} indicating tip height {}; pow family: {:?}",

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -621,7 +621,7 @@ impl MainLoopHandler {
                         let stay_in_sync_mode = stay_in_sync_mode(
                             &last_block.kernel.header,
                             &main_loop_state.sync_state,
-                            cli_args.max_number_of_blocks_before_syncing,
+                            cli_args.sync_mode_threshold,
                         );
                         if !stay_in_sync_mode {
                             info!("Exiting sync mode");
@@ -721,7 +721,7 @@ impl MainLoopHandler {
                     let stay_in_sync_mode = stay_in_sync_mode(
                         global_state_mut.chain.light_state().header(),
                         &main_loop_state.sync_state,
-                        cli_args.max_number_of_blocks_before_syncing,
+                        cli_args.sync_mode_threshold,
                     );
                     if !stay_in_sync_mode {
                         info!("Exiting sync mode");

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -352,7 +352,7 @@ impl PotentialPeersState {
 fn stay_in_sync_mode(
     own_block_tip_header: &BlockHeader,
     sync_state: &SyncState,
-    max_number_of_blocks_before_syncing: usize,
+    sync_mode_threshold: usize,
 ) -> bool {
     let max_claimed_pow = sync_state
         .peer_sync_states
@@ -366,7 +366,7 @@ fn stay_in_sync_mode(
         Some(max_claim) => {
             own_block_tip_header.cumulative_proof_of_work < max_claim.claimed_max_pow
                 && max_claim.claimed_max_height - own_block_tip_header.height
-                    > max_number_of_blocks_before_syncing as i128 / 2
+                    > sync_mode_threshold as i128 / 2
         }
     }
 }
@@ -602,7 +602,7 @@ impl MainLoopHandler {
                         warn!("Blocks were not new. Not storing blocks.");
 
                         // TODO: Consider fixing deep reorganization problem described above.
-                        // Alternatively set the `max_number_of_blocks_before_syncing` value higher
+                        // Alternatively set the `sync_mode_threshold` value higher
                         // if this problem is encountered.
                         return Ok(());
                     }

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -348,17 +348,6 @@ impl PotentialPeersState {
     }
 }
 
-/// Return a boolean indicating if synchronization mode should be entered
-fn enter_sync_mode(
-    own_block_tip_header: &BlockHeader,
-    peer_synchronization_state: PeerSynchronizationState,
-    max_number_of_blocks_before_syncing: usize,
-) -> bool {
-    own_block_tip_header.cumulative_proof_of_work < peer_synchronization_state.claimed_max_pow
-        && peer_synchronization_state.claimed_max_height - own_block_tip_header.height
-            > max_number_of_blocks_before_syncing as i128
-}
-
 /// Return a boolean indicating if synchronization mode should be left
 fn stay_in_sync_mode(
     own_block_tip_header: &BlockHeader,
@@ -683,30 +672,31 @@ impl MainLoopHandler {
             PeerTaskToMain::AddPeerMaxBlockHeight((
                 socket_addr,
                 claimed_max_height,
-                claimed_max_pow_family,
+                claimed_max_accumulative_pow,
             )) => {
                 log_slow_scope!(fn_name!() + "::PeerTaskToMain::AddPeerMaxBlockHeight");
 
                 let claimed_state =
-                    PeerSynchronizationState::new(claimed_max_height, claimed_max_pow_family);
+                    PeerSynchronizationState::new(claimed_max_height, claimed_max_accumulative_pow);
                 main_loop_state
                     .sync_state
                     .peer_sync_states
                     .insert(socket_addr, claimed_state);
 
-                // Check if synchronization mode should be activated. Synchronization mode is entered if
-                // PoW family exceeds our tip and if the height difference is beyond a threshold value.
-                // TODO: If we are not checking the PoW claims of the tip this can be abused by forcing
-                // the client into synchronization mode.
+                // Check if synchronization mode should be activated.
+                // Synchronization mode is entered if accumulated PoW exceeds
+                // our tip and if the height difference is positive and beyond
+                // a threshold value.
+                // TODO: If we are not checking the PoW claims of the tip this
+                // can be abused by forcing the client into synchronization
+                // mode.
                 let mut global_state_mut = self.global_state_lock.lock_guard_mut().await;
-                if enter_sync_mode(
-                    global_state_mut.chain.light_state().header(),
-                    claimed_state,
-                    cli_args.max_number_of_blocks_before_syncing / 3,
-                ) {
+                if global_state_mut
+                    .should_enter_sync_mode(claimed_max_height, claimed_max_accumulative_pow)
+                {
                     info!(
                     "Entering synchronization mode due to peer {} indicating tip height {}; pow family: {:?}",
-                    socket_addr, claimed_max_height, claimed_max_pow_family
+                    socket_addr, claimed_max_height, claimed_max_accumulative_pow
                 );
                     global_state_mut.net.syncing = true;
                     self.main_to_miner_tx.send(MainToMiner::StartSyncing);

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -1641,7 +1641,7 @@ mod test {
             peer_to_main_rx,
             state,
             _own_handshake_data,
-        ) = get_test_genesis_setup(network, num_init_peers_outgoing)
+        ) = get_test_genesis_setup(network, num_init_peers_outgoing, cli_args::Args::default())
             .await
             .unwrap();
         assert!(

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -884,6 +884,7 @@ pub(crate) mod mine_loop_tests {
     use crate::models::blockchain::type_scripts::neptune_coins::NeptuneCoins;
     use crate::models::proof_abstractions::mast_hash::MastHash;
     use crate::models::proof_abstractions::timestamp::Timestamp;
+    use crate::models::proof_abstractions::verifier::verify;
     use crate::models::state::mempool::TransactionOrigin;
     use crate::models::state::wallet::transaction_output::TxOutput;
     use crate::models::state::wallet::utxo_notification::UtxoNotificationMedium;
@@ -891,8 +892,6 @@ pub(crate) mod mine_loop_tests {
     use crate::tests::shared::make_mock_transaction_with_mutator_set_hash;
     use crate::tests::shared::mock_genesis_global_state;
     use crate::tests::shared::random_transaction_kernel;
-    use crate::triton_vm;
-    use crate::triton_vm::stark::Stark;
     use crate::util_types::test_shared::mutator_set::pseudorandom_addition_record;
     use crate::util_types::test_shared::mutator_set::random_mmra;
     use crate::util_types::test_shared::mutator_set::random_mutator_set_accumulator;
@@ -1165,11 +1164,15 @@ pub(crate) mod mine_loop_tests {
             let cb_txkmh = transaction_empty_mempool.kernel.mast_hash();
             let cb_tx_claim = SingleProof::claim(cb_txkmh);
             assert!(
-                triton_vm::verify(
-                    Stark::default(),
-                    &cb_tx_claim,
-                    &transaction_empty_mempool.proof.clone().into_single_proof()
-                ),
+                verify(
+                    cb_tx_claim.clone(),
+                    transaction_empty_mempool
+                        .proof
+                        .clone()
+                        .into_single_proof()
+                        .clone()
+                )
+                .await,
                 "Transaction proof for coinbase transaction must be valid."
             );
 

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -364,7 +364,7 @@ pub(crate) async fn make_coinbase_transaction_stateless(
 
 /// Compute `TransactionDetails` and a list of `TxOutput`s for a coinbase
 /// transaction.
-fn prepare_coinbase_transaction_stateless(
+pub(super) fn prepare_coinbase_transaction_stateless(
     latest_block: &Block,
     composer_parameters: ComposerParameters,
     timestamp: Timestamp,

--- a/src/models/blockchain/block/block_height.rs
+++ b/src/models/blockchain/block/block_height.rs
@@ -35,8 +35,12 @@ impl BlockHeight {
         Self(self.0 + BFieldElement::one())
     }
 
-    pub fn previous(&self) -> Self {
-        Self(self.0 - BFieldElement::one())
+    pub fn previous(&self) -> Option<Self> {
+        if self.is_genesis() {
+            None
+        } else {
+            Some(Self(self.0 - BFieldElement::one()))
+        }
     }
 
     pub const fn genesis() -> Self {
@@ -54,6 +58,13 @@ impl BlockHeight {
         let ret = (left / 2) + (right / 2) + (left % 2 + right % 2) / 2;
 
         Self(BFieldElement::new(ret))
+    }
+
+    /// Subtract a number from a block height.
+    //
+    // *NOT* implemented as trait `CheckedSub` because of type mismatch.
+    pub(crate) fn checked_sub(&self, v: u64) -> Option<Self> {
+        self.0.value().checked_sub(v).map(|x| x.into())
     }
 }
 

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -254,8 +254,7 @@ impl Block {
         let header =
             primitive_witness.header(timestamp, nonce_preimage.hash(), target_block_interval);
         let (appendix, proof) = {
-            let block_proof_witness =
-                BlockProofWitness::produce(primitive_witness, triton_vm_job_queue).await?;
+            let block_proof_witness = BlockProofWitness::produce(primitive_witness).await?;
             let appendix = block_proof_witness.appendix();
             let claim = BlockProgram::claim(&body, &appendix);
             let proof = BlockProgram

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -1065,11 +1065,11 @@ mod block_tests {
     use crate::models::state::wallet::transaction_output::TxOutput;
     use crate::models::state::wallet::utxo_notification::UtxoNotificationMedium;
     use crate::models::state::wallet::WalletSecret;
+    use crate::tests::shared::fake_valid_successor_for_tests;
     use crate::tests::shared::invalid_block_with_transaction;
     use crate::tests::shared::make_mock_block;
     use crate::tests::shared::make_mock_transaction;
     use crate::tests::shared::mock_genesis_global_state;
-    use crate::tests::shared::valid_successor_for_tests;
     use crate::util_types::mutator_set::archival_mmr::ArchivalMmr;
 
     #[test]
@@ -1157,7 +1157,7 @@ mod block_tests {
         let now = genesis_block.kernel.header.timestamp + Timestamp::hours(2);
         let mut rng: StdRng = SeedableRng::seed_from_u64(2225550001);
 
-        let mut block1 = valid_successor_for_tests(&genesis_block, now, rng.gen()).await;
+        let mut block1 = fake_valid_successor_for_tests(&genesis_block, now, rng.gen()).await;
 
         let timestamp = block1.kernel.header.timestamp;
         assert!(block1.is_valid(&genesis_block, timestamp).await);
@@ -1266,7 +1266,7 @@ mod block_tests {
         use super::*;
         use crate::mine_loop::mine_loop_tests::make_coinbase_transaction_from_state;
         use crate::models::state::wallet::address::KeyType;
-        use crate::tests::shared::valid_successor_for_tests;
+        use crate::tests::shared::fake_valid_successor_for_tests;
 
         #[traced_test]
         #[tokio::test]
@@ -1285,7 +1285,7 @@ mod block_tests {
             let plus_seven_months = genesis_block.kernel.header.timestamp + Timestamp::months(7);
             let mut rng: StdRng = SeedableRng::seed_from_u64(2225550001);
             let block1 =
-                valid_successor_for_tests(&genesis_block, plus_seven_months, rng.gen()).await;
+                fake_valid_successor_for_tests(&genesis_block, plus_seven_months, rng.gen()).await;
 
             let alice_wallet = WalletSecret::devnet_wallet();
             let mut alice = mock_genesis_global_state(
@@ -1444,7 +1444,7 @@ mod block_tests {
             let mut now = genesis_block.kernel.header.timestamp + Timestamp::hours(2);
             let mut rng: StdRng = SeedableRng::seed_from_u64(2225550001);
 
-            let mut block1 = valid_successor_for_tests(&genesis_block, now, rng.gen()).await;
+            let mut block1 = fake_valid_successor_for_tests(&genesis_block, now, rng.gen()).await;
 
             // Set block timestamp 1 hour in the future.  (is valid)
             let future_time1 = now + Timestamp::hours(1);

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -58,13 +58,13 @@ use crate::models::proof_abstractions::mast_hash::MastHash;
 use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
 use crate::models::proof_abstractions::tasm::program::TritonVmProofJobOptions;
 use crate::models::proof_abstractions::timestamp::Timestamp;
+use crate::models::proof_abstractions::verifier::verify;
 use crate::models::proof_abstractions::SecretWitness;
 use crate::models::state::wallet::address::ReceivingAddress;
 use crate::models::state::wallet::expected_utxo::ExpectedUtxo;
 use crate::models::state::wallet::expected_utxo::UtxoNotifier;
 use crate::models::state::wallet::WalletSecret;
 use crate::prelude::twenty_first;
-use crate::triton_vm;
 use crate::util_types::mutator_set::addition_record::AdditionRecord;
 use crate::util_types::mutator_set::commit;
 use crate::util_types::mutator_set::mutator_set_accumulator::MutatorSetAccumulator;
@@ -283,11 +283,11 @@ impl Block {
     ) -> anyhow::Result<Block> {
         let tx_claim = SingleProof::claim(transaction.kernel.mast_hash());
         assert!(
-            triton_vm::verify(
-                Stark::default(),
-                &tx_claim,
-                &transaction.proof.clone().into_single_proof()
-            ),
+            verify(
+                tx_claim.clone(),
+                transaction.proof.clone().into_single_proof().clone()
+            )
+            .await,
             "Transaction proof must be valid to generate a block"
         );
         assert!(

--- a/src/models/blockchain/block/validity/block_program.rs
+++ b/src/models/blockchain/block/validity/block_program.rs
@@ -397,10 +397,7 @@ pub(crate) mod test {
         let _guard = rt.enter();
 
         let block_proof_witness = rt
-            .block_on(BlockProofWitness::produce(
-                block_primitive_witness,
-                &TritonVmJobQueue::dummy(),
-            ))
+            .block_on(BlockProofWitness::produce(block_primitive_witness))
             .unwrap();
 
         let block_program_nondeterminism = block_proof_witness.nondeterminism();

--- a/src/models/blockchain/block/validity/block_program.rs
+++ b/src/models/blockchain/block/validity/block_program.rs
@@ -10,7 +10,6 @@ use tasm_lib::memory::FIRST_NON_DETERMINISTICALLY_INITIALIZED_MEMORY_ADDRESS;
 use tasm_lib::prelude::DataType;
 use tasm_lib::prelude::Digest;
 use tasm_lib::prelude::Library;
-use tasm_lib::triton_vm;
 use tasm_lib::triton_vm::isa::triton_asm;
 use tasm_lib::triton_vm::isa::triton_instr;
 use tasm_lib::triton_vm::prelude::BFieldCodec;
@@ -21,7 +20,6 @@ use tasm_lib::triton_vm::proof::Claim;
 use tasm_lib::triton_vm::proof::Proof;
 use tasm_lib::triton_vm::stark::Stark;
 use tasm_lib::verifier::stark_verify::StarkVerify;
-use tokio::task;
 use tracing::debug;
 
 use super::block_proof_witness::BlockProofWitness;
@@ -35,6 +33,7 @@ use crate::models::proof_abstractions::mast_hash::MastHash;
 use crate::models::proof_abstractions::tasm::builtins as tasmlib;
 use crate::models::proof_abstractions::tasm::builtins::verify_stark;
 use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
+use crate::models::proof_abstractions::verifier::verify;
 
 /// Verifies that all claims listed in the appendix are true.
 ///
@@ -60,10 +59,7 @@ impl BlockProgram {
         let proof_clone = proof.clone();
 
         debug!("** Calling triton_vm::verify to verify block proof ...");
-        let verdict =
-            task::spawn_blocking(move || triton_vm::verify(Stark::default(), &claim, &proof_clone))
-                .await
-                .expect("should be able to verify block proof in new tokio task");
+        let verdict = verify(claim, proof_clone).await;
         debug!("** Call to triton_vm::verify to verify block proof completed; verdict: {verdict}.");
 
         verdict

--- a/src/models/blockchain/block/validity/block_proof_witness.rs
+++ b/src/models/blockchain/block/validity/block_proof_witness.rs
@@ -5,7 +5,6 @@ use serde::Serialize;
 use tasm_lib::memory::encode_to_memory;
 use tasm_lib::memory::FIRST_NON_DETERMINISTICALLY_INITIALIZED_MEMORY_ADDRESS;
 use tasm_lib::prelude::TasmObject;
-use tasm_lib::triton_vm;
 use tasm_lib::triton_vm::prelude::BFieldCodec;
 use tasm_lib::triton_vm::prelude::BFieldElement;
 use tasm_lib::triton_vm::prelude::Program;
@@ -48,7 +47,6 @@ impl BlockProofWitness {
     }
 
     fn with_claim(mut self, claim: Claim, proof: Proof) -> Self {
-        debug_assert!(triton_vm::verify(Stark::default(), &claim, &proof));
         self.claims.push(claim);
         self.proofs.push(proof);
 

--- a/src/models/blockchain/block/validity/block_proof_witness.rs
+++ b/src/models/blockchain/block/validity/block_proof_witness.rs
@@ -18,7 +18,6 @@ use tasm_lib::verifier::stark_verify::StarkVerify;
 
 use super::block_primitive_witness::BlockPrimitiveWitness;
 use super::block_program::BlockProgram;
-use crate::job_queue::triton_vm::TritonVmJobQueue;
 use crate::models::blockchain::block::block_body::BlockBody;
 use crate::models::blockchain::block::block_body::BlockBodyField;
 use crate::models::blockchain::block::BlockAppendix;
@@ -66,7 +65,6 @@ impl BlockProofWitness {
 
     pub(crate) async fn produce(
         block_primitive_witness: BlockPrimitiveWitness,
-        _triton_vm_job_queue: &TritonVmJobQueue,
     ) -> anyhow::Result<BlockProofWitness> {
         let txk_mast_hash = block_primitive_witness
             .body()

--- a/src/models/blockchain/block/validity/block_proof_witness.rs
+++ b/src/models/blockchain/block/validity/block_proof_witness.rs
@@ -49,7 +49,7 @@ impl BlockProofWitness {
     }
 
     fn with_claim(mut self, claim: Claim, proof: Proof) -> Self {
-        assert!(triton_vm::verify(Stark::default(), &claim, &proof));
+        debug_assert!(triton_vm::verify(Stark::default(), &claim, &proof));
         self.claims.push(claim);
         self.proofs.push(proof);
 

--- a/src/models/blockchain/transaction/validity/single_proof.rs
+++ b/src/models/blockchain/transaction/validity/single_proof.rs
@@ -859,7 +859,7 @@ mod test {
             )
             .await
             .unwrap();
-            assert!(proof_collection.verify(txk_mast_hash));
+            assert!(proof_collection.verify(txk_mast_hash).await);
 
             let witness = SingleProofWitness::from_collection(proof_collection);
             let claim = witness.claim();
@@ -898,7 +898,7 @@ mod test {
             )
             .await
             .unwrap();
-            assert!(proof_collection.verify(txk_mast_hash));
+            assert!(proof_collection.verify(txk_mast_hash).await);
 
             let witness = SingleProofWitness::from_collection(proof_collection);
             let claim = witness.claim();

--- a/src/models/blockchain/type_scripts/native_currency.rs
+++ b/src/models/blockchain/type_scripts/native_currency.rs
@@ -1205,9 +1205,7 @@ pub mod test {
     use proptest::strategy::ValueTree;
     use proptest::test_runner::TestRunner;
     use proptest_arbitrary_interop::arb;
-    use tasm_lib::triton_vm;
     use tasm_lib::triton_vm::proof::Claim;
-    use tasm_lib::triton_vm::stark::Stark;
     use test_strategy::proptest;
 
     use super::*;
@@ -1224,6 +1222,7 @@ pub mod test {
     use crate::models::proof_abstractions::tasm::program::test::consensus_program_negative_test;
     use crate::models::proof_abstractions::tasm::program::ConsensusError;
     use crate::models::proof_abstractions::timestamp::Timestamp;
+    use crate::models::proof_abstractions::verifier::verify;
 
     fn assert_both_rust_and_tasm_halt_gracefully(
         native_currency_witness: NativeCurrencyWitness,
@@ -1492,10 +1491,7 @@ pub mod test {
             )
             .await
             .unwrap();
-        assert!(
-            triton_vm::verify(Stark::default(), &claim, &proof),
-            "proof fails"
-        );
+        assert!(verify(claim, proof).await, "proof fails");
     }
 
     #[proptest]

--- a/src/models/channel.rs
+++ b/src/models/channel.rs
@@ -133,7 +133,7 @@ impl MainToPeerTask {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum PeerTaskToMain {
     NewBlocks(Vec<Block>),
     AddPeerMaxBlockHeight((SocketAddr, BlockHeight, ProofOfWork)),
@@ -144,7 +144,7 @@ pub(crate) enum PeerTaskToMain {
     DisconnectFromLongestLivedPeer,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PeerTaskToMainTransaction {
     pub transaction: Transaction,
     pub confirmable_for_block: Digest,

--- a/src/models/peer.rs
+++ b/src/models/peer.rs
@@ -738,6 +738,8 @@ pub(crate) struct SyncChallengeResponse {
 }
 
 impl SyncChallengeResponse {
+    /// Determine whether the `SyncChallengeResponse` answers the given
+    /// `IssuedSyncChallenge`, and not some other one.
     pub(crate) fn matches(&self, issued_challenge: IssuedSyncChallenge) -> bool {
         let Ok(tip_predecessor) = Block::try_from(self.tip_parent.clone()) else {
             return false;
@@ -755,6 +757,8 @@ impl SyncChallengeResponse {
             && tip.has_proof_of_work(tip_predecessor.header())
     }
 
+    /// Determine whether the proofs in `SyncChallengeResponse` are valid. Also
+    /// checks proof-of-work.
     pub(crate) async fn is_valid(&self, now: Timestamp) -> bool {
         let Ok(tip_predecessor) = Block::try_from(self.tip_parent.clone()) else {
             return false;

--- a/src/models/peer/transfer_block.rs
+++ b/src/models/peer/transfer_block.rs
@@ -79,8 +79,8 @@ mod test {
     use super::*;
     use crate::models::peer::Network;
     use crate::models::proof_abstractions::timestamp::Timestamp;
+    use crate::tests::shared::fake_valid_sequence_of_blocks_for_tests;
     use crate::tests::shared::invalid_empty_block;
-    use crate::tests::shared::valid_sequence_of_blocks_for_tests;
 
     #[test]
     fn cannot_transfer_blocks_that_are_not_single_proof_supported() {
@@ -105,7 +105,7 @@ mod test {
         // TransferBlock::into() will panic if it
         // encounters the genesis block.
         let genesis = Block::genesis_block(network);
-        let [block1] = valid_sequence_of_blocks_for_tests(
+        let [block1] = fake_valid_sequence_of_blocks_for_tests(
             &genesis,
             Timestamp::hours(1),
             StdRng::seed_from_u64(5550001).gen(),

--- a/src/models/proof_abstractions/mod.rs
+++ b/src/models/proof_abstractions/mod.rs
@@ -10,6 +10,7 @@ use triton_vm::prelude::PublicInput;
 pub mod mast_hash;
 pub mod tasm;
 pub mod timestamp;
+pub mod verifier;
 
 /// A `SecretWitness` is data that makes a `ConsensusProgram` halt gracefully, but
 /// that should be hidden behind a zero-knowledge proof.

--- a/src/models/proof_abstractions/verifier.rs
+++ b/src/models/proof_abstractions/verifier.rs
@@ -44,8 +44,8 @@ pub(crate) async fn cache_true_claim(claim: Claim) {
 #[cfg(test)]
 pub(crate) mod test {
     use itertools::Itertools;
-    use rand::{thread_rng, Rng};
-
+    use rand::thread_rng;
+    use rand::Rng;
     use tasm_lib::prelude::Tip5;
     use triton_vm::prelude::BFieldCodec;
 

--- a/src/models/proof_abstractions/verifier.rs
+++ b/src/models/proof_abstractions/verifier.rs
@@ -1,0 +1,76 @@
+use tasm_lib::triton_vm;
+use tasm_lib::triton_vm::proof::Claim;
+use tasm_lib::triton_vm::proof::Proof;
+use tasm_lib::triton_vm::stark::Stark;
+use tokio::task;
+
+#[cfg(test)]
+static CLAIMS_CACHE: std::sync::LazyLock<tokio::sync::Mutex<std::collections::HashSet<Claim>>> =
+    std::sync::LazyLock::new(|| tokio::sync::Mutex::new(std::collections::HashSet::new()));
+
+/// Verify a Triton VM (claim,proof) pair for default STARK parameters.
+///
+/// When the test flag is set, this function checks whether the claim is present
+/// in the `CLAIMS_CACHE` and if so returns true early (*i.e.*, without running
+/// the verifier). When the test flag is set and the cache does not contain the
+/// claim and verification succeeds, the claim is added to the cache. The only
+/// other way to populate the cache is through method [`cache_true_claim`].
+pub(crate) async fn verify(claim: Claim, proof: Proof) -> bool {
+    #[cfg(test)]
+    if CLAIMS_CACHE.lock().await.contains(&claim) {
+        return true;
+    }
+
+    let claim_clone = claim.clone();
+    let verdict =
+        task::spawn_blocking(move || triton_vm::verify(Stark::default(), &claim_clone, &proof))
+            .await
+            .expect("should be able to verify proof in new tokio task");
+
+    #[cfg(test)]
+    if verdict {
+        cache_true_claim(claim).await;
+    }
+
+    verdict
+}
+
+/// Add a claim to the `CLAIMS_CACHE`.
+#[cfg(test)]
+pub(crate) async fn cache_true_claim(claim: Claim) {
+    CLAIMS_CACHE.lock().await.insert(claim);
+}
+
+#[cfg(test)]
+pub(crate) mod test {
+    use itertools::Itertools;
+    use rand::{thread_rng, Rng};
+
+    use tasm_lib::prelude::Tip5;
+    use triton_vm::prelude::BFieldCodec;
+
+    use super::*;
+
+    pub(crate) fn bogus_proof(claim: &Claim) -> Proof {
+        Proof(Tip5::hash_varlen(&claim.encode()).values().to_vec())
+    }
+
+    #[tokio::test]
+    async fn test_claims_cache() {
+        // generate random claim and bogus proof
+        let mut rng = thread_rng();
+        let some_claim = Claim::new(rng.gen())
+            .with_input((0..10).map(|_| rng.gen()).collect_vec())
+            .with_output((0..10).map(|_| rng.gen()).collect_vec());
+        let some_proof = bogus_proof(&some_claim);
+
+        // verification must fail
+        assert!(!verify(some_claim.clone(), some_proof.clone()).await);
+
+        // put claim into cache
+        cache_true_claim(some_claim.clone()).await;
+
+        // verification must succeed
+        assert!(verify(some_claim, some_proof).await);
+    }
+}

--- a/src/models/state/archival_state.rs
+++ b/src/models/state/archival_state.rs
@@ -613,7 +613,11 @@ impl ArchivalState {
         loop {
             if aocl_leaf_index < record.min_aocl_index {
                 // Look below current height
-                max_block_height = record.block_header.height.previous();
+                max_block_height = record
+                    .block_header
+                    .height
+                    .previous()
+                    .expect("Genesis-block should be special-cased earlier in function.");
             } else if aocl_leaf_index > record.max_aocl_index() {
                 // Look above current height
                 min_block_height = record.block_header.height.next();

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -1550,7 +1550,7 @@ mod tests {
         let (block_1b, _) =
             make_mock_block(&genesis_block, Some(in_seven_years), bob_key, rng.gen()).await;
         assert!(
-            block_1b.header().height.previous().is_genesis(),
+            block_1b.header().height.previous().unwrap().is_genesis(),
             "Sanity check that new tip has height 1"
         );
         alice.set_new_tip(block_1b.clone()).await.unwrap();

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -346,8 +346,17 @@ impl GlobalState {
         height
     }
 
-    /// Return a boolean indicating if synchronization mode should be entered
-    pub(crate) fn should_enter_sync_mode(
+    /// Determine whether the conditions are met to enter into sync mode.
+    ///
+    /// Specifically, compute a boolean value based on
+    ///  - whether the foreign cumulative proof-of-work exceeds that of our own;
+    ///  - whether the foreign block has a bigger block height and the height
+    ///    difference exceeds the threshold set by the CLI.
+    ///
+    /// The main loop relies on this criterion to decide whether to enter sync
+    /// mode. If the main loop activates sync mode, it affects the entire
+    /// application.
+    pub(crate) fn sync_mode_criterion(
         &self,
         max_height: BlockHeight,
         cumulative_pow: ProofOfWork,

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -50,8 +50,6 @@ use super::blockchain::block::Block;
 use super::blockchain::transaction::primitive_witness::PrimitiveWitness;
 use super::blockchain::transaction::Transaction;
 use super::blockchain::type_scripts::neptune_coins::NeptuneCoins;
-use super::peer::peer_block_notifications::PeerBlockNotification;
-use super::peer::PeerSynchronizationState;
 use super::proof_abstractions::timestamp::Timestamp;
 use crate::config_models::cli_args;
 use crate::database::storage::storage_schema::traits::StorageWriter as SW;

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -1553,6 +1553,10 @@ impl GlobalState {
                 bail!("could not fetch indicated block pair");
             };
 
+            // The MMR membership proofs will be invalid here if the peer's tip
+            // does not match ours. That's a known deficiency of this function,
+            // and can be fixed by correctly handling the construction of old
+            // MMR-MPs from the current archival MMR state.
             block_mmr_mps.push(
                 self.chain
                     .archival_state()

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -354,8 +354,7 @@ impl GlobalState {
     ) -> bool {
         let own_block_tip_header = self.chain.light_state().header();
         own_block_tip_header.cumulative_proof_of_work < cumulative_pow
-            && max_height - own_block_tip_header.height
-                > self.cli().max_number_of_blocks_before_syncing as i128
+            && max_height - own_block_tip_header.height > self.cli().sync_mode_threshold as i128
     }
 
     pub(crate) fn composer_parameters(

--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -377,10 +377,7 @@ impl PeerLoopHandler {
                     .expect("fork reconcilliation blocks cannot contain genesis")
                     == received_block.kernel.header.height
                     && peer_state.fork_reconciliation_blocks.len() + 1
-                        < self
-                            .global_state_lock
-                            .cli()
-                            .max_number_of_blocks_before_syncing
+                        < self.global_state_lock.cli().sync_mode_threshold
             {
                 peer_state.fork_reconciliation_blocks.push(*received_block);
             } else {
@@ -982,9 +979,7 @@ impl PeerLoopHandler {
                 // or `STANDARD_BLOCK_BATCH_SIZE` number of blocks in response.
                 let len_of_response = cmp::min(
                     max_response_len,
-                    self.global_state_lock
-                        .cli()
-                        .max_number_of_blocks_before_syncing,
+                    self.global_state_lock.cli().sync_mode_threshold,
                 );
                 let len_of_response = cmp::max(len_of_response, MINIMUM_BLOCK_BATCH_SIZE);
                 let len_of_response = cmp::min(len_of_response, STANDARD_BLOCK_BATCH_SIZE);
@@ -1427,9 +1422,7 @@ impl PeerLoopHandler {
 
                 let max_response_len = std::cmp::min(
                     STANDARD_BLOCK_BATCH_SIZE,
-                    self.global_state_lock
-                        .cli()
-                        .max_number_of_blocks_before_syncing,
+                    self.global_state_lock.cli().sync_mode_threshold,
                 );
 
                 peer.send(PeerMessage::BlockRequestBatch(BlockRequestBatch {
@@ -2520,7 +2513,7 @@ mod peer_loop_tests {
 
         // Restrict max number of blocks held in memory to 2.
         let mut cli = state_lock.cli().clone();
-        cli.max_number_of_blocks_before_syncing = 2;
+        cli.sync_mode_threshold = 2;
         state_lock.set_cli(cli).await;
 
         let (hsd1, peer_address1) = get_dummy_peer_connection_data_genesis(Network::Alpha, 1).await;

--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -28,7 +28,6 @@ use crate::models::blockchain::transaction::Transaction;
 use crate::models::channel::MainToPeerTask;
 use crate::models::channel::PeerTaskToMain;
 use crate::models::channel::PeerTaskToMainTransaction;
-use crate::models::peer::peer_block_notifications::PeerBlockNotification;
 use crate::models::peer::transfer_block::TransferBlock;
 use crate::models::peer::BlockProposalRequest;
 use crate::models::peer::BlockRequestBatch;
@@ -556,7 +555,7 @@ impl PeerLoopHandler {
                 let block = match Block::try_from(*t_block) {
                     Ok(block) => Box::new(block),
                     Err(e) => {
-                        warn!("Peer sent invalid block");
+                        warn!("Peer sent invalid block: {e:?}");
                         self.punish(NegativePeerSanction::InvalidTransferBlock)
                             .await?;
 
@@ -772,7 +771,7 @@ impl PeerLoopHandler {
                             received_blocks.push(block);
                         }
                         Err(e) => {
-                            warn!("Received invalid transfer block from peer.");
+                            warn!("Received invalid transfer block from peer: {e:?}");
                             self.punish(NegativePeerSanction::InvalidTransferBlock)
                                 .await?;
                             return Ok(KEEP_CONNECTION_ALIVE);
@@ -924,7 +923,7 @@ impl PeerLoopHandler {
                     "Responding to sync challenge from {}",
                     self.peer_address.ip()
                 );
-                peer.send(PeerMessage::SyncChallengeResponse(response))
+                peer.send(PeerMessage::SyncChallengeResponse(Box::new(response)))
                     .await?;
 
                 Ok(KEEP_CONNECTION_ALIVE)

--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -563,7 +563,7 @@ impl PeerLoopHandler {
                     block_notification.height
                 );
                 let state = self.global_state_lock.lock_guard().await;
-                if state.should_enter_sync_mode(
+                if state.sync_mode_criterion(
                     block_notification.height,
                     block_notification.cumulative_proof_of_work,
                 ) {

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -250,6 +250,7 @@ pub(crate) async fn mock_genesis_global_state(
 pub(crate) async fn get_test_genesis_setup(
     network: Network,
     peer_count: u8,
+    cli: cli_args::Args,
 ) -> Result<(
     broadcast::Sender<MainToPeerTask>,
     broadcast::Receiver<MainToPeerTask>,
@@ -264,13 +265,7 @@ pub(crate) async fn get_test_genesis_setup(
     let from_main_rx_clone = peer_broadcast_tx.subscribe();
 
     let devnet_wallet = WalletSecret::devnet_wallet();
-    let state = mock_genesis_global_state(
-        network,
-        peer_count,
-        devnet_wallet,
-        cli_args::Args::default(),
-    )
-    .await;
+    let state = mock_genesis_global_state(network, peer_count, devnet_wallet, cli).await;
     Ok((
         peer_broadcast_tx,
         from_main_rx_clone,


### PR DESCRIPTION
 - Stylistic changes.
 - Use verify wrapper, which uses true claims cache to bypass call to `triton_vm::verify` for tests.
 - Move logic from `peer_loop` to `GlobalState`.
 - Add rng on `PeerLoopHandler` to derandomize randomness in challenge.
 - Add (positive) test with mocked communication between Alice and Bob whereby Bob triggers Alice to go into sync mode.