### PR TITLE
trace: Reduce severity of duration-check log message

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -578,7 +578,7 @@ impl Drop for ScopeDurationLogger<'_> {
                     self.description, duration, threshold, self.location,
                 );
 
-                tracing::warn!("{}", msg);
+                tracing::debug!("{}", msg);
             }
         } else {
             let msg = format!(


### PR DESCRIPTION
When running the client, I want WARN log messages to catch my attention. But these warnings from the duration-checker completely spam my log output so I don't notice other warnings.

With this change, the messages are still printed but only with the DEBUG severity.