### PR TITLE
refactor(peer_loop): Extra check of double spending txs

### DIFF
--- a/src/models/blockchain/transaction/mod.rs
+++ b/src/models/blockchain/transaction/mod.rs
@@ -305,14 +305,13 @@ impl Transaction {
     /// PrimitiveWitness::validate and ProofCollection/RemovalRecordsIntegrity.
     /// AOCL membership is a feature of *validity*, which is a pre-requisite to
     /// confirmability.
-    pub fn is_confirmable_relative_to(
+    pub(crate) fn is_confirmable_relative_to(
         &self,
         mutator_set_accumulator: &MutatorSetAccumulator,
     ) -> bool {
         self.kernel
-            .inputs
-            .iter()
-            .all(|rr| rr.validate(mutator_set_accumulator))
+            .is_confirmable_relative_to(mutator_set_accumulator)
+            .is_ok()
     }
 }
 

--- a/src/models/peer.rs
+++ b/src/models/peer.rs
@@ -84,6 +84,7 @@ pub enum NegativePeerSanction {
     UnconfirmableTransaction,
     TransactionWithNegativeFee,
     DoubleSpendingTransaction,
+    CannotApplyTransactionToMutatorSet,
 
     InvalidBlockMmrAuthentication,
 
@@ -132,6 +133,9 @@ impl Display for NegativePeerSanction {
             NegativePeerSanction::UnconfirmableTransaction => "unconfirmable transaction",
             NegativePeerSanction::TransactionWithNegativeFee => "negative-fee transaction",
             NegativePeerSanction::DoubleSpendingTransaction => "double-spending transaction",
+            NegativePeerSanction::CannotApplyTransactionToMutatorSet => {
+                "cannot apply tx to mutator set"
+            }
             NegativePeerSanction::NonMinedTransactionHasCoinbase => {
                 "non-mined transaction has coinbase"
             }
@@ -217,6 +221,7 @@ impl Sanction for NegativePeerSanction {
             NegativePeerSanction::UnconfirmableTransaction => -2,
             NegativePeerSanction::TransactionWithNegativeFee => -22,
             NegativePeerSanction::DoubleSpendingTransaction => -14,
+            NegativePeerSanction::CannotApplyTransactionToMutatorSet => -3,
             NegativePeerSanction::NonMinedTransactionHasCoinbase => -10,
             NegativePeerSanction::NoStandingFoundMaybeCrash => -10,
             NegativePeerSanction::BlockProposalNotFound => -1,

--- a/src/models/peer.rs
+++ b/src/models/peer.rs
@@ -83,6 +83,7 @@ pub enum NegativePeerSanction {
     InvalidTransaction,
     UnconfirmableTransaction,
     TransactionWithNegativeFee,
+    DoubleSpendingTransaction,
 
     InvalidBlockMmrAuthentication,
 
@@ -130,6 +131,7 @@ impl Display for NegativePeerSanction {
             NegativePeerSanction::InvalidTransaction => "invalid transaction",
             NegativePeerSanction::UnconfirmableTransaction => "unconfirmable transaction",
             NegativePeerSanction::TransactionWithNegativeFee => "negative-fee transaction",
+            NegativePeerSanction::DoubleSpendingTransaction => "double-spending transaction",
             NegativePeerSanction::NonMinedTransactionHasCoinbase => {
                 "non-mined transaction has coinbase"
             }
@@ -214,6 +216,7 @@ impl Sanction for NegativePeerSanction {
             NegativePeerSanction::InvalidTransaction => -10,
             NegativePeerSanction::UnconfirmableTransaction => -2,
             NegativePeerSanction::TransactionWithNegativeFee => -22,
+            NegativePeerSanction::DoubleSpendingTransaction => -14,
             NegativePeerSanction::NonMinedTransactionHasCoinbase => -10,
             NegativePeerSanction::NoStandingFoundMaybeCrash => -10,
             NegativePeerSanction::BlockProposalNotFound => -1,


### PR DESCRIPTION
Ensure that double spending transactions never make it into the mempool, or are relayed to other peers. 

This is not a consensus change, as the same check happens in `Block::is_valid`. But it moves the check earlier up in the pipeline. Previously, it was only checked if all removal records have valid MMR membership proofs, not that they also set indices that were not already set.

This error message is reported:
```
2025-02-16T05:45:22.184331881Z  INFO ThreadId(06) neptune_cash::peer_loop: Got block proposal from peer.                                                                                
2025-02-16T05:45:22.323280118Z  WARN ThreadId(06) neptune_cash::models::blockchain::block: mutator set update must be possible 
```

I suspect the problem is that double-spending transactions are relayed on the network. And block proposals are invalid because of this, meaning that composers are wasting resources and missing out on block rewards. And guessers are idling because they don't have any work.