### PR TITLE
feat: record sent tx details in wallet, rate-limit sent payments to 2 per block.

### DIFF
--- a/src/main_loop/proof_upgrader.rs
+++ b/src/main_loop/proof_upgrader.rs
@@ -453,7 +453,7 @@ impl UpgradeJob {
                     )
                 })
                 .collect_vec();
-            let gobbler = PrimitiveWitness::from_transaction_details(gobbler);
+            let gobbler = PrimitiveWitness::from_transaction_details(&gobbler);
             let gobbler_proof =
                 SingleProof::produce(&gobbler, triton_vm_job_queue, proof_job_options.clone())
                     .await?;

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -393,7 +393,7 @@ pub(crate) async fn make_coinbase_transaction_stateless(
 
     info!("Start: generate single proof for coinbase transaction");
     let transaction = GlobalState::create_raw_transaction(
-        transaction_details,
+        &transaction_details,
         proving_power,
         vm_job_queue,
         job_options,
@@ -572,7 +572,7 @@ pub(crate) async fn create_block_transaction_from(
     if transactions_to_merge.is_empty() {
         let nop =
             TransactionDetails::nop(predecessor_block.mutator_set_accumulator_after(), timestamp);
-        let nop = PrimitiveWitness::from_transaction_details(nop);
+        let nop = PrimitiveWitness::from_transaction_details(&nop);
         let nop_proof = SingleProof::produce(&nop, vm_job_queue, job_options.clone()).await?;
         let nop = Transaction {
             kernel: nop.kernel,
@@ -1182,7 +1182,7 @@ pub(crate) mod mine_loop_tests {
             alice_key.to_address().into(),
             false,
         );
-        let (tx_from_alice, _maybe_change_output) = alice
+        let (tx_from_alice, _, _maybe_change_output) = alice
             .lock_guard()
             .await
             .create_transaction_with_prover_capability(

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -1327,7 +1327,7 @@ pub(crate) mod block_tests {
                 .await;
                 alice.set_new_tip(block1.clone()).await.unwrap();
                 let outputs = vec![output_to_self.clone(); i];
-                let (tx2, _) = alice
+                let (tx2, _, _) = alice
                     .lock_guard_mut()
                     .await
                     .create_transaction_with_prover_capability(
@@ -1383,7 +1383,7 @@ pub(crate) mod block_tests {
                 )
                 .await
                 .unwrap();
-                let (tx3, _) = alice
+                let (tx3, _, _) = alice
                     .lock_guard_mut()
                     .await
                     .create_transaction_with_prover_capability(
@@ -1664,7 +1664,7 @@ pub(crate) mod block_tests {
                 true,
             );
             let fee = NativeCurrencyAmount::coins(1);
-            let (tx1, _) = alice
+            let (tx1, _, _) = alice
                 .lock_guard()
                 .await
                 .create_transaction_with_prover_capability(
@@ -1683,7 +1683,7 @@ pub(crate) mod block_tests {
                 Block::block_template_invalid_proof(&genesis_block, tx1, in_seven_months, None);
             alice.set_new_tip(block1.clone()).await.unwrap();
 
-            let (tx2, _) = alice
+            let (tx2, _, _) = alice
                 .lock_guard()
                 .await
                 .create_transaction_with_prover_capability(

--- a/src/models/blockchain/block/validity/block_program.rs
+++ b/src/models/blockchain/block/validity/block_program.rs
@@ -512,7 +512,7 @@ pub(crate) mod test {
 
         let genesis_block = Block::genesis(network);
         let now = genesis_block.header().timestamp + Timestamp::months(12);
-        let (tx, _) = alice
+        let (tx, _, _) = alice
             .lock_guard()
             .await
             .create_transaction_with_prover_capability(

--- a/src/models/blockchain/transaction/primitive_witness.rs
+++ b/src/models/blockchain/transaction/primitive_witness.rs
@@ -153,7 +153,7 @@ impl PrimitiveWitness {
     /// # Panics
     /// Panics if transaction validity cannot be satisfied.
     fn generate_primitive_witness(
-        unlocked_utxos: Vec<UnlockedUtxo>,
+        unlocked_utxos: &[UnlockedUtxo],
         output_utxos: Vec<Utxo>,
         sender_randomnesses: Vec<Digest>,
         receiver_digests: Vec<Digest>,
@@ -231,7 +231,7 @@ impl PrimitiveWitness {
     }
 
     /// Create a [`PrimitiveWitness`] from [`TransactionDetails`].
-    pub(crate) fn from_transaction_details(transaction_details: TransactionDetails) -> Self {
+    pub(crate) fn from_transaction_details(transaction_details: &TransactionDetails) -> Self {
         let TransactionDetails {
             tx_inputs,
             tx_outputs,
@@ -244,15 +244,15 @@ impl PrimitiveWitness {
         // complete transaction kernel
         let removal_records = tx_inputs
             .iter()
-            .map(|txi| txi.removal_record(&mutator_set_accumulator))
+            .map(|txi| txi.removal_record(mutator_set_accumulator))
             .collect_vec();
         let kernel = TransactionKernelProxy {
             inputs: removal_records,
             outputs: tx_outputs.addition_records(),
             public_announcements: tx_outputs.public_announcements(),
-            fee,
-            timestamp,
-            coinbase,
+            fee: *fee,
+            timestamp: *timestamp,
+            coinbase: *coinbase,
             mutator_set_hash: mutator_set_accumulator.hash(),
             merge_bit: false,
         }
@@ -269,7 +269,7 @@ impl PrimitiveWitness {
             sender_randomnesses,
             receiver_digests,
             kernel.clone(),
-            mutator_set_accumulator,
+            mutator_set_accumulator.clone(),
         )
     }
 

--- a/src/models/state/archival_state.rs
+++ b/src/models/state/archival_state.rs
@@ -1360,7 +1360,7 @@ mod archival_state_tests {
 
         let tx_output_anyone_can_spend =
             TxOutput::no_notification(utxo, rng.random(), rng.random(), false);
-        let (sender_tx, _change_output) = alice
+        let (sender_tx, _, _change_output) = alice
             .lock_guard()
             .await
             .create_transaction_with_prover_capability(
@@ -1466,7 +1466,7 @@ mod archival_state_tests {
         let fee = NativeCurrencyAmount::zero();
 
         let in_seven_months = Timestamp::now() + Timestamp::months(7);
-        let (big_tx, _) = alice
+        let (big_tx, _, _) = alice
             .lock_guard()
             .await
             .create_transaction_with_prover_capability(
@@ -1482,7 +1482,7 @@ mod archival_state_tests {
             .unwrap();
         let block_1a = invalid_block_with_transaction(&genesis_block, big_tx);
 
-        let (empty_tx, _) = alice
+        let (empty_tx, _, _) = alice
             .lock_guard()
             .await
             .create_transaction_with_prover_capability(
@@ -1567,7 +1567,7 @@ mod archival_state_tests {
         let num_blocks = 30;
         for _ in 0..num_blocks {
             let timestamp = previous_block.header().timestamp + Timestamp::months(7);
-            let (tx, _) = alice
+            let (tx, _, _) = alice
                 .lock_guard()
                 .await
                 .create_transaction_with_prover_capability(
@@ -1811,7 +1811,7 @@ mod archival_state_tests {
             .next_unused_spending_key(KeyType::Symmetric)
             .await
             .unwrap();
-        let (tx_to_alice_and_bob, change_utxo) = premine_rec
+        let (tx_to_alice_and_bob, _, change_utxo) = premine_rec
             .lock_guard()
             .await
             .create_transaction_with_prover_capability(
@@ -2016,7 +2016,7 @@ mod archival_state_tests {
             .wallet_secret
             .nth_symmetric_key_for_tests(0)
             .into();
-        let (tx_from_alice, alice_change) = alice
+        let (tx_from_alice, _, alice_change) = alice
             .lock_guard()
             .await
             .create_transaction_with_prover_capability(
@@ -2062,7 +2062,7 @@ mod archival_state_tests {
             .wallet_secret
             .nth_symmetric_key_for_tests(0)
             .into();
-        let (tx_from_bob, bob_change) = bob
+        let (tx_from_bob, _, bob_change) = bob
             .lock_guard()
             .await
             .create_transaction_with_prover_capability(

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -979,7 +979,7 @@ mod tests {
         .await;
         let in_seven_months = genesis_block.kernel.header.timestamp + Timestamp::months(7);
         let high_fee = NativeCurrencyAmount::coins(15);
-        let (tx_by_bob, _maybe_change_output) = bob
+        let (tx_by_bob, _, _maybe_change_output) = bob
             .lock_guard()
             .await
             .create_transaction_with_prover_capability(
@@ -1133,7 +1133,7 @@ mod tests {
         let now = genesis_block.kernel.header.timestamp;
         let in_seven_months = now + Timestamp::months(7);
         let in_eight_months = now + Timestamp::months(8);
-        let (tx_by_bob, maybe_change_output) = bob
+        let (tx_by_bob, _, maybe_change_output) = bob
             .lock_guard()
             .await
             .create_transaction_with_prover_capability(
@@ -1174,7 +1174,7 @@ mod tests {
             alice_address.into(),
             true,
         )];
-        let (tx_from_alice_original, _maybe_change_output) = alice
+        let (tx_from_alice_original, _, _maybe_change_output) = alice
             .lock_guard()
             .await
             .create_transaction_with_prover_capability(
@@ -1467,7 +1467,7 @@ mod tests {
             .to_owned();
         let now = genesis_block.kernel.header.timestamp;
         let in_seven_years = now + Timestamp::months(7 * 12);
-        let (unmined_tx, _maybe_change_output) = alice
+        let (unmined_tx, _, _maybe_change_output) = alice
             .lock_guard()
             .await
             .create_transaction_with_prover_capability(
@@ -1595,7 +1595,7 @@ mod tests {
                     false,
                 );
                 let tx_outputs: TxOutputList = vec![receiver_data.clone()].into();
-                let (tx, _maybe_change_output) = preminer_clone
+                let (tx, _, _maybe_change_output) = preminer_clone
                     .clone()
                     .lock_guard()
                     .await
@@ -1799,7 +1799,7 @@ mod tests {
             )
             .await;
             let in_seven_months = genesis_block.kernel.header.timestamp + Timestamp::months(7);
-            let (tx_by_bob, _maybe_change_output) = bob
+            let (tx_by_bob, _, _maybe_change_output) = bob
                 .lock_guard()
                 .await
                 .create_transaction_with_prover_capability(

--- a/src/models/state/wallet/mod.rs
+++ b/src/models/state/wallet/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod incoming_utxo;
 pub(crate) mod monitored_utxo;
 pub(crate) mod rusty_wallet_database;
 pub mod secret_key_material;
+pub mod sent_transaction;
 pub(crate) mod transaction_output;
 pub(crate) mod unlocked_utxo;
 pub mod utxo_notification;
@@ -955,7 +956,7 @@ mod wallet_tests {
 
         let receiver_data_to_alice: TxOutputList =
             vec![receiver_data_12_to_alice, receiver_data_1_to_alice].into();
-        let (tx, _change_output) = bob
+        let (tx, _, _change_output) = bob
             .create_transaction_with_prover_capability(
                 receiver_data_to_alice.clone(),
                 bob_wallet.nth_generation_spending_key_for_tests(0).into(),
@@ -1192,7 +1193,7 @@ mod wallet_tests {
             false,
         );
 
-        let (tx_from_bob, _maybe_change_output) = bob
+        let (tx_from_bob, _, _maybe_change_output) = bob
             .create_transaction_with_prover_capability(
                 vec![receiver_data_1_to_alice_new.clone()].into(),
                 bob_wallet.nth_generation_spending_key_for_tests(0).into(),
@@ -1404,7 +1405,7 @@ mod wallet_tests {
         let tx_output =
             TxOutput::no_notification(anyone_can_spend_utxo, rng.random(), rng.random(), false);
         let change_key = WalletSecret::devnet_wallet().nth_symmetric_key_for_tests(0);
-        let (sender_tx, _change_output) = bob
+        let (sender_tx, _, _change_output) = bob
             .lock_guard()
             .await
             .create_transaction_with_prover_capability(

--- a/src/models/state/wallet/rusty_wallet_database.rs
+++ b/src/models/state/wallet/rusty_wallet_database.rs
@@ -2,6 +2,7 @@ use twenty_first::math::tip5::Digest;
 
 use super::expected_utxo::ExpectedUtxo;
 use super::monitored_utxo::MonitoredUtxo;
+use super::sent_transaction::SentTransaction;
 use crate::database::storage::storage_schema::traits::*;
 use crate::database::storage::storage_schema::DbtSingleton;
 use crate::database::storage::storage_schema::DbtVec;
@@ -37,6 +38,9 @@ pub struct RustyWalletDatabase {
     /// list of pre-images to guesser digests in blocks we found. Allows wallet
     /// to spend guesser-fee UTXOs.
     guesser_preimages: DbtVec<Digest>,
+
+    /// list of transactions sent by this wallet.
+    sent_transactions: DbtVec<SentTransaction>,
 }
 
 impl RustyWalletDatabase {
@@ -57,6 +61,11 @@ impl RustyWalletDatabase {
             .new_vec::<ExpectedUtxo>("expected_utxos")
             .await;
 
+        let sent_transactions = storage
+            .schema
+            .new_vec::<SentTransaction>("sent_transactions")
+            .await;
+
         let sync_label = storage.schema.new_singleton::<Digest>("sync_label").await;
         let counter = storage.schema.new_singleton::<u64>("counter").await;
 
@@ -75,6 +84,7 @@ impl RustyWalletDatabase {
             storage,
             monitored_utxos,
             expected_utxos,
+            sent_transactions,
             sync_label,
             counter,
             generation_key_counter,
@@ -101,6 +111,16 @@ impl RustyWalletDatabase {
     /// get mutable expected_utxos.
     pub fn expected_utxos_mut(&mut self) -> &mut DbtVec<ExpectedUtxo> {
         &mut self.expected_utxos
+    }
+
+    /// get sent transactions
+    pub fn sent_transactions(&self) -> &DbtVec<SentTransaction> {
+        &self.sent_transactions
+    }
+
+    /// get mutable sent transactions
+    pub fn sent_transactions_mut(&mut self) -> &mut DbtVec<SentTransaction> {
+        &mut self.sent_transactions
     }
 
     pub fn guesser_preimages(&self) -> &DbtVec<Digest> {

--- a/src/models/state/wallet/sent_transaction.rs
+++ b/src/models/state/wallet/sent_transaction.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use tasm_lib::prelude::Digest;
 
-use super::unlocked_utxo::UnlockedUtxo;
+use crate::models::blockchain::transaction::utxo::Utxo;
 use crate::models::blockchain::type_scripts::native_currency_amount::NativeCurrencyAmount;
 use crate::models::proof_abstractions::timestamp::Timestamp;
 use crate::models::state::transaction_details::TransactionDetails;
@@ -15,7 +15,7 @@ use crate::models::state::wallet::transaction_output::TxOutputList;
 /// of wallet history display.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SentTransaction {
-    pub tx_inputs: Vec<UnlockedUtxo>,
+    pub tx_inputs: Vec<Utxo>,
     pub tx_outputs: TxOutputList,
     pub fee: NativeCurrencyAmount,
     pub timestamp: Timestamp,
@@ -32,7 +32,7 @@ impl From<(TransactionDetails, Digest)> for SentTransaction {
 impl SentTransaction {
     pub(crate) fn new(td: TransactionDetails, tip_when_sent: Digest) -> Self {
         Self {
-            tx_inputs: td.tx_inputs,
+            tx_inputs: td.tx_inputs.into_iter().map(|u| u.utxo).collect(),
             tx_outputs: td.tx_outputs,
             fee: td.fee,
             timestamp: td.timestamp,

--- a/src/models/state/wallet/sent_transaction.rs
+++ b/src/models/state/wallet/sent_transaction.rs
@@ -1,0 +1,42 @@
+use serde::Deserialize;
+use serde::Serialize;
+use tasm_lib::prelude::Digest;
+
+use super::unlocked_utxo::UnlockedUtxo;
+use crate::models::blockchain::type_scripts::native_currency_amount::NativeCurrencyAmount;
+use crate::models::proof_abstractions::timestamp::Timestamp;
+use crate::models::state::transaction_details::TransactionDetails;
+use crate::models::state::wallet::transaction_output::TxOutputList;
+
+/// represents a user-level tx that has been sent by this wallet.
+///
+/// this type is intended for storing in the wallet-db in order to
+/// group together inputs and outputs as a single payment for purposes
+/// of wallet history display.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SentTransaction {
+    pub tx_inputs: Vec<UnlockedUtxo>,
+    pub tx_outputs: TxOutputList,
+    pub fee: NativeCurrencyAmount,
+    pub timestamp: Timestamp,
+    pub tip_when_sent: Digest, // tip block when sent.  (not when confirmed)
+}
+
+impl From<(TransactionDetails, Digest)> for SentTransaction {
+    fn from(data: (TransactionDetails, Digest)) -> Self {
+        let (td, tip_when_sent) = data;
+        Self::new(td, tip_when_sent)
+    }
+}
+
+impl SentTransaction {
+    pub(crate) fn new(td: TransactionDetails, tip_when_sent: Digest) -> Self {
+        Self {
+            tx_inputs: td.tx_inputs,
+            tx_outputs: td.tx_outputs,
+            fee: td.fee,
+            timestamp: td.timestamp,
+            tip_when_sent,
+        }
+    }
+}

--- a/src/models/state/wallet/transaction_output.rs
+++ b/src/models/state/wallet/transaction_output.rs
@@ -4,6 +4,8 @@ use std::ops::Deref;
 use std::ops::DerefMut;
 
 use itertools::Itertools;
+use serde::Deserialize;
+use serde::Serialize;
 
 use super::utxo_notification::UtxoNotifyMethod;
 use crate::config_models::network::Network;
@@ -26,7 +28,7 @@ use crate::util_types::mutator_set::commit;
 ///
 /// Contains data that a UTXO recipient requires in order to be notified about
 /// and claim a given UTXO.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TxOutput {
     utxo: Utxo,
     sender_randomness: Digest,
@@ -212,7 +214,7 @@ impl TxOutput {
 }
 
 /// Represents a list of [TxOutput]
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct TxOutputList(Vec<TxOutput>);
 
 impl Deref for TxOutputList {

--- a/src/models/state/wallet/unlocked_utxo.rs
+++ b/src/models/state/wallet/unlocked_utxo.rs
@@ -1,3 +1,5 @@
+use serde::Deserialize;
+use serde::Serialize;
 use tasm_lib::triton_vm::prelude::Tip5;
 
 use super::address::SpendingKey;
@@ -8,8 +10,8 @@ use crate::util_types::mutator_set::ms_membership_proof::MsMembershipProof;
 use crate::util_types::mutator_set::mutator_set_accumulator::MutatorSetAccumulator;
 use crate::util_types::mutator_set::removal_record::RemovalRecord;
 
-#[derive(Debug, Clone)]
-pub(crate) struct UnlockedUtxo {
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UnlockedUtxo {
     pub utxo: Utxo,
     lock_script_and_witness: LockScriptAndWitness,
     membership_proof: MsMembershipProof,

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -36,6 +36,7 @@ use super::expected_utxo::ExpectedUtxo;
 use super::expected_utxo::UtxoNotifier;
 use super::incoming_utxo::IncomingUtxo;
 use super::rusty_wallet_database::RustyWalletDatabase;
+use super::sent_transaction::SentTransaction;
 use super::unlocked_utxo::UnlockedUtxo;
 use super::wallet_status::WalletStatus;
 use super::wallet_status::WalletStatusElement;
@@ -536,6 +537,50 @@ impl WalletState {
     /// Returns the number of expected UTXOs in the database.
     pub(crate) async fn num_expected_utxos(&self) -> u64 {
         self.wallet_db.expected_utxos().len().await
+    }
+
+    /// adds a [SentTransaction] to the wallet db
+    pub(crate) async fn add_sent_transaction(&mut self, sent_transaction: SentTransaction) {
+        self.wallet_db
+            .sent_transactions_mut()
+            .push(sent_transaction)
+            .await;
+    }
+
+    /// returns a count of transactions this wallet sent at given block.
+    ///
+    /// note that the block specifies the current tip at the moment the
+    /// transactions were sent -- NOT when they were confirmed.
+    ///
+    /// This fn is provided to facilitate send-rate limiting.
+    /// ie to limit how many payments the wallet can send per block.
+    ///
+    /// once send-rate limiting is disabled, this fn can probably be removed.
+    pub(crate) async fn count_sent_transactions_at_block(&self, block: Digest) -> usize {
+        let list = self.wallet_db.sent_transactions();
+        let len = list.len().await;
+
+        // iterate over list in reverse order (newest blocks first)
+        let stream = list.stream_many_values((0..len).rev()).await;
+        pin_mut!(stream); // needed for iteration
+
+        let mut count: usize = 0;
+
+        // note; this loop assumes that SentTransaction are ordered such
+        // that any elements with the same tip_when_sent (digest) are next
+        // to eachother, which should normally be true.
+        // that assumption allows us to break early rather than checking the
+        // entire list.
+
+        while let Some(stx) = stream.next().await {
+            if stx.tip_when_sent == block {
+                count += 1;
+            } else if count > 0 {
+                break;
+            }
+        }
+
+        count
     }
 
     // note: does not verify we do not have any dups.
@@ -1755,7 +1800,7 @@ mod tests {
             false,
         );
         let tx_outputs = vec![txoutput.clone(), txoutput.clone()];
-        let (tx_block2, _) = bob
+        let (tx_block2, _, _) = bob
             .lock_guard_mut()
             .await
             .create_transaction_with_prover_capability(
@@ -1799,7 +1844,7 @@ mod tests {
 
         // Repeat the outputs to Alice in block 3 and verify correct new
         // balance.
-        let (tx_block3, _) = bob
+        let (tx_block3, _, _) = bob
             .lock_guard_mut()
             .await
             .create_transaction_with_prover_capability(
@@ -1859,7 +1904,7 @@ mod tests {
             false,
         );
         let fee = NativeCurrencyAmount::coins(10);
-        let (mut tx_block2, _) = bob
+        let (mut tx_block2, _, _) = bob
             .lock_guard_mut()
             .await
             .create_transaction_with_prover_capability(
@@ -1959,7 +2004,7 @@ mod tests {
             false,
         );
         let fee = NativeCurrencyAmount::coins(10);
-        let (mut tx_block2, _) = bob
+        let (mut tx_block2, _, _) = bob
             .lock_guard_mut()
             .await
             .create_transaction_with_prover_capability(
@@ -2667,7 +2712,7 @@ mod tests {
             let block2_timestamp = block1.header().timestamp + Timestamp::minutes(2);
             let fee = NativeCurrencyAmount::coins(1);
             let a_key = GenerationSpendingKey::derive_from_seed(rng.random());
-            let (mut tx_spending_guesser_fee, _) = bob
+            let (mut tx_spending_guesser_fee, _, _) = bob
                 .global_state_lock
                 .lock_guard()
                 .await
@@ -2814,7 +2859,7 @@ mod tests {
                     UtxoNotificationMedium::OnChain,
                 );
 
-                let (tx, _change_output) = gs
+                let (tx, _, _change_output) = gs
                     .create_transaction_with_prover_capability(
                         tx_outputs,
                         change_key,
@@ -3406,7 +3451,7 @@ mod tests {
                     an_address.into(),
                     false,
                 );
-                let (spending_tx, _) = alice_global_lock
+                let (spending_tx, _, _) = alice_global_lock
                     .global_state_lock
                     .lock_guard()
                     .await

--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -3200,7 +3200,7 @@ mod peer_loop_tests {
             .nth_symmetric_key_for_tests(0);
         let genesis_block = Block::genesis(network);
         let now = genesis_block.kernel.header.timestamp;
-        let (transaction_1, _change_output) = state_lock
+        let (transaction_1, _, _change_output) = state_lock
             .lock_guard()
             .await
             .create_transaction_with_prover_capability(
@@ -3283,7 +3283,7 @@ mod peer_loop_tests {
 
         let genesis_block = Block::genesis(network);
         let now = genesis_block.kernel.header.timestamp;
-        let (transaction_1, _change_output) = state_lock
+        let (transaction_1, _, _change_output) = state_lock
             .lock_guard()
             .await
             .create_transaction_with_prover_capability(

--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -4626,10 +4626,10 @@ mod rpc_server_tests {
             let ctx = context::current();
             let timestamp = network.launch_date() + Timestamp::months(7);
 
-            let address: ReceivingAddress = GenerationSpendingKey::derive_from_seed(rng.gen())
+            let address: ReceivingAddress = GenerationSpendingKey::derive_from_seed(rng.random())
                 .to_address()
                 .into();
-            let amount = NativeCurrencyAmount::coins(rng.gen_range(0..10));
+            let amount = NativeCurrencyAmount::coins(rng.random_range(0..10));
             let fee = NativeCurrencyAmount::coins(1);
 
             let outputs = vec![(address, amount)];

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -894,7 +894,7 @@ pub(crate) async fn fake_valid_block_from_tx_for_tests(
 async fn fake_create_transaction_from_details_for_tests(
     transaction_details: TransactionDetails,
 ) -> Transaction {
-    let kernel = PrimitiveWitness::from_transaction_details(transaction_details).kernel;
+    let kernel = PrimitiveWitness::from_transaction_details(&transaction_details).kernel;
 
     let claim = SingleProof::claim(kernel.mast_hash());
     cache_true_claim(claim).await;


### PR DESCRIPTION
addresses #364.   (lays groundwork)

This PR records details of sent tx in the wallet-db.

This ensures that wallets will have sufficient metadata to group together utxos related to a single payment, eg when displaying wallet history.

It is also used for adding a 2 payments per block rate limit implemented in the rpc send APIs.  This limit applies only until block height 25000, approx 5.6 months after launch.

Changes:
 * add SentTransction type in sent_transaction.rs
 * add RustyWalletDatabase::sent_transactions: DbtVec<SentTransaction>
 * some fn now take references instead of owned values, to avoid clone.
 * create_transaction_with_prover_capability() returns TransactionDetails
 * impl serialize traits for TxOutput, TxOutputList, UnlockedUtxo
 * make UnlockedUtxo pub
 * add WalletState::add_sent_transaction()
 * add WalletState::count_sent_transactions_at_block()
 * impl rate limit check in send_to_many_inner_with_mock_proof_option()
 * record spent tx to wallet in send_to_many_inner_with_mock_proof_option()
 * add RateLimit variant to SendError

Tests:
 * adds test rpc_server::send_tests::send_rate_limit()

here is a screenshot of the rate-limit in effect, after 3rd payment send attempt at a given block height.

![screen](https://github.com/user-attachments/assets/94d51761-4c65-4d1a-8f4d-7c3d71571f5c)

------

Of note for reviewers:

1. Please review fields of the new type SentTransaction.   These are just copied from TransactionDetails, but I removed the optional coinbase field and the mutator_set_accumulator field, as it is 88 bytes.  q's:  are we likely to need mutator_set_accumulator field for anything?   should we change Vec<UnlockedUtxo> to Vec<Utxo> to save some space?  Should we likewise reduce size of TxOutputList somehow?   Most wallets won't have a huge number of sent transactions, but some might, particularly for automated services.

2. does 2 seem reasonable for the rate limit?  (ie 3rd send is blocked)

3. Are we sure about the 25000 block time-limit for the rate limit?
