### PR TITLE
chore: normalize --port arg between rpc clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ neptune-cli --help
 
 To get e.g. the block height of a running daemon, execute
 ```
-neptune-cli --server-addr block-height
+neptune-cli block-height
 ```
 
-If you set up `neptune-core` on a different address or port from the default (127.0.0.1:9799), then the flag `--server-addr [ip_address:port]` is your friend.
+If you set up `neptune-core` to listen for RPC requests on a different port from the default (9799), then the flag `--port <port>` is your friend.
 
 ## Setup for Development (Ubuntu)
 

--- a/docs/src/neptune-core/overview.md
+++ b/docs/src/neptune-core/overview.md
@@ -129,7 +129,7 @@ To develop a new RPC, it can be productive to view two terminals simultaneously 
 
 ```bash
 XDG_DATA_HOME=~/.local/share/neptune-integration-test/0/ RUST_LOG=debug cargo run -- --compose --guess --network regtest # Window1 RPC-server
-XDG_DATA_HOME=~/.local/share/neptune-integration-test/0/ RUST_LOG=trace cargo run --bin rpc_cli -- --server-addr 127.0.0.1:9799 send '[{"public_key": "0399bb06fa556962201e1647a7c5b231af6ff6dd6d1c1a8599309caa126526422e", "amount":{"values":[11,0,0,0]}}]' # Window2 RPC-client
+XDG_DATA_HOME=~/.local/share/neptune-integration-test/0/ RUST_LOG=trace cargo run --bin rpc_cli -- --port 9799 send '[{"public_key": "0399bb06fa556962201e1647a7c5b231af6ff6dd6d1c1a8599309caa126526422e", "amount":{"values":[11,0,0,0]}}]' # Window2 RPC-client
 ```
 
 Note that the client exists quickly, so here the `.pretty()` tracing subscriber is suitable, while `.compact()` is perhaps better for the server.

--- a/src/bin/neptune-cli.rs
+++ b/src/bin/neptune-cli.rs
@@ -2,6 +2,7 @@ use std::io;
 use std::io::stdout;
 use std::io::Write;
 use std::net::IpAddr;
+use std::net::Ipv4Addr;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -363,9 +364,9 @@ enum Command {
 #[derive(Debug, Clone, Parser)]
 #[clap(name = "neptune-cli", about = "An RPC client")]
 struct Config {
-    /// Sets the server address to connect to.
-    #[clap(long, default_value = "127.0.0.1:9799")]
-    server_addr: SocketAddr,
+    /// Sets the neptune-core rpc server localhost port to connect to.
+    #[clap(short, long, default_value = "9799", value_name = "port")]
+    port: u16,
 
     /// neptune-core data directory containing wallet and blockchain state
     #[clap(long)]
@@ -684,7 +685,8 @@ async fn main() -> Result<()> {
     }
 
     // all other operations need a connection to the server
-    let Ok(transport) = tarpc::serde_transport::tcp::connect(args.server_addr, Json::default).await
+    let server_socket = SocketAddr::new(std::net::IpAddr::V4(Ipv4Addr::LOCALHOST), args.port);
+    let Ok(transport) = tarpc::serde_transport::tcp::connect(server_socket, Json::default).await
     else {
         eprintln!("This command requires a connection to `neptune-core`, but that connection could not be established. Is `neptune-core` running?");
         return Ok(());

--- a/src/bin/neptune-dashboard.rs
+++ b/src/bin/neptune-dashboard.rs
@@ -18,8 +18,8 @@ pub mod dashboard_src;
 #[derive(Debug, Parser, Clone)]
 #[clap(name = "neptune-dashboard", about = "Terminal user interface")]
 pub struct Config {
-    /// Sets the server address to connect to.
-    #[clap(long, default_value = "9799", value_name = "PORT")]
+    /// Sets the neptune-core rpc server localhost port to connect to.
+    #[clap(short, long, default_value = "9799", value_name = "port")]
     port: u16,
 
     /// neptune-core data directory containing wallet and blockchain state


### PR DESCRIPTION
closes #376.   (see for rationale)

modifies neptune-cli and neptune-dashboard to both use the same argument for specifying neptune-core rpc port:

```
-p, --port <port>          Sets the neptune-core rpc server localhost port to connect to [default: 9799]
```

also updates README and mdbook docs.