### PR TITLE
refactor!: Seal trait `ConsensusProgram`

### DIFF
--- a/src/models/blockchain/block/validity.rs
+++ b/src/models/blockchain/block/validity.rs
@@ -15,6 +15,7 @@ use self::correct_mutator_set_update::CorrectMutatorSetUpdate;
 use self::mmr_membership::MmrMembership;
 use self::predecessor_is_valid::PredecessorIsValid;
 use super::Block;
+use crate::models::proof_abstractions::tasm::program;
 use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
 use crate::models::proof_abstractions::SecretWitness;
 
@@ -75,6 +76,8 @@ impl SecretWitness for PrincipalBlockValidationWitness {
         todo!()
     }
 }
+
+impl program::private::Seal for PrincipalBlockValidationLogic {}
 
 impl ConsensusProgram for PrincipalBlockValidationLogic {
     fn source(&self) {

--- a/src/models/blockchain/block/validity/block_program.rs
+++ b/src/models/blockchain/block/validity/block_program.rs
@@ -32,6 +32,7 @@ use crate::models::blockchain::type_scripts::neptune_coins::NeptuneCoins;
 use crate::models::proof_abstractions::mast_hash::MastHash;
 use crate::models::proof_abstractions::tasm::builtins as tasmlib;
 use crate::models::proof_abstractions::tasm::builtins::verify_stark;
+use crate::models::proof_abstractions::tasm::program;
 use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
 use crate::models::proof_abstractions::verifier::verify;
 
@@ -65,6 +66,8 @@ impl BlockProgram {
         verdict
     }
 }
+
+impl program::private::Seal for BlockProgram {}
 
 impl ConsensusProgram for BlockProgram {
     fn source(&self) {

--- a/src/models/blockchain/block/validity/coinbase_is_valid.rs
+++ b/src/models/blockchain/block/validity/coinbase_is_valid.rs
@@ -9,6 +9,7 @@ use tasm_lib::twenty_first;
 use twenty_first::math::bfield_codec::BFieldCodec;
 
 use crate::models::blockchain::block::Block;
+use crate::models::proof_abstractions::tasm::program;
 use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
 use crate::models::proof_abstractions::SecretWitness;
 
@@ -36,6 +37,8 @@ impl SecretWitness for CoinbaseIsValidWitness {
 pub struct CoinbaseIsValid {
     witness: CoinbaseIsValidWitness,
 }
+
+impl program::private::Seal for CoinbaseIsValid {}
 
 impl ConsensusProgram for CoinbaseIsValid {
     fn source(&self) {

--- a/src/models/blockchain/block/validity/correct_control_parameter_update.rs
+++ b/src/models/blockchain/block/validity/correct_control_parameter_update.rs
@@ -8,6 +8,7 @@ use tasm_lib::triton_vm::prelude::*;
 use tasm_lib::twenty_first::math::bfield_codec::BFieldCodec;
 
 use crate::models::blockchain::block::Block;
+use crate::models::proof_abstractions::tasm::program;
 use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
 use crate::models::proof_abstractions::SecretWitness;
 
@@ -34,6 +35,8 @@ impl SecretWitness for CorrectControlParameterUpdateWitness {
 pub struct CorrectControlParameterUpdate {
     pub witness: CorrectControlParameterUpdateWitness,
 }
+
+impl program::private::Seal for CorrectControlParameterUpdate {}
 
 impl ConsensusProgram for CorrectControlParameterUpdate {
     fn source(&self) {

--- a/src/models/blockchain/block/validity/correct_mmr_update.rs
+++ b/src/models/blockchain/block/validity/correct_mmr_update.rs
@@ -8,6 +8,7 @@ use tasm_lib::triton_vm::prelude::*;
 use tasm_lib::twenty_first::math::bfield_codec::BFieldCodec;
 use tasm_lib::twenty_first::util_types::mmr::mmr_accumulator::MmrAccumulator;
 
+use crate::models::proof_abstractions::tasm::program;
 use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
 use crate::models::proof_abstractions::SecretWitness;
 
@@ -34,6 +35,8 @@ impl SecretWitness for CorrectMmrUpdateWitness {
 pub struct CorrectMmrUpdate {
     pub witness: CorrectMmrUpdateWitness,
 }
+
+impl program::private::Seal for CorrectMmrUpdate {}
 
 impl ConsensusProgram for CorrectMmrUpdate {
     fn source(&self) {

--- a/src/models/blockchain/block/validity/correct_mutator_set_update.rs
+++ b/src/models/blockchain/block/validity/correct_mutator_set_update.rs
@@ -7,6 +7,7 @@ use tasm_lib::library::Library;
 use tasm_lib::triton_vm::prelude::*;
 
 use crate::models::blockchain::block::BFieldCodec;
+use crate::models::proof_abstractions::tasm::program;
 use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
 use crate::models::proof_abstractions::SecretWitness;
 use crate::util_types::mutator_set::mutator_set_accumulator::MutatorSetAccumulator;
@@ -34,6 +35,8 @@ impl SecretWitness for CorrectMutatorSetUpdateWitness {
 pub struct CorrectMutatorSetUpdate {
     pub witness: CorrectMutatorSetUpdateWitness,
 }
+
+impl program::private::Seal for CorrectMutatorSetUpdate {}
 
 impl ConsensusProgram for CorrectMutatorSetUpdate {
     fn source(&self) {

--- a/src/models/blockchain/block/validity/mmr_membership.rs
+++ b/src/models/blockchain/block/validity/mmr_membership.rs
@@ -8,6 +8,7 @@ use tasm_lib::triton_vm::prelude::*;
 use twenty_first::math::bfield_codec::BFieldCodec;
 use twenty_first::prelude::MmrMembershipProof;
 
+use crate::models::proof_abstractions::tasm::program;
 use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
 use crate::models::proof_abstractions::SecretWitness;
 
@@ -34,6 +35,8 @@ impl SecretWitness for MmrMembershipWitness {
 pub struct MmrMembership {
     witness: MmrMembershipWitness,
 }
+
+impl program::private::Seal for MmrMembership {}
 
 impl ConsensusProgram for MmrMembership {
     fn source(&self) {

--- a/src/models/blockchain/block/validity/predecessor_is_valid.rs
+++ b/src/models/blockchain/block/validity/predecessor_is_valid.rs
@@ -8,6 +8,7 @@ use tasm_lib::triton_vm::prelude::*;
 use tasm_lib::twenty_first::math::bfield_codec::BFieldCodec;
 
 use crate::models::blockchain::block::Block;
+use crate::models::proof_abstractions::tasm::program;
 use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
 use crate::models::proof_abstractions::SecretWitness;
 
@@ -34,6 +35,8 @@ impl SecretWitness for PredecessorIsValidWitness {
 pub struct PredecessorIsValid {
     pub witness: PredecessorIsValidWitness,
 }
+
+impl program::private::Seal for PredecessorIsValid {}
 
 impl ConsensusProgram for PredecessorIsValid {
     fn source(&self) {

--- a/src/models/blockchain/transaction/validity/collect_lock_scripts.rs
+++ b/src/models/blockchain/transaction/validity/collect_lock_scripts.rs
@@ -25,6 +25,7 @@ use crate::models::blockchain::transaction::primitive_witness::PrimitiveWitness;
 use crate::models::blockchain::transaction::primitive_witness::SaltedUtxos;
 use crate::models::blockchain::transaction::utxo::Utxo;
 use crate::models::proof_abstractions::tasm::builtins as tasmlib;
+use crate::models::proof_abstractions::tasm::program;
 use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
 use crate::models::proof_abstractions::SecretWitness;
 use crate::prelude::triton_vm;
@@ -72,6 +73,8 @@ impl SecretWitness for CollectLockScriptsWitness {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, GetSize, BFieldCodec)]
 pub struct CollectLockScripts;
+
+impl program::private::Seal for CollectLockScripts {}
 
 impl ConsensusProgram for CollectLockScripts {
     fn source(&self) {

--- a/src/models/blockchain/transaction/validity/collect_type_scripts.rs
+++ b/src/models/blockchain/transaction/validity/collect_type_scripts.rs
@@ -30,6 +30,7 @@ use crate::models::blockchain::transaction::primitive_witness::SaltedUtxos;
 use crate::models::blockchain::transaction::utxo::Coin;
 use crate::models::blockchain::transaction::utxo::Utxo;
 use crate::models::proof_abstractions::tasm::builtins as tasmlib;
+use crate::models::proof_abstractions::tasm::program;
 use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
 use crate::models::proof_abstractions::SecretWitness;
 use crate::prelude::triton_vm;
@@ -84,6 +85,8 @@ impl SecretWitness for CollectTypeScriptsWitness {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, GetSize, BFieldCodec)]
 pub struct CollectTypeScripts;
+
+impl program::private::Seal for CollectTypeScripts {}
 
 impl ConsensusProgram for CollectTypeScripts {
     fn source(&self) {

--- a/src/models/blockchain/transaction/validity/kernel_to_outputs.rs
+++ b/src/models/blockchain/transaction/validity/kernel_to_outputs.rs
@@ -24,6 +24,7 @@ use crate::models::blockchain::transaction::transaction_kernel::TransactionKerne
 use crate::models::blockchain::transaction::utxo::Utxo;
 use crate::models::proof_abstractions::mast_hash::MastHash;
 use crate::models::proof_abstractions::tasm::builtins as tasmlib;
+use crate::models::proof_abstractions::tasm::program;
 use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
 use crate::models::proof_abstractions::SecretWitness;
 use crate::util_types::mutator_set::addition_record::AdditionRecord;
@@ -111,6 +112,8 @@ impl SecretWitness for KernelToOutputsWitness {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, GetSize, FieldCount, BFieldCodec)]
 pub struct KernelToOutputs;
+
+impl program::private::Seal for KernelToOutputs {}
 
 impl ConsensusProgram for KernelToOutputs {
     fn source(&self) {

--- a/src/models/blockchain/transaction/validity/removal_records_integrity.rs
+++ b/src/models/blockchain/transaction/validity/removal_records_integrity.rs
@@ -42,6 +42,7 @@ use crate::models::blockchain::transaction::PrimitiveWitness;
 use crate::models::blockchain::type_scripts::neptune_coins::NeptuneCoins;
 use crate::models::proof_abstractions::mast_hash::MastHash;
 use crate::models::proof_abstractions::tasm::builtins as tasmlib;
+use crate::models::proof_abstractions::tasm::program;
 use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
 use crate::models::proof_abstractions::SecretWitness;
 use crate::util_types::mutator_set::addition_record::AdditionRecord;
@@ -365,6 +366,8 @@ impl RemovalRecordsIntegrityWitness {
         (mmra, mps)
     }
 }
+
+impl program::private::Seal for RemovalRecordsIntegrity {}
 
 impl ConsensusProgram for RemovalRecordsIntegrity {
     fn source(&self) {

--- a/src/models/blockchain/transaction/validity/single_proof.rs
+++ b/src/models/blockchain/transaction/validity/single_proof.rs
@@ -29,6 +29,7 @@ use crate::models::blockchain::transaction::validity::tasm::claims::generate_rri
 use crate::models::blockchain::transaction::Claim;
 use crate::models::proof_abstractions::mast_hash::MastHash;
 use crate::models::proof_abstractions::tasm::builtins as tasmlib;
+use crate::models::proof_abstractions::tasm::program;
 use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
 use crate::job_queue::triton_vm::TritonVmJobQueue;
 use crate::models::proof_abstractions::SecretWitness;
@@ -251,6 +252,8 @@ impl SingleProof {
         Ok(single_proof)
     }
 }
+
+impl program::private::Seal for SingleProof {}
 
 impl ConsensusProgram for SingleProof {
     fn source(&self) {

--- a/src/models/blockchain/type_scripts/native_currency.rs
+++ b/src/models/blockchain/type_scripts/native_currency.rs
@@ -38,6 +38,7 @@ use crate::models::blockchain::type_scripts::BFieldCodec;
 use crate::models::blockchain::type_scripts::TypeScriptAndWitness;
 use crate::models::proof_abstractions::mast_hash::MastHash;
 use crate::models::proof_abstractions::tasm::builtins as tasm;
+use crate::models::proof_abstractions::tasm::program;
 use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
 use crate::models::proof_abstractions::timestamp::Timestamp;
 use crate::models::proof_abstractions::SecretWitness;
@@ -84,6 +85,8 @@ impl NativeCurrency {
         BFieldElement::new(18168297044820278740),
     ]);
 }
+
+impl program::private::Seal for NativeCurrencyWitness {}
 
 impl ConsensusProgram for NativeCurrency {
     #[allow(clippy::needless_return)]

--- a/src/models/blockchain/type_scripts/time_lock.rs
+++ b/src/models/blockchain/type_scripts/time_lock.rs
@@ -27,6 +27,7 @@ use crate::models::blockchain::transaction::utxo::Utxo;
 use crate::models::blockchain::type_scripts::TypeScriptAndWitness;
 use crate::models::proof_abstractions::mast_hash::MastHash;
 use crate::models::proof_abstractions::tasm::builtins as tasm;
+use crate::models::proof_abstractions::tasm::program;
 use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
 use crate::models::proof_abstractions::timestamp::Timestamp;
 use crate::models::proof_abstractions::SecretWitness;
@@ -56,6 +57,8 @@ impl TimeLock {
             .unwrap_or_else(Timestamp::zero)
     }
 }
+
+impl program::private::Seal for TimeLock {}
 
 impl ConsensusProgram for TimeLock {
     #[allow(clippy::needless_return)]

--- a/src/models/proof_abstractions/tasm/program.rs
+++ b/src/models/proof_abstractions/tasm/program.rs
@@ -17,6 +17,10 @@ use super::prover_job::ProverJobSettings;
 use crate::job_queue::triton_vm::TritonVmJobPriority;
 use crate::job_queue::triton_vm::TritonVmJobQueue;
 
+pub(crate) mod private {
+    pub trait Seal {}
+}
+
 #[derive(Debug, Clone)]
 pub enum ConsensusError {
     RustShadowPanic(String),
@@ -25,9 +29,11 @@ pub enum ConsensusError {
 
 /// A `ConsensusProgram` represents the logic subprogram for transaction or
 /// block validity.
+///
+/// This is a _sealed_ trait. It cannot be implemented outside of this crate.
 pub trait ConsensusProgram
 where
-    Self: RefUnwindSafe + std::fmt::Debug,
+    Self: RefUnwindSafe + std::fmt::Debug + private::Seal,
 {
     /// The canonical reference source code for the consensus program, written in
     /// the subset of rust that the tasm-lang compiler understands. To run this


### PR DESCRIPTION
From the functions defined in the trait `ConsensusProgram` it feels like _only_ Neptune core should ever provide implementations of this trait. Is that correct? If so, we can [seal the trait](https://predr.ag/blog/definitive-guide-to-sealed-traits-in-rust/) (like this PR suggests) and prevent downstream crates from providing additional implementations for `ConsensusProgram`.

If the trait is not even supposed to be _used_ outside of Neptune core I suggest to make it a `pub(crate) trait` instead.