### PR TITLE
feat(archival_state): Add block's PoW witness to `BlockRecord`

### DIFF
--- a/src/models/database.rs
+++ b/src/models/database.rs
@@ -6,6 +6,7 @@ use serde::Serialize;
 use twenty_first::math::digest::Digest;
 
 use super::blockchain::block::block_header::BlockHeader;
+use super::blockchain::block::block_header::HeaderToBlockHashWitness;
 use super::blockchain::block::block_height::BlockHeight;
 use super::peer::PeerStanding;
 use super::proof_abstractions::timestamp::Timestamp;
@@ -31,6 +32,9 @@ pub struct BlockRecord {
 
     /// The number of addition records in this block
     pub num_additions: u64,
+
+    /// The data missing from BlockHeader in order to calculate the block hash.
+    pub(crate) block_hash_witness: HeaderToBlockHashWitness,
 }
 
 impl BlockRecord {

--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -60,7 +60,6 @@ use crate::models::state::GlobalStateLock;
 const STANDARD_BLOCK_BATCH_SIZE: usize = 250;
 const MAX_PEER_LIST_LENGTH: usize = 10;
 const MINIMUM_BLOCK_BATCH_SIZE: usize = 2;
-pub(crate) const MIN_BLOCK_HEIGHT_FOR_SYNCING: u64 = 10;
 
 const KEEP_CONNECTION_ALIVE: bool = false;
 const DISCONNECT_CONNECTION: bool = true;
@@ -3570,6 +3569,7 @@ mod peer_loop_tests {
 
     mod sync_challenges {
         use super::*;
+        use crate::models::peer::SYNC_CHALLENGE_POW_WITNESS_LENGTH;
         use crate::tests::shared::fake_valid_sequence_of_blocks_for_tests_dyn;
 
         #[traced_test]
@@ -3752,7 +3752,7 @@ mod peer_loop_tests {
                 &block_1,
                 TARGET_BLOCK_INTERVAL,
                 rng.gen(),
-                rng.gen_range(11..20),
+                rng.gen_range(SYNC_CHALLENGE_POW_WITNESS_LENGTH..20),
             )
             .await;
             for block in &blocks {


### PR DESCRIPTION
Add a new field to BlockRecord for the block's PoW witness which allows for the calculation of the block hash without needing knowledge of the entire block.