### PR TITLE
refactor(Block): Require guesser gets at least 1/4 of block subsidy

### DIFF
--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -1160,7 +1160,9 @@ pub(crate) mod mine_loop_tests {
             .unwrap();
 
         let mut cli = cli_args::Args::default();
-        for guesser_fee_fraction in [0f64, 0.5, 1.0] {
+        for guesser_fee_fraction in [0.25f64, 0.5, 1.0] {
+            println!("guesser_fee_fraction: {guesser_fee_fraction}");
+
             // Verify constructed coinbase transaction and block template when mempool is empty
             assert!(
                 alice.lock_guard().await.mempool.is_empty(),

--- a/src/models/blockchain/type_scripts/neptune_coins.rs
+++ b/src/models/blockchain/type_scripts/neptune_coins.rs
@@ -198,8 +198,22 @@ impl NeptuneCoins {
     pub(crate) fn lossy_f64_fraction_mul(&self, fraction: f64) -> Option<NeptuneCoins> {
         assert!((0.0..=1.0).contains(&fraction));
 
+        // A few special-case handlings to avoid rounding errors on common fractions.
         if fraction == 1.0 {
             return Some(*self);
+        }
+
+        if fraction == 0.5 {
+            let mut ret = *self;
+            ret.div_two();
+            return Some(ret);
+        }
+
+        if fraction == 0.25 {
+            let mut ret = *self;
+            ret.div_two();
+            ret.div_two();
+            return Some(ret);
         }
 
         let value_as_f64 = self.0 as f64;

--- a/src/models/state/archival_state.rs
+++ b/src/models/state/archival_state.rs
@@ -1813,7 +1813,7 @@ mod archival_state_tests {
             .unwrap();
         println!("Generated transaction for Alice and Bob.");
 
-        let guesser_fraction = 0f64;
+        let guesser_fraction = 0.5f64;
         let (cbtx, composer_expected_utxos) = make_coinbase_transaction_from_state(
             &premine_rec
                 .global_state_lock
@@ -1943,14 +1943,16 @@ mod archival_state_tests {
         );
 
         let block_subsidy = Block::block_subsidy(block_1.header().height);
-        let mut liquid_reward = block_subsidy;
-        liquid_reward.div_two();
+        let mut total_composer_reward = block_subsidy;
+        total_composer_reward.div_two();
+        let mut liquid_composer_reward = total_composer_reward;
+        liquid_composer_reward.div_two();
         assert_eq!(
             // premine receiver mined block 1: So new balance is:
             // premine + block_reward / 2 - sent_to_alice - sent_to_bob - tx-fee
             // = 20 + 64 - 10 - 5 - 1
             // = 68
-            liquid_reward + NeptuneCoins::new(20 - 10 - 5 - 1),
+            liquid_composer_reward + NeptuneCoins::new(20 - 10 - 5 - 1),
             premine_rec
                 .lock_guard()
                 .await
@@ -1961,7 +1963,7 @@ mod archival_state_tests {
 
         let after_cb_timelock_expiration = block_1.header().timestamp + Timestamp::months(37);
         assert_eq!(
-            block_subsidy + NeptuneCoins::new(20 - 10 - 5 - 1),
+            total_composer_reward + NeptuneCoins::new(20 - 10 - 5 - 1),
             premine_rec
                 .lock_guard()
                 .await

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -2428,7 +2428,7 @@ mod global_state_tests {
         let in_seven_months = genesis_block.kernel.header.timestamp + Timestamp::months(7);
         let in_eight_months = in_seven_months + Timestamp::months(1);
 
-        let guesser_fraction = 0f64;
+        let guesser_fraction = 0.9f64;
         let (coinbase_transaction, coinbase_expected_utxos) = make_coinbase_transaction_from_state(
             &genesis_block,
             &premine_receiver,

--- a/src/models/state/wallet/mod.rs
+++ b/src/models/state/wallet/mod.rs
@@ -1177,7 +1177,7 @@ mod wallet_tests {
             .await
             .unwrap();
 
-        let guesser_fraction = 0f64;
+        let guesser_fraction = 0.8f64;
         let (coinbase_tx, expected_composer_utxos) = make_coinbase_transaction_from_state(
             &alice
                 .global_state_lock
@@ -1354,7 +1354,7 @@ mod wallet_tests {
 
         let mut rng = StdRng::seed_from_u64(87255549301u64);
 
-        let guesser_fraction = 0f64;
+        let guesser_fraction = 0.9f64;
         let (cbtx, _cb_expected) = make_coinbase_transaction_from_state(
             &bob.global_state_lock
                 .lock_guard()


### PR DESCRIPTION
Require that guesser gets at least 1/4 of block subsidy.

This change incentivizes the rational guesser to know the preimage of the nonce. If this rule was not there, a mining venture could set the guesser fraction to 0 leaving the entire block subsidy for the composer. With this setup, the composer could skip one invocation of Tip5 since the nonce would not have to be the output of Tip5 but could instead be an arbitrary number. This would give centralized mining ventures and unfair advantage and thus disincentivize Neptune's two-step mining. The hash rate advantage of this approach would be about 15 %.

This change also makes it easier for composers to pick up multiple fee-paying transactions and merge them into an existing block proposal, thus increasing the guesser reward. If mining venture does not bother with using a Tip5-digest for the nonce, they will not have an incentive to pick up and merge fee-paying transactions while PoW guessing is still ongoing. Or, to be more precise, it'll be twice as expensive computationally to pick up fee-paying transactions, as the fee cannot simply be passed onto the transaction fee but must be merged with a transaction with a negative fee.

This change *also* protects against a deterioration of the anonymity set that would happen if the guesser-reward was zero, as those UTXOs would be unlikely to ever be spent.