### PR TITLE
perf: announce mined block to peers immediately.

### DIFF
--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -508,7 +508,7 @@ impl MainLoopHandler {
                     );
                 }
 
-                // Share block with peers firs thing.
+                // Share block with peers first thing.
                 info!("broadcasting new block to peers");
                 self.main_to_peer_broadcast_tx
                     .send(MainToPeerTask::Block(new_block.clone()))


### PR DESCRIPTION
A miner who finds a new block wants it to be broadcast to peers immediately so they have best chance to win the lottery race.

Previously a mined block was not being broadcast until after set_new_self_mined_tip() which is an expensive function.

The benefit to doing it that way is we can be certain we will have the block when a peer rqquests it.

This commit broadcasts the new block announcement before calling set_new_self_mined_tip().

However it does it inside a global state write-lock, ie:

1. obtain write-lock
2. broadcast to peers
3. set_new_self_mined_tip()
4. release write-lock.

As such, any incoming peer request will have to acquire a read-lock which cannot happen until set_new_self_mined_tip() completes.

-----

it has worked fine thus far in limited testing.   ie, I was able to mine and broadcast blocks with 3 nodes on regtest.  