### PR TITLE
Make trait `ConsensusProgram` private

### DIFF
--- a/src/models/blockchain/block/validity.rs
+++ b/src/models/blockchain/block/validity.rs
@@ -77,6 +77,7 @@ impl SecretWitness for PrincipalBlockValidationWitness {
 }
 
 impl ConsensusProgram for PrincipalBlockValidationLogic {
+    #[cfg(test)]
     fn source(&self) {
         todo!()
     }

--- a/src/models/blockchain/block/validity.rs
+++ b/src/models/blockchain/block/validity.rs
@@ -77,11 +77,6 @@ impl SecretWitness for PrincipalBlockValidationWitness {
 }
 
 impl ConsensusProgram for PrincipalBlockValidationLogic {
-    #[cfg(test)]
-    fn source(&self) {
-        todo!()
-    }
-
     fn library_and_code(&self) -> (Library, Vec<LabelledInstruction>) {
         todo!()
     }
@@ -90,5 +85,17 @@ impl ConsensusProgram for PrincipalBlockValidationLogic {
         static HASH: OnceLock<Digest> = OnceLock::new();
 
         *HASH.get_or_init(|| self.program().hash())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::proof_abstractions::tasm::program::test::ConsensusProgramSpecification;
+
+    impl ConsensusProgramSpecification for PrincipalBlockValidationLogic {
+        fn source(&self) {
+            todo!()
+        }
     }
 }

--- a/src/models/blockchain/block/validity/block_program.rs
+++ b/src/models/blockchain/block/validity/block_program.rs
@@ -64,61 +64,6 @@ impl BlockProgram {
 }
 
 impl ConsensusProgram for BlockProgram {
-    #[cfg(test)]
-    fn source(&self) {
-        use tasm_lib::triton_vm::prelude::BFieldElement;
-
-        use crate::models::proof_abstractions::tasm::builtins as tasmlib;
-        use crate::models::proof_abstractions::tasm::builtins::verify_stark;
-
-        let block_body_digest: Digest = tasmlib::tasmlib_io_read_stdin___digest();
-        let start_address: BFieldElement = FIRST_NON_DETERMINISTICALLY_INITIALIZED_MEMORY_ADDRESS;
-        let block_witness: BlockProofWitness = tasmlib::decode_from_memory(start_address);
-        let claims: Vec<Claim> = block_witness.claims;
-        let proofs: Vec<Proof> = block_witness.proofs;
-
-        let block_body = &block_witness.block_body;
-
-        let txk_mast_hash: Digest = tasmlib::tasmlib_io_read_secin___digest();
-        let txk_mast_hash_as_leaf = Tip5::hash(&txk_mast_hash);
-        tasmlib::tasmlib_hashing_merkle_verify(
-            block_body_digest,
-            BlockBodyField::TransactionKernel as u32,
-            txk_mast_hash_as_leaf,
-            BlockBody::MAST_HEIGHT as u32,
-        );
-
-        // Verify fee is legal
-        let fee = &block_body.transaction_kernel.fee;
-        let fee_hash = Tip5::hash(fee);
-        tasmlib::tasmlib_hashing_merkle_verify(
-            txk_mast_hash,
-            TransactionKernelField::Fee as u32,
-            fee_hash,
-            TransactionKernel::MAST_HEIGHT as u32,
-        );
-
-        assert!(!fee.is_negative());
-        assert!(*fee <= NativeCurrencyAmount::max());
-
-        // Verify that merge bit is set
-        let merge_bit_hash = Tip5::hash(&1);
-        tasmlib::tasmlib_hashing_merkle_verify(
-            txk_mast_hash,
-            TransactionKernelField::MergeBit as u32,
-            merge_bit_hash,
-            TransactionKernel::MAST_HEIGHT as u32,
-        );
-
-        let mut i = 0;
-        while i < claims.len() {
-            tasmlib::tasmlib_io_write_to_stdout___digest(Tip5::hash(&claims[i]));
-            verify_stark(Stark::default(), &claims[i], &proofs[i]);
-
-            i += 1;
-        }
-    }
-
     fn library_and_code(&self) -> (Library, Vec<LabelledInstruction>) {
         let mut library = Library::new();
 
@@ -361,6 +306,7 @@ pub(crate) mod test {
     use rand::rngs::StdRng;
     use rand::Rng;
     use rand::SeedableRng;
+    use tasm_lib::triton_vm::prelude::BFieldElement;
     use tasm_lib::triton_vm::vm::PublicInput;
     use tracing_test::traced_test;
 
@@ -375,7 +321,9 @@ pub(crate) mod test {
     use crate::models::blockchain::block::Block;
     use crate::models::blockchain::block::TritonVmProofJobOptions;
     use crate::models::blockchain::transaction::Transaction;
-    use crate::models::proof_abstractions::mast_hash::MastHash;
+    use crate::models::proof_abstractions::tasm::builtins as tasm;
+    use crate::models::proof_abstractions::tasm::builtins::verify_stark;
+    use crate::models::proof_abstractions::tasm::program::test::ConsensusProgramSpecification;
     use crate::models::proof_abstractions::timestamp::Timestamp;
     use crate::models::proof_abstractions::SecretWitness;
     use crate::models::state::tx_proving_capability::TxProvingCapability;
@@ -383,6 +331,58 @@ pub(crate) mod test {
     use crate::models::state::wallet::utxo_notification::UtxoNotificationMedium;
     use crate::models::state::wallet::WalletSecret;
     use crate::tests::shared::mock_genesis_global_state;
+
+    impl ConsensusProgramSpecification for BlockProgram {
+        fn source(&self) {
+            let block_body_digest: Digest = tasm::tasmlib_io_read_stdin___digest();
+            let start_address: BFieldElement =
+                FIRST_NON_DETERMINISTICALLY_INITIALIZED_MEMORY_ADDRESS;
+            let block_witness: BlockProofWitness = tasm::decode_from_memory(start_address);
+            let claims: Vec<Claim> = block_witness.claims;
+            let proofs: Vec<Proof> = block_witness.proofs;
+
+            let block_body = &block_witness.block_body;
+
+            let txk_mast_hash: Digest = tasm::tasmlib_io_read_secin___digest();
+            let txk_mast_hash_as_leaf = Tip5::hash(&txk_mast_hash);
+            tasm::tasmlib_hashing_merkle_verify(
+                block_body_digest,
+                BlockBodyField::TransactionKernel as u32,
+                txk_mast_hash_as_leaf,
+                BlockBody::MAST_HEIGHT as u32,
+            );
+
+            // Verify fee is legal
+            let fee = &block_body.transaction_kernel.fee;
+            let fee_hash = Tip5::hash(fee);
+            tasm::tasmlib_hashing_merkle_verify(
+                txk_mast_hash,
+                TransactionKernelField::Fee as u32,
+                fee_hash,
+                TransactionKernel::MAST_HEIGHT as u32,
+            );
+
+            assert!(!fee.is_negative());
+            assert!(*fee <= NativeCurrencyAmount::max());
+
+            // Verify that merge bit is set
+            let merge_bit_hash = Tip5::hash(&1);
+            tasm::tasmlib_hashing_merkle_verify(
+                txk_mast_hash,
+                TransactionKernelField::MergeBit as u32,
+                merge_bit_hash,
+                TransactionKernel::MAST_HEIGHT as u32,
+            );
+
+            let mut i = 0;
+            while i < claims.len() {
+                tasm::tasmlib_io_write_to_stdout___digest(Tip5::hash(&claims[i]));
+                verify_stark(Stark::default(), &claims[i], &proofs[i]);
+
+                i += 1;
+            }
+        }
+    }
 
     #[traced_test]
     #[test]

--- a/src/models/blockchain/block/validity/block_program.rs
+++ b/src/models/blockchain/block/validity/block_program.rs
@@ -13,7 +13,6 @@ use tasm_lib::prelude::Library;
 use tasm_lib::triton_vm::isa::triton_asm;
 use tasm_lib::triton_vm::isa::triton_instr;
 use tasm_lib::triton_vm::prelude::BFieldCodec;
-use tasm_lib::triton_vm::prelude::BFieldElement;
 use tasm_lib::triton_vm::prelude::LabelledInstruction;
 use tasm_lib::triton_vm::prelude::Tip5;
 use tasm_lib::triton_vm::proof::Claim;
@@ -30,8 +29,6 @@ use crate::models::blockchain::transaction::transaction_kernel::TransactionKerne
 use crate::models::blockchain::transaction::transaction_kernel::TransactionKernelField;
 use crate::models::blockchain::type_scripts::native_currency_amount::NativeCurrencyAmount;
 use crate::models::proof_abstractions::mast_hash::MastHash;
-use crate::models::proof_abstractions::tasm::builtins as tasmlib;
-use crate::models::proof_abstractions::tasm::builtins::verify_stark;
 use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
 use crate::models::proof_abstractions::verifier::verify;
 
@@ -67,7 +64,13 @@ impl BlockProgram {
 }
 
 impl ConsensusProgram for BlockProgram {
+    #[cfg(test)]
     fn source(&self) {
+        use tasm_lib::triton_vm::prelude::BFieldElement;
+
+        use crate::models::proof_abstractions::tasm::builtins as tasmlib;
+        use crate::models::proof_abstractions::tasm::builtins::verify_stark;
+
         let block_body_digest: Digest = tasmlib::tasmlib_io_read_stdin___digest();
         let start_address: BFieldElement = FIRST_NON_DETERMINISTICALLY_INITIALIZED_MEMORY_ADDRESS;
         let block_witness: BlockProofWitness = tasmlib::decode_from_memory(start_address);

--- a/src/models/blockchain/block/validity/coinbase_is_valid.rs
+++ b/src/models/blockchain/block/validity/coinbase_is_valid.rs
@@ -38,6 +38,7 @@ pub struct CoinbaseIsValid {
 }
 
 impl ConsensusProgram for CoinbaseIsValid {
+    #[cfg(test)]
     fn source(&self) {
         todo!()
     }

--- a/src/models/blockchain/block/validity/coinbase_is_valid.rs
+++ b/src/models/blockchain/block/validity/coinbase_is_valid.rs
@@ -38,11 +38,6 @@ pub struct CoinbaseIsValid {
 }
 
 impl ConsensusProgram for CoinbaseIsValid {
-    #[cfg(test)]
-    fn source(&self) {
-        todo!()
-    }
-
     fn library_and_code(&self) -> (Library, Vec<LabelledInstruction>) {
         todo!()
     }
@@ -51,5 +46,17 @@ impl ConsensusProgram for CoinbaseIsValid {
         static HASH: OnceLock<Digest> = OnceLock::new();
 
         *HASH.get_or_init(|| self.program().hash())
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::models::proof_abstractions::tasm::program::test::ConsensusProgramSpecification;
+
+    impl ConsensusProgramSpecification for CoinbaseIsValid {
+        fn source(&self) {
+            todo!()
+        }
     }
 }

--- a/src/models/blockchain/block/validity/correct_control_parameter_update.rs
+++ b/src/models/blockchain/block/validity/correct_control_parameter_update.rs
@@ -36,11 +36,6 @@ pub struct CorrectControlParameterUpdate {
 }
 
 impl ConsensusProgram for CorrectControlParameterUpdate {
-    #[cfg(test)]
-    fn source(&self) {
-        todo!()
-    }
-
     fn library_and_code(&self) -> (Library, Vec<LabelledInstruction>) {
         todo!()
     }
@@ -49,5 +44,17 @@ impl ConsensusProgram for CorrectControlParameterUpdate {
         static HASH: OnceLock<Digest> = OnceLock::new();
 
         *HASH.get_or_init(|| self.program().hash())
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::models::proof_abstractions::tasm::program::test::ConsensusProgramSpecification;
+
+    impl ConsensusProgramSpecification for CorrectControlParameterUpdate {
+        fn source(&self) {
+            todo!()
+        }
     }
 }

--- a/src/models/blockchain/block/validity/correct_control_parameter_update.rs
+++ b/src/models/blockchain/block/validity/correct_control_parameter_update.rs
@@ -36,6 +36,7 @@ pub struct CorrectControlParameterUpdate {
 }
 
 impl ConsensusProgram for CorrectControlParameterUpdate {
+    #[cfg(test)]
     fn source(&self) {
         todo!()
     }

--- a/src/models/blockchain/block/validity/correct_mmr_update.rs
+++ b/src/models/blockchain/block/validity/correct_mmr_update.rs
@@ -36,6 +36,7 @@ pub struct CorrectMmrUpdate {
 }
 
 impl ConsensusProgram for CorrectMmrUpdate {
+    #[cfg(test)]
     fn source(&self) {
         todo!()
     }

--- a/src/models/blockchain/block/validity/correct_mmr_update.rs
+++ b/src/models/blockchain/block/validity/correct_mmr_update.rs
@@ -36,11 +36,6 @@ pub struct CorrectMmrUpdate {
 }
 
 impl ConsensusProgram for CorrectMmrUpdate {
-    #[cfg(test)]
-    fn source(&self) {
-        todo!()
-    }
-
     fn library_and_code(&self) -> (Library, Vec<LabelledInstruction>) {
         todo!()
     }
@@ -49,5 +44,17 @@ impl ConsensusProgram for CorrectMmrUpdate {
         static HASH: OnceLock<Digest> = OnceLock::new();
 
         *HASH.get_or_init(|| self.program().hash())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::proof_abstractions::tasm::program::test::ConsensusProgramSpecification;
+
+    impl ConsensusProgramSpecification for CorrectMmrUpdate {
+        fn source(&self) {
+            todo!()
+        }
     }
 }

--- a/src/models/blockchain/block/validity/correct_mutator_set_update.rs
+++ b/src/models/blockchain/block/validity/correct_mutator_set_update.rs
@@ -36,11 +36,6 @@ pub struct CorrectMutatorSetUpdate {
 }
 
 impl ConsensusProgram for CorrectMutatorSetUpdate {
-    #[cfg(test)]
-    fn source(&self) {
-        todo!()
-    }
-
     fn library_and_code(&self) -> (Library, Vec<LabelledInstruction>) {
         todo!()
     }
@@ -49,5 +44,17 @@ impl ConsensusProgram for CorrectMutatorSetUpdate {
         static HASH: OnceLock<Digest> = OnceLock::new();
 
         *HASH.get_or_init(|| self.program().hash())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::proof_abstractions::tasm::program::test::ConsensusProgramSpecification;
+
+    impl ConsensusProgramSpecification for CorrectMutatorSetUpdate {
+        fn source(&self) {
+            todo!()
+        }
     }
 }

--- a/src/models/blockchain/block/validity/correct_mutator_set_update.rs
+++ b/src/models/blockchain/block/validity/correct_mutator_set_update.rs
@@ -36,6 +36,7 @@ pub struct CorrectMutatorSetUpdate {
 }
 
 impl ConsensusProgram for CorrectMutatorSetUpdate {
+    #[cfg(test)]
     fn source(&self) {
         todo!()
     }

--- a/src/models/blockchain/block/validity/mmr_membership.rs
+++ b/src/models/blockchain/block/validity/mmr_membership.rs
@@ -36,6 +36,7 @@ pub struct MmrMembership {
 }
 
 impl ConsensusProgram for MmrMembership {
+    #[cfg(test)]
     fn source(&self) {
         todo!()
     }

--- a/src/models/blockchain/block/validity/mmr_membership.rs
+++ b/src/models/blockchain/block/validity/mmr_membership.rs
@@ -36,11 +36,6 @@ pub struct MmrMembership {
 }
 
 impl ConsensusProgram for MmrMembership {
-    #[cfg(test)]
-    fn source(&self) {
-        todo!()
-    }
-
     fn library_and_code(&self) -> (Library, Vec<LabelledInstruction>) {
         todo!()
     }
@@ -49,5 +44,17 @@ impl ConsensusProgram for MmrMembership {
         static HASH: OnceLock<Digest> = OnceLock::new();
 
         *HASH.get_or_init(|| self.program().hash())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::proof_abstractions::tasm::program::test::ConsensusProgramSpecification;
+
+    impl ConsensusProgramSpecification for MmrMembership {
+        fn source(&self) {
+            todo!()
+        }
     }
 }

--- a/src/models/blockchain/block/validity/predecessor_is_valid.rs
+++ b/src/models/blockchain/block/validity/predecessor_is_valid.rs
@@ -36,11 +36,6 @@ pub struct PredecessorIsValid {
 }
 
 impl ConsensusProgram for PredecessorIsValid {
-    #[cfg(test)]
-    fn source(&self) {
-        todo!()
-    }
-
     fn library_and_code(&self) -> (Library, Vec<LabelledInstruction>) {
         todo!()
     }
@@ -49,5 +44,17 @@ impl ConsensusProgram for PredecessorIsValid {
         static HASH: OnceLock<Digest> = OnceLock::new();
 
         *HASH.get_or_init(|| self.program().hash())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::proof_abstractions::tasm::program::test::ConsensusProgramSpecification;
+
+    impl ConsensusProgramSpecification for PredecessorIsValid {
+        fn source(&self) {
+            todo!()
+        }
     }
 }

--- a/src/models/blockchain/block/validity/predecessor_is_valid.rs
+++ b/src/models/blockchain/block/validity/predecessor_is_valid.rs
@@ -36,6 +36,7 @@ pub struct PredecessorIsValid {
 }
 
 impl ConsensusProgram for PredecessorIsValid {
+    #[cfg(test)]
     fn source(&self) {
         todo!()
     }

--- a/src/models/blockchain/transaction/validity/collect_lock_scripts.rs
+++ b/src/models/blockchain/transaction/validity/collect_lock_scripts.rs
@@ -24,7 +24,6 @@ use crate::models::blockchain::shared::Hash;
 use crate::models::blockchain::transaction::primitive_witness::PrimitiveWitness;
 use crate::models::blockchain::transaction::primitive_witness::SaltedUtxos;
 use crate::models::blockchain::transaction::utxo::Utxo;
-use crate::models::proof_abstractions::tasm::builtins as tasmlib;
 use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
 use crate::models::proof_abstractions::SecretWitness;
 use crate::prelude::triton_vm;
@@ -74,7 +73,10 @@ impl SecretWitness for CollectLockScriptsWitness {
 pub struct CollectLockScripts;
 
 impl ConsensusProgram for CollectLockScripts {
+    #[cfg(test)]
     fn source(&self) {
+        use crate::models::proof_abstractions::tasm::builtins as tasmlib;
+
         let siu_digest: Digest = tasmlib::tasmlib_io_read_stdin___digest();
         let start_address: BFieldElement = FIRST_NON_DETERMINISTICALLY_INITIALIZED_MEMORY_ADDRESS;
         let clsw: CollectLockScriptsWitness = tasmlib::decode_from_memory(start_address);

--- a/src/models/blockchain/transaction/validity/collect_type_scripts.rs
+++ b/src/models/blockchain/transaction/validity/collect_type_scripts.rs
@@ -83,74 +83,6 @@ impl SecretWitness for CollectTypeScriptsWitness {
 pub struct CollectTypeScripts;
 
 impl ConsensusProgram for CollectTypeScripts {
-    #[cfg(test)]
-    fn source(&self) {
-        use crate::models::proof_abstractions::tasm::builtins as tasmlib;
-
-        let siu_digest: Digest = tasmlib::tasmlib_io_read_stdin___digest();
-        let sou_digest: Digest = tasmlib::tasmlib_io_read_stdin___digest();
-        let start_address: BFieldElement = FIRST_NON_DETERMINISTICALLY_INITIALIZED_MEMORY_ADDRESS;
-        let ctsw: CollectTypeScriptsWitness = tasmlib::decode_from_memory(start_address);
-
-        // divine in the salted input UTXOs with hash
-        let salted_input_utxos: &SaltedUtxos = &ctsw.salted_input_utxos;
-        let input_utxos: &Vec<Utxo> = &salted_input_utxos.utxos;
-
-        // verify that the divined data matches with the explicit input digest
-        let salted_input_utxos_hash: Digest = Tip5::hash(salted_input_utxos);
-        assert_eq!(siu_digest, salted_input_utxos_hash);
-
-        // divine in the salted output UTXOs with hash
-        let salted_output_utxos: &SaltedUtxos = &ctsw.salted_output_utxos;
-        let output_utxos: &Vec<Utxo> = &salted_output_utxos.utxos;
-
-        // verify that the divined data matches with the explicit input digest
-        let salted_output_utxos_hash: Digest = Tip5::hash(salted_output_utxos);
-        assert_eq!(sou_digest, salted_output_utxos_hash);
-
-        // iterate over all input UTXOs and collect the type script hashes
-        let mut type_script_hashes: Vec<Digest> = Vec::with_capacity(input_utxos.len());
-        let mut i = 0;
-        while i < input_utxos.len() {
-            let utxo: &Utxo = &input_utxos[i];
-
-            let mut j = 0;
-            while j < utxo.coins().len() {
-                let coin: &Coin = &utxo.coins()[j];
-                if !type_script_hashes.contains(&coin.type_script_hash) {
-                    type_script_hashes.push(coin.type_script_hash);
-                }
-                j += 1;
-            }
-
-            i += 1;
-        }
-
-        // iterate over all output UTXOs and collect the type script hashes
-        i = 0;
-        while i < output_utxos.len() {
-            let utxo: &Utxo = &output_utxos[i];
-
-            let mut j = 0;
-            while j < utxo.coins().len() {
-                let coin: &Coin = &utxo.coins()[j];
-                if !type_script_hashes.contains(&coin.type_script_hash) {
-                    type_script_hashes.push(coin.type_script_hash);
-                }
-                j += 1;
-            }
-
-            i += 1;
-        }
-
-        // output all type script hashes
-        i = 0;
-        while i < type_script_hashes.len() {
-            tasmlib::tasmlib_io_write_to_stdout___digest(type_script_hashes[i]);
-            i += 1;
-        }
-    }
-
     fn library_and_code(&self) -> (Library, Vec<LabelledInstruction>) {
         let mut library = Library::new();
         let field_with_size_salted_input_utxos =
@@ -392,17 +324,84 @@ mod test {
     use proptest::test_runner::TestCaseError;
     use proptest::test_runner::TestRunner;
     use proptest_arbitrary_interop::arb;
+    use tasm_lib::memory::FIRST_NON_DETERMINISTICALLY_INITIALIZED_MEMORY_ADDRESS;
     use tasm_lib::triton_vm;
     use tasm_lib::triton_vm::stark::Stark;
     use test_strategy::proptest;
 
-    use crate::models::blockchain::transaction::primitive_witness::PrimitiveWitness;
-    use crate::models::blockchain::transaction::validity::collect_type_scripts::CollectTypeScripts;
-    use crate::models::blockchain::transaction::validity::collect_type_scripts::CollectTypeScriptsWitness;
+    use super::*;
     use crate::models::blockchain::type_scripts::time_lock::neptune_arbitrary::arbitrary_primitive_witness_with_active_timelocks;
-    use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
+    use crate::models::proof_abstractions::tasm::builtins as tasm;
+    use crate::models::proof_abstractions::tasm::program::test::ConsensusProgramSpecification;
     use crate::models::proof_abstractions::timestamp::Timestamp;
-    use crate::models::proof_abstractions::SecretWitness;
+
+    impl ConsensusProgramSpecification for CollectTypeScripts {
+        fn source(&self) {
+            let siu_digest: Digest = tasm::tasmlib_io_read_stdin___digest();
+            let sou_digest: Digest = tasm::tasmlib_io_read_stdin___digest();
+            let start_address: BFieldElement =
+                FIRST_NON_DETERMINISTICALLY_INITIALIZED_MEMORY_ADDRESS;
+            let ctsw: CollectTypeScriptsWitness = tasm::decode_from_memory(start_address);
+
+            // divine in the salted input UTXOs with hash
+            let salted_input_utxos: &SaltedUtxos = &ctsw.salted_input_utxos;
+            let input_utxos: &Vec<Utxo> = &salted_input_utxos.utxos;
+
+            // verify that the divined data matches with the explicit input digest
+            let salted_input_utxos_hash: Digest = Tip5::hash(salted_input_utxos);
+            assert_eq!(siu_digest, salted_input_utxos_hash);
+
+            // divine in the salted output UTXOs with hash
+            let salted_output_utxos: &SaltedUtxos = &ctsw.salted_output_utxos;
+            let output_utxos: &Vec<Utxo> = &salted_output_utxos.utxos;
+
+            // verify that the divined data matches with the explicit input digest
+            let salted_output_utxos_hash: Digest = Tip5::hash(salted_output_utxos);
+            assert_eq!(sou_digest, salted_output_utxos_hash);
+
+            // iterate over all input UTXOs and collect the type script hashes
+            let mut type_script_hashes: Vec<Digest> = Vec::with_capacity(input_utxos.len());
+            let mut i = 0;
+            while i < input_utxos.len() {
+                let utxo: &Utxo = &input_utxos[i];
+
+                let mut j = 0;
+                while j < utxo.coins().len() {
+                    let coin: &Coin = &utxo.coins()[j];
+                    if !type_script_hashes.contains(&coin.type_script_hash) {
+                        type_script_hashes.push(coin.type_script_hash);
+                    }
+                    j += 1;
+                }
+
+                i += 1;
+            }
+
+            // iterate over all output UTXOs and collect the type script hashes
+            i = 0;
+            while i < output_utxos.len() {
+                let utxo: &Utxo = &output_utxos[i];
+
+                let mut j = 0;
+                while j < utxo.coins().len() {
+                    let coin: &Coin = &utxo.coins()[j];
+                    if !type_script_hashes.contains(&coin.type_script_hash) {
+                        type_script_hashes.push(coin.type_script_hash);
+                    }
+                    j += 1;
+                }
+
+                i += 1;
+            }
+
+            // output all type script hashes
+            i = 0;
+            while i < type_script_hashes.len() {
+                tasm::tasmlib_io_write_to_stdout___digest(type_script_hashes[i]);
+                i += 1;
+            }
+        }
+    }
 
     fn prop(primitive_witness: PrimitiveWitness) -> std::result::Result<(), TestCaseError> {
         let collect_type_scripts_witness = CollectTypeScriptsWitness::from(&primitive_witness);

--- a/src/models/blockchain/transaction/validity/kernel_to_outputs.rs
+++ b/src/models/blockchain/transaction/validity/kernel_to_outputs.rs
@@ -21,13 +21,9 @@ use crate::models::blockchain::transaction::primitive_witness::PrimitiveWitness;
 use crate::models::blockchain::transaction::primitive_witness::SaltedUtxos;
 use crate::models::blockchain::transaction::transaction_kernel::TransactionKernel;
 use crate::models::blockchain::transaction::transaction_kernel::TransactionKernelField;
-use crate::models::blockchain::transaction::utxo::Utxo;
 use crate::models::proof_abstractions::mast_hash::MastHash;
-use crate::models::proof_abstractions::tasm::builtins as tasmlib;
 use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
 use crate::models::proof_abstractions::SecretWitness;
-use crate::util_types::mutator_set::addition_record::AdditionRecord;
-use crate::util_types::mutator_set::commit;
 
 #[derive(
     Clone,
@@ -113,7 +109,13 @@ impl SecretWitness for KernelToOutputsWitness {
 pub struct KernelToOutputs;
 
 impl ConsensusProgram for KernelToOutputs {
+    #[cfg(test)]
     fn source(&self) {
+        use crate::models::blockchain::transaction::utxo::Utxo;
+        use crate::models::proof_abstractions::tasm::builtins as tasmlib;
+        use crate::util_types::mutator_set::addition_record::AdditionRecord;
+        use crate::util_types::mutator_set::commit;
+
         let txk_digest: Digest = tasmlib::tasmlib_io_read_stdin___digest();
         let start_address: BFieldElement = FIRST_NON_DETERMINISTICALLY_INITIALIZED_MEMORY_ADDRESS;
         let ktow: KernelToOutputsWitnessMemory = tasmlib::decode_from_memory(start_address);

--- a/src/models/blockchain/transaction/validity/kernel_to_outputs.rs
+++ b/src/models/blockchain/transaction/validity/kernel_to_outputs.rs
@@ -109,52 +109,6 @@ impl SecretWitness for KernelToOutputsWitness {
 pub struct KernelToOutputs;
 
 impl ConsensusProgram for KernelToOutputs {
-    #[cfg(test)]
-    fn source(&self) {
-        use crate::models::blockchain::transaction::utxo::Utxo;
-        use crate::models::proof_abstractions::tasm::builtins as tasmlib;
-        use crate::util_types::mutator_set::addition_record::AdditionRecord;
-        use crate::util_types::mutator_set::commit;
-
-        let txk_digest: Digest = tasmlib::tasmlib_io_read_stdin___digest();
-        let start_address: BFieldElement = FIRST_NON_DETERMINISTICALLY_INITIALIZED_MEMORY_ADDRESS;
-        let ktow: KernelToOutputsWitnessMemory = tasmlib::decode_from_memory(start_address);
-
-        // divine in the salted output UTXOs with hash
-        let salted_output_utxos: &SaltedUtxos = &ktow.output_utxos;
-        let output_utxos: &Vec<Utxo> = &salted_output_utxos.utxos;
-
-        // divine in the commitment randomness
-        let sender_randomnesses: &Vec<Digest> = &ktow.sender_randomnesses;
-        let receiver_digests: &Vec<Digest> = &ktow.receiver_digests;
-
-        // compute the canonical commitments (= addition records)
-        let mut addition_records: Vec<AdditionRecord> = Vec::with_capacity(output_utxos.len());
-        let mut i = 0;
-        while i < output_utxos.len() {
-            let addition_record: AdditionRecord = commit(
-                Hash::hash(&output_utxos[i]),
-                sender_randomnesses[i],
-                receiver_digests[i],
-            );
-            addition_records.push(addition_record);
-            i += 1;
-        }
-
-        // authenticate the addition records against the txk mast hash
-        let addition_records_hash: Digest = Hash::hash(&addition_records);
-        tasmlib::tasmlib_hashing_merkle_verify(
-            txk_digest,
-            TransactionKernelField::Outputs as u32,
-            addition_records_hash,
-            TransactionKernel::MAST_HEIGHT as u32,
-        );
-
-        // output hash of salted output UTXOs
-        let salted_output_utxos_hash: Digest = Hash::hash(salted_output_utxos);
-        tasmlib::tasmlib_io_write_to_stdout___digest(salted_output_utxos_hash);
-    }
-
     fn library_and_code(&self) -> (Library, Vec<LabelledInstruction>) {
         let mut library = Library::new();
 
@@ -346,13 +300,60 @@ mod test {
     use proptest::prop_assert_eq;
     use proptest::strategy::Strategy;
     use proptest::test_runner::TestRunner;
+    use tasm_lib::triton_vm;
     use test_strategy::proptest;
 
-    use super::KernelToOutputsWitness;
-    use crate::models::blockchain::transaction::primitive_witness::PrimitiveWitness;
-    use crate::models::blockchain::transaction::validity::kernel_to_outputs::KernelToOutputs;
-    use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
-    use crate::models::proof_abstractions::SecretWitness;
+    use super::*;
+    use crate::models::blockchain::transaction::utxo::Utxo;
+    use crate::models::proof_abstractions::tasm::builtins as tasm;
+    use crate::models::proof_abstractions::tasm::program::test::ConsensusProgramSpecification;
+    use crate::triton_vm::proof::Claim;
+    use crate::triton_vm::stark::Stark;
+    use crate::util_types::mutator_set::addition_record::AdditionRecord;
+    use crate::util_types::mutator_set::commit;
+
+    impl ConsensusProgramSpecification for KernelToOutputs {
+        fn source(&self) {
+            let txk_digest: Digest = tasm::tasmlib_io_read_stdin___digest();
+            let start_address: BFieldElement =
+                FIRST_NON_DETERMINISTICALLY_INITIALIZED_MEMORY_ADDRESS;
+            let ktow: KernelToOutputsWitnessMemory = tasm::decode_from_memory(start_address);
+
+            // divine in the salted output UTXOs with hash
+            let salted_output_utxos: &SaltedUtxos = &ktow.output_utxos;
+            let output_utxos: &Vec<Utxo> = &salted_output_utxos.utxos;
+
+            // divine in the commitment randomness
+            let sender_randomnesses: &Vec<Digest> = &ktow.sender_randomnesses;
+            let receiver_digests: &Vec<Digest> = &ktow.receiver_digests;
+
+            // compute the canonical commitments (= addition records)
+            let mut addition_records: Vec<AdditionRecord> = Vec::with_capacity(output_utxos.len());
+            let mut i = 0;
+            while i < output_utxos.len() {
+                let addition_record: AdditionRecord = commit(
+                    Hash::hash(&output_utxos[i]),
+                    sender_randomnesses[i],
+                    receiver_digests[i],
+                );
+                addition_records.push(addition_record);
+                i += 1;
+            }
+
+            // authenticate the addition records against the txk mast hash
+            let addition_records_hash: Digest = Hash::hash(&addition_records);
+            tasm::tasmlib_hashing_merkle_verify(
+                txk_digest,
+                TransactionKernelField::Outputs as u32,
+                addition_records_hash,
+                TransactionKernel::MAST_HEIGHT as u32,
+            );
+
+            // output hash of salted output UTXOs
+            let salted_output_utxos_hash: Digest = Hash::hash(salted_output_utxos);
+            tasm::tasmlib_io_write_to_stdout___digest(salted_output_utxos_hash);
+        }
+    }
 
     #[proptest(cases = 12)]
     fn kernel_to_outputs_proptest(
@@ -399,10 +400,6 @@ mod test {
 
         assert_eq!(kernel_to_outputs_witness.output(), tasm_result);
     }
-    use tasm_lib::triton_vm;
-
-    use crate::triton_vm::proof::Claim;
-    use crate::triton_vm::stark::Stark;
 
     #[test]
     fn kernel_to_outputs_failing_proof() {

--- a/src/models/blockchain/transaction/validity/proof_collection.rs
+++ b/src/models/blockchain/transaction/validity/proof_collection.rs
@@ -411,6 +411,7 @@ pub mod test {
     use test_strategy::proptest;
 
     use super::*;
+    use crate::models::proof_abstractions::tasm::program::test::ConsensusProgramSpecification;
 
     #[proptest(cases = 5)]
     fn can_produce_valid_collection(
@@ -423,7 +424,7 @@ pub mod test {
     impl ProofCollection {
         pub(crate) fn can_produce(primitive_witness: &PrimitiveWitness) -> bool {
             fn witness_halts_gracefully(
-                program: impl ConsensusProgram,
+                program: impl ConsensusProgramSpecification,
                 witness: impl SecretWitness,
             ) -> bool {
                 program

--- a/src/models/blockchain/transaction/validity/removal_records_integrity.rs
+++ b/src/models/blockchain/transaction/validity/removal_records_integrity.rs
@@ -360,112 +360,6 @@ impl RemovalRecordsIntegrityWitness {
 }
 
 impl ConsensusProgram for RemovalRecordsIntegrity {
-    #[cfg(test)]
-    fn source(&self) {
-        use strum::EnumCount;
-
-        use crate::models::blockchain::transaction::utxo::Utxo;
-        use crate::models::proof_abstractions::tasm::builtins as tasmlib;
-        use crate::util_types::mutator_set::addition_record::AdditionRecord;
-        use crate::util_types::mutator_set::commit;
-        use crate::util_types::mutator_set::get_swbf_indices;
-        use crate::util_types::mutator_set::removal_record::AbsoluteIndexSet;
-
-        let txk_digest: Digest = tasmlib::tasmlib_io_read_stdin___digest();
-
-        let start_address: BFieldElement = FIRST_NON_DETERMINISTICALLY_INITIALIZED_MEMORY_ADDRESS;
-        let rriw: RemovalRecordsIntegrityWitnessMemory = tasmlib::decode_from_memory(start_address);
-
-        // divine in the salted input UTXOs with hash
-        let salted_input_utxos: &SaltedUtxos = &rriw.input_utxos;
-        let input_utxos: &[Utxo] = &salted_input_utxos.utxos;
-
-        // divine in the mutator set accumulator
-        let aocl: MmrAccumulator = rriw.aocl;
-        let swbfi: MmrAccumulator = rriw.swbfi;
-
-        // authenticate the mutator set accumulator against the txk mast hash
-        let aocl_mmr_bagged: Digest = aocl.bag_peaks();
-        let inactive_swbf_bagged: Digest = swbfi.bag_peaks();
-        let left = Hash::hash_pair(aocl_mmr_bagged, inactive_swbf_bagged);
-        let active_swbf_digest: Digest = tasmlib::tasmlib_io_read_secin___digest();
-        let default = Digest::default();
-        let right = Hash::hash_pair(active_swbf_digest, default);
-        let msah: Digest = Hash::hash_pair(left, right);
-        tasmlib::tasmlib_hashing_merkle_verify(
-            txk_digest,
-            TransactionKernelField::MutatorSetHash as u32,
-            Hash::hash(&msah),
-            TransactionKernelField::COUNT.next_power_of_two().ilog2(),
-        );
-
-        // authenticate divined removal records against txk mast hash
-        let removal_records_digest: Digest = Hash::hash(&rriw.removal_records);
-        tasmlib::tasmlib_hashing_merkle_verify(
-            txk_digest,
-            TransactionKernelField::Inputs as u32,
-            removal_records_digest,
-            TransactionKernelField::COUNT.next_power_of_two().ilog2(),
-        );
-
-        // authenticate coinbase against kernel mast hash
-        let coinbase: Option<NativeCurrencyAmount> = rriw.coinbase;
-        let coinbase_leaf: Digest = Hash::hash(&coinbase);
-        tasmlib::tasmlib_hashing_merkle_verify(
-            txk_digest,
-            TransactionKernelField::Coinbase as u32,
-            coinbase_leaf,
-            TransactionKernelField::COUNT.next_power_of_two().ilog2(),
-        );
-
-        // Assert that a coinbase transaction has no inputs. This, combined with
-        // a potential future softfork requiring each block to have at least one
-        // input in its transaction, forces the miner to prove at least one
-        // execution of a `Merge` which removes any incentive to mine empty
-        // blocks. Mining empty blocks could otherwise be beneficial since it
-        // allows the miner to complete the proofs faster and get to the
-        // guessing part as soon as possible, to the detriment of the network.
-        assert!(coinbase.is_none() || input_utxos.is_empty());
-
-        // iterate over all input UTXOs
-        let mut input_index: usize = 0;
-        while input_index < input_utxos.len() {
-            let utxo: &Utxo = &input_utxos[input_index];
-            let utxo_hash = Hash::hash(utxo);
-            let claimed_absolute_indices: &AbsoluteIndexSet =
-                &rriw.removal_records[input_index].absolute_indices;
-
-            // verify AOCL membership
-            let aocl_leaf_index: u64 = tasmlib::tasmlib_io_read_secin___u64();
-            let receiver_preimage: Digest = tasmlib::tasmlib_io_read_secin___digest();
-            let sender_randomness: Digest = tasmlib::tasmlib_io_read_secin___digest();
-            let addition_record: AdditionRecord =
-                commit(utxo_hash, sender_randomness, receiver_preimage.hash());
-            assert!(tasmlib::mmr_verify_from_secret_in_leaf_index_on_stack(
-                &aocl.peaks(),
-                aocl.num_leafs(),
-                aocl_leaf_index,
-                addition_record.canonical_commitment,
-            ));
-
-            // calculate absolute index set
-            let index_set = get_swbf_indices(
-                utxo_hash,
-                sender_randomness,
-                receiver_preimage,
-                aocl_leaf_index,
-            );
-
-            assert_eq!(index_set, claimed_absolute_indices.to_array());
-
-            input_index += 1;
-        }
-
-        // compute and output hash of salted input UTXOs
-        let hash_of_inputs: Digest = Hash::hash(salted_input_utxos);
-        tasmlib::tasmlib_io_write_to_stdout___digest(hash_of_inputs);
-    }
-
     fn library_and_code(&self) -> (Library, Vec<LabelledInstruction>) {
         let mut library = Library::new();
 
@@ -1095,11 +989,119 @@ mod tests {
     use proptest::strategy::Strategy;
     use proptest::test_runner::TestCaseResult;
     use proptest::test_runner::TestRunner;
+    use strum::EnumCount;
     use tasm_lib::hashing::merkle_verify::MerkleVerify;
     use test_strategy::proptest;
 
     use super::*;
+    use crate::models::blockchain::transaction::utxo::Utxo;
     use crate::models::blockchain::transaction::TransactionKernelModifier;
+    use crate::models::proof_abstractions::tasm::builtins as tasm;
+    use crate::models::proof_abstractions::tasm::program::test::ConsensusProgramSpecification;
+    use crate::util_types::mutator_set::addition_record::AdditionRecord;
+    use crate::util_types::mutator_set::commit;
+    use crate::util_types::mutator_set::get_swbf_indices;
+    use crate::util_types::mutator_set::removal_record::AbsoluteIndexSet;
+
+    impl ConsensusProgramSpecification for RemovalRecordsIntegrity {
+        fn source(&self) {
+            let txk_digest: Digest = tasm::tasmlib_io_read_stdin___digest();
+
+            let start_address: BFieldElement =
+                FIRST_NON_DETERMINISTICALLY_INITIALIZED_MEMORY_ADDRESS;
+            let rriw: RemovalRecordsIntegrityWitnessMemory =
+                tasm::decode_from_memory(start_address);
+
+            // divine in the salted input UTXOs with hash
+            let salted_input_utxos: &SaltedUtxos = &rriw.input_utxos;
+            let input_utxos: &[Utxo] = &salted_input_utxos.utxos;
+
+            // divine in the mutator set accumulator
+            let aocl: MmrAccumulator = rriw.aocl;
+            let swbfi: MmrAccumulator = rriw.swbfi;
+
+            // authenticate the mutator set accumulator against the txk mast hash
+            let aocl_mmr_bagged: Digest = aocl.bag_peaks();
+            let inactive_swbf_bagged: Digest = swbfi.bag_peaks();
+            let left = Hash::hash_pair(aocl_mmr_bagged, inactive_swbf_bagged);
+            let active_swbf_digest: Digest = tasm::tasmlib_io_read_secin___digest();
+            let default = Digest::default();
+            let right = Hash::hash_pair(active_swbf_digest, default);
+            let msah: Digest = Hash::hash_pair(left, right);
+            tasm::tasmlib_hashing_merkle_verify(
+                txk_digest,
+                TransactionKernelField::MutatorSetHash as u32,
+                Hash::hash(&msah),
+                TransactionKernelField::COUNT.next_power_of_two().ilog2(),
+            );
+
+            // authenticate divined removal records against txk mast hash
+            let removal_records_digest: Digest = Hash::hash(&rriw.removal_records);
+            tasm::tasmlib_hashing_merkle_verify(
+                txk_digest,
+                TransactionKernelField::Inputs as u32,
+                removal_records_digest,
+                TransactionKernelField::COUNT.next_power_of_two().ilog2(),
+            );
+
+            // authenticate coinbase against kernel mast hash
+            let coinbase: Option<NativeCurrencyAmount> = rriw.coinbase;
+            let coinbase_leaf: Digest = Hash::hash(&coinbase);
+            tasm::tasmlib_hashing_merkle_verify(
+                txk_digest,
+                TransactionKernelField::Coinbase as u32,
+                coinbase_leaf,
+                TransactionKernelField::COUNT.next_power_of_two().ilog2(),
+            );
+
+            // Assert that a coinbase transaction has no inputs. This, combined with
+            // a potential future softfork requiring each block to have at least one
+            // input in its transaction, forces the miner to prove at least one
+            // execution of a `Merge` which removes any incentive to mine empty
+            // blocks. Mining empty blocks could otherwise be beneficial since it
+            // allows the miner to complete the proofs faster and get to the
+            // guessing part as soon as possible, to the detriment of the network.
+            assert!(coinbase.is_none() || input_utxos.is_empty());
+
+            // iterate over all input UTXOs
+            let mut input_index: usize = 0;
+            while input_index < input_utxos.len() {
+                let utxo: &Utxo = &input_utxos[input_index];
+                let utxo_hash = Hash::hash(utxo);
+                let claimed_absolute_indices: &AbsoluteIndexSet =
+                    &rriw.removal_records[input_index].absolute_indices;
+
+                // verify AOCL membership
+                let aocl_leaf_index: u64 = tasm::tasmlib_io_read_secin___u64();
+                let receiver_preimage: Digest = tasm::tasmlib_io_read_secin___digest();
+                let sender_randomness: Digest = tasm::tasmlib_io_read_secin___digest();
+                let addition_record: AdditionRecord =
+                    commit(utxo_hash, sender_randomness, receiver_preimage.hash());
+                assert!(tasm::mmr_verify_from_secret_in_leaf_index_on_stack(
+                    &aocl.peaks(),
+                    aocl.num_leafs(),
+                    aocl_leaf_index,
+                    addition_record.canonical_commitment,
+                ));
+
+                // calculate absolute index set
+                let index_set = get_swbf_indices(
+                    utxo_hash,
+                    sender_randomness,
+                    receiver_preimage,
+                    aocl_leaf_index,
+                );
+
+                assert_eq!(index_set, claimed_absolute_indices.to_array());
+
+                input_index += 1;
+            }
+
+            // compute and output hash of salted input UTXOs
+            let hash_of_inputs: Digest = Hash::hash(salted_input_utxos);
+            tasm::tasmlib_io_write_to_stdout___digest(hash_of_inputs);
+        }
+    }
 
     fn prop_positive(
         removal_records_integrity_witness: RemovalRecordsIntegrityWitness,

--- a/src/models/blockchain/transaction/validity/removal_records_integrity.rs
+++ b/src/models/blockchain/transaction/validity/removal_records_integrity.rs
@@ -10,7 +10,6 @@ use rand::RngCore;
 use rand::SeedableRng;
 use serde_derive::Deserialize;
 use serde_derive::Serialize;
-use strum::EnumCount;
 use tasm_lib::data_type::DataType;
 use tasm_lib::field;
 use tasm_lib::field_with_size;
@@ -37,18 +36,12 @@ use crate::models::blockchain::shared::Hash;
 use crate::models::blockchain::transaction::primitive_witness::SaltedUtxos;
 use crate::models::blockchain::transaction::transaction_kernel::TransactionKernel;
 use crate::models::blockchain::transaction::transaction_kernel::TransactionKernelField;
-use crate::models::blockchain::transaction::utxo::Utxo;
 use crate::models::blockchain::transaction::PrimitiveWitness;
 use crate::models::blockchain::type_scripts::native_currency_amount::NativeCurrencyAmount;
 use crate::models::proof_abstractions::mast_hash::MastHash;
-use crate::models::proof_abstractions::tasm::builtins as tasmlib;
 use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
 use crate::models::proof_abstractions::SecretWitness;
-use crate::util_types::mutator_set::addition_record::AdditionRecord;
-use crate::util_types::mutator_set::commit;
-use crate::util_types::mutator_set::get_swbf_indices;
 use crate::util_types::mutator_set::ms_membership_proof::MsMembershipProof;
-use crate::util_types::mutator_set::removal_record::AbsoluteIndexSet;
 use crate::util_types::mutator_set::removal_record::RemovalRecord;
 use crate::util_types::mutator_set::shared::NUM_TRIALS;
 use crate::util_types::mutator_set::shared::WINDOW_SIZE;
@@ -367,7 +360,17 @@ impl RemovalRecordsIntegrityWitness {
 }
 
 impl ConsensusProgram for RemovalRecordsIntegrity {
+    #[cfg(test)]
     fn source(&self) {
+        use strum::EnumCount;
+
+        use crate::models::blockchain::transaction::utxo::Utxo;
+        use crate::models::proof_abstractions::tasm::builtins as tasmlib;
+        use crate::util_types::mutator_set::addition_record::AdditionRecord;
+        use crate::util_types::mutator_set::commit;
+        use crate::util_types::mutator_set::get_swbf_indices;
+        use crate::util_types::mutator_set::removal_record::AbsoluteIndexSet;
+
         let txk_digest: Digest = tasmlib::tasmlib_io_read_stdin___digest();
 
         let start_address: BFieldElement = FIRST_NON_DETERMINISTICALLY_INITIALIZED_MEMORY_ADDRESS;
@@ -972,9 +975,14 @@ pub mod neptune_arbitrary {
     use super::*;
     use crate::models::blockchain::transaction::transaction_kernel::TransactionKernelModifier;
     use crate::models::blockchain::transaction::transaction_kernel::TransactionKernelProxy;
+    use crate::models::blockchain::transaction::utxo::Utxo;
+    use crate::util_types::mutator_set::addition_record::AdditionRecord;
+    use crate::util_types::mutator_set::commit;
+    use crate::util_types::mutator_set::get_swbf_indices;
+    use crate::util_types::mutator_set::removal_record::AbsoluteIndexSet;
 
     impl<'a> Arbitrary<'a> for RemovalRecordsIntegrityWitness {
-        fn arbitrary(u: &mut ::arbitrary::Unstructured<'a>) -> ::arbitrary::Result<Self> {
+        fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
             let num_inputs = u.int_in_range(1..=3usize)?;
             let _num_outputs = u.int_in_range(1..=3usize)?;
             let _num_public_announcements = u.int_in_range(0..=2usize)?;

--- a/src/models/blockchain/transaction/validity/single_proof.rs
+++ b/src/models/blockchain/transaction/validity/single_proof.rs
@@ -255,73 +255,6 @@ impl SingleProof {
 }
 
 impl ConsensusProgram for SingleProof {
-    #[cfg(test)]
-    fn source(&self) {
-        use crate::models::proof_abstractions::tasm::builtins as tasmlib;
-
-        let stark: Stark = Stark::default();
-        let own_program_digest: Digest = tasmlib::own_program_digest();
-        let txk_digest: Digest = tasmlib::tasmlib_io_read_stdin___digest();
-
-        match tasmlib::decode_from_memory(FIRST_NON_DETERMINISTICALLY_INITIALIZED_MEMORY_ADDRESS) {
-            SingleProofWitness::Collection(pc) => {
-                assert_eq!(txk_digest, pc.kernel_mast_hash);
-
-                let claimed_merge_bit = false;
-                tasmlib::tasmlib_hashing_merkle_verify(
-                    txk_digest,
-                    TransactionKernelField::MergeBit as u32,
-                    Tip5::hash(&claimed_merge_bit),
-                    TransactionKernel::MAST_HEIGHT as u32,
-                );
-
-                let removal_records_integrity_claim: Claim = pc.removal_records_integrity_claim();
-                tasmlib::verify_stark(
-                    stark,
-                    &removal_records_integrity_claim,
-                    &pc.removal_records_integrity,
-                );
-
-                let kernel_to_outputs_claim: Claim = pc.kernel_to_outputs_claim();
-                tasmlib::verify_stark(stark, &kernel_to_outputs_claim, &pc.kernel_to_outputs);
-
-                let collect_lock_scripts_claim: Claim = pc.collect_lock_scripts_claim();
-                tasmlib::verify_stark(stark, &collect_lock_scripts_claim, &pc.collect_lock_scripts);
-
-                let collect_type_scripts_claim: Claim = pc.collect_type_scripts_claim();
-                tasmlib::verify_stark(stark, &collect_type_scripts_claim, &pc.collect_type_scripts);
-
-                let mut i = 0;
-                let lock_script_claims: Vec<Claim> = pc.lock_script_claims();
-                assert_eq!(lock_script_claims.len(), pc.lock_script_hashes.len());
-                while i < pc.lock_script_hashes.len() {
-                    let claim: &Claim = &lock_script_claims[i];
-                    let lock_script_halts_proof: &Proof = &pc.lock_scripts_halt[i];
-                    tasmlib::verify_stark(stark, claim, lock_script_halts_proof);
-
-                    i += 1;
-                }
-
-                i = 0;
-                let type_script_claims = pc.type_script_claims();
-                assert_eq!(type_script_claims.len(), pc.type_script_hashes.len());
-                while i < pc.type_script_hashes.len() {
-                    let claim: &Claim = &type_script_claims[i];
-                    let type_script_halts_proof: &Proof = &pc.type_scripts_halt[i];
-                    tasmlib::verify_stark(stark, claim, type_script_halts_proof);
-                    i += 1;
-                }
-            }
-            SingleProofWitness::Update(witness) => {
-                debug_assert_eq!(txk_digest, witness.new_kernel_mast_hash);
-                witness.branch_source(own_program_digest, txk_digest);
-            }
-            SingleProofWitness::Merger(witness) => {
-                witness.branch_source(own_program_digest, txk_digest)
-            }
-        }
-    }
-
     fn library_and_code(&self) -> (Library, Vec<LabelledInstruction>) {
         let mut library = Library::new();
 
@@ -750,9 +683,85 @@ mod test {
     use crate::models::blockchain::transaction::validity::tasm::single_proof::merge_branch::test::deterministic_merge_witness;
     use crate::models::blockchain::transaction::validity::tasm::single_proof::update_branch::test::deterministic_update_witness_only_additions;
     use crate::models::blockchain::type_scripts::time_lock::neptune_arbitrary::arbitrary_primitive_witness_with_expired_timelocks;
+    use crate::models::proof_abstractions::tasm::builtins as tasm;
+    use crate::models::proof_abstractions::tasm::program::test::ConsensusProgramSpecification;
     use crate::models::proof_abstractions::tasm::program::ConsensusError;
-    use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
     use crate::models::proof_abstractions::timestamp::Timestamp;
+
+    impl ConsensusProgramSpecification for SingleProof {
+        fn source(&self) {
+            let stark: Stark = Stark::default();
+            let own_program_digest: Digest = tasm::own_program_digest();
+            let txk_digest: Digest = tasm::tasmlib_io_read_stdin___digest();
+
+            match tasm::decode_from_memory(FIRST_NON_DETERMINISTICALLY_INITIALIZED_MEMORY_ADDRESS) {
+                SingleProofWitness::Collection(pc) => {
+                    assert_eq!(txk_digest, pc.kernel_mast_hash);
+
+                    let claimed_merge_bit = false;
+                    tasm::tasmlib_hashing_merkle_verify(
+                        txk_digest,
+                        TransactionKernelField::MergeBit as u32,
+                        Tip5::hash(&claimed_merge_bit),
+                        TransactionKernel::MAST_HEIGHT as u32,
+                    );
+
+                    let removal_records_integrity_claim: Claim =
+                        pc.removal_records_integrity_claim();
+                    tasm::verify_stark(
+                        stark,
+                        &removal_records_integrity_claim,
+                        &pc.removal_records_integrity,
+                    );
+
+                    let kernel_to_outputs_claim: Claim = pc.kernel_to_outputs_claim();
+                    tasm::verify_stark(stark, &kernel_to_outputs_claim, &pc.kernel_to_outputs);
+
+                    let collect_lock_scripts_claim: Claim = pc.collect_lock_scripts_claim();
+                    tasm::verify_stark(
+                        stark,
+                        &collect_lock_scripts_claim,
+                        &pc.collect_lock_scripts,
+                    );
+
+                    let collect_type_scripts_claim: Claim = pc.collect_type_scripts_claim();
+                    tasm::verify_stark(
+                        stark,
+                        &collect_type_scripts_claim,
+                        &pc.collect_type_scripts,
+                    );
+
+                    let mut i = 0;
+                    let lock_script_claims: Vec<Claim> = pc.lock_script_claims();
+                    assert_eq!(lock_script_claims.len(), pc.lock_script_hashes.len());
+                    while i < pc.lock_script_hashes.len() {
+                        let claim: &Claim = &lock_script_claims[i];
+                        let lock_script_halts_proof: &Proof = &pc.lock_scripts_halt[i];
+                        tasm::verify_stark(stark, claim, lock_script_halts_proof);
+
+                        i += 1;
+                    }
+
+                    i = 0;
+                    let type_script_claims = pc.type_script_claims();
+                    assert_eq!(type_script_claims.len(), pc.type_script_hashes.len());
+                    while i < pc.type_script_hashes.len() {
+                        let claim: &Claim = &type_script_claims[i];
+                        let type_script_halts_proof: &Proof = &pc.type_scripts_halt[i];
+                        tasm::verify_stark(stark, claim, type_script_halts_proof);
+                        i += 1;
+                    }
+                }
+                SingleProofWitness::Update(witness) => {
+                    debug_assert_eq!(txk_digest, witness.new_kernel_mast_hash);
+                    witness.branch_source(own_program_digest, txk_digest);
+                }
+                SingleProofWitness::Merger(witness) => {
+                    witness.branch_source(own_program_digest, txk_digest)
+                }
+            }
+        }
+    }
 
     impl SingleProofWitness {
         pub(crate) fn into_update(self) -> UpdateWitness {

--- a/src/models/blockchain/transaction/validity/single_proof.rs
+++ b/src/models/blockchain/transaction/validity/single_proof.rs
@@ -28,7 +28,6 @@ use crate::models::blockchain::transaction::validity::tasm::claims::generate_typ
 use crate::models::blockchain::transaction::validity::tasm::claims::generate_rri_claim::GenerateRriClaim;
 use crate::models::blockchain::transaction::Claim;
 use crate::models::proof_abstractions::mast_hash::MastHash;
-use crate::models::proof_abstractions::tasm::builtins as tasmlib;
 use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
 use crate::job_queue::triton_vm::TritonVmJobQueue;
 use crate::models::proof_abstractions::SecretWitness;
@@ -256,7 +255,10 @@ impl SingleProof {
 }
 
 impl ConsensusProgram for SingleProof {
+    #[cfg(test)]
     fn source(&self) {
+        use crate::models::proof_abstractions::tasm::builtins as tasmlib;
+
         let stark: Stark = Stark::default();
         let own_program_digest: Digest = tasmlib::own_program_digest();
         let txk_digest: Digest = tasmlib::tasmlib_io_read_stdin___digest();

--- a/src/models/blockchain/transaction/validity/single_proof.rs
+++ b/src/models/blockchain/transaction/validity/single_proof.rs
@@ -965,7 +965,6 @@ mod test {
 
         use crate::models::blockchain::transaction::transaction_kernel::TransactionKernelModifier;
         use crate::models::blockchain::transaction::validity::tasm::single_proof::update_branch::test::deterministic_update_witness_additions_and_removals;
-        use crate::models::proof_abstractions::tasm::program::test::consensus_program_negative_test;
         use crate::util_types::test_shared::mutator_set::pseudorandom_removal_record;
 
         use super::*;
@@ -1025,12 +1024,12 @@ mod test {
             let claim = bad_witness.claim();
             let input = PublicInput::new(claim.input.clone());
             let nondeterminism = bad_witness.nondeterminism();
-            consensus_program_negative_test(
-                SingleProof,
-                &input,
+            let test_result = SingleProof.test_assertion_failure(
+                input,
                 nondeterminism,
                 &[UpdateBranch::NEW_TIMESTAMP_NOT_GEQ_THAN_OLD_ERROR],
             );
+            test_result.unwrap();
         }
 
         fn bad_new_aocl(good_witness: &UpdateWitness) {
@@ -1052,12 +1051,12 @@ mod test {
                 FIRST_NON_DETERMINISTICALLY_INITIALIZED_MEMORY_ADDRESS,
                 &witness_again,
             );
-            consensus_program_negative_test(
-                SingleProof,
-                &input,
+            let test_result = SingleProof.test_assertion_failure(
+                input,
                 nondeterminism,
                 &[MerkleVerify::ROOT_MISMATCH_ERROR_ID],
             );
+            test_result.unwrap();
         }
 
         fn bad_old_aocl(good_witness: &UpdateWitness) {
@@ -1079,12 +1078,12 @@ mod test {
                 FIRST_NON_DETERMINISTICALLY_INITIALIZED_MEMORY_ADDRESS,
                 &witness_again,
             );
-            consensus_program_negative_test(
-                SingleProof,
-                &input,
+            let test_result = SingleProof.test_assertion_failure(
+                input,
                 nondeterminism,
                 &[MerkleVerify::ROOT_MISMATCH_ERROR_ID],
             );
+            test_result.unwrap();
         }
 
         fn bad_absolute_index_set_value(good_witness: &UpdateWitness) {
@@ -1104,12 +1103,12 @@ mod test {
             let claim = bad_witness.claim();
             let input = PublicInput::new(claim.input.clone());
             let nondeterminism = bad_witness.nondeterminism();
-            consensus_program_negative_test(
-                SingleProof,
-                &input,
+            let test_result = SingleProof.test_assertion_failure(
+                input,
                 nondeterminism,
                 &[UpdateBranch::INPUT_SETS_NOT_EQUAL_ERROR],
             );
+            test_result.unwrap();
         }
 
         fn bad_absolute_index_set_length_too_short(good_witness: &UpdateWitness) {
@@ -1126,12 +1125,12 @@ mod test {
             let claim = bad_witness.claim();
             let input = PublicInput::new(claim.input.clone());
             let nondeterminism = bad_witness.nondeterminism();
-            consensus_program_negative_test(
-                SingleProof,
-                &input,
+            let test_result = SingleProof.test_assertion_failure(
+                input,
                 nondeterminism,
                 &[UpdateBranch::INPUT_SETS_NOT_EQUAL_ERROR],
             );
+            test_result.unwrap();
         }
 
         fn bad_absolute_index_set_length_too_long(good_witness: &UpdateWitness) {
@@ -1150,12 +1149,12 @@ mod test {
             let claim = bad_witness.claim();
             let input = PublicInput::new(claim.input.clone());
             let nondeterminism = bad_witness.nondeterminism();
-            consensus_program_negative_test(
-                SingleProof,
-                &input,
+            let test_result = SingleProof.test_assertion_failure(
+                input,
                 nondeterminism,
                 &[UpdateBranch::INPUT_SETS_NOT_EQUAL_ERROR],
             );
+            test_result.unwrap();
         }
 
         #[tokio::test]

--- a/src/models/blockchain/transaction/validity/tasm/single_proof/merge_branch.rs
+++ b/src/models/blockchain/transaction/validity/tasm/single_proof/merge_branch.rs
@@ -4,11 +4,9 @@ use std::cmp::max;
 
 use authenticate_coinbase_fields::AuthenticateCoinbaseFields;
 use itertools::Itertools;
-use num_traits::CheckedAdd;
 use rand::prelude::SliceRandom;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
-use strum::EnumCount;
 use tasm_lib::data_type::DataType;
 use tasm_lib::field;
 use tasm_lib::field_with_size;
@@ -39,12 +37,10 @@ use crate::models::blockchain::transaction::TransactionKernel;
 use crate::models::blockchain::transaction::TransactionKernelProxy;
 use crate::models::blockchain::type_scripts::native_currency_amount::NativeCurrencyAmount;
 use crate::models::proof_abstractions::mast_hash::MastHash;
-use crate::models::proof_abstractions::tasm::builtins as tasmlib;
 use crate::models::proof_abstractions::timestamp::Timestamp;
 use crate::prelude::triton_vm::prelude::triton_asm;
 use crate::triton_vm::prelude::NonDeterminism;
 use crate::util_types::mutator_set::addition_record::AdditionRecord;
-use crate::util_types::mutator_set::removal_record::RemovalRecord;
 
 // Dictated by the witness type of SingleProof
 const MERGE_WITNESS_ADDRESS: BFieldElement = BFieldElement::new(2);
@@ -185,11 +181,18 @@ impl MergeWitness {
         nondeterminism.digests.extend(digests);
     }
 
+    #[cfg(test)]
     pub(crate) fn branch_source(
         &self,
         single_proof_program_digest: Digest,
         new_txk_digest: Digest,
     ) {
+        use num_traits::CheckedAdd;
+        use strum::EnumCount;
+
+        use crate::models::proof_abstractions::tasm::builtins as tasmlib;
+        use crate::util_types::mutator_set::removal_record::RemovalRecord;
+
         // divine the witness for this proof
         let mw = tasmlib::decode_from_memory::<MergeWitness>(MERGE_WITNESS_ADDRESS);
 

--- a/src/models/blockchain/transaction/validity/tasm/single_proof/update_branch.rs
+++ b/src/models/blockchain/transaction/validity/tasm/single_proof/update_branch.rs
@@ -155,202 +155,6 @@ impl UpdateWitness {
             .individual_tokens
             .extend_from_slice(&self.old_kernel.merge_bit.encode());
     }
-
-    #[cfg(test)]
-    pub(crate) fn branch_source(
-        &self,
-        single_proof_program_digest: Digest,
-        new_txk_digest: Digest,
-    ) {
-        use strum::EnumCount;
-
-        use crate::models::proof_abstractions::tasm::builtins as tasmlib;
-        use crate::models::proof_abstractions::timestamp::Timestamp;
-
-        // divine the witness for this proof
-        let uw: UpdateWitness = tasmlib::decode_from_memory(UPDATE_WITNESS_ADDRESS);
-
-        // get the kernel of the out-of-date transaction
-        let old_txk_digest: Digest = uw.old_kernel_mast_hash;
-        let old_txk_digest_as_input: Vec<BFieldElement> =
-            old_txk_digest.reversed().values().to_vec();
-
-        // verify the proof of the out-of-date transaction
-        let claim: Claim =
-            Claim::new(single_proof_program_digest).with_input(old_txk_digest_as_input);
-        let proof: &Proof = &uw.old_proof;
-        tasmlib::verify_stark(Stark::default(), &claim, proof);
-
-        // authenticate the new mutator set accumulator against the txk mast hash
-        let new_aocl_mmr: MmrAccumulator = uw.new_aocl;
-        let new_aocl_mmr_bagged = new_aocl_mmr.bag_peaks();
-        let new_inactive_swbf_bagged: Digest = uw.new_swbfi_bagged;
-        let new_left: Digest = Hash::hash_pair(new_aocl_mmr_bagged, new_inactive_swbf_bagged);
-        let new_active_swbf_digest: Digest = uw.new_swbfa_hash;
-        let default: Digest = Digest::default();
-        let new_right: Digest = Hash::hash_pair(new_active_swbf_digest, default);
-        let new_msah: Digest = Hash::hash_pair(new_left, new_right);
-        tasmlib::tasmlib_hashing_merkle_verify(
-            new_txk_digest,
-            TransactionKernelField::MutatorSetHash as u32,
-            Hash::hash(&new_msah),
-            TransactionKernelField::COUNT.next_power_of_two().ilog2(),
-        );
-
-        // authenticate the old mutator set accumulator against the txk mast hash
-        let old_aocl_mmr: MmrAccumulator = uw.old_aocl;
-        let old_aocl_mmr_bagged = old_aocl_mmr.bag_peaks();
-        let old_inactive_swbf_bagged: Digest = uw.old_swbfi_bagged;
-        let old_left: Digest = Hash::hash_pair(old_aocl_mmr_bagged, old_inactive_swbf_bagged);
-        let old_active_swbf_digest: Digest = uw.old_swbfa_hash;
-        let old_right: Digest = Hash::hash_pair(old_active_swbf_digest, default);
-        let old_msah: Digest = Hash::hash_pair(old_left, old_right);
-        tasmlib::tasmlib_hashing_merkle_verify(
-            old_txk_digest,
-            TransactionKernelField::MutatorSetHash as u32,
-            Hash::hash(&old_msah),
-            TransactionKernelField::COUNT.next_power_of_two().ilog2(),
-        );
-
-        // mutator set can change, but we only care about extensions of the AOCL MMR
-        tasmlib::verify_mmr_successor_proof(&old_aocl_mmr, &new_aocl_mmr, &uw.aocl_successor_proof);
-
-        // verify update ...
-
-        // authenticate inputs
-        let old_inputs = &uw.old_kernel.inputs;
-        let new_inputs = &uw.new_kernel.inputs;
-        let old_inputs_hash: Digest = Hash::hash(old_inputs);
-        let new_inputs_hash: Digest = Hash::hash(new_inputs);
-        tasmlib::tasmlib_hashing_merkle_verify(
-            old_txk_digest,
-            TransactionKernelField::Inputs as u32,
-            old_inputs_hash,
-            TransactionKernelField::COUNT.next_power_of_two().ilog2(),
-        );
-        tasmlib::tasmlib_hashing_merkle_verify(
-            new_txk_digest,
-            TransactionKernelField::Inputs as u32,
-            new_inputs_hash,
-            TransactionKernelField::COUNT.next_power_of_two().ilog2(),
-        );
-
-        // inputs' index sets are identical
-        let mut old_index_set_digests: Vec<Digest> = Vec::new();
-        let mut new_index_set_digests: Vec<Digest> = Vec::new();
-        assert_eq!(old_inputs.len(), new_inputs.len());
-        let mut i: usize = 0;
-        while i < old_inputs.len() {
-            old_index_set_digests.push(Hash::hash(&old_inputs[i].absolute_indices));
-            new_index_set_digests.push(Hash::hash(&new_inputs[i].absolute_indices));
-            i += 1;
-        }
-        old_index_set_digests.sort();
-        new_index_set_digests.sort();
-        assert_eq!(old_index_set_digests, new_index_set_digests);
-
-        // outputs are identical
-        let outputs_hash: Digest = uw.outputs_hash;
-        tasmlib::tasmlib_hashing_merkle_verify(
-            old_txk_digest,
-            TransactionKernelField::Outputs as u32,
-            outputs_hash,
-            TransactionKernel::MAST_HEIGHT as u32,
-        );
-        tasmlib::tasmlib_hashing_merkle_verify(
-            new_txk_digest,
-            TransactionKernelField::Outputs as u32,
-            outputs_hash,
-            TransactionKernel::MAST_HEIGHT as u32,
-        );
-
-        // public announcements are identical
-        let public_announcements_hash: Digest = uw.public_announcements_hash;
-        tasmlib::tasmlib_hashing_merkle_verify(
-            old_txk_digest,
-            TransactionKernelField::PublicAnnouncements as u32,
-            public_announcements_hash,
-            TransactionKernel::MAST_HEIGHT as u32,
-        );
-        tasmlib::tasmlib_hashing_merkle_verify(
-            new_txk_digest,
-            TransactionKernelField::PublicAnnouncements as u32,
-            public_announcements_hash,
-            TransactionKernel::MAST_HEIGHT as u32,
-        );
-
-        // fees are identical
-        let fee_hash: Digest = Hash::hash(&uw.new_kernel.fee);
-        tasmlib::tasmlib_hashing_merkle_verify(
-            old_txk_digest,
-            TransactionKernelField::Fee as u32,
-            fee_hash,
-            TransactionKernel::MAST_HEIGHT as u32,
-        );
-        tasmlib::tasmlib_hashing_merkle_verify(
-            new_txk_digest,
-            TransactionKernelField::Fee as u32,
-            fee_hash,
-            TransactionKernel::MAST_HEIGHT as u32,
-        );
-
-        // coinbases is both transaction is `None`
-        let coinbase: Option<NativeCurrencyAmount> = None;
-        let coinbase_hash: Digest = Tip5::hash(&coinbase);
-        tasmlib::tasmlib_hashing_merkle_verify(
-            old_txk_digest,
-            TransactionKernelField::Coinbase as u32,
-            coinbase_hash,
-            TransactionKernel::MAST_HEIGHT as u32,
-        );
-        tasmlib::tasmlib_hashing_merkle_verify(
-            new_txk_digest,
-            TransactionKernelField::Coinbase as u32,
-            coinbase_hash,
-            TransactionKernel::MAST_HEIGHT as u32,
-        );
-
-        // timestamp increases or no change
-        let new_timestamp: Timestamp = uw.new_kernel.timestamp;
-        let new_timestamp_hash: Digest = Hash::hash(&new_timestamp);
-        let old_timestamp: Timestamp = uw.old_kernel.timestamp;
-        let old_timestamp_hash: Digest = Hash::hash(&old_timestamp);
-        tasmlib::tasmlib_hashing_merkle_verify(
-            old_txk_digest,
-            TransactionKernelField::Timestamp as u32,
-            old_timestamp_hash,
-            TransactionKernel::MAST_HEIGHT as u32,
-        );
-        tasmlib::tasmlib_hashing_merkle_verify(
-            new_txk_digest,
-            TransactionKernelField::Timestamp as u32,
-            new_timestamp_hash,
-            TransactionKernel::MAST_HEIGHT as u32,
-        );
-        assert!(new_timestamp >= old_timestamp);
-
-        // merge bit unchanged
-        let merge_bit: BFieldElement = tasmlib::tasmlib_io_read_secin___bfe();
-
-        // May God have mercy upon my soul
-        assert!(merge_bit.value() == 0 || merge_bit.value() == 1);
-        let merge_bit: bool = merge_bit.value() != 0;
-
-        let merge_bit_leaf = Tip5::hash(&merge_bit);
-
-        tasmlib::tasmlib_hashing_merkle_verify(
-            old_txk_digest,
-            TransactionKernelField::MergeBit as u32,
-            merge_bit_leaf,
-            TransactionKernel::MAST_HEIGHT as u32,
-        );
-        tasmlib::tasmlib_hashing_merkle_verify(
-            new_txk_digest,
-            TransactionKernelField::MergeBit as u32,
-            merge_bit_leaf,
-            TransactionKernel::MAST_HEIGHT as u32,
-        );
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -834,14 +638,13 @@ impl BasicSnippet for UpdateBranch {
 
 #[cfg(test)]
 pub(crate) mod test {
-    use itertools::Itertools;
     use proptest::collection::vec;
     use proptest::strategy::Strategy;
     use proptest::strategy::ValueTree;
     use proptest::test_runner::TestRunner;
     use proptest_arbitrary_interop::arb;
+    use strum::EnumCount;
     use tasm_lib::triton_vm::prelude::*;
-    use tasm_lib::twenty_first::util_types::mmr::mmr_successor_proof::MmrSuccessorProof;
 
     use super::*;
     use crate::job_queue::triton_vm::TritonVmJobPriority;
@@ -850,10 +653,203 @@ pub(crate) mod test {
     use crate::models::blockchain::transaction::PrimitiveWitness;
     use crate::models::blockchain::transaction::Transaction;
     use crate::models::blockchain::transaction::TransactionKernelModifier;
+    use crate::models::proof_abstractions::tasm::builtins as tasm;
     use crate::models::proof_abstractions::timestamp::Timestamp;
     use crate::util_types::mutator_set::addition_record::AdditionRecord;
 
     // The main tests are actually in [`../../single_proof.rs`].
+
+    impl UpdateWitness {
+        pub fn branch_source(&self, single_proof_program_digest: Digest, new_txk_digest: Digest) {
+            // divine the witness for this proof
+            let uw: UpdateWitness = tasm::decode_from_memory(UPDATE_WITNESS_ADDRESS);
+
+            // get the kernel of the out-of-date transaction
+            let old_txk_digest: Digest = uw.old_kernel_mast_hash;
+            let old_txk_digest_as_input: Vec<BFieldElement> =
+                old_txk_digest.reversed().values().to_vec();
+
+            // verify the proof of the out-of-date transaction
+            let claim: Claim =
+                Claim::new(single_proof_program_digest).with_input(old_txk_digest_as_input);
+            let proof: &Proof = &uw.old_proof;
+            tasm::verify_stark(Stark::default(), &claim, proof);
+
+            // authenticate the new mutator set accumulator against the txk mast hash
+            let new_aocl_mmr: MmrAccumulator = uw.new_aocl;
+            let new_aocl_mmr_bagged = new_aocl_mmr.bag_peaks();
+            let new_inactive_swbf_bagged: Digest = uw.new_swbfi_bagged;
+            let new_left: Digest = Hash::hash_pair(new_aocl_mmr_bagged, new_inactive_swbf_bagged);
+            let new_active_swbf_digest: Digest = uw.new_swbfa_hash;
+            let default: Digest = Digest::default();
+            let new_right: Digest = Hash::hash_pair(new_active_swbf_digest, default);
+            let new_msah: Digest = Hash::hash_pair(new_left, new_right);
+            tasm::tasmlib_hashing_merkle_verify(
+                new_txk_digest,
+                TransactionKernelField::MutatorSetHash as u32,
+                Hash::hash(&new_msah),
+                TransactionKernelField::COUNT.next_power_of_two().ilog2(),
+            );
+
+            // authenticate the old mutator set accumulator against the txk mast hash
+            let old_aocl_mmr: MmrAccumulator = uw.old_aocl;
+            let old_aocl_mmr_bagged = old_aocl_mmr.bag_peaks();
+            let old_inactive_swbf_bagged: Digest = uw.old_swbfi_bagged;
+            let old_left: Digest = Hash::hash_pair(old_aocl_mmr_bagged, old_inactive_swbf_bagged);
+            let old_active_swbf_digest: Digest = uw.old_swbfa_hash;
+            let old_right: Digest = Hash::hash_pair(old_active_swbf_digest, default);
+            let old_msah: Digest = Hash::hash_pair(old_left, old_right);
+            tasm::tasmlib_hashing_merkle_verify(
+                old_txk_digest,
+                TransactionKernelField::MutatorSetHash as u32,
+                Hash::hash(&old_msah),
+                TransactionKernelField::COUNT.next_power_of_two().ilog2(),
+            );
+
+            // mutator set can change, but we only care about extensions of the AOCL MMR
+            tasm::verify_mmr_successor_proof(
+                &old_aocl_mmr,
+                &new_aocl_mmr,
+                &uw.aocl_successor_proof,
+            );
+
+            // verify update ...
+
+            // authenticate inputs
+            let old_inputs = &uw.old_kernel.inputs;
+            let new_inputs = &uw.new_kernel.inputs;
+            let old_inputs_hash: Digest = Hash::hash(old_inputs);
+            let new_inputs_hash: Digest = Hash::hash(new_inputs);
+            tasm::tasmlib_hashing_merkle_verify(
+                old_txk_digest,
+                TransactionKernelField::Inputs as u32,
+                old_inputs_hash,
+                TransactionKernelField::COUNT.next_power_of_two().ilog2(),
+            );
+            tasm::tasmlib_hashing_merkle_verify(
+                new_txk_digest,
+                TransactionKernelField::Inputs as u32,
+                new_inputs_hash,
+                TransactionKernelField::COUNT.next_power_of_two().ilog2(),
+            );
+
+            // inputs' index sets are identical
+            let mut old_index_set_digests: Vec<Digest> = Vec::new();
+            let mut new_index_set_digests: Vec<Digest> = Vec::new();
+            assert_eq!(old_inputs.len(), new_inputs.len());
+            let mut i: usize = 0;
+            while i < old_inputs.len() {
+                old_index_set_digests.push(Hash::hash(&old_inputs[i].absolute_indices));
+                new_index_set_digests.push(Hash::hash(&new_inputs[i].absolute_indices));
+                i += 1;
+            }
+            old_index_set_digests.sort();
+            new_index_set_digests.sort();
+            assert_eq!(old_index_set_digests, new_index_set_digests);
+
+            // outputs are identical
+            let outputs_hash: Digest = uw.outputs_hash;
+            tasm::tasmlib_hashing_merkle_verify(
+                old_txk_digest,
+                TransactionKernelField::Outputs as u32,
+                outputs_hash,
+                TransactionKernel::MAST_HEIGHT as u32,
+            );
+            tasm::tasmlib_hashing_merkle_verify(
+                new_txk_digest,
+                TransactionKernelField::Outputs as u32,
+                outputs_hash,
+                TransactionKernel::MAST_HEIGHT as u32,
+            );
+
+            // public announcements are identical
+            let public_announcements_hash: Digest = uw.public_announcements_hash;
+            tasm::tasmlib_hashing_merkle_verify(
+                old_txk_digest,
+                TransactionKernelField::PublicAnnouncements as u32,
+                public_announcements_hash,
+                TransactionKernel::MAST_HEIGHT as u32,
+            );
+            tasm::tasmlib_hashing_merkle_verify(
+                new_txk_digest,
+                TransactionKernelField::PublicAnnouncements as u32,
+                public_announcements_hash,
+                TransactionKernel::MAST_HEIGHT as u32,
+            );
+
+            // fees are identical
+            let fee_hash: Digest = Hash::hash(&uw.new_kernel.fee);
+            tasm::tasmlib_hashing_merkle_verify(
+                old_txk_digest,
+                TransactionKernelField::Fee as u32,
+                fee_hash,
+                TransactionKernel::MAST_HEIGHT as u32,
+            );
+            tasm::tasmlib_hashing_merkle_verify(
+                new_txk_digest,
+                TransactionKernelField::Fee as u32,
+                fee_hash,
+                TransactionKernel::MAST_HEIGHT as u32,
+            );
+
+            // coinbases is both transaction is `None`
+            let coinbase: Option<NativeCurrencyAmount> = None;
+            let coinbase_hash: Digest = Tip5::hash(&coinbase);
+            tasm::tasmlib_hashing_merkle_verify(
+                old_txk_digest,
+                TransactionKernelField::Coinbase as u32,
+                coinbase_hash,
+                TransactionKernel::MAST_HEIGHT as u32,
+            );
+            tasm::tasmlib_hashing_merkle_verify(
+                new_txk_digest,
+                TransactionKernelField::Coinbase as u32,
+                coinbase_hash,
+                TransactionKernel::MAST_HEIGHT as u32,
+            );
+
+            // timestamp increases or no change
+            let new_timestamp: Timestamp = uw.new_kernel.timestamp;
+            let new_timestamp_hash: Digest = Hash::hash(&new_timestamp);
+            let old_timestamp: Timestamp = uw.old_kernel.timestamp;
+            let old_timestamp_hash: Digest = Hash::hash(&old_timestamp);
+            tasm::tasmlib_hashing_merkle_verify(
+                old_txk_digest,
+                TransactionKernelField::Timestamp as u32,
+                old_timestamp_hash,
+                TransactionKernel::MAST_HEIGHT as u32,
+            );
+            tasm::tasmlib_hashing_merkle_verify(
+                new_txk_digest,
+                TransactionKernelField::Timestamp as u32,
+                new_timestamp_hash,
+                TransactionKernel::MAST_HEIGHT as u32,
+            );
+            assert!(new_timestamp >= old_timestamp);
+
+            // merge bit unchanged
+            let merge_bit: BFieldElement = tasm::tasmlib_io_read_secin___bfe();
+
+            // May God have mercy upon my soul
+            assert!(merge_bit.value() == 0 || merge_bit.value() == 1);
+            let merge_bit: bool = merge_bit.value() != 0;
+
+            let merge_bit_leaf = Tip5::hash(&merge_bit);
+
+            tasm::tasmlib_hashing_merkle_verify(
+                old_txk_digest,
+                TransactionKernelField::MergeBit as u32,
+                merge_bit_leaf,
+                TransactionKernel::MAST_HEIGHT as u32,
+            );
+            tasm::tasmlib_hashing_merkle_verify(
+                new_txk_digest,
+                TransactionKernelField::MergeBit as u32,
+                merge_bit_leaf,
+                TransactionKernel::MAST_HEIGHT as u32,
+            );
+        }
+    }
 
     /// Return an update witness where the mutator set has had both elements
     /// added and removed.

--- a/src/models/blockchain/transaction/validity/tasm/single_proof/update_branch.rs
+++ b/src/models/blockchain/transaction/validity/tasm/single_proof/update_branch.rs
@@ -1,5 +1,4 @@
 use itertools::Itertools;
-use strum::EnumCount;
 use tasm_lib::data_type::DataType;
 use tasm_lib::field;
 use tasm_lib::field_with_size;
@@ -28,9 +27,7 @@ use crate::models::blockchain::transaction::Proof;
 use crate::models::blockchain::transaction::TransactionKernel;
 use crate::models::blockchain::type_scripts::native_currency_amount::NativeCurrencyAmount;
 use crate::models::proof_abstractions::mast_hash::MastHash;
-use crate::models::proof_abstractions::tasm::builtins as tasmlib;
 use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
-use crate::models::proof_abstractions::timestamp::Timestamp;
 use crate::twenty_first::util_types::mmr::mmr_accumulator::MmrAccumulator;
 use crate::util_types::mutator_set::mutator_set_accumulator::MutatorSetAccumulator;
 use crate::models::blockchain::transaction::validity::tasm::claims::generate_single_proof_claim::GenerateSingleProofClaim;
@@ -159,11 +156,17 @@ impl UpdateWitness {
             .extend_from_slice(&self.old_kernel.merge_bit.encode());
     }
 
+    #[cfg(test)]
     pub(crate) fn branch_source(
         &self,
         single_proof_program_digest: Digest,
         new_txk_digest: Digest,
     ) {
+        use strum::EnumCount;
+
+        use crate::models::proof_abstractions::tasm::builtins as tasmlib;
+        use crate::models::proof_abstractions::timestamp::Timestamp;
+
         // divine the witness for this proof
         let uw: UpdateWitness = tasmlib::decode_from_memory(UPDATE_WITNESS_ADDRESS);
 

--- a/src/models/blockchain/type_scripts/native_currency.rs
+++ b/src/models/blockchain/type_scripts/native_currency.rs
@@ -3,8 +3,6 @@ use std::sync::OnceLock;
 
 use get_size2::GetSize;
 use itertools::Itertools;
-use num_traits::CheckedAdd;
-use num_traits::Zero;
 use serde::Deserialize;
 use serde::Serialize;
 use tasm_lib::data_type::DataType;
@@ -26,7 +24,6 @@ use super::native_currency_amount::NativeCurrencyAmount;
 use super::TypeScript;
 use super::TypeScriptWitness;
 use crate::models::blockchain::block::MINING_REWARD_TIME_LOCK_PERIOD;
-use crate::models::blockchain::shared::Hash;
 use crate::models::blockchain::transaction::primitive_witness::PrimitiveWitness;
 use crate::models::blockchain::transaction::primitive_witness::SaltedUtxos;
 use crate::models::blockchain::transaction::transaction_kernel::TransactionKernel;
@@ -37,7 +34,6 @@ use crate::models::blockchain::transaction::validity::tasm::coinbase_amount::Coi
 use crate::models::blockchain::type_scripts::BFieldCodec;
 use crate::models::blockchain::type_scripts::TypeScriptAndWitness;
 use crate::models::proof_abstractions::mast_hash::MastHash;
-use crate::models::proof_abstractions::tasm::builtins as tasm;
 use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
 use crate::models::proof_abstractions::timestamp::Timestamp;
 use crate::models::proof_abstractions::SecretWitness;
@@ -86,8 +82,14 @@ impl NativeCurrency {
 }
 
 impl ConsensusProgram for NativeCurrency {
-    #[allow(clippy::needless_return)]
+    #[cfg(test)]
     fn source(&self) {
+        use num_traits::CheckedAdd;
+        use num_traits::Zero;
+
+        use crate::models::blockchain::shared::Hash;
+        use crate::models::proof_abstractions::tasm::builtins as tasm;
+
         // get in the current program's hash digest
         let self_digest: Digest = tasm::own_program_digest();
 
@@ -1472,8 +1474,8 @@ pub mod test {
             .unwrap()
             .current();
         let txk_mast_hash = primitive_witness.kernel.mast_hash();
-        let salted_input_utxos_hash = Hash::hash(&primitive_witness.input_utxos);
-        let salted_output_utxos_hash = Hash::hash(&primitive_witness.output_utxos);
+        let salted_input_utxos_hash = Tip5::hash(&primitive_witness.input_utxos);
+        let salted_output_utxos_hash = Tip5::hash(&primitive_witness.output_utxos);
 
         let native_currency_witness = NativeCurrencyWitness::from(primitive_witness);
         let type_script_and_witness = TypeScriptAndWitness::new_with_nondeterminism(

--- a/src/models/blockchain/type_scripts/native_currency.rs
+++ b/src/models/blockchain/type_scripts/native_currency.rs
@@ -1060,7 +1060,6 @@ pub mod test {
     use crate::models::blockchain::type_scripts::time_lock::neptune_arbitrary::arbitrary_primitive_witness_with_active_timelocks;
     use crate::models::blockchain::type_scripts::time_lock::TimeLock;
     use crate::models::proof_abstractions::tasm::builtins as tasm;
-    use crate::models::proof_abstractions::tasm::program::test::consensus_program_negative_test;
     use crate::models::proof_abstractions::tasm::program::test::ConsensusProgramSpecification;
     use crate::models::proof_abstractions::tasm::program::ConsensusError;
     use crate::models::proof_abstractions::timestamp::Timestamp;
@@ -1270,7 +1269,8 @@ pub mod test {
     ) {
         let stdin = native_currency_witness.standard_input();
         let nd = native_currency_witness.nondeterminism();
-        consensus_program_negative_test(NativeCurrency, &stdin, nd, expected_error_ids);
+        let test_result = NativeCurrency.test_assertion_failure(stdin, nd, expected_error_ids);
+        test_result.unwrap();
     }
 
     #[test]

--- a/src/models/proof_abstractions/tasm/environment.rs
+++ b/src/models/proof_abstractions/tasm/environment.rs
@@ -11,7 +11,6 @@ use std::collections::HashMap;
 use std::collections::VecDeque;
 
 use tasm_lib::prelude::Digest;
-use tasm_lib::triton_vm::prelude::NonDeterminism;
 use tasm_lib::twenty_first::math::b_field_element::BFieldElement;
 
 thread_local! {
@@ -26,10 +25,11 @@ thread_local! {
     pub(super) static PROGRAM_DIGEST: RefCell<Digest> = RefCell::new(Digest::default());
 }
 
+#[cfg(test)]
 pub(crate) fn init(
     program_digest: Digest,
     input: &[BFieldElement],
-    nondeterminism: NonDeterminism,
+    nondeterminism: tasm_lib::triton_vm::prelude::NonDeterminism,
 ) {
     PUB_INPUT.with(|v| {
         *v.borrow_mut() = input.to_vec().into();

--- a/src/models/proof_abstractions/tasm/program.rs
+++ b/src/models/proof_abstractions/tasm/program.rs
@@ -4,6 +4,7 @@ use tasm_lib::library::Library;
 use tasm_lib::prelude::Digest;
 use tasm_lib::triton_vm::error::InstructionError;
 use tasm_lib::triton_vm::prelude::*;
+use tracing::debug;
 
 use super::prover_job::ProverJob;
 use super::prover_job::ProverJobError;
@@ -24,32 +25,16 @@ pub(crate) trait ConsensusProgram
 where
     Self: RefUnwindSafe + std::fmt::Debug,
 {
-    /// The canonical reference source code for the consensus program, written in
-    /// the subset of rust that the tasm-lang compiler understands. To run this
-    /// program, call [`Self::run_rust`], which spawns a new thread, boots the
-    /// environment, and executes the program.
-    #[cfg(test)]
-    fn source(&self);
-
     /// Helps identify all imported Triton assembly snippets.
-    /// You probably want to use [`Self::code`].
+    /// You probably want to use [`Self::program`].
     // Implemented this way to ensure synchronicity between the library in use
     // and the actual code.
-    #[doc(hidden)]
     fn library_and_code(&self) -> (Library, Vec<LabelledInstruction>);
-
-    /// A derivative of source, in Triton-assembler (tasm) rather than rust. Either
-    /// produced automatically or hand-optimized.
-    ///
-    /// See also [`Self::program`].
-    fn code(&self) -> Vec<LabelledInstruction> {
-        let (_, code) = self.library_and_code();
-        code
-    }
 
     /// The Triton VM [`Program`].
     fn program(&self) -> Program {
-        Program::new(&self.code())
+        let (_, code) = self.library_and_code();
+        Program::new(&code)
     }
 
     /// The [program](Self::program)'s hash [digest](Digest).
@@ -57,108 +42,6 @@ where
     // note: we do not provide a default impl because implementors should cache
     // their Digest with OnceLock.
     fn hash(&self) -> Digest;
-
-    /// Run the source program natively in rust, but with the emulated TritonVM
-    /// environment for input, output, nondeterminism, and program digest.
-    #[cfg(test)]
-    fn run_rust(
-        &self,
-        input: &PublicInput,
-        nondeterminism: NonDeterminism,
-    ) -> Result<Vec<BFieldElement>, ConsensusError> {
-        use std::panic::catch_unwind;
-
-        use itertools::Itertools;
-        use tracing::debug;
-
-        debug!(
-            "Running consensus program with input: {}",
-            input.individual_tokens.iter().map(|b| b.value()).join(",")
-        );
-        let program_digest = catch_unwind(|| self.hash()).unwrap_or_default();
-        let emulation_result = catch_unwind(|| {
-            super::environment::init(program_digest, &input.individual_tokens, nondeterminism);
-            self.source();
-            super::environment::PUB_OUTPUT.take()
-        });
-
-        emulation_result.map_err(|e| ConsensusError::RustShadowPanic(format!("{e:?}")))
-    }
-
-    /// Use Triton VM to run the tasm code.
-    ///
-    /// Should only be called in tests. In production code, use [`Self::run_rust`]
-    /// instead – it's faster.
-    #[cfg(test)]
-    fn run_tasm(
-        &self,
-        input: &PublicInput,
-        nondeterminism: NonDeterminism,
-    ) -> Result<Vec<BFieldElement>, ConsensusError> {
-        let mut vm_state = VMState::new(self.program(), input.clone(), nondeterminism.clone());
-        tasm_lib::maybe_write_debuggable_vm_state_to_disk(&vm_state);
-
-        let init_stack = vm_state.op_stack.clone();
-        if let Err(err) = vm_state.run() {
-            let err_str = format!("Triton VM failed.\nError: {err}\nVMState:\n{vm_state}");
-            eprintln!("{err_str}");
-            return Err(ConsensusError::TritonVMPanic(err_str, err));
-        }
-
-        // Do some sanity checks that are likely to catch programming
-        // errors in the consensus program. This doesn't catch
-        // soundness errors, though, since a valid proof could still be
-        // generated even though one of these checks fail.
-        assert!(
-            vm_state.secret_digests.is_empty(),
-            "Secret digest list must be empty after executing consensus program"
-        );
-        assert_eq!(&init_stack, &vm_state.op_stack);
-
-        Ok(vm_state.public_output)
-    }
-
-    /// `Ok(())` iff the given input & non-determinism triggers the failure of
-    /// either the instruction `assert` or `assert_vector`, and if that
-    /// instruction's error ID is one of the expected error IDs.
-    #[cfg(test)]
-    fn test_assertion_failure(
-        &self,
-        public_input: PublicInput,
-        non_determinism: NonDeterminism,
-        expected_error_ids: &[i128],
-    ) -> proptest::test_runner::TestCaseResult {
-        use itertools::Itertools;
-
-        let fail = |reason: String| Err(proptest::test_runner::TestCaseError::Fail(reason.into()));
-
-        let tasm_result = self.run_tasm(&public_input, non_determinism.clone());
-        let Err(ConsensusError::TritonVMPanic(_, err)) = tasm_result else {
-            return fail("expected a failure in Triton VM, but it halted gracefully".into());
-        };
-
-        let err = match err {
-            InstructionError::AssertionFailed(err)
-            | InstructionError::VectorAssertionFailed(_, err) => err,
-            _ => return fail(format!("expected an assertion failure, but got: {err}")),
-        };
-
-        let ids_str = expected_error_ids.iter().join(", ");
-        let expected_ids_str = format!("expected an error ID in {{{ids_str}}}");
-        let Some(err_id) = err.id else {
-            return fail(format!("{expected_ids_str}, but found none"));
-        };
-
-        proptest::prop_assert!(
-            expected_error_ids.contains(&err_id),
-            "{expected_ids_str}, but found {err_id}",
-        );
-
-        let rust_result = self.run_rust(&public_input, non_determinism.clone());
-        proptest::prop_assert!(rust_result.is_err());
-
-        Ok(())
-    }
 
     /// Run the program and generate a proof for it, assuming running halts
     /// gracefully.
@@ -168,9 +51,6 @@ where
     ///
     /// This method is a thin wrapper around [`prove_consensus_program`], which
     /// does the same but for arbitrary programs.
-    #[allow(async_fn_in_trait)] // Trait must be public bc of benchmarks.
-    #[allow(private_interfaces)] // Trait must be public bc of benchmarks.
-    #[doc(hidden)]
     async fn prove(
         &self,
         claim: Claim,
@@ -295,6 +175,7 @@ pub mod test {
     use std::io::stdout;
     use std::io::Read;
     use std::io::Write;
+    use std::panic::catch_unwind;
     use std::path::Path;
     use std::path::PathBuf;
     use std::time::Duration;
@@ -312,12 +193,118 @@ pub mod test {
 
     use super::*;
     use crate::models::blockchain::shared::Hash;
+    use crate::models::proof_abstractions::tasm::environment;
     use crate::triton_vm::stark::Stark;
 
     const TEST_DATA_DIR: &str = "test_data";
     const TEST_NAME_HTTP_HEADER_KEY: &str = "Test-Name";
 
-    pub(crate) fn consensus_program_negative_test<T: ConsensusProgram>(
+    pub(crate) trait ConsensusProgramSpecification: ConsensusProgram {
+        /// The canonical reference source code for the consensus program, written in
+        /// the subset of rust that the tasm-lang compiler understands. To run this
+        /// program, call [`Self::run_rust`], which spawns a new thread, boots the
+        /// environment, and executes the program.
+        #[cfg(test)]
+        fn source(&self);
+
+        /// Run the source program natively in rust, but with the emulated TritonVM
+        /// environment for input, output, nondeterminism, and program digest.
+        #[cfg(test)]
+        fn run_rust(
+            &self,
+            input: &PublicInput,
+            nondeterminism: NonDeterminism,
+        ) -> Result<Vec<BFieldElement>, ConsensusError> {
+            debug!(
+                "Running consensus program with input: {}",
+                input.individual_tokens.iter().map(|b| b.value()).join(",")
+            );
+            let program_digest = catch_unwind(|| self.hash()).unwrap_or_default();
+            let emulation_result = catch_unwind(|| {
+                environment::init(program_digest, &input.individual_tokens, nondeterminism);
+                self.source();
+                environment::PUB_OUTPUT.take()
+            });
+
+            emulation_result.map_err(|e| ConsensusError::RustShadowPanic(format!("{e:?}")))
+        }
+
+        /// Use Triton VM to run the tasm code.
+        ///
+        /// Should only be called in tests. In production code, use [`Self::run_rust`]
+        /// instead – it's faster.
+        #[cfg(test)]
+        fn run_tasm(
+            &self,
+            input: &PublicInput,
+            nondeterminism: NonDeterminism,
+        ) -> Result<Vec<BFieldElement>, ConsensusError> {
+            let mut vm_state = VMState::new(self.program(), input.clone(), nondeterminism.clone());
+            tasm_lib::maybe_write_debuggable_vm_state_to_disk(&vm_state);
+
+            let init_stack = vm_state.op_stack.clone();
+            if let Err(err) = vm_state.run() {
+                let err_str = format!("Triton VM failed.\nError: {err}\nVMState:\n{vm_state}");
+                eprintln!("{err_str}");
+                return Err(ConsensusError::TritonVMPanic(err_str, err));
+            }
+
+            // Do some sanity checks that are likely to catch programming
+            // errors in the consensus program. This doesn't catch
+            // soundness errors, though, since a valid proof could still be
+            // generated even though one of these checks fail.
+            assert!(
+                vm_state.secret_digests.is_empty(),
+                "Secret digest list must be empty after executing consensus program"
+            );
+            assert_eq!(&init_stack, &vm_state.op_stack);
+
+            Ok(vm_state.public_output)
+        }
+
+        /// `Ok(())` iff the given input & non-determinism triggers the failure of
+        /// either the instruction `assert` or `assert_vector`, and if that
+        /// instruction's error ID is one of the expected error IDs.
+        #[cfg(test)]
+        fn test_assertion_failure(
+            &self,
+            public_input: PublicInput,
+            non_determinism: NonDeterminism,
+            expected_error_ids: &[i128],
+        ) -> proptest::test_runner::TestCaseResult {
+            let fail =
+                |reason: String| Err(proptest::test_runner::TestCaseError::Fail(reason.into()));
+
+            let tasm_result = self.run_tasm(&public_input, non_determinism.clone());
+            let Err(ConsensusError::TritonVMPanic(_, err)) = tasm_result else {
+                return fail("expected a failure in Triton VM, but it halted gracefully".into());
+            };
+
+            let err = match err {
+                InstructionError::AssertionFailed(err)
+                | InstructionError::VectorAssertionFailed(_, err) => err,
+                _ => return fail(format!("expected an assertion failure, but got: {err}")),
+            };
+
+            let ids_str = expected_error_ids.iter().join(", ");
+            let expected_ids_str = format!("expected an error ID in {{{ids_str}}}");
+            let Some(err_id) = err.id else {
+                return fail(format!("{expected_ids_str}, but found none"));
+            };
+
+            proptest::prop_assert!(
+                expected_error_ids.contains(&err_id),
+                "{expected_ids_str}, but found {err_id}",
+            );
+
+            let rust_result = self.run_rust(&public_input, non_determinism.clone());
+            proptest::prop_assert!(rust_result.is_err());
+
+            Ok(())
+        }
+    }
+
+    pub(crate) fn consensus_program_negative_test<T: ConsensusProgramSpecification>(
         consensus_program: T,
         input: &PublicInput,
         nondeterminism: NonDeterminism,


### PR DESCRIPTION
The fallout from marking trait `ConsensusProgram` as `pub(crate)` suggests to me that the trait functions `source` and `run_rust` don't really belong in trait `ConsensusProgram`. Perhaps a `#[cfg(test)] trait ShadowedConsensusProgram` or similar could work.