### PR TITLE
fix: Fix benchmark build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all-targets -- -D warnings
 
+      - name: Build benches
+        run: cargo build --benches
+
       - name: Run tests without benches
         run: >
           cargo test

--- a/src/models/proof_abstractions/tasm/program.rs
+++ b/src/models/proof_abstractions/tasm/program.rs
@@ -21,7 +21,10 @@ pub enum ConsensusError {
 
 /// A `ConsensusProgram` represents the logic subprogram for transaction or
 /// block validity.
-pub(crate) trait ConsensusProgram
+///
+/// This trait is required for benchmarks, but is not part of the public API.
+#[doc(hidden)]
+pub trait ConsensusProgram
 where
     Self: RefUnwindSafe + std::fmt::Debug,
 {
@@ -51,6 +54,12 @@ where
     ///
     /// This method is a thin wrapper around [`prove_consensus_program`], which
     /// does the same but for arbitrary programs.
+    //
+    // The entire trait is only `pub` to facilitate benchmarks; it is not part of
+    // the public API. The suppressed lints below are not nice, but I don't know
+    // how else to make it work.
+    #[allow(async_fn_in_trait)]
+    #[allow(private_interfaces)]
     async fn prove(
         &self,
         claim: Claim,


### PR DESCRIPTION
Make trait `ConsensusProgram` public again, fixing the build failure of the benchmark.

Also make sure that continuous integration picks up on blunders like these in the future by building all benchmarks.

fix #365, fix #377