### PR TITLE
fix: report guessing time correctly

### DIFF
--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -678,19 +678,14 @@ pub(crate) async fn mine(
             && is_connected;
 
         // if start_guessing is true, then we are in a state change from
-        // a non-guessing state to a guessing state.
+        // inactive state to guessing state.
         //
         // if start_guessing is false and should_guess is true then we
         // have already been guessing and are restarting with new params.
-        let start_guessing = match (mining_status, should_guess) {
-            (MiningStatus::Inactive, true) => true,
-            (MiningStatus::Composing(_), true) => {
-                // shouldn't ever happen, warn if so.
-                warn!("guessing while mining_status is composing.");
-                true
-            }
-            _ => false,
-        };
+        let start_guessing = matches!(
+            (mining_status, should_guess),
+            (MiningStatus::Inactive, true)
+        );
 
         if start_guessing {
             let proposal = maybe_proposal.unwrap(); // is_some() verified above


### PR DESCRIPTION
![screen](https://github.com/user-attachments/assets/d6826b8f-f3b0-4b6a-bf57-bc9c726f5d60)

note the "guessing for 240 seconds".   It doesn't loop back to 0 every 20 seconds anymore.


fixes #405

Refactors mining loop a bit such that:
1. state transition from not-guessing to guessing is identifiable.
2. state transition from guessing to inactive is identifiable.
3. globalState mining_status is set to guessing when guessing starts
4. mining_status is set to inactive when guessing ends.

Previously mining_status was being set to guessing when guessing first starts, then inactive after 20 seconds, then guessing again, then inactive after 20 seconds, and so on until a block is found or guessing is cancelled.  Thus the max reported duration of guessing was 20 seconds.

With this change, the reported duration accurately reflects the actual amount of time spent in the guessing state, regardless of the restarts every 20 seconds.

There is also a minor cleanup that aims to preserve existing logic but move duplicated code into a common place, which makes this complicated fn a bit more readable.

Overall, I consider this a minor-ish refactor as it does not attempt to alter the core logic of the 20 second guessing task timer, but rather preserves and simplifies it a bit.

-----

testing:

I've been running this for a couple hours in these 3 roles:  compose, compose & guess, guess.

I also tested neptune-cli commands:  pause-miner, restart-miner while guessing.

So far everything has worked as expected.

Nonetheless this is a complex and sensitive area of the code.  It would be great if it could be tested with a faster composing machine for at least a few blocks.

