### PR TITLE
Lossless Display for `NativeCurrencyAmount`

### DIFF
--- a/src/bin/dashboard_src/send_screen.rs
+++ b/src/bin/dashboard_src/send_screen.rs
@@ -1,6 +1,5 @@
 use std::cmp::max;
 use std::error::Error;
-use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::SystemTime;
@@ -107,7 +106,7 @@ impl SendScreen {
         // TODO: Let user specify this number
         let fee = NativeCurrencyAmount::zero();
 
-        let valid_amount = match NativeCurrencyAmount::from_str(&amount) {
+        let valid_amount = match NativeCurrencyAmount::coins_from_str(&amount) {
             Ok(a) => a,
             Err(e) => {
                 *notice_arc.lock().await = format!("amount: {}", e);

--- a/src/bin/neptune-cli.rs
+++ b/src/bin/neptune-cli.rs
@@ -108,7 +108,7 @@ impl FromStr for TransactionOutput {
 
         Ok(Self {
             address: parts[0].to_string(),
-            amount: NativeCurrencyAmount::from_str(parts[1])?,
+            amount: NativeCurrencyAmount::coins_from_str(parts[1])?,
         })
     }
 }
@@ -287,9 +287,11 @@ enum Command {
         address: String,
 
         /// amount to send
+        #[clap(value_parser = NativeCurrencyAmount::coins_from_str)]
         amount: NativeCurrencyAmount,
 
         /// transaction fee
+        #[clap(value_parser = NativeCurrencyAmount::coins_from_str)]
         fee: NativeCurrencyAmount,
 
         /// local tag for identifying a receiver
@@ -303,6 +305,7 @@ enum Command {
         /// format: address:amount address:amount ...
         #[clap(value_parser, num_args = 1.., required=true, value_delimiter = ' ')]
         outputs: Vec<TransactionOutput>,
+        #[clap(value_parser = NativeCurrencyAmount::coins_from_str)]
         fee: NativeCurrencyAmount,
     },
 

--- a/src/config_models/cli_args.rs
+++ b/src/config_models/cli_args.rs
@@ -127,7 +127,7 @@ pub struct Args {
     /// Determines the minimum fee to take as a reward for upgrading foreign
     /// transaction proofs. Foreign transactions where a fee below this
     /// threshold cannot be collected by proof upgrading will not be upgraded.
-    #[clap(long, default_value = "0.01")]
+    #[clap(long, default_value = "0.01", value_parser = NativeCurrencyAmount::coins_from_str)]
     pub(crate) min_gobbling_fee: NativeCurrencyAmount,
 
     /// Prune the mempool when it exceeds this size in RAM.

--- a/src/main_loop/proof_upgrader.rs
+++ b/src/main_loop/proof_upgrader.rs
@@ -196,7 +196,7 @@ impl UpgradeJob {
                 ..
             } => {
                 let reciprocal = 1.0 / (collection.num_proofs() as f64);
-                gobbling_fee.lossy_f64_fraction_mul(reciprocal).unwrap()
+                gobbling_fee.lossy_f64_fraction_mul(reciprocal)
             }
             UpgradeJob::Merge { gobbling_fee, .. } => {
                 let mut rate = *gobbling_fee;
@@ -616,10 +616,7 @@ pub(super) fn get_upgrade_task_from_mempool(
         .mempool
         .most_dense_proof_collection(num_proofs_threshold)
     {
-        let gobbling_fee = kernel
-            .fee
-            .lossy_f64_fraction_mul(gobbling_fraction)
-            .unwrap();
+        let gobbling_fee = kernel.fee.lossy_f64_fraction_mul(gobbling_fraction);
         let gobbling_fee =
             if gobbling_fee >= min_gobbling_fee && tx_origin == TransactionOrigin::Foreign {
                 gobbling_fee
@@ -654,9 +651,7 @@ pub(super) fn get_upgrade_task_from_mempool(
     )) = global_state.mempool.most_dense_single_proof_pair()
     {
         let gobbling_fee = left_kernel.fee + right_kernel.fee;
-        let gobbling_fee = gobbling_fee
-            .lossy_f64_fraction_mul(gobbling_fraction)
-            .unwrap();
+        let gobbling_fee = gobbling_fee.lossy_f64_fraction_mul(gobbling_fraction);
         let gobbling_fee = if gobbling_fee >= min_gobbling_fee {
             gobbling_fee
         } else {

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -443,11 +443,8 @@ pub(super) fn prepare_coinbase_transaction_stateless(
     info!("Creating coinbase for block of height {next_block_height}.");
 
     let coinbase_amount = Block::block_subsidy(next_block_height);
-    let Some(guesser_fee) =
-        coinbase_amount.lossy_f64_fraction_mul(composer_parameters.guesser_fee_fraction())
-    else {
-        bail!("Guesser fee times block subsidy must be valid amount");
-    };
+    let guesser_fee =
+        coinbase_amount.lossy_f64_fraction_mul(composer_parameters.guesser_fee_fraction());
 
     info!("Setting guesser_fee to {guesser_fee}.");
 

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -1589,10 +1589,7 @@ pub(crate) mod block_tests {
             let mut transaction = make_mock_transaction(vec![], vec![]);
 
             transaction.kernel = TransactionKernelModifier::default()
-                .fee(
-                    NativeCurrencyAmount::from_nau(1337.into())
-                        .expect("given number should be valid NativeCurrencyAmount amount"),
-                )
+                .fee(NativeCurrencyAmount::from_nau(1337.into()))
                 .modify(transaction.kernel);
 
             let mut block = invalid_block_with_transaction(&genesis_block, transaction);

--- a/src/models/blockchain/block/validity/block_primitive_witness.rs
+++ b/src/models/blockchain/block/validity/block_primitive_witness.rs
@@ -248,7 +248,7 @@ pub(crate) mod test {
                     )| {
                         let mut input_amounts = input_distribution
                             .into_iter()
-                            .map(|fraction| total_input.lossy_f64_fraction_mul(fraction).unwrap())
+                            .map(|fraction| total_input.lossy_f64_fraction_mul(fraction))
                             .collect_vec();
                         input_amounts.push(
                             total_input

--- a/src/models/blockchain/transaction/mod.rs
+++ b/src/models/blockchain/transaction/mod.rs
@@ -293,7 +293,7 @@ impl Transaction {
         let transaction_as_bytes = bincode::serialize(&self).unwrap();
         let transaction_size = BigInt::from(transaction_as_bytes.get_size());
         let transaction_fee = self.kernel.fee.to_nau();
-        BigRational::new_raw(transaction_fee, transaction_size)
+        BigRational::new_raw(transaction_fee.into(), transaction_size)
     }
 
     /// Determine if the transaction can be validly confirmed if the block has

--- a/src/models/blockchain/transaction/primitive_witness.rs
+++ b/src/models/blockchain/transaction/primitive_witness.rs
@@ -934,7 +934,6 @@ pub mod neptune_arbitrary {
 mod test {
     use itertools::izip;
     use itertools::Itertools;
-    use num_bigint::BigInt;
     use num_traits::CheckedAdd;
     use num_traits::CheckedSub;
     use num_traits::Zero;
@@ -1636,7 +1635,7 @@ mod test {
                 | ((u32s[1] as u128) << 32)
                 | ((u32s[2] as u128) << 64)
                 | ((u32s[3] as u128) << 96);
-            total = total + NativeCurrencyAmount::from_nau(BigInt::from(amount)).unwrap();
+            total = total + NativeCurrencyAmount::from_nau(amount.try_into().unwrap());
         }
         prop_assert!(total <= NativeCurrencyAmount::coins(42000000));
     }

--- a/src/models/blockchain/transaction/validity/tasm/single_proof/merge_branch/authenticate_coinbase_fields.rs
+++ b/src/models/blockchain/transaction/validity/tasm/single_proof/merge_branch/authenticate_coinbase_fields.rs
@@ -266,8 +266,6 @@ mod tests {
     use std::collections::HashMap;
     use std::collections::VecDeque;
 
-    use num_bigint::BigInt;
-    use num_traits::FromPrimitive;
     use num_traits::Zero;
     use proptest::prelude::Strategy;
     use proptest::test_runner::TestRunner;
@@ -394,25 +392,19 @@ mod tests {
 
         // Verify that the entire u128 is checked, not just a top-limb
         prop(
-            Some(NativeCurrencyAmount::from_nau(BigInt::from_u128(3).unwrap()).unwrap()),
+            Some(NativeCurrencyAmount::from_nau(3.into())),
             None,
-            Some(
-                NativeCurrencyAmount::from_nau(BigInt::from_u128(3 + (1 << 32)).unwrap()).unwrap(),
-            ),
+            Some(NativeCurrencyAmount::from_nau(3 + (1_i128 << 32))),
         );
         prop(
-            Some(NativeCurrencyAmount::from_nau(BigInt::from_u128(3).unwrap()).unwrap()),
+            Some(NativeCurrencyAmount::from_nau((3).into())),
             None,
-            Some(
-                NativeCurrencyAmount::from_nau(BigInt::from_u128(3 + (1 << 64)).unwrap()).unwrap(),
-            ),
+            Some(NativeCurrencyAmount::from_nau(3 + (1_i128 << 64))),
         );
         prop(
-            Some(NativeCurrencyAmount::from_nau(BigInt::from_u128(3).unwrap()).unwrap()),
+            Some(NativeCurrencyAmount::from_nau((3).into())),
             None,
-            Some(
-                NativeCurrencyAmount::from_nau(BigInt::from_u128(3 + (1 << 96)).unwrap()).unwrap(),
-            ),
+            Some(NativeCurrencyAmount::from_nau(3 + (1_i128 << 96))),
         );
     }
 

--- a/src/models/blockchain/type_scripts/native_currency_amount.rs
+++ b/src/models/blockchain/type_scripts/native_currency_amount.rs
@@ -448,8 +448,8 @@ impl NativeCurrencyAmount {
             BigInt::from_str(substrings[2])?
         };
         let power = substrings[2].len();
-        let ten = BigInt::from_str("10")?;
-        let mut decimal_shift = BigInt::from_u8(1).unwrap();
+        let ten = BigInt::from(10_u8);
+        let mut decimal_shift = BigInt::from(1_u8);
         for _ in 0..power {
             decimal_shift *= ten.clone();
         }

--- a/src/models/blockchain/type_scripts/native_currency_amount.rs
+++ b/src/models/blockchain/type_scripts/native_currency_amount.rs
@@ -129,11 +129,17 @@ impl NativeCurrencyAmount {
 
     /// Convert the amount to Neptune atomic units (nau) as a 64-bit floating
     /// point number. Note that this function loses precision!
+    ///
+    /// Quantities whose unit is nau are used for internal logic and are not to
+    /// be used for user-facing displays.
     pub fn to_nau_f64(&self) -> f64 {
         self.0 as f64
     }
 
-    /// Convert the amount to Neptune atomic units (nau)
+    /// Convert the amount (of Neptune Coins) to Neptune atomic units (nau).
+    ///
+    /// Quantities whose unit is nau are used for internal logic and are not to
+    /// be used for user-facing displays.
     pub fn to_nau(&self) -> i128 {
         self.0
     }

--- a/src/models/blockchain/type_scripts/native_currency_amount.rs
+++ b/src/models/blockchain/type_scripts/native_currency_amount.rs
@@ -273,7 +273,7 @@ impl NativeCurrencyAmount {
     /// corresponding to `-NativeCurrencyAmount::MAX` and
     /// `NativeCurrencyAmount::from_nau(BigInt::from(1u8)).unwrap()`; see tests
     /// `display_lossless_can_produce_36_chars` and
-    /// `display_lossless_can_produce_43_chars`.
+    /// `display_lossless_can_produce_44_chars`.
     pub(crate) fn display_lossless(&self) -> String {
         self.display_n_decimals(34)
     }
@@ -545,8 +545,6 @@ pub mod neptune_arbitrary {
 
 #[cfg(test)]
 pub(crate) mod test {
-    use std::str::FromStr;
-
     use arbitrary::Arbitrary;
     use arbitrary::Unstructured;
     use get_size2::GetSize;

--- a/src/models/blockchain/type_scripts/native_currency_amount.rs
+++ b/src/models/blockchain/type_scripts/native_currency_amount.rs
@@ -237,7 +237,7 @@ impl NativeCurrencyAmount {
     /// This method rounds the amount if necessary. To avoid losing precision,
     /// set `n` to `usize::MAX` or anything greater than or equal to 34, or just
     /// call [`Self::display_lossless`].
-    pub(crate) fn display_n_decimals(&self, n: usize) -> String {
+    pub fn display_n_decimals(&self, n: usize) -> String {
         if self.is_negative() {
             return "-".to_owned() + &self.neg().display_n_decimals(n);
         }
@@ -274,7 +274,7 @@ impl NativeCurrencyAmount {
     /// `NativeCurrencyAmount::from_nau(BigInt::from(1u8)).unwrap()`; see tests
     /// `display_lossless_can_produce_36_chars` and
     /// `display_lossless_can_produce_44_chars`.
-    pub(crate) fn display_lossless(&self) -> String {
+    pub fn display_lossless(&self) -> String {
         self.display_n_decimals(34)
     }
 }

--- a/src/models/blockchain/type_scripts/native_currency_amount.rs
+++ b/src/models/blockchain/type_scripts/native_currency_amount.rs
@@ -144,6 +144,9 @@ impl NativeCurrencyAmount {
         Self(nau)
     }
 
+    /// Multiply the amount by a non-negative 32-bit number.
+    ///
+    /// Crashes in case of overflow.
     pub fn scalar_mul(&self, factor: u32) -> Self {
         let factor_as_i128 = factor as i128;
         let (res, overflow) = self.0.overflowing_mul(factor_as_i128);

--- a/src/models/blockchain/type_scripts/native_currency_amount.rs
+++ b/src/models/blockchain/type_scripts/native_currency_amount.rs
@@ -467,15 +467,13 @@ impl NativeCurrencyAmount {
             }
         };
         if -BigInt::from(Self::MAX_NAU) > nau || nau > BigInt::from(Self::MAX_NAU) {
-            return Err(anyhow::Error::msg(
-                "amount of Neptune coins too large or too small",
-            ));
+            bail!("amount of Neptune coins too large or too small",);
         }
         match i128::try_from(nau) {
             Ok(i) => Ok(Self(i)),
-            Err(e) => Err(anyhow::Error::msg(format!(
-                "invalid amount of Neptune coins: {e:?}"
-            ))),
+            Err(e) => {
+                bail!("invalid amount of Neptune coins: {e:?}");
+            }
         }
     }
 }

--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -45,7 +45,6 @@
 use std::collections::HashMap;
 use std::net::IpAddr;
 use std::net::SocketAddr;
-use std::str::FromStr;
 
 use anyhow::anyhow;
 use anyhow::Result;
@@ -1168,7 +1167,7 @@ impl RPC for NeptuneRPCServer {
         token.auth(&self.valid_tokens)?;
 
         // parse string
-        if let Ok(amt) = NativeCurrencyAmount::from_str(&amount_string) {
+        if let Ok(amt) = NativeCurrencyAmount::coins_from_str(&amount_string) {
             Ok(Some(amt))
         } else {
             Ok(None)

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -414,7 +414,7 @@ pub fn pseudorandom_option<T>(seed: [u8; 32], thing: T) -> Option<T> {
 pub fn pseudorandom_amount(seed: [u8; 32]) -> NativeCurrencyAmount {
     let mut rng: StdRng = SeedableRng::from_seed(seed);
     let number: u128 = rng.gen::<u128>() >> 10;
-    NativeCurrencyAmount::from_nau(number.into()).unwrap()
+    NativeCurrencyAmount::from_nau(number.try_into().unwrap())
 }
 
 pub fn pseudorandom_utxo(seed: [u8; 32]) -> Utxo {


### PR DESCRIPTION
Most importantly, add methods `display_n_decimals` and `display_lossless`.

Also:
 - Refactor to avoid `BigInt` in conversions when possible. Percolate simpler types.
 - Disambiguate `from_str` by renaming to `coins_from_str`.