### PR TITLE
Refuse connections from recent disconnects

### DIFF
--- a/src/config_models/cli_args.rs
+++ b/src/config_models/cli_args.rs
@@ -260,6 +260,18 @@ pub struct Args {
     /// Exposing the data directory leaks some privacy. Disable to prevent.
     #[clap(long)]
     pub disable_cookie_hint: bool,
+
+    /// The duration (in seconds) during which new connection attempts from peers
+    /// are ignored after a connection to them was closed.
+    ///
+    /// Does not affect abnormally closed connections. For example, if a connection
+    /// is dropped due to networking issues, an immediate reconnection attempt is
+    /// not affected by this cooldown.
+    //
+    // The default should be larger than the default interval between peer discovery
+    // to meaningfully suppress rapid reconnection attempts.
+    #[clap(long, default_value = "1800", value_parser = duration_from_seconds_str)]
+    pub reconnect_cooldown: Duration,
 }
 
 impl Default for Args {
@@ -278,6 +290,10 @@ fn fraction_validator(s: &str) -> Result<f64, String> {
     } else {
         Err(format!("Fraction must be between 0 and 1, got {value}"))
     }
+}
+
+fn duration_from_seconds_str(s: &str) -> Result<Duration, std::num::ParseIntError> {
+    Ok(Duration::from_secs(s.parse()?))
 }
 
 impl Args {

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -2412,26 +2412,18 @@ mod test {
 
             // main loop should send a `Disconnect` message
             let main_to_peers_message = main_to_peer_rx.recv().await.unwrap();
-            assert!(matches!(
-                main_to_peers_message,
-                MainToPeerTask::Disconnect(_)
-            ));
             let MainToPeerTask::Disconnect(observed_drop_peer_socket_address) =
                 main_to_peers_message
             else {
-                unreachable!()
+                panic!("Expected disconnect, got {main_to_peers_message:?}");
             };
 
             // matched observed droppee against expectation
             assert_eq!(
                 expected_drop_peer_socket_address,
-                observed_drop_peer_socket_address
+                observed_drop_peer_socket_address,
             );
-
-            println!(
-                "Dropped connection with {}.",
-                expected_drop_peer_socket_address
-            );
+            println!("Dropped connection with {expected_drop_peer_socket_address}.");
 
             // don't forget to terminate the peer task, which is still running
             incoming_peer_task_handle.abort();


### PR DESCRIPTION
In order to reduce the potential connection flood, rapid re-connection attempts after a disconnect are ignored.

If node A decides to (gracefully) terminate the connection to some node B, then node A blocks any connection attempts from node B for some time. The cool-down time can be configured through the command-line interface's argument “reconnect_cooldown”. The argument is given in seconds. The default is 30 seconds.

~~This introduces a breaking change because the public enum `ConnectionRefusedReason` gets a new variant `RecentlyDisconnected`. This enum is now marked `#[non_exhaustive]` to prevent future variant additions from being breaking again.~~

This introduces a breaking change because the public structure `NetworkingState` gains a new, private field.
