### PR TITLE
Automatic Recognition of Guesser UTXOs

### DIFF
--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -525,13 +525,9 @@ impl MainLoopHandler {
                     );
 
                 let update_jobs = global_state_mut
-                    .set_new_self_mined_tip(
+                    .set_new_self_composed_tip(
                         new_block.as_ref().clone(),
-                        [
-                            new_block_info.composer_utxos,
-                            new_block_info.guesser_fee_utxo_infos,
-                        ]
-                        .concat(),
+                        new_block_info.composer_utxos,
                     )
                     .await?;
                 drop(global_state_mut);

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -562,11 +562,13 @@ impl MainLoopHandler {
                     return Ok(None);
                 }
 
-                self.main_to_peer_broadcast_tx
+                if !self.global_state_lock.cli().secret_compositions {
+                    self.main_to_peer_broadcast_tx
                     .send(MainToPeerTask::BlockProposalNotification((&block).into()))
                     .expect(
                         "Peer handler broadcast channel prematurely closed. This should never happen.",
                     );
+                }
 
                 {
                     // Use block proposal and add expected UTXOs from this

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -525,10 +525,7 @@ impl MainLoopHandler {
                     );
 
                 let update_jobs = global_state_mut
-                    .set_new_self_composed_tip(
-                        new_block.as_ref().clone(),
-                        new_block_info.composer_utxos,
-                    )
+                    .set_new_tip(new_block.as_ref().clone())
                     .await?;
                 drop(global_state_mut);
 

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -294,16 +294,9 @@ Difficulty threshold: {threshold}
 "#
     );
 
-    let guesser_fee_utxo_infos = block.guesser_fee_expected_utxos(guesser_key.preimage());
-    assert!(
-        !guesser_fee_utxo_infos.is_empty(),
-        "All mined blocks have guesser fees"
-    );
-
     let new_block_found = NewBlockFound {
         block: Box::new(block),
         composer_utxos,
-        guesser_fee_utxo_infos,
     };
 
     sender

--- a/src/models/channel.rs
+++ b/src/models/channel.rs
@@ -60,7 +60,6 @@ impl MainToMiner {
 #[derive(Clone, Debug)]
 pub(crate) struct NewBlockFound {
     pub block: Box<Block>,
-    pub composer_utxos: Vec<ExpectedUtxo>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/models/channel.rs
+++ b/src/models/channel.rs
@@ -61,7 +61,6 @@ impl MainToMiner {
 pub(crate) struct NewBlockFound {
     pub block: Box<Block>,
     pub composer_utxos: Vec<ExpectedUtxo>,
-    pub guesser_fee_utxo_infos: Vec<ExpectedUtxo>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/models/state/block_proposal.rs
+++ b/src/models/state/block_proposal.rs
@@ -19,15 +19,6 @@ pub(crate) enum BlockProposal {
 }
 
 impl BlockProposal {
-    /// Returns the UTXOs for the composer if this is our composition,
-    /// otherwise returns the empty list.
-    pub(crate) fn composer_utxos(&self) -> Vec<ExpectedUtxo> {
-        match self {
-            BlockProposal::OwnComposition((_, utxo_info)) => utxo_info.clone(),
-            _ => vec![],
-        }
-    }
-
     pub(crate) fn own_proposal(block: Block, expected_utxos: Vec<ExpectedUtxo>) -> Self {
         Self::OwnComposition((block, expected_utxos))
     }

--- a/src/models/state/wallet/address/hash_lock_key.rs
+++ b/src/models/state/wallet/address/hash_lock_key.rs
@@ -24,10 +24,6 @@ impl HashLockKey {
         self.preimage.hash()
     }
 
-    pub(crate) fn preimage(&self) -> Digest {
-        self.preimage
-    }
-
     pub(crate) fn from_preimage(preimage: Digest) -> Self {
         Self { preimage }
     }
@@ -72,5 +68,10 @@ impl HashLockKey {
         );
 
         instructions.into()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn preimage(&self) -> Digest {
+        self.preimage
     }
 }

--- a/src/models/state/wallet/incoming_utxo.rs
+++ b/src/models/state/wallet/incoming_utxo.rs
@@ -23,9 +23,9 @@ use crate::util_types::mutator_set::commit;
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(any(test, feature = "arbitrary-impls"), derive(Arbitrary))]
 pub(crate) struct IncomingUtxo {
-    pub utxo: Utxo,
-    pub sender_randomness: Digest,
-    pub receiver_preimage: Digest,
+    pub(crate) utxo: Utxo,
+    pub(crate) sender_randomness: Digest,
+    pub(crate) receiver_preimage: Digest,
 }
 
 impl From<&ExpectedUtxo> for IncomingUtxo {

--- a/src/models/state/wallet/mod.rs
+++ b/src/models/state/wallet/mod.rs
@@ -201,16 +201,22 @@ impl WalletSecret {
         Ok((wallet, wallet_secret_file_locations))
     }
 
-    /// Returns the spending for guessing on top of the given block.
-    pub(crate) fn guesser_spending_key(&self, prev_block_digest: Digest) -> HashLockKey {
-        HashLockKey::from_preimage(Tip5::hash_varlen(
+    /// Return the guesser preimage for guessing on top of a given block (as
+    /// identified by the block's predecessor's hash).
+    pub(crate) fn guesser_preimage(&self, prev_block_digest: Digest) -> Digest {
+        Tip5::hash_varlen(
             &[
                 self.secret_seed.0.encode(),
                 vec![hash_lock_key::RAW_HASH_LOCK_KEY_FLAG],
                 prev_block_digest.encode(),
             ]
             .concat(),
-        ))
+        )
+    }
+
+    /// Returns the spending key for guessing on top of the given block.
+    pub(crate) fn guesser_spending_key(&self, prev_block_digest: Digest) -> HashLockKey {
+        HashLockKey::from_preimage(self.guesser_preimage(prev_block_digest))
     }
 
     /// derives a generation spending key at `index`

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -1088,18 +1088,16 @@ impl WalletState {
         let spent_inputs: Vec<(Utxo, AbsoluteIndexSet, u64)> =
             self.scan_for_spent_utxos(&tx_kernel).await;
 
-        let onchain_received_outputs = self.scan_for_announced_utxos(&tx_kernel);
-
         let MutatorSetUpdate {
             additions: addition_records,
             removals: _removal_records,
         } = new_block.mutator_set_update();
 
+        let onchain_received_outputs = self.scan_for_announced_utxos(&tx_kernel);
         let offchain_received_outputs = self
             .scan_for_expected_utxos(&addition_records)
             .await
             .collect_vec();
-
         let guesser_fee_outputs = self.scan_for_guesser_fee_utxos(new_block);
 
         let all_spendable_received_outputs = onchain_received_outputs

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -2868,13 +2868,17 @@ mod tests {
             half_coinbase_amt.div_two();
             let send_amt = NativeCurrencyAmount::coins(5);
 
-            let timestamp = Block::genesis(network).header().timestamp + Timestamp::hours(1);
+            let genesis_block = Block::genesis(network);
+            let timestamp = genesis_block.header().timestamp + Timestamp::hours(1);
 
             // mine a block to our wallet.  we should have 100 coins after.
-            let tip_digest =
-                mine_block_to_wallet_invalid_block_proof(&mut global_state_lock, timestamp)
-                    .await?
-                    .hash();
+            let tip_digest = mine_block_to_wallet_invalid_block_proof(
+                &mut global_state_lock,
+                genesis_block.hash(),
+                timestamp,
+            )
+            .await?
+            .hash();
 
             let tx = {
                 // verify that confirmed and unconfirmed balances.

--- a/src/models/state/wallet/wallet_status.rs
+++ b/src/models/state/wallet/wallet_status.rs
@@ -101,7 +101,7 @@ impl WalletStatus {
         self.synced_unspent
             .iter()
             .map(|(wse, _msmp)| &wse.utxo)
-            .filter(|utxo| utxo.is_timelocked_but_otherwise_spendable_at(timestamp))
+            .filter(|utxo| !utxo.can_spend_at(timestamp))
             .map(|utxo| utxo.get_native_currency_amount())
             .sum::<NativeCurrencyAmount>()
     }

--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -4280,8 +4280,6 @@ mod rpc_server_tests {
 
                     rpc_server
                         .state
-                        .lock_guard_mut()
-                        .await
                         .set_new_self_composed_tip(block1.clone(), composer_expected_utxos)
                         .await
                         .unwrap();
@@ -4411,8 +4409,6 @@ mod rpc_server_tests {
                     make_mock_block(&genesis_block, None, bob_key, Default::default()).await;
 
                 bob.state
-                    .lock_guard_mut()
-                    .await
                     .set_new_self_composed_tip(block1.clone(), composer_expected_utxos)
                     .await
                     .unwrap();

--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -4282,7 +4282,7 @@ mod rpc_server_tests {
                         .state
                         .lock_guard_mut()
                         .await
-                        .set_new_self_mined_tip(block1.clone(), composer_expected_utxos)
+                        .set_new_self_composed_tip(block1.clone(), composer_expected_utxos)
                         .await
                         .unwrap();
 
@@ -4407,13 +4407,13 @@ mod rpc_server_tests {
 
                 let bob_key = bob_wallet.nth_generation_spending_key(0);
                 let genesis_block = Block::genesis(network);
-                let (block1, composer_expected) =
+                let (block1, composer_expected_utxos) =
                     make_mock_block(&genesis_block, None, bob_key, Default::default()).await;
 
                 bob.state
                     .lock_guard_mut()
                     .await
-                    .set_new_self_mined_tip(block1.clone(), composer_expected)
+                    .set_new_self_composed_tip(block1.clone(), composer_expected_utxos)
                     .await
                     .unwrap();
 
@@ -4734,7 +4734,7 @@ mod rpc_server_tests {
                 // --- Init.  append the block to blockchain ---
                 rpc_server
                     .state
-                    .set_new_self_mined_tip(block_1.clone(), composer_utxos)
+                    .set_new_self_composed_tip(block_1.clone(), composer_utxos)
                     .await?;
 
                 {

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -822,14 +822,8 @@ pub(crate) async fn mine_block_to_wallet_invalid_block_proof(
     let mut block = Block::block_template_invalid_proof(&tip_block, transaction, timestamp, None);
     block.set_header_guesser_digest(guesser_preimage.hash());
 
-    let expected_utxos = block
-        .guesser_fee_expected_utxos(guesser_preimage)
-        .into_iter()
-        .chain(expected_composer_utxos)
-        .collect_vec();
-
     global_state_lock
-        .set_new_self_mined_tip(block.clone(), expected_utxos)
+        .set_new_self_composed_tip(block.clone(), expected_composer_utxos)
         .await?;
 
     Ok(block)

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -801,6 +801,7 @@ pub(crate) async fn mock_genesis_archival_state(
 /// block proof.
 pub(crate) async fn mine_block_to_wallet_invalid_block_proof(
     global_state_lock: &mut GlobalStateLock,
+    prev_block_digest: Digest,
     timestamp: Timestamp,
 ) -> Result<Block> {
     let tip_block = global_state_lock
@@ -818,7 +819,12 @@ pub(crate) async fn mine_block_to_wallet_invalid_block_proof(
     )
     .await?;
 
-    let guesser_preimage = Digest::default();
+    let guesser_preimage = global_state_lock
+        .lock_guard()
+        .await
+        .wallet_state
+        .wallet_secret
+        .guesser_preimage(prev_block_digest);
     let mut block = Block::block_template_invalid_proof(&tip_block, transaction, timestamp, None);
     block.set_header_guesser_digest(guesser_preimage.hash());
 


### PR DESCRIPTION
The guesser UTXOs are locked through a `RawHashLock`. Only the guesser is knowledgeable of the key that can release this lock.

Prior to this PR, this key was already deterministically derived from the wallet secret and the previous block hash. Despite this deterministic derivation, the rest of the pipeline assumed no such structure. In particular, a successful guesser task would pass the guesser preimage upstream; and explicit `ExpectedUtxo`s would be generated so that the wallet can claim these UTXOs.

This commit
 - Modifies the wallet update function so that it checks an incoming block against what the guesser preimage would be if this wallet had been the one to guess it. This change obviates the need to transmit `ExpectedUtxo`s to the wallet update function.
 - Removes the parts of the mechanism whereby an unstructured guesser preimage or `ExpectedUtxo`s for guesser fee UTXOs are passed around.
 
Also:
 - Refactor method `is_timelocked_but_otherwise_spendable_at` on `Utxo`. While this refactor was useful in debugging this PR, it is tangentially if at all related.

Closes #413.
