### PR TITLE
feat: Scan Mode

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,7 @@ jobs:
           --
           --skip mine_20_blocks_in_40_seconds
           --skip hash_rate_independent_of_tx_size
+          --skip blocks_with_0_to_10_inputs_and_successors_are_valid
 
         # `--doc` cannot be mixed with other target option
       - name: Run documentation tests

--- a/src/bin/neptune-cli.rs
+++ b/src/bin/neptune-cli.rs
@@ -1198,9 +1198,9 @@ fn get_nth_receiving_address(
     let wallet_file_name = WalletFileContext::wallet_secret_path(&wallet_dir);
     if !wallet_file_name.exists() {
         bail!("No wallet file found at {}.", wallet_file_name.display());
-    } else {
-        println!("{}", wallet_file_name.display());
     }
+
+    println!("{}", wallet_file_name.display());
 
     let wallet_file = match WalletFile::read_from_file(&wallet_file_name) {
         Ok(ws) => ws,

--- a/src/bin/neptune-cli.rs
+++ b/src/bin/neptune-cli.rs
@@ -424,7 +424,14 @@ async fn main() -> Result<()> {
             // Get wallet object, create various wallet secret files
             DataDirectory::create_dir_if_not_exists(&wallet_dir).await?;
 
-            let (_, secret_file_paths) = WalletSecret::read_from_file_or_create(&wallet_dir)?;
+            let (_, secret_file_paths, wallet_is_new) =
+                WalletSecret::read_from_file_or_create(&wallet_dir)?;
+
+            if wallet_is_new {
+                println!("New wallet generated.");
+            } else {
+                println!("Not generating a new wallet because an existing one is present already.");
+            }
 
             println!(
                 "Wallet stored in: {}\nMake sure you also see this path if you run the neptune-core client",

--- a/src/config_models/cli_args.rs
+++ b/src/config_models/cli_args.rs
@@ -406,21 +406,12 @@ fn parse_range(unparsed_range: &str) -> Result<RangeInclusive<u64>, String> {
         return Err(error_message);
     };
 
-    let start = match start
+    let start = start
         .is_empty()
-        .then_some(Ok(0_u64))
+        .then_some(Ok(0))
         .or_else(|| Some(start.parse()))
         .unwrap()
-    {
-        Ok(u) => u,
-        Err(e) => {
-            let error_message = format!(
-                "Invalid start \"{start}\" in range \
-                \"{unparsed_range}\": {e:?}"
-            );
-            return Err(error_message);
-        }
-    };
+        .map_err(|e| format!("Invalid start \"{start}\" in range \"{unparsed_range}\": {e:?}"))?;
 
     let end = if end.is_empty() {
         u64::MAX

--- a/src/config_models/cli_args.rs
+++ b/src/config_models/cli_args.rs
@@ -289,7 +289,7 @@ pub struct Args {
     /// secret seed onto a new machine. In such cases, this subcommand will
     /// instruct the client to scan incoming blocks for transactions tied to
     /// future derivation indices --
-    /// [`ScanModeConfiguration::default_num_future_keys()`] by default, but
+    /// [`ScanModeConfiguration`]`::default().num_future_keys()` by default, but
     /// this parameter can be adjusted with the `--scan-keys` subcommand.
     ///
     /// The argument to this subcommand is the range of blocks where this extra-
@@ -335,7 +335,7 @@ pub struct Args {
      - `neptune-core --scan-blocks 13..=37` (13, 37, and everything in\n\
        between)\n\
      - `neptune-core --scan-blocks 13:37` (python index ranges also work)",
-    ScanModeConfiguration::default_num_future_keys()
+    ScanModeConfiguration::default().num_future_keys()
         ))]
     pub(crate) scan_blocks: Option<RangeInclusive<u64>>,
 

--- a/src/config_models/cli_args.rs
+++ b/src/config_models/cli_args.rs
@@ -369,26 +369,27 @@ fn parse_range(s: &str) -> Result<RangeInclusive<u64>, String> {
         return Err("Invalid range format".to_string());
     }
 
-    let parse_lower_bound = |s: &str| -> Result<Option<u64>, String> {
-        if s.is_empty() {
+    let parse_lower_bound = |s_: &str| -> Result<Option<u64>, String> {
+        if s_.is_empty() {
             Ok(None)
         } else {
-            s.parse()
+            s_.parse()
                 .map(Some)
                 .map_err(|_| "Invalid number".to_string())
         }
     };
 
-    let parse_upper_bound = |s: &str| -> Result<Option<u64>, String> {
-        if s.is_empty() {
+    let parse_upper_bound = |s_: &str| -> Result<Option<u64>, String> {
+        if s_.is_empty() {
             Ok(None)
-        } else if s.starts_with('=') {
-            s[1..]
+        } else if s_.starts_with('=') {
+            s_.strip_prefix('=')
+                .unwrap()
                 .parse()
                 .map(Some)
                 .map_err(|_| "Invalid number".to_string())
         } else {
-            match s.parse().map(|u: u64| u.checked_sub(1u64)) {
+            match s_.parse().map(|u: u64| u.checked_sub(1u64)) {
                 Ok(Some(u)) => Ok(Some(u)),
                 Ok(None) => Err("Invalid upper bound.".to_string()),
                 Err(e) => Err(format!("Invalid number: {e:?}")),
@@ -396,7 +397,7 @@ fn parse_range(s: &str) -> Result<RangeInclusive<u64>, String> {
         }
     };
 
-    let start = parse_lower_bound(parts.get(0).unwrap_or(&""))?;
+    let start = parse_lower_bound(parts.first().unwrap_or(&""))?;
     let end = parse_upper_bound(parts.get(1).unwrap_or(&""))?;
 
     match (start, end) {

--- a/src/config_models/cli_args.rs
+++ b/src/config_models/cli_args.rs
@@ -286,12 +286,21 @@ pub struct Args {
     /// However, this counter can be lost, for instance after importing the
     /// secret seed onto a new machine. In such cases, this subcommand will
     /// instruct the client to scan incoming blocks for transactions tied to
-    /// future derivation indices -- 2^1337 by default, but this parameter can
-    /// be adjusted with the `--scan-keys` subcommand.
+    /// future derivation indices --
+    /// [`ScanModeConfiguration::default_num_future_keys()`] by default, but
+    /// this parameter can be adjusted with the `--scan-keys` subcommand.
     ///
     /// The argument to this subcommand is the range of blocks where this extra-
     /// ordinary scanning step takes place. If no argument is supplied, the step
     /// takes place for every incoming block.
+    ///
+    /// Examples:
+    ///  - `neptune-core --scan-blocks ..` (scan all blocks)
+    ///  - `neptune-core --scan-blocks ..1337` (everything up to 1337)
+    ///  - `neptune-core --scan-blocks 1337..` (1337 and everything after)
+    ///  - `neptune-core --scan-blocks 13..=37` (13, 37, and everything in
+    ///    between)
+    ///  - `neptune-core --scan-blocks 13:37` (python index ranges also work)
     #[clap(long, value_parser = parse_range, action = clap::ArgAction::Set,
         num_args = 0..=1, long_help = format!(
             "\
@@ -306,10 +315,19 @@ pub struct Args {
     instruct the client to scan incoming blocks for transactions tied to\n\
     future derivation indices -- {} by default, but this parameter can be\n\
     adjusted with the `--scan-keys` subcommand.\n\
-    \
+    \n\
     The argument to this subcommand is the range of blocks where this extra-\n\
     ordinary scanning step takes place. If no argument is supplied, the step\n\
-    takes place for every incoming block.", ScanModeConfiguration::default_num_future_keys()
+    takes place for every incoming block.\n\
+    \n\
+    Examples: \n\
+     - `neptune-core --scan-blocks ..` (scan all blocks)\n\
+     - `neptune-core --scan-blocks ..1337` (everything up to 1337)\n\
+     - `neptune-core --scan-blocks 1337..` (1337 and everything after)\n\
+     - `neptune-core --scan-blocks 13..=37` (13, 37, and everything in\n\
+       between)\n\
+     - `neptune-core --scan-blocks 13:37` (python index ranges also work)",
+    ScanModeConfiguration::default_num_future_keys()
         ))]
     pub(crate) scan_blocks: Option<RangeInclusive<u64>>,
 
@@ -329,6 +347,8 @@ pub struct Args {
     /// When this flag is set, by default all blocks will be scanned. The
     /// subcommand `--scan-blocks` can be used to restrict the range of blocks
     /// that undergo this scan.
+    ///
+    /// Example: `neptune-core --scan-keys 42`
     #[clap(long)]
     pub(crate) scan_keys: Option<usize>,
 }

--- a/src/config_models/cli_args.rs
+++ b/src/config_models/cli_args.rs
@@ -303,6 +303,12 @@ pub struct Args {
     ///  - `neptune-core --scan-blocks 13..=37` (13, 37, and everything in
     ///    between)
     ///  - `neptune-core --scan-blocks 13:37` (python index ranges also work)
+    //
+    // Everything above should constitute the help documentation for this
+    // command, with the exception of the concrete value for the default number
+    // of future indices. To present the user with that piece of information,
+    // we override this docstring by setting `long_help`, which allows us to
+    // invoke `format!` and embed the integer.
     #[clap(long, value_parser = parse_range, action = clap::ArgAction::Set,
         num_args = 0..=1, long_help = format!(
             "\

--- a/src/config_models/data_directory.rs
+++ b/src/config_models/data_directory.rs
@@ -16,9 +16,9 @@ use crate::models::state::networking_state::BANNED_IPS_DB_NAME;
 use crate::models::state::shared::BLOCK_FILENAME_EXTENSION;
 use crate::models::state::shared::BLOCK_FILENAME_PREFIX;
 use crate::models::state::shared::DIR_NAME_FOR_BLOCKS;
-use crate::models::state::wallet::WALLET_DB_NAME;
-use crate::models::state::wallet::WALLET_DIRECTORY;
-use crate::models::state::wallet::WALLET_OUTPUT_COUNT_DB_NAME;
+use crate::models::state::wallet::wallet_file::WALLET_DB_NAME;
+use crate::models::state::wallet::wallet_file::WALLET_DIRECTORY;
+use crate::models::state::wallet::wallet_file::WALLET_OUTPUT_COUNT_DB_NAME;
 
 const UTXO_TRANSFER_DIRECTORY: &str = "utxo-transfer";
 const RPC_COOKIE_FILE_NAME: &str = ".cookie"; // matches bitcoin-core name.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,8 +106,7 @@ pub async fn initialize(cli_args: cli_args::Args) -> Result<i32> {
         WalletFileContext::read_from_file_or_create(&data_directory.wallet_directory_path())?;
     info!("Now getting wallet state. This may take a while if the database needs pruning.");
     let wallet_state =
-        WalletState::new_from_wallet_file_context(&data_directory, wallet_file_context, &cli_args)
-            .await;
+        WalletState::new_from_context(&data_directory, wallet_file_context, &cli_args).await;
     info!("Got wallet state.");
 
     // Connect to or create databases for block index, peers, mutator set, block sync

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,11 +102,16 @@ pub async fn initialize(cli_args: cli_args::Args) -> Result<i32> {
     // Get wallet object, create various wallet secret files
     let wallet_dir = data_directory.wallet_directory_path();
     DataDirectory::create_dir_if_not_exists(&wallet_dir).await?;
-    let (wallet_secret, _) =
+    let (wallet_secret, _, wallet_was_new) =
         WalletSecret::read_from_file_or_create(&data_directory.wallet_directory_path())?;
     info!("Now getting wallet state. This may take a while if the database needs pruning.");
-    let wallet_state =
-        WalletState::new_from_wallet_secret(&data_directory, wallet_secret, &cli_args).await;
+    let wallet_state = WalletState::new_from_wallet_secret(
+        &data_directory,
+        wallet_secret,
+        &cli_args,
+        wallet_was_new,
+    )
+    .await;
     info!("Got wallet state.");
 
     // Connect to or create databases for block index, peers, mutator set, block sync

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -1994,7 +1994,7 @@ mod test {
                 .lock_guard()
                 .await
                 .wallet_state
-                .wallet_secret
+                .wallet_entropy
                 .nth_generation_spending_key_for_tests(0);
             let in_seven_months = global_state_lock
                 .lock_guard()

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -521,7 +521,7 @@ pub(crate) async fn create_block_transaction_from(
         .lock_guard()
         .await
         .wallet_state
-        .wallet_secret
+        .wallet_entropy
         .nth_generation_spending_key(0);
     let composer_parameters = global_state_lock
         .lock_guard()
@@ -698,7 +698,7 @@ pub(crate) async fn mine(
                 .lock_guard()
                 .await
                 .wallet_state
-                .wallet_secret
+                .wallet_entropy
                 .guesser_spending_key(proposal.header().prev_block_digest);
 
             let latest_block_header = global_state_lock
@@ -960,6 +960,7 @@ pub(crate) mod mine_loop_tests {
     use crate::models::state::mempool::TransactionOrigin;
     use crate::models::state::wallet::transaction_output::TxOutput;
     use crate::models::state::wallet::utxo_notification::UtxoNotificationMedium;
+    use crate::models::state::wallet::wallet_entropy::WalletEntropy;
     use crate::tests::shared::dummy_expected_utxo;
     use crate::tests::shared::invalid_empty_block;
     use crate::tests::shared::make_mock_transaction_with_mutator_set_hash;
@@ -968,7 +969,6 @@ pub(crate) mod mine_loop_tests {
     use crate::util_types::test_shared::mutator_set::pseudorandom_addition_record;
     use crate::util_types::test_shared::mutator_set::random_mmra;
     use crate::util_types::test_shared::mutator_set::random_mutator_set_accumulator;
-    use crate::WalletSecret;
 
     /// Produce a transaction that allocates the given fraction of the block
     /// subsidy to the wallet in two UTXOs, one time-locked and one liquid.
@@ -997,7 +997,7 @@ pub(crate) mod mine_loop_tests {
             .lock_guard()
             .await
             .wallet_state
-            .wallet_secret
+            .wallet_entropy
             .nth_generation_spending_key(0);
         let receiving_address = coinbase_recipient_spending_key.to_address();
         let next_block_height: BlockHeight = latest_block.header().height.next();
@@ -1005,7 +1005,7 @@ pub(crate) mod mine_loop_tests {
             .lock_guard()
             .await
             .wallet_state
-            .wallet_secret
+            .wallet_entropy
             .generate_sender_randomness(next_block_height, receiving_address.privacy_digest());
         let vm_job_queue = global_state_lock.vm_job_queue();
 
@@ -1060,7 +1060,7 @@ pub(crate) mod mine_loop_tests {
         let global_state_lock = mock_genesis_global_state(
             network,
             2,
-            WalletSecret::devnet_wallet(),
+            WalletEntropy::devnet_wallet(),
             cli_args::Args::default(),
         )
         .await;
@@ -1127,7 +1127,7 @@ pub(crate) mod mine_loop_tests {
         let global_state_lock = mock_genesis_global_state(
             network,
             2,
-            WalletSecret::devnet_wallet(),
+            WalletEntropy::devnet_wallet(),
             cli_args::Args::default(),
         )
         .await;
@@ -1159,7 +1159,7 @@ pub(crate) mod mine_loop_tests {
         let mut alice = mock_genesis_global_state(
             network,
             2,
-            WalletSecret::devnet_wallet(),
+            WalletEntropy::devnet_wallet(),
             cli_args::Args::default(),
         )
         .await;
@@ -1182,7 +1182,7 @@ pub(crate) mod mine_loop_tests {
             .lock_guard()
             .await
             .wallet_state
-            .wallet_secret
+            .wallet_entropy
             .nth_generation_spending_key_for_tests(0);
         let output_to_alice = TxOutput::offchain_native_currency(
             NativeCurrencyAmount::coins(4),
@@ -1321,7 +1321,7 @@ pub(crate) mod mine_loop_tests {
         let mut alice = mock_genesis_global_state(
             network,
             2,
-            WalletSecret::devnet_wallet(),
+            WalletEntropy::devnet_wallet(),
             cli_args::Args::default(),
         )
         .await;
@@ -1384,7 +1384,7 @@ pub(crate) mod mine_loop_tests {
         let global_state_lock = mock_genesis_global_state(
             network,
             2,
-            WalletSecret::devnet_wallet(),
+            WalletEntropy::devnet_wallet(),
             cli_args::Args::default(),
         )
         .await;
@@ -1407,7 +1407,7 @@ pub(crate) mod mine_loop_tests {
             .lock_guard()
             .await
             .wallet_state
-            .wallet_secret
+            .wallet_entropy
             .guesser_spending_key(tip_block_orig.hash());
         let mut block =
             Block::block_template_invalid_proof(&tip_block_orig, transaction, launch_date, None);
@@ -1451,7 +1451,7 @@ pub(crate) mod mine_loop_tests {
         let global_state_lock = mock_genesis_global_state(
             network,
             2,
-            WalletSecret::devnet_wallet(),
+            WalletEntropy::devnet_wallet(),
             cli_args::Args::default(),
         )
         .await;
@@ -1559,7 +1559,7 @@ pub(crate) mod mine_loop_tests {
         let global_state_lock = mock_genesis_global_state(
             network,
             2,
-            WalletSecret::devnet_wallet(),
+            WalletEntropy::devnet_wallet(),
             cli_args::Args::default(),
         )
         .await;
@@ -1774,7 +1774,7 @@ pub(crate) mod mine_loop_tests {
         let global_state_lock = mock_genesis_global_state(
             network,
             2,
-            WalletSecret::devnet_wallet(),
+            WalletEntropy::devnet_wallet(),
             cli_args::Args::default(),
         )
         .await;

--- a/src/models/blockchain/block/block_height.rs
+++ b/src/models/blockchain/block/block_height.rs
@@ -27,6 +27,8 @@ pub struct BlockHeight(BFieldElement);
 pub const BLOCKS_PER_GENERATION: u64 = 160815;
 
 impl BlockHeight {
+    pub const MAX: u64 = BFieldElement::MAX;
+
     pub fn get_generation(&self) -> u64 {
         self.0.value() / BLOCKS_PER_GENERATION
     }

--- a/src/models/blockchain/block/block_height.rs
+++ b/src/models/blockchain/block/block_height.rs
@@ -1,3 +1,4 @@
+use std::cmp::min;
 use std::cmp::Ordering;
 use std::fmt::Display;
 use std::ops::Add;
@@ -16,6 +17,11 @@ use twenty_first::math::bfield_codec::BFieldCodec;
 
 use crate::prelude::twenty_first;
 
+/// The distance, in number of blocks, to the genesis block.
+///
+/// This struct wraps around a [`BFieldElement`], so the maximum block height
+/// is P-1 = 2^64 - 2^32. With an average block time of 588 seconds, this
+/// maximum will be reached roughly 344 trillion years after launch. Not urgent.
 #[derive(
     Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize, Hash, BFieldCodec, GetSize,
 )]
@@ -84,7 +90,7 @@ impl From<BlockHeight> for BFieldElement {
 
 impl From<u64> for BlockHeight {
     fn from(val: u64) -> Self {
-        BlockHeight(BFieldElement::new(val))
+        BlockHeight(BFieldElement::new(min(BFieldElement::MAX, val)))
     }
 }
 

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -61,7 +61,7 @@ use crate::models::proof_abstractions::verifier::verify;
 use crate::models::proof_abstractions::SecretWitness;
 use crate::models::state::wallet::address::hash_lock_key::HashLockKey;
 use crate::models::state::wallet::address::ReceivingAddress;
-use crate::models::state::wallet::WalletSecret;
+use crate::models::state::wallet::wallet_entropy::WalletEntropy;
 use crate::prelude::twenty_first;
 use crate::util_types::mutator_set::addition_record::AdditionRecord;
 use crate::util_types::mutator_set::commit;
@@ -473,7 +473,7 @@ impl Block {
 
     fn premine_distribution() -> Vec<(ReceivingAddress, NativeCurrencyAmount)> {
         // The premine UTXOs can be hardcoded here.
-        let authority_wallet = WalletSecret::devnet_wallet();
+        let authority_wallet = WalletEntropy::devnet_wallet();
         let authority_receiving_address = authority_wallet
             .nth_generation_spending_key(0)
             .to_address()
@@ -1031,7 +1031,7 @@ pub(crate) mod block_tests {
     use crate::models::state::tx_proving_capability::TxProvingCapability;
     use crate::models::state::wallet::transaction_output::TxOutput;
     use crate::models::state::wallet::utxo_notification::UtxoNotificationMedium;
-    use crate::models::state::wallet::WalletSecret;
+    use crate::models::state::wallet::wallet_entropy::WalletEntropy;
     use crate::tests::shared::fake_valid_successor_for_tests;
     use crate::tests::shared::invalid_block_with_transaction;
     use crate::tests::shared::make_mock_block;
@@ -1093,7 +1093,7 @@ pub(crate) mod block_tests {
     async fn test_difficulty_control_matches() {
         let network = Network::Main;
 
-        let a_wallet_secret = WalletSecret::new_random();
+        let a_wallet_secret = WalletEntropy::new_random();
         let a_key = a_wallet_secret.nth_generation_spending_key_for_tests(0);
 
         // TODO: Can this outer-loop be parallelized?
@@ -1200,7 +1200,7 @@ pub(crate) mod block_tests {
         let mut mmra = MmrAccumulator::new_from_leafs(vec![genesis_block.hash()]);
 
         for i in 0..55 {
-            let wallet_secret = WalletSecret::new_random();
+            let wallet_secret = WalletEntropy::new_random();
             let key = wallet_secret.nth_generation_spending_key_for_tests(0);
             let (new_block, _) =
                 make_mock_block(blocks.last().unwrap(), None, key, rng.random()).await;
@@ -1291,7 +1291,7 @@ pub(crate) mod block_tests {
                 fake_valid_successor_for_tests(&genesis_block, plus_seven_months, rng.random())
                     .await;
 
-            let alice_wallet = WalletSecret::devnet_wallet();
+            let alice_wallet = WalletEntropy::devnet_wallet();
             let mut alice = mock_genesis_global_state(
                 network,
                 3,
@@ -1660,7 +1660,7 @@ pub(crate) mod block_tests {
             let launch_date = genesis_block.header().timestamp;
             let in_seven_months = launch_date + Timestamp::months(7);
             let in_eight_months = launch_date + Timestamp::months(8);
-            let alice_wallet = WalletSecret::devnet_wallet();
+            let alice_wallet = WalletEntropy::devnet_wallet();
             let alice_key = alice_wallet.nth_generation_spending_key(0);
             let alice_address = alice_key.to_address();
             let mut alice =

--- a/src/models/blockchain/block/validity/block_program.rs
+++ b/src/models/blockchain/block/validity/block_program.rs
@@ -354,7 +354,7 @@ pub(crate) mod test {
     use crate::models::state::tx_proving_capability::TxProvingCapability;
     use crate::models::state::wallet::transaction_output::TxOutput;
     use crate::models::state::wallet::utxo_notification::UtxoNotificationMedium;
-    use crate::models::state::wallet::WalletSecret;
+    use crate::models::state::wallet::wallet_entropy::WalletEntropy;
     use crate::tests::shared::mock_genesis_global_state;
     use crate::GlobalStateLock;
 
@@ -492,11 +492,11 @@ pub(crate) mod test {
 
         let network = Network::Main;
         let mut rng: StdRng = SeedableRng::seed_from_u64(2225550001);
-        let alice_wallet = WalletSecret::devnet_wallet();
+        let alice_wallet = WalletEntropy::devnet_wallet();
         let alice = mock_genesis_global_state(
             network,
             3,
-            WalletSecret::devnet_wallet(),
+            WalletEntropy::devnet_wallet(),
             cli_args::Args::default(),
         )
         .await;

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -840,7 +840,7 @@ mod tests {
     use crate::models::state::wallet::transaction_output::TxOutput;
     use crate::models::state::wallet::transaction_output::TxOutputList;
     use crate::models::state::wallet::utxo_notification::UtxoNotificationMedium;
-    use crate::models::state::wallet::WalletSecret;
+    use crate::models::state::wallet::wallet_entropy::WalletEntropy;
     use crate::models::state::GlobalStateLock;
     use crate::models::state::TritonVmJobQueue;
     use crate::tests::shared::make_mock_block;
@@ -975,7 +975,7 @@ mod tests {
         let network = Network::Main;
         let mut mempool = setup_mock_mempool(0, network, TransactionOrigin::Foreign).await;
         let genesis_block = Block::genesis(network);
-        let bob_wallet_secret = WalletSecret::devnet_wallet();
+        let bob_wallet_secret = WalletEntropy::devnet_wallet();
         let bob_spending_key = bob_wallet_secret.nth_generation_spending_key_for_tests(0);
         let bob = mock_genesis_global_state(
             network,
@@ -1095,7 +1095,7 @@ mod tests {
 
         let mut rng: StdRng = StdRng::seed_from_u64(0x03ce19960c467f90u64);
         let network = Network::Main;
-        let bob_wallet_secret = WalletSecret::devnet_wallet();
+        let bob_wallet_secret = WalletEntropy::devnet_wallet();
         let bob_spending_key = bob_wallet_secret.nth_generation_spending_key_for_tests(0);
         let mut bob =
             mock_genesis_global_state(network, 2, bob_wallet_secret, cli_args::Args::default())
@@ -1103,7 +1103,7 @@ mod tests {
 
         let bob_address = bob_spending_key.to_address();
 
-        let alice_wallet = WalletSecret::new_pseudorandom(rng.random());
+        let alice_wallet = WalletEntropy::new_pseudorandom(rng.random());
         let alice_key = alice_wallet.nth_generation_spending_key_for_tests(0);
         let alice_address = alice_key.to_address();
         let mut alice =
@@ -1443,7 +1443,7 @@ mod tests {
         // non-empty. Then mine a a block 1b that also does not contain this
         // transaction.
         let network = Network::Main;
-        let alice_wallet = WalletSecret::devnet_wallet();
+        let alice_wallet = WalletEntropy::devnet_wallet();
         let alice_key = alice_wallet.nth_generation_spending_key_for_tests(0);
         let proving_capability = TxProvingCapability::SingleProof;
         let cli_with_proof_capability = cli_args::Args {
@@ -1454,7 +1454,7 @@ mod tests {
             mock_genesis_global_state(network, 2, alice_wallet, cli_with_proof_capability).await;
 
         let mut rng: StdRng = StdRng::seed_from_u64(u64::from_str_radix("42", 6).unwrap());
-        let bob_wallet_secret = WalletSecret::new_pseudorandom(rng.random());
+        let bob_wallet_secret = WalletEntropy::new_pseudorandom(rng.random());
         let bob_key = bob_wallet_secret.nth_generation_spending_key_for_tests(0);
         let bob_address = bob_key.to_address();
 
@@ -1575,7 +1575,7 @@ mod tests {
         let mut preminer = mock_genesis_global_state(
             network,
             2,
-            WalletSecret::devnet_wallet(),
+            WalletEntropy::devnet_wallet(),
             cli_args::Args::default(),
         )
         .await;
@@ -1583,7 +1583,7 @@ mod tests {
             .lock_guard()
             .await
             .wallet_state
-            .wallet_secret
+            .wallet_entropy
             .nth_generation_spending_key_for_tests(0);
         let premine_address = premine_spending_key.to_address();
         let mut rng = StdRng::seed_from_u64(589111u64);
@@ -1796,7 +1796,7 @@ mod tests {
             fee: NativeCurrencyAmount,
         ) -> Transaction {
             let genesis_block = Block::genesis(network);
-            let bob_wallet_secret = WalletSecret::devnet_wallet();
+            let bob_wallet_secret = WalletEntropy::devnet_wallet();
             let bob_spending_key = bob_wallet_secret.nth_generation_spending_key_for_tests(0);
             let bob = mock_genesis_global_state(
                 network,

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -1073,8 +1073,10 @@ impl GlobalState {
                 Err(err) => bail!("Could not restore MS membership proof. Got: {err}"),
             };
 
-            let mut restored_mutxo =
-                MonitoredUtxo::new(incoming_utxo.utxo, self.wallet_state.number_of_mps_per_utxo);
+            let mut restored_mutxo = MonitoredUtxo::new(
+                incoming_utxo.utxo,
+                self.wallet_state.configuration.num_mps_per_utxo,
+            );
             restored_mutxo.add_membership_proof_for_tip(tip_hash, restored_msmp);
 
             // Add block info for restored MUTXO

--- a/src/models/state/wallet/address/address_type.rs
+++ b/src/models/state/wallet/address/address_type.rs
@@ -33,7 +33,7 @@ use crate::BFieldElement;
 /// Enumerates available cryptographic key implementations for sending funds.
 ///
 /// In most (but not all) cases there is a matching address.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[repr(u8)]
 pub enum KeyType {
     /// To unlock, prove knowledge of the preimage.

--- a/src/models/state/wallet/mod.rs
+++ b/src/models/state/wallet/mod.rs
@@ -10,6 +10,7 @@ pub mod sent_transaction;
 pub(crate) mod transaction_output;
 pub(crate) mod unlocked_utxo;
 pub mod utxo_notification;
+pub(crate) mod wallet_configuration;
 pub(crate) mod wallet_entropy;
 pub mod wallet_file;
 pub(crate) mod wallet_state;

--- a/src/models/state/wallet/scan_mode_configuration.rs
+++ b/src/models/state/wallet/scan_mode_configuration.rs
@@ -1,3 +1,4 @@
+use std::cmp::min;
 use std::ops::RangeInclusive;
 
 use crate::models::blockchain::block::block_height::BlockHeight;
@@ -52,7 +53,7 @@ impl ScanModeConfiguration {
     /// Constructor-helper for setting the range of blocks to scan.
     pub(crate) fn blocks<T: Into<u64> + Copy>(mut self, block_heights: RangeInclusive<T>) -> Self {
         let first_height: u64 = block_heights.start().to_owned().into();
-        let last_height: u64 = block_heights.end().to_owned().into();
+        let last_height: u64 = min(block_heights.end().to_owned().into(), BlockHeight::MAX);
         self.first_block_height = BlockHeight::from(first_height);
         self.last_block_height = Some(BlockHeight::from(last_height));
         self

--- a/src/models/state/wallet/scan_mode_configuration.rs
+++ b/src/models/state/wallet/scan_mode_configuration.rs
@@ -44,7 +44,7 @@ impl ScanModeConfiguration {
     }
 
     /// Constructor-helper for setting the number of future keys to scan for.
-    pub(crate) fn for_future_keys(mut self, num_future_keys: usize) -> Self {
+    pub(crate) fn for_many_future_keys(mut self, num_future_keys: usize) -> Self {
         self.num_future_keys = num_future_keys;
         self
     }

--- a/src/models/state/wallet/scan_mode_configuration.rs
+++ b/src/models/state/wallet/scan_mode_configuration.rs
@@ -74,8 +74,4 @@ impl ScanModeConfiguration {
     pub(crate) fn num_future_keys(&self) -> usize {
         self.num_future_keys
     }
-
-    pub(crate) fn default_num_future_keys() -> usize {
-        Self::default().num_future_keys()
-    }
 }

--- a/src/models/state/wallet/scan_mode_configuration.rs
+++ b/src/models/state/wallet/scan_mode_configuration.rs
@@ -33,11 +33,11 @@ impl Default for ScanModeConfiguration {
 impl ScanModeConfiguration {
     /// Constructor for `ScanModeConfiguration`.
     ///
-    /// Best used in conjuction with constructor-helpers
+    /// Best used in conjunction with constructor-helpers
     /// [`Self::for_future_keys`] and [`Self::blocks`], *e.g.*:
     ///
     /// ```notest
-    /// let config = ScanModeConfiguration::scan().blocks(1..=2).for_future_keys(3);
+    /// let config = ScanModeConfiguration::scan().blocks(1..=2).for_many_future_keys(3);
     /// ```
     pub(crate) fn scan() -> Self {
         Default::default()
@@ -59,6 +59,10 @@ impl ScanModeConfiguration {
     }
 
     /// Determine whether to scan a block given its height.
+    ///
+    /// Marked `pub(crate)` for testing. Not part of the API. Use
+    /// [`Self::block_is_in_range`] instead.
+    #[doc(hidden)]
     pub(crate) fn block_height_is_in_range(&self, block_height: BlockHeight) -> bool {
         self.first_block_height <= block_height
             && self.last_block_height.is_none_or(|lbh| lbh >= block_height)

--- a/src/models/state/wallet/scan_mode_configuration.rs
+++ b/src/models/state/wallet/scan_mode_configuration.rs
@@ -13,7 +13,7 @@ use crate::models::blockchain::block::Block;
 /// wallet secret seed but with future derivation indices. If an incoming
 /// message is observed, the derivation index counter is updated accordingly.
 /// The number of future indices to scan for is a tunable parameter.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ScanModeConfiguration {
     num_future_keys: usize,
     first_block_height: BlockHeight,

--- a/src/models/state/wallet/scan_mode_configuration.rs
+++ b/src/models/state/wallet/scan_mode_configuration.rs
@@ -36,8 +36,8 @@ impl ScanModeConfiguration {
     /// Best used in conjuction with constructor-helpers
     /// [`Self::for_future_keys`] and [`Self::blocks`], *e.g.*:
     ///
-    /// ```
-    /// let config = ScanModeConfiguration::scan().blocks(1..2).for_future_keys(3);
+    /// ```notest
+    /// let config = ScanModeConfiguration::scan().blocks(1..=2).for_future_keys(3);
     /// ```
     pub(crate) fn scan() -> Self {
         Default::default()

--- a/src/models/state/wallet/scan_mode_configuration.rs
+++ b/src/models/state/wallet/scan_mode_configuration.rs
@@ -1,0 +1,81 @@
+use std::ops::RangeInclusive;
+
+use crate::models::blockchain::block::block_height::BlockHeight;
+use crate::models::blockchain::block::Block;
+
+/// Configuration settings for Scan Mode.
+///
+/// When scan mode is active, an extra step is performed by the wallet state
+/// when updating the wallet state with a new block. This extra step checks to
+/// see if the incoming block has a height captured by the target range and if
+/// so, scans the block for public announcements that can be decrypted by
+/// *future* keys, meaning keys that are derived deterministically from the
+/// wallet secret seed but with future derivation indices. If an incoming
+/// message is observed, the derivation index counter is updated accordingly.
+/// The number of future indices to scan for is a tunable parameter.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ScanModeConfiguration {
+    num_future_keys: usize,
+    first_block_height: BlockHeight,
+    last_block_height: Option<BlockHeight>,
+}
+
+impl Default for ScanModeConfiguration {
+    fn default() -> Self {
+        Self {
+            num_future_keys: 25,
+            first_block_height: BlockHeight::genesis(),
+            last_block_height: None,
+        }
+    }
+}
+
+impl ScanModeConfiguration {
+    /// Constructor for `ScanModeConfiguration`.
+    ///
+    /// Best used in conjuction with constructor-helpers
+    /// [`Self::for_future_keys`] and [`Self::blocks`], *e.g.*:
+    ///
+    /// ```
+    /// let config = ScanModeConfiguration::scan().blocks(1..2).for_future_keys(3);
+    /// ```
+    pub(crate) fn scan() -> Self {
+        Default::default()
+    }
+
+    /// Constructor-helper for setting the number of future keys to scan for.
+    pub(crate) fn for_future_keys(mut self, num_future_keys: usize) -> Self {
+        self.num_future_keys = num_future_keys;
+        self
+    }
+
+    /// Constructor-helper for setting the range of blocks to scan.
+    pub(crate) fn blocks<T: Into<u64> + Copy>(mut self, block_heights: RangeInclusive<T>) -> Self {
+        let first_height: u64 = block_heights.start().to_owned().into();
+        let last_height: u64 = block_heights.end().to_owned().into();
+        self.first_block_height = BlockHeight::from(first_height);
+        self.last_block_height = Some(BlockHeight::from(last_height));
+        self
+    }
+
+    /// Determine whether to scan a block given its height.
+    pub(crate) fn block_height_is_in_range(&self, block_height: BlockHeight) -> bool {
+        self.first_block_height <= block_height
+            && self.last_block_height.is_none_or(|lbh| lbh >= block_height)
+    }
+
+    /// Determine whether to scan the given block.
+    pub(crate) fn block_is_in_range(&self, block: &Block) -> bool {
+        let block_height = block.header().height;
+        self.block_height_is_in_range(block_height)
+    }
+
+    /// How many future keys to scan for.
+    pub(crate) fn num_future_keys(&self) -> usize {
+        self.num_future_keys
+    }
+
+    pub(crate) fn default_num_future_keys() -> usize {
+        Self::default().num_future_keys()
+    }
+}

--- a/src/models/state/wallet/scan_mode_configuration.rs
+++ b/src/models/state/wallet/scan_mode_configuration.rs
@@ -1,4 +1,3 @@
-use std::cmp::min;
 use std::ops::RangeInclusive;
 
 use crate::models::blockchain::block::block_height::BlockHeight;
@@ -53,7 +52,10 @@ impl ScanModeConfiguration {
     /// Constructor-helper for setting the range of blocks to scan.
     pub(crate) fn blocks<T: Into<u64> + Copy>(mut self, block_heights: RangeInclusive<T>) -> Self {
         let first_height: u64 = block_heights.start().to_owned().into();
-        let last_height: u64 = min(block_heights.end().to_owned().into(), BlockHeight::MAX);
+        let last_height: u64 = block_heights.end().to_owned().into();
+
+        // note: `From<u64> for BlockHeight` clamps large values to
+        // `BFieldElement::MAX` rather than wrapping round.
         self.first_block_height = BlockHeight::from(first_height);
         self.last_block_height = Some(BlockHeight::from(last_height));
         self

--- a/src/models/state/wallet/transaction_output.rs
+++ b/src/models/state/wallet/transaction_output.rs
@@ -374,7 +374,7 @@ mod tests {
     use crate::models::blockchain::type_scripts::native_currency_amount::NativeCurrencyAmount;
     use crate::models::state::wallet::address::generation_address::GenerationReceivingAddress;
     use crate::models::state::wallet::address::KeyType;
-    use crate::models::state::wallet::WalletSecret;
+    use crate::models::state::wallet::wallet_entropy::WalletEntropy;
     use crate::tests::shared::mock_genesis_global_state;
 
     impl TxOutput {
@@ -404,7 +404,7 @@ mod tests {
         let global_state_lock = mock_genesis_global_state(
             Network::RegTest,
             2,
-            WalletSecret::devnet_wallet(),
+            WalletEntropy::devnet_wallet(),
             cli_args::Args::default(),
         )
         .await;
@@ -422,7 +422,7 @@ mod tests {
 
         let sender_randomness = state
             .wallet_state
-            .wallet_secret
+            .wallet_entropy
             .generate_sender_randomness(block_height, address.privacy_digest());
 
         for owned_utxo_notification_medium in [
@@ -453,7 +453,7 @@ mod tests {
         let mut global_state_lock = mock_genesis_global_state(
             Network::RegTest,
             2,
-            WalletSecret::devnet_wallet(),
+            WalletEntropy::devnet_wallet(),
             cli_args::Args::default(),
         )
         .await;
@@ -490,7 +490,7 @@ mod tests {
             let utxo = Utxo::new_native_currency(address.lock_script(), amount);
             let sender_randomness = state
                 .wallet_state
-                .wallet_secret
+                .wallet_entropy
                 .generate_sender_randomness(block_height, address.privacy_digest());
 
             let tx_output = TxOutput::auto(

--- a/src/models/state/wallet/wallet_configuration.rs
+++ b/src/models/state/wallet/wallet_configuration.rs
@@ -83,10 +83,7 @@ impl WalletConfiguration {
     /// Activate scan mode with default parameters, if not active already.
     pub(crate) fn enable_scan_mode(&mut self) {
         if self.scan_mode.is_none() {
-            info!(
-                "Activating scan mode: wallet file present but \
-            databse absent; wallet may have been imported."
-            );
+            info!("Activating scan mode with default configurations.");
             self.scan_mode = Some(ScanModeConfiguration::default());
         }
     }

--- a/src/models/state/wallet/wallet_configuration.rs
+++ b/src/models/state/wallet/wallet_configuration.rs
@@ -67,10 +67,7 @@ impl WalletConfiguration {
                 Some(ScanModeConfiguration::scan().blocks(range.to_owned()))
             }
             (Some(range), Some(num_future_keys)) => {
-                info!(
-                    "Activating scan mode: CLI arguments `--scan-keys` and \
-                `--scan-blocks`."
-                );
+                info!("Activating scan mode: CLI arguments `--scan-keys` and `--scan-blocks`.");
                 Some(
                     ScanModeConfiguration::scan()
                         .blocks(range.to_owned())
@@ -209,21 +206,21 @@ mod test {
         let network = Network::Main;
         let data_dir = unit_test_data_directory(network).unwrap();
 
-        let lb = 10;
-        let ub = 20;
+        let lower_bound = 10;
+        let upper_bound = 20;
 
         // activate scan mode by setting --scan-blocks, so num future keys
         // will assume its default value
         let cli_args = Args {
-            scan_blocks: Some(lb..=ub),
+            scan_blocks: Some(lower_bound..=upper_bound),
             ..Default::default()
         };
         let configuration = WalletConfiguration::new(&data_dir).absorb_options(&cli_args);
         let scan_mode = configuration.scan_mode.unwrap();
 
-        for h in (lb - 5)..(ub + 5) {
+        for h in (lower_bound - 5)..(upper_bound + 5) {
             assert_eq!(
-                (lb..=ub).contains(&h),
+                (lower_bound..=upper_bound).contains(&h),
                 scan_mode.block_height_is_in_range(BlockHeight::from(h)),
             );
         }

--- a/src/models/state/wallet/wallet_configuration.rs
+++ b/src/models/state/wallet/wallet_configuration.rs
@@ -1,0 +1,231 @@
+use std::path::PathBuf;
+
+use tracing::info;
+
+use crate::config_models::cli_args;
+use crate::config_models::data_directory::DataDirectory;
+use crate::config_models::network::Network;
+
+use super::scan_mode_configuration::ScanModeConfiguration;
+use super::wallet_file::WALLET_INCOMING_SECRETS_FILE_NAME;
+
+/// Configuration options for [`WalletState`](super::wallet_state::WalletState).
+///
+/// These configurations are often downstream from CLI arguments. However,
+/// exceptions to this rule exist. For instance: scan mode can be activated by
+/// importing a wallet, even without CLI arguments.
+#[derive(Debug, Clone)]
+pub(crate) struct WalletConfiguration {
+    /// Whether we are in scan mode and, if so, how many future keys to scan
+    /// with and the range of block heights where the scanning step is done.
+    pub(crate) scan_mode: Option<ScanModeConfiguration>,
+
+    /// How many mutator set membership proofs to store per monitored UTXO.
+    pub(crate) num_mps_per_utxo: usize,
+
+    /// Where wallet files are stored
+    wallet_files_directory: PathBuf,
+
+    /// Where the wallet database is stored
+    wallet_database_directory: PathBuf,
+
+    /// Which network we are on
+    network: Network,
+}
+
+impl WalletConfiguration {
+    /// Constructor for [`WalletConfiguration`].
+    ///
+    /// Best used in combination with self-consuming constructor-helpers
+    /// [`Self::absorb_options`] and [`Self::with_scan_mode_if_necessary`], in
+    /// that order.
+    pub(crate) fn new(data_dir: &DataDirectory) -> Self {
+        Self {
+            scan_mode: None,
+            num_mps_per_utxo: 0,
+            wallet_files_directory: data_dir.wallet_directory_path(),
+            wallet_database_directory: data_dir.wallet_database_dir_path(),
+            network: Network::Main,
+        }
+    }
+
+    /// Self-consuming constructor-helper for [`WalletConfiguration`].
+    ///
+    /// Extract those configuration options from the CLI arguments that are
+    /// relevant for wallet state management.
+    pub(crate) fn absorb_options(mut self, cli_args: &cli_args::Args) -> Self {
+        self.num_mps_per_utxo = cli_args.number_of_mps_per_utxo;
+
+        self.scan_mode = match (&cli_args.scan_blocks, cli_args.scan_keys) {
+            (None, None) => None,
+            (None, Some(num_future_keys)) => {
+                info!("Activating scan mode: CLI argument `--scan-keys`.");
+                Some(ScanModeConfiguration::scan().for_many_future_keys(num_future_keys))
+            }
+            (Some(range), None) => {
+                info!("Activating scan mode: CLI argument `--scan-blocks`.");
+                Some(ScanModeConfiguration::scan().blocks(range.to_owned()))
+            }
+            (Some(range), Some(num_future_keys)) => {
+                info!(
+                    "Activating scan mode: CLI arguments `--scan-keys` and \
+                `--scan-blocks`."
+                );
+                Some(
+                    ScanModeConfiguration::scan()
+                        .blocks(range.to_owned())
+                        .for_many_future_keys(num_future_keys),
+                )
+            }
+        };
+
+        self.network = cli_args.network;
+
+        self
+    }
+
+    /// Self-consuming constructor-helper for [`WalletConfiguration`].
+    ///
+    /// If not already active, activate scan mode if necessary.
+    ///
+    /// Specifically, scan mode is activated with default parameters if (all
+    /// of):
+    ///  - it is not already active,
+    ///  - the wallet file was present (it is not new), and
+    ///  - the wallet database was absent (it is new).
+    ///
+    /// The latter two bullet points indicate that the wallet was imported,
+    /// perhaps via the command line tool.
+    pub(crate) fn with_scan_mode_if_necessary(
+        mut self,
+        wallet_was_new: bool,
+        database_was_new: bool,
+    ) -> Self {
+        if self.scan_mode.is_none() && !wallet_was_new && database_was_new {
+            info!(
+                "Activating scan mode: wallet file present but \
+            databse absent; wallet may have been imported."
+            );
+            self.scan_mode = Some(ScanModeConfiguration::default());
+        }
+        self
+    }
+
+    pub(crate) fn incoming_secrets_path(&self) -> PathBuf {
+        self.wallet_files_directory_path()
+            .join(WALLET_INCOMING_SECRETS_FILE_NAME)
+    }
+
+    pub(crate) fn wallet_files_directory_path(&self) -> PathBuf {
+        self.wallet_files_directory.to_owned()
+    }
+
+    pub(crate) fn wallet_database_directory_path(&self) -> PathBuf {
+        self.wallet_database_directory.to_owned()
+    }
+
+    pub(crate) fn network(&self) -> Network {
+        self.network
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::config_models::cli_args::Args;
+    use crate::models::blockchain::block::block_height::BlockHeight;
+    use crate::tests::shared::unit_test_data_directory;
+
+    use super::*;
+    #[test]
+    fn scan_mode_is_off_by_default() {
+        let network = Network::Main;
+        let data_dir = unit_test_data_directory(network).unwrap();
+        let configuration = WalletConfiguration::new(&data_dir).absorb_options(&Args::default());
+        assert!(configuration.scan_mode.is_none());
+    }
+
+    #[test]
+    fn scan_mode_is_on_with_scan_blocks_or_scan_keys() {
+        let network = Network::Main;
+        let data_dir = unit_test_data_directory(network).unwrap();
+
+        let cli_args_1 = Args {
+            scan_blocks: Some(0u64..=10),
+            ..Default::default()
+        };
+        let configuration_1 = WalletConfiguration::new(&data_dir).absorb_options(&cli_args_1);
+        assert!(configuration_1.scan_mode.is_some());
+
+        let cli_args_2 = Args {
+            scan_keys: Some(10),
+            ..Default::default()
+        };
+        let configuration_2 = WalletConfiguration::new(&data_dir).absorb_options(&cli_args_2);
+        assert!(configuration_2.scan_mode.is_some());
+
+        let cli_args_3 = Args {
+            scan_blocks: Some(0u64..=10),
+            scan_keys: Some(10),
+            ..Default::default()
+        };
+        let configuration_3 = WalletConfiguration::new(&data_dir).absorb_options(&cli_args_3);
+        assert!(configuration_3.scan_mode.is_some());
+    }
+
+    #[test]
+    fn scan_mode_is_on_if_wallet_was_imported() {
+        let network = Network::Main;
+        let data_dir = unit_test_data_directory(network).unwrap();
+        let cli_args = Args {
+            scan_blocks: Some(0u64..=10),
+            ..Default::default()
+        };
+        let configuration = WalletConfiguration::new(&data_dir)
+            .absorb_options(&cli_args)
+            .with_scan_mode_if_necessary(false, true);
+        assert!(configuration.scan_mode.is_some());
+    }
+
+    #[test]
+    fn num_future_keys_default_is_sane() {
+        let network = Network::Main;
+        let data_dir = unit_test_data_directory(network).unwrap();
+
+        // activate scan mode by setting --scan-blocks, so num future keys
+        // will assume its default value
+        let cli_args = Args {
+            scan_blocks: Some(0u64..=10),
+            ..Default::default()
+        };
+        let configuration = WalletConfiguration::new(&data_dir).absorb_options(&cli_args);
+
+        let scan_mode = configuration.scan_mode.unwrap();
+        assert!(scan_mode.num_future_keys() > 0);
+        assert!(scan_mode.num_future_keys() < 10_000);
+    }
+
+    #[test]
+    fn block_height_range_check_agrees_with_interval_membership() {
+        let network = Network::Main;
+        let data_dir = unit_test_data_directory(network).unwrap();
+
+        let lb = 10;
+        let ub = 20;
+
+        // activate scan mode by setting --scan-blocks, so num future keys
+        // will assume its default value
+        let cli_args = Args {
+            scan_blocks: Some(lb..=ub),
+            ..Default::default()
+        };
+        let configuration = WalletConfiguration::new(&data_dir).absorb_options(&cli_args);
+        let scan_mode = configuration.scan_mode.unwrap();
+
+        for h in (lb - 5)..(ub + 5) {
+            assert_eq!(
+                (lb..=ub).contains(&h),
+                scan_mode.block_height_is_in_range(BlockHeight::from(h)),
+            );
+        }
+    }
+}

--- a/src/models/state/wallet/wallet_entropy.rs
+++ b/src/models/state/wallet/wallet_entropy.rs
@@ -1,0 +1,207 @@
+use super::address::generation_address;
+use super::address::hash_lock_key;
+use super::address::hash_lock_key::HashLockKey;
+use super::address::symmetric_key;
+use super::secret_key_material::SecretKeyMaterial;
+use anyhow::Result;
+use serde::Deserialize;
+use serde::Serialize;
+use tasm_lib::prelude::Tip5;
+use twenty_first::math::b_field_element::BFieldElement;
+use twenty_first::math::bfield_codec::BFieldCodec;
+use twenty_first::math::digest::Digest;
+use twenty_first::math::x_field_element::XFieldElement;
+use zeroize::ZeroizeOnDrop;
+
+use crate::models::blockchain::block::block_height::BlockHeight;
+use crate::prelude::twenty_first;
+use crate::Hash;
+
+/// The wallet's one source of randomness, from which all keys are derived.
+///
+/// This struct wraps around [`SecretKeyMaterial`], which contains the secret
+/// data. The wrapper supplies arithmetic functions for use in the context of a
+/// wallet for Neptune Cash.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, ZeroizeOnDrop)]
+pub struct WalletEntropy {
+    secret_seed: SecretKeyMaterial,
+}
+
+impl WalletEntropy {
+    pub(crate) fn new(secret_seed: SecretKeyMaterial) -> Self {
+        Self { secret_seed }
+    }
+
+    /// Create a `WalletEntropy` object with a fixed digest
+    pub(crate) fn devnet_wallet() -> Self {
+        let secret_seed = SecretKeyMaterial(XFieldElement::new([
+            BFieldElement::new(12063201067205522823),
+            BFieldElement::new(1529663126377206632),
+            BFieldElement::new(2090171368883726200),
+        ]));
+
+        Self::new(secret_seed)
+    }
+
+    /// Return the guesser preimage for guessing on top of a given block (as
+    /// identified by the block's predecessor's hash).
+    pub(crate) fn guesser_preimage(&self, prev_block_digest: Digest) -> Digest {
+        Tip5::hash_varlen(
+            &[
+                self.secret_seed.0.encode(),
+                vec![hash_lock_key::RAW_HASH_LOCK_KEY_FLAG],
+                prev_block_digest.encode(),
+            ]
+            .concat(),
+        )
+    }
+
+    /// Returns the spending key for guessing on top of the given block.
+    pub(crate) fn guesser_spending_key(&self, prev_block_digest: Digest) -> HashLockKey {
+        HashLockKey::from_preimage(self.guesser_preimage(prev_block_digest))
+    }
+
+    /// derives a generation spending key at `index`
+    //
+    // note: this is a read-only method and does not modify wallet state.  When
+    // requesting a new key for purposes of a new wallet receiving address,
+    // callers should use [wallet_state::WalletState::next_unused_spending_key()]
+    // which takes &mut self.
+    pub fn nth_generation_spending_key(
+        &self,
+        index: u64,
+    ) -> generation_address::GenerationSpendingKey {
+        // We keep n between 0 and 2^16 as this makes it possible to scan all possible addresses
+        // in case you don't know with what counter you made the address
+        let key_seed = Hash::hash_varlen(
+            &[
+                self.secret_seed.0.encode(),
+                vec![
+                    generation_address::GENERATION_FLAG,
+                    BFieldElement::new(index),
+                ],
+            ]
+            .concat(),
+        );
+        generation_address::GenerationSpendingKey::derive_from_seed(key_seed)
+    }
+
+    /// derives a symmetric key at `index`
+    //
+    // note: this is a read-only method and does not modify wallet state.  When
+    // requesting a new key for purposes of a new wallet receiving address,
+    // callers should use [wallet_state::WalletState::next_unused_spending_key()]
+    // which takes &mut self.
+    pub fn nth_symmetric_key(&self, index: u64) -> symmetric_key::SymmetricKey {
+        let key_seed = Hash::hash_varlen(
+            &[
+                self.secret_seed.0.encode(),
+                vec![symmetric_key::SYMMETRIC_KEY_FLAG, BFieldElement::new(index)],
+            ]
+            .concat(),
+        );
+        symmetric_key::SymmetricKey::from_seed(key_seed)
+    }
+
+    // note: legacy tests were written to call nth_generation_spending_key()
+    // when requesting a new address.  As such, they may be unprepared to mutate
+    // wallet state.  This method enables them to compile while making clear
+    // it is an improper usage.
+    //
+    // [wallet_state::WalletState::next_unused_generation_spending_key()] should be used
+    #[cfg(test)]
+    pub fn nth_generation_spending_key_for_tests(
+        &self,
+        counter: u64,
+    ) -> generation_address::GenerationSpendingKey {
+        self.nth_generation_spending_key(counter)
+    }
+
+    // note: legacy tests were written to call nth_symmetric_key()
+    // when requesting a new key.  As such, they may be unprepared to mutate
+    // wallet state.  This method enables them to compile while making clear
+    // it is an improper usage.
+    //
+    // [wallet_state::WalletState::next_unused_symmetric_key()] should be used
+    #[cfg(test)]
+    pub fn nth_symmetric_key_for_tests(&self, counter: u64) -> symmetric_key::SymmetricKey {
+        self.nth_symmetric_key(counter)
+    }
+
+    /// Return a deterministic seed that can be used to seed an RNG
+    pub(crate) fn deterministic_derived_seed(&self, block_height: BlockHeight) -> Digest {
+        const SEED_FLAG: u64 = 0x2315439570c4a85fu64;
+        Hash::hash_varlen(
+            &[
+                self.secret_seed.0.encode(),
+                vec![BFieldElement::new(SEED_FLAG), block_height.into()],
+            ]
+            .concat(),
+        )
+    }
+
+    /// Return a seed used to randomize shuffling.
+    pub(crate) fn shuffle_seed(&self, block_height: BlockHeight) -> [u8; 32] {
+        let secure_seed_from_wallet = self.deterministic_derived_seed(block_height);
+        let seed: [u8; Digest::BYTES] = secure_seed_from_wallet.into();
+
+        seed[0..32].try_into().unwrap()
+    }
+
+    /// Return the secret key that is used to deterministically generate commitment pseudo-randomness
+    /// for the mutator set.
+    pub fn generate_sender_randomness(
+        &self,
+        block_height: BlockHeight,
+        receiver_digest: Digest,
+    ) -> Digest {
+        const SENDER_RANDOMNESS_FLAG: u64 = 0x5e116e1270u64;
+        Hash::hash_varlen(
+            &[
+                self.secret_seed.0.encode(),
+                vec![
+                    BFieldElement::new(SENDER_RANDOMNESS_FLAG),
+                    block_height.into(),
+                ],
+                receiver_digest.encode(),
+            ]
+            .concat(),
+        )
+    }
+
+    /// Convert a secret seed phrase (list of 18 valid BIP-39 words) to a
+    /// [`WalletEntropy`] object
+    pub fn from_phrase(phrase: &[String]) -> Result<Self> {
+        let key = SecretKeyMaterial::from_phrase(phrase)?;
+        Ok(Self::new(key))
+    }
+
+    /// Create a new `WalletEntropy` object and populate it with entropy
+    /// obtained via `rand::rng()` from the operating system.
+    #[cfg(test)]
+    pub(crate) fn new_random() -> Self {
+        Self::new_pseudorandom(rand::Rng::random(&mut rand::rng()))
+    }
+
+    /// Create a new `WalletEntropy` object and populate it by expanding a given
+    /// seed.
+    #[cfg(test)]
+    pub(crate) fn new_pseudorandom(seed: [u8; 32]) -> Self {
+        let mut rng: rand::rngs::StdRng = rand::SeedableRng::from_seed(seed);
+        Self {
+            secret_seed: SecretKeyMaterial(rand::Rng::random(&mut rng)),
+        }
+    }
+}
+
+impl From<SecretKeyMaterial> for WalletEntropy {
+    fn from(value: SecretKeyMaterial) -> Self {
+        Self { secret_seed: value }
+    }
+}
+
+impl From<WalletEntropy> for SecretKeyMaterial {
+    fn from(value: WalletEntropy) -> Self {
+        value.secret_seed.clone()
+    }
+}

--- a/src/models/state/wallet/wallet_entropy.rs
+++ b/src/models/state/wallet/wallet_entropy.rs
@@ -1,8 +1,3 @@
-use super::address::generation_address;
-use super::address::hash_lock_key;
-use super::address::hash_lock_key::HashLockKey;
-use super::address::symmetric_key;
-use super::secret_key_material::SecretKeyMaterial;
 use anyhow::Result;
 use serde::Deserialize;
 use serde::Serialize;
@@ -14,6 +9,11 @@ use twenty_first::math::x_field_element::XFieldElement;
 use zeroize::ZeroizeOnDrop;
 
 use crate::models::blockchain::block::block_height::BlockHeight;
+use crate::models::state::wallet::address::generation_address;
+use crate::models::state::wallet::address::hash_lock_key;
+use crate::models::state::wallet::address::hash_lock_key::HashLockKey;
+use crate::models::state::wallet::address::symmetric_key;
+use crate::models::state::wallet::secret_key_material::SecretKeyMaterial;
 use crate::prelude::twenty_first;
 use crate::Hash;
 

--- a/src/models/state/wallet/wallet_entropy.rs
+++ b/src/models/state/wallet/wallet_entropy.rs
@@ -15,7 +15,6 @@ use crate::models::state::wallet::address::hash_lock_key::HashLockKey;
 use crate::models::state::wallet::address::symmetric_key;
 use crate::models::state::wallet::secret_key_material::SecretKeyMaterial;
 use crate::prelude::twenty_first;
-use crate::Hash;
 
 /// The wallet's one source of randomness, from which all keys are derived.
 ///
@@ -73,7 +72,7 @@ impl WalletEntropy {
     ) -> generation_address::GenerationSpendingKey {
         // We keep n between 0 and 2^16 as this makes it possible to scan all possible addresses
         // in case you don't know with what counter you made the address
-        let key_seed = Hash::hash_varlen(
+        let key_seed = Tip5::hash_varlen(
             &[
                 self.secret_seed.0.encode(),
                 vec![
@@ -93,7 +92,7 @@ impl WalletEntropy {
     // callers should use [wallet_state::WalletState::next_unused_spending_key()]
     // which takes &mut self.
     pub fn nth_symmetric_key(&self, index: u64) -> symmetric_key::SymmetricKey {
-        let key_seed = Hash::hash_varlen(
+        let key_seed = Tip5::hash_varlen(
             &[
                 self.secret_seed.0.encode(),
                 vec![symmetric_key::SYMMETRIC_KEY_FLAG, BFieldElement::new(index)],
@@ -131,7 +130,7 @@ impl WalletEntropy {
     /// Return a deterministic seed that can be used to seed an RNG
     pub(crate) fn deterministic_derived_seed(&self, block_height: BlockHeight) -> Digest {
         const SEED_FLAG: u64 = 0x2315439570c4a85fu64;
-        Hash::hash_varlen(
+        Tip5::hash_varlen(
             &[
                 self.secret_seed.0.encode(),
                 vec![BFieldElement::new(SEED_FLAG), block_height.into()],
@@ -156,7 +155,7 @@ impl WalletEntropy {
         receiver_digest: Digest,
     ) -> Digest {
         const SENDER_RANDOMNESS_FLAG: u64 = 0x5e116e1270u64;
-        Hash::hash_varlen(
+        Tip5::hash_varlen(
             &[
                 self.secret_seed.0.encode(),
                 vec![

--- a/src/models/state/wallet/wallet_file.rs
+++ b/src/models/state/wallet/wallet_file.rs
@@ -1,0 +1,247 @@
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+
+use anyhow::bail;
+use anyhow::Context;
+use anyhow::Result;
+use rand::rng;
+use rand::Rng;
+use serde::Deserialize;
+use serde::Serialize;
+use tracing::info;
+use zeroize::ZeroizeOnDrop;
+
+use super::secret_key_material::SecretKeyMaterial;
+use super::wallet_entropy::WalletEntropy;
+
+pub const WALLET_DIRECTORY: &str = "wallet";
+pub const WALLET_SECRET_FILE_NAME: &str = "wallet.dat";
+pub const WALLET_OUTGOING_SECRETS_FILE_NAME: &str = "outgoing_randomness.dat";
+pub const WALLET_INCOMING_SECRETS_FILE_NAME: &str = "incoming_randomness.dat";
+const STANDARD_WALLET_NAME: &str = "standard_wallet";
+const STANDARD_WALLET_VERSION: u8 = 0;
+pub const WALLET_DB_NAME: &str = "wallet";
+pub const WALLET_OUTPUT_COUNT_DB_NAME: &str = "wallout_output_count_db";
+
+/// Wrapper around [`WalletFile`] with extra context.
+#[derive(Debug, Clone)]
+pub struct WalletFileContext {
+    pub(crate) wallet_file: WalletFile,
+
+    pub wallet_secret_path: PathBuf,
+    pub incoming_randomness_file: PathBuf,
+    pub outgoing_randomness_file: PathBuf,
+
+    pub wallet_is_new: bool,
+}
+
+impl WalletFileContext {
+    pub fn wallet_secret_path(wallet_directory_path: &Path) -> PathBuf {
+        wallet_directory_path.join(WALLET_SECRET_FILE_NAME)
+    }
+
+    fn wallet_outgoing_secrets_path(wallet_directory_path: &Path) -> PathBuf {
+        wallet_directory_path.join(WALLET_OUTGOING_SECRETS_FILE_NAME)
+    }
+
+    fn wallet_incoming_secrets_path(wallet_directory_path: &Path) -> PathBuf {
+        wallet_directory_path.join(WALLET_INCOMING_SECRETS_FILE_NAME)
+    }
+
+    /// Read a wallet from disk or create it.
+    ///
+    /// Read a wallet file from the `wallet.dat`` file in the given directory if
+    /// it exists, or otherwise create new wallet secret and save it there.
+    /// Also, create files for incoming and outgoing randomness which should be
+    /// appended to with each incoming and outgoing transaction.
+    ///
+    /// # Return Value
+    ///
+    /// Returns a `Result`-wrapped tuple consisting of
+    ///  - a `WalletSecret` instance
+    ///  - a tuple of file names of files containing wallet info
+    ///  - a boolean indicating whether a new wallet secret was generated (true)
+    ///    or an old one read from disk (false)
+    ///
+    pub fn read_from_file_or_create(wallet_directory_path: &Path) -> Result<Self> {
+        let wallet_secret_path = Self::wallet_secret_path(wallet_directory_path);
+        let wallet_is_new;
+        let wallet_secret = if wallet_secret_path.exists() {
+            info!(
+                "***** Reading wallet from {} *****\n\n\n",
+                wallet_secret_path.display()
+            );
+            wallet_is_new = false;
+            WalletFile::read_from_file(&wallet_secret_path)?
+        } else {
+            info!(
+                "***** Creating new wallet in {} *****\n\n\n",
+                wallet_secret_path.display()
+            );
+            let new_wallet: WalletFile = WalletFile::new_random();
+            new_wallet.save_to_disk(&wallet_secret_path)?;
+            wallet_is_new = true;
+            new_wallet
+        };
+
+        // Generate files for outgoing and ingoing randomness if those files
+        // do not already exist
+        let outgoing_randomness_file: PathBuf =
+            Self::wallet_outgoing_secrets_path(wallet_directory_path);
+        if !outgoing_randomness_file.exists() {
+            WalletFile::create_empty_wallet_randomness_file(&outgoing_randomness_file)
+                .unwrap_or_else(|_| {
+                    panic!(
+                "Create file for outgoing randomness must succeed. Attempted to create file: {}",
+                outgoing_randomness_file.to_string_lossy()
+            )
+                });
+        }
+
+        let incoming_randomness_file = Self::wallet_incoming_secrets_path(wallet_directory_path);
+        if !incoming_randomness_file.exists() {
+            WalletFile::create_empty_wallet_randomness_file(&incoming_randomness_file)
+                .unwrap_or_else(|_| {
+                    panic!(
+                "Create file for outgoing randomness must succeed. Attempted to create file: {}",
+                incoming_randomness_file.to_string_lossy()
+            )
+                });
+        }
+
+        // Sanity checks that files were actually created
+        if !wallet_secret_path.exists() {
+            bail!(
+                "Wallet secret file '{}' must exist on disk after reading/creating it.",
+                wallet_secret_path.display()
+            );
+        }
+        if !outgoing_randomness_file.exists() {
+            bail!(
+                "file containing outgoing randomness '{}' must exist on disk.",
+                outgoing_randomness_file.display()
+            );
+        }
+        if !incoming_randomness_file.exists() {
+            bail!(
+                "file containing ingoing randomness '{}' must exist on disk.",
+                incoming_randomness_file.display()
+            );
+        }
+
+        Ok(Self {
+            wallet_file: wallet_secret,
+            wallet_secret_path,
+            incoming_randomness_file,
+            outgoing_randomness_file,
+            wallet_is_new,
+        })
+    }
+
+    /// Extract the entropy
+    pub(crate) fn entropy(&self) -> WalletEntropy {
+        self.wallet_file.entropy()
+    }
+}
+
+/// Immutable secret data related to the wallet.
+///
+/// The struct contains all the information we want to store in a JSON file,
+/// which is not updated during regular program execution.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, ZeroizeOnDrop)]
+pub struct WalletFile {
+    name: String,
+
+    secret_seed: SecretKeyMaterial,
+    version: u8,
+}
+
+impl WalletFile {
+    pub fn new(secret_seed: SecretKeyMaterial) -> Self {
+        Self {
+            name: STANDARD_WALLET_NAME.to_string(),
+            secret_seed,
+            version: STANDARD_WALLET_VERSION,
+        }
+    }
+
+    fn new_random() -> Self {
+        Self::new(SecretKeyMaterial(rng().random()))
+    }
+
+    pub fn entropy(&self) -> WalletEntropy {
+        WalletEntropy::new(self.secret_seed.clone())
+    }
+
+    pub fn secret_key(&self) -> SecretKeyMaterial {
+        self.entropy().into()
+    }
+
+    /// Read Wallet from file as JSON
+    pub fn read_from_file(wallet_file: &Path) -> Result<Self> {
+        let wallet_file_content: String = fs::read_to_string(wallet_file)
+            .with_context(|| format!("Failed to read wallet from {}", wallet_file.display(),))?;
+
+        serde_json::from_str::<WalletFile>(&wallet_file_content)
+            .with_context(|| format!("Failed to decode wallet from {}", wallet_file.display(),))
+    }
+
+    /// Used to generate both the file for incoming and outgoing randomness
+    fn create_empty_wallet_randomness_file(file_path: &Path) -> Result<()> {
+        let init_value: String = String::default();
+
+        #[cfg(unix)]
+        {
+            Self::create_wallet_file_unix(&file_path.to_path_buf(), init_value)
+        }
+        #[cfg(not(unix))]
+        {
+            Self::create_wallet_file_windows(&file_path.to_path_buf(), init_value)
+        }
+    }
+
+    /// Save this wallet to disk. If necessary, create the file (with restrictive permissions).
+    pub fn save_to_disk(&self, wallet_file: &Path) -> Result<()> {
+        let wallet_secret_as_json: String = serde_json::to_string(self).unwrap();
+
+        #[cfg(unix)]
+        {
+            Self::create_wallet_file_unix(&wallet_file.to_path_buf(), wallet_secret_as_json)
+        }
+        #[cfg(not(unix))]
+        {
+            Self::create_wallet_file_windows(&wallet_file.to_path_buf(), wallet_secret_as_json)
+        }
+    }
+
+    #[cfg(unix)]
+    /// Create a wallet file, and set restrictive permissions
+    fn create_wallet_file_unix(path: &PathBuf, file_content: String) -> Result<()> {
+        // On Unix/Linux we set the file permissions to 600, to disallow
+        // other users on the same machine to access the secrets.
+        // I don't think the `std::os::unix` library can be imported on a Windows machine,
+        // so this function and the below import is only compiled on Unix machines.
+        use std::os::unix::prelude::OpenOptionsExt;
+        fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .mode(0o600)
+            .open(path)
+            .unwrap();
+        fs::write(path.clone(), file_content).context("Failed to write wallet file to disk")
+    }
+
+    #[cfg(not(unix))]
+    /// Create a wallet file, without setting restrictive UNIX permissions
+    fn create_wallet_file_windows(path: &PathBuf, wallet_as_json: String) -> Result<()> {
+        fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(path)
+            .unwrap();
+        fs::write(path.clone(), wallet_as_json).context("Failed to write wallet file to disk")
+    }
+}

--- a/src/models/state/wallet/wallet_file.rs
+++ b/src/models/state/wallet/wallet_file.rs
@@ -51,19 +51,10 @@ impl WalletFileContext {
 
     /// Read a wallet from disk or create it.
     ///
-    /// Read a wallet file from the `wallet.dat`` file in the given directory if
+    /// Read a wallet file from the `wallet.dat` file in the given directory if
     /// it exists, or otherwise create new wallet secret and save it there.
     /// Also, create files for incoming and outgoing randomness which should be
     /// appended to with each incoming and outgoing transaction.
-    ///
-    /// # Return Value
-    ///
-    /// Returns a `Result`-wrapped tuple consisting of
-    ///  - a `WalletSecret` instance
-    ///  - a tuple of file names of files containing wallet info
-    ///  - a boolean indicating whether a new wallet secret was generated (true)
-    ///    or an old one read from disk (false)
-    ///
     pub fn read_from_file_or_create(wallet_directory_path: &Path) -> Result<Self> {
         let wallet_secret_path = Self::wallet_secret_path(wallet_directory_path);
         let wallet_is_new;
@@ -79,7 +70,7 @@ impl WalletFileContext {
                 "***** Creating new wallet in {} *****\n\n\n",
                 wallet_secret_path.display()
             );
-            let new_wallet: WalletFile = WalletFile::new_random();
+            let new_wallet = WalletFile::new_random();
             new_wallet.save_to_disk(&wallet_secret_path)?;
             wallet_is_new = true;
             new_wallet
@@ -87,15 +78,15 @@ impl WalletFileContext {
 
         // Generate files for outgoing and ingoing randomness if those files
         // do not already exist
-        let outgoing_randomness_file: PathBuf =
-            Self::wallet_outgoing_secrets_path(wallet_directory_path);
+        let outgoing_randomness_file = Self::wallet_outgoing_secrets_path(wallet_directory_path);
         if !outgoing_randomness_file.exists() {
             WalletFile::create_empty_wallet_randomness_file(&outgoing_randomness_file)
                 .unwrap_or_else(|_| {
                     panic!(
-                "Create file for outgoing randomness must succeed. Attempted to create file: {}",
-                outgoing_randomness_file.to_string_lossy()
-            )
+                        "Create file for outgoing randomness must succeed. \
+                        Attempted to create file: {}",
+                        outgoing_randomness_file.to_string_lossy()
+                    )
                 });
         }
 
@@ -104,9 +95,10 @@ impl WalletFileContext {
             WalletFile::create_empty_wallet_randomness_file(&incoming_randomness_file)
                 .unwrap_or_else(|_| {
                     panic!(
-                "Create file for outgoing randomness must succeed. Attempted to create file: {}",
-                incoming_randomness_file.to_string_lossy()
-            )
+                        "Create file for outgoing randomness must succeed. \
+                        Attempted to create file: {}",
+                        incoming_randomness_file.to_string_lossy()
+                    )
                 });
         }
 
@@ -203,7 +195,7 @@ impl WalletFile {
 
     /// Save this wallet to disk. If necessary, create the file (with restrictive permissions).
     pub fn save_to_disk(&self, wallet_file: &Path) -> Result<()> {
-        let wallet_secret_as_json: String = serde_json::to_string(self).unwrap();
+        let wallet_secret_as_json: String = serde_json::to_string(self)?;
 
         #[cfg(unix)]
         {
@@ -228,8 +220,7 @@ impl WalletFile {
             .truncate(false)
             .write(true)
             .mode(0o600)
-            .open(path)
-            .unwrap();
+            .open(path)?;
         fs::write(path.clone(), file_content).context("Failed to write wallet file to disk")
     }
 
@@ -240,8 +231,7 @@ impl WalletFile {
             .create(true)
             .truncate(false)
             .write(true)
-            .open(path)
-            .unwrap();
+            .open(path)?;
         fs::write(path.clone(), wallet_as_json).context("Failed to write wallet file to disk")
     }
 }

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -316,7 +316,10 @@ impl WalletState {
         let scan_mode = match (&cli_args.scan_blocks, cli_args.scan_keys) {
             (None, None) => {
                 if !wallet_was_new && database_was_new {
-                    info!("Activating scan mode: wallet file present but databse absent; wallet may have been imported.");
+                    info!(
+                        "Activating scan mode: wallet file present but \
+                    databse absent; wallet may have been imported."
+                    );
                     Some(ScanModeConfiguration::default())
                 } else {
                     None
@@ -331,7 +334,10 @@ impl WalletState {
                 Some(ScanModeConfiguration::scan().blocks(range.to_owned()))
             }
             (Some(range), Some(num_future_keys)) => {
-                info!("Activating scan mode: CLI arguments `--scan-keys` and `--scan-blocks`.");
+                info!(
+                    "Activating scan mode: CLI arguments `--scan-keys` and \
+                `--scan-blocks`."
+                );
                 Some(
                     ScanModeConfiguration::scan()
                         .blocks(range.to_owned())

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -324,7 +324,7 @@ impl WalletState {
             }
             (None, Some(num_future_keys)) => {
                 info!("Activating scan mode: CLI argument `--scan-keys`.");
-                Some(ScanModeConfiguration::scan().for_future_keys(num_future_keys))
+                Some(ScanModeConfiguration::scan().for_many_future_keys(num_future_keys))
             }
             (Some(range), None) => {
                 info!("Activating scan mode: CLI argument `--scan-blocks`.");
@@ -335,7 +335,7 @@ impl WalletState {
                 Some(
                     ScanModeConfiguration::scan()
                         .blocks(range.to_owned())
-                        .for_future_keys(num_future_keys),
+                        .for_many_future_keys(num_future_keys),
                 )
             }
         };

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -728,9 +728,6 @@ impl WalletState {
         self.get_all_known_spending_keys().flat_map(|key| key.scan_for_announced_utxos(tx_kernel))
 
         // filter for presence in transaction
-        //
-        // note: this is a nice sanity check, but probably is un-necessary
-        //       work that can eventually be removed.
         .filter(|au| match tx_kernel.outputs.contains(&au.addition_record()) {
             true => true,
             false => {
@@ -954,7 +951,8 @@ impl WalletState {
     ///
     /// Specifically, return an iterator over tuples (key type, derivation
     /// index, spending key) for the next `num_future_keys` to be derived, for
-    /// key types "Generation" and "Symmetric Key".
+    /// key types "Generation" and "Symmetric Key". This function does **not**
+    /// increment the derivation counter.
     pub(crate) async fn get_future_spending_keys(
         &self,
         num_future_keys: usize,
@@ -3925,6 +3923,8 @@ mod tests {
     }
 
     pub(crate) mod scan_mode {
+        use std::hint::black_box;
+
         use rand::rngs::StdRng;
         use rand::{rng, SeedableRng};
 
@@ -4060,7 +4060,7 @@ mod tests {
             .await;
             let scan_mode = wallet_state.scan_mode.unwrap();
             assert!(scan_mode.num_future_keys() > 0);
-            assert!(scan_mode.num_future_keys() < 1_000_000);
+            assert!(scan_mode.num_future_keys() < 10_000);
         }
 
         #[tokio::test]
@@ -4233,6 +4233,50 @@ mod tests {
                     );
                 }
             }
+        }
+
+        #[tokio::test]
+        async fn get_future_keys_do_not_modify_counters() {
+            let network = Network::Main;
+            let mut rng = StdRng::from_rng(&mut rng());
+            let wallet_secret = WalletSecret::new_pseudorandom(rng.random());
+            let data_dir = unit_test_data_directory(network).unwrap();
+            let wallet_state = WalletState::new_from_wallet_secret(
+                &data_dir,
+                wallet_secret.clone(),
+                &cli_args::Args::default(),
+                false,
+            )
+            .await;
+
+            // generate iterators for future keys
+            let generation_counter = wallet_state.wallet_db.get_generation_key_counter().await;
+            let symmetric_counter = wallet_state.wallet_db.get_symmetric_key_counter().await;
+
+            // don't just generate the iterators; run through them also
+            let num_future_keys = 100;
+            let future_generation_keys = wallet_state
+                .get_future_generation_spending_keys(num_future_keys)
+                .await
+                .collect_vec();
+            let future_symmetric_keys = wallet_state
+                .get_future_symmetric_keys(num_future_keys)
+                .await
+                .collect_vec();
+
+            // verify that the counters haven't changed
+            assert_eq!(
+                generation_counter,
+                wallet_state.wallet_db.get_generation_key_counter().await
+            );
+            assert_eq!(
+                symmetric_counter,
+                wallet_state.wallet_db.get_symmetric_key_counter().await
+            );
+
+            // make sure passing over the iterators is not being optimized away
+            black_box(future_generation_keys);
+            black_box(future_symmetric_keys);
         }
     }
 }

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -741,13 +741,13 @@ impl WalletState {
     }
 
     /// Scan the given transaction for announced UTXOs as recognized by *future*
-    /// keys, *.i.e.*, keys that will be derived by the next n derivation
+    /// keys, *i.e.*, keys that will be derived by the next n derivation
     /// indices.
     async fn scan_for_utxos_announced_to_future_keys<'a>(
         &'a self,
         num_future_keys: usize,
         tx_kernel: &'a TransactionKernel,
-    ) -> impl Iterator<Item = (KeyType, u64, SpendingKey, IncomingUtxo)> + 'a {
+    ) -> impl Iterator<Item = (KeyType, u64, IncomingUtxo)> + 'a {
         self.get_future_spending_keys(num_future_keys).await
             .flat_map(|(key_type, derivation_index, key)| key.scan_for_announced_utxos(tx_kernel).into_iter().filter(|au| match tx_kernel.outputs.contains(&au.addition_record()) {
                 true => true,
@@ -755,7 +755,7 @@ impl WalletState {
                     warn!("Transaction does not contain announced UTXO encrypted to own receiving address. Announced UTXO was: {:#?}", au.utxo);
                     false
                 }
-            }).map(move |au| (key_type, derivation_index, key, au)))
+            }).map(move |au| (key_type, derivation_index,  au)))
     }
 
     /// Scan the given list of addition records for items that match with list
@@ -1024,6 +1024,28 @@ impl WalletState {
         }
     }
 
+    pub(crate) async fn bump_derivation_counter(&mut self, key_type: KeyType, max_used_index: u64) {
+        if self
+            .spending_key_counter(key_type)
+            .await
+            .is_some_and(|current_counter| max_used_index + 1 > current_counter)
+        {
+            match key_type {
+                KeyType::RawHashLock => (),
+                KeyType::Generation => {
+                    self.wallet_db
+                        .set_generation_key_counter(max_used_index + 1)
+                        .await
+                }
+                KeyType::Symmetric => {
+                    self.wallet_db
+                        .set_symmetric_key_counter(max_used_index + 1)
+                        .await
+                }
+            }
+        }
+    }
+
     /// Get index of the next unused spending key of a given type.
     pub async fn spending_key_counter(&self, key_type: KeyType) -> Option<u64> {
         match key_type {
@@ -1204,7 +1226,46 @@ impl WalletState {
         let spent_inputs: Vec<(Utxo, AbsoluteIndexSet, u64)> =
             self.scan_for_spent_utxos(&tx_kernel).await;
 
-        let onchain_received_outputs = self.scan_for_utxos_announced_to_known_keys(&tx_kernel);
+        let onchain_received_outputs = self
+            .scan_for_utxos_announced_to_known_keys(&tx_kernel)
+            .collect_vec(); // drop immutable borrow of self, for (maybe) bumping below
+
+        // if scan mode is active, scan the block with keys that will be
+        // derived in the future
+        let mut outputs_recovered_through_scan_mode = vec![];
+        if let Some(scan_mode_configuration) = self.scan_mode {
+            if scan_mode_configuration.block_is_in_range(new_block) {
+                let mut max_counters = HashMap::<KeyType, u64>::new();
+                for (key_type, derivation_index, incoming_utxo) in self
+                    .scan_for_utxos_announced_to_future_keys(
+                        scan_mode_configuration.num_future_keys(),
+                        &tx_kernel,
+                    )
+                    .await
+                {
+                    if max_counters
+                        .get(&key_type)
+                        .is_none_or(|&current_max_derivation_index| {
+                            current_max_derivation_index < derivation_index
+                        })
+                    {
+                        max_counters.insert(key_type, derivation_index);
+                    }
+                    outputs_recovered_through_scan_mode.push(incoming_utxo);
+                }
+
+                info!(
+                    "Scan Mode: recovered {} UTXOs in block {}",
+                    outputs_recovered_through_scan_mode.len(),
+                    new_block.header().height
+                );
+
+                for (key_type, derivation_index) in max_counters.into_iter() {
+                    self.bump_derivation_counter(key_type, derivation_index)
+                        .await;
+                }
+            }
+        }
 
         let MutatorSetUpdate {
             additions: addition_records,
@@ -1218,6 +1279,8 @@ impl WalletState {
         let guesser_fee_outputs = self.scan_for_guesser_fee_utxos(new_block);
 
         let all_spendable_received_outputs = onchain_received_outputs
+            .into_iter()
+            .chain(outputs_recovered_through_scan_mode)
             .chain(offchain_received_outputs.iter().cloned())
             .filter(|announced_utxo| announced_utxo.utxo.all_type_script_states_are_valid())
             .chain(guesser_fee_outputs);

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -3954,45 +3954,51 @@ mod tests {
             let rusty_wallet_database_2 = mock_rusty_wallet_database().await;
             let rusty_wallet_database_3 = mock_rusty_wallet_database().await;
 
-            let mut cli_args = Args::default();
-            cli_args.scan_blocks = Some(0u64..=10);
-            let wallet_state = WalletState::new_from_wallet_secret_and_database(
+            let cli_args_1 = Args {
+                scan_blocks: Some(0u64..=10),
+                ..Default::default()
+            };
+            let wallet_state_1 = WalletState::new_from_wallet_secret_and_database(
                 rusty_wallet_database_1,
                 &data_dir,
                 wallet_secret.clone(),
-                &cli_args,
+                &cli_args_1,
                 false,
                 false,
             )
             .await;
-            assert!(wallet_state.scan_mode.is_some());
+            assert!(wallet_state_1.scan_mode.is_some());
 
-            cli_args = Args::default();
-            cli_args.scan_keys = Some(10);
-            let wallet_state = WalletState::new_from_wallet_secret_and_database(
+            let cli_args_2 = Args {
+                scan_keys: Some(10),
+                ..Default::default()
+            };
+            let wallet_state_2 = WalletState::new_from_wallet_secret_and_database(
                 rusty_wallet_database_2,
                 &data_dir,
                 wallet_secret.clone(),
-                &cli_args,
+                &cli_args_2,
                 false,
                 false,
             )
             .await;
-            assert!(wallet_state.scan_mode.is_some());
+            assert!(wallet_state_2.scan_mode.is_some());
 
-            cli_args = Args::default();
-            cli_args.scan_blocks = Some(0u64..=10);
-            cli_args.scan_keys = Some(10);
-            let wallet_state = WalletState::new_from_wallet_secret_and_database(
+            let cli_args_3 = Args {
+                scan_blocks: Some(0u64..=10),
+                scan_keys: Some(10),
+                ..Default::default()
+            };
+            let wallet_state_3 = WalletState::new_from_wallet_secret_and_database(
                 rusty_wallet_database_3,
                 &data_dir,
                 wallet_secret,
-                &cli_args,
+                &cli_args_3,
                 false,
                 false,
             )
             .await;
-            assert!(wallet_state.scan_mode.is_some());
+            assert!(wallet_state_3.scan_mode.is_some());
         }
 
         #[tokio::test]
@@ -4001,8 +4007,10 @@ mod tests {
             let data_dir = mock_data_dir();
             let rusty_wallet_database = mock_rusty_wallet_database().await;
 
-            let mut cli_args = Args::default();
-            cli_args.scan_blocks = Some(0u64..=10);
+            let cli_args = Args {
+                scan_blocks: Some(0u64..=10),
+                ..Default::default()
+            };
             let wallet_state = WalletState::new_from_wallet_secret_and_database(
                 rusty_wallet_database,
                 &data_dir,
@@ -4023,8 +4031,10 @@ mod tests {
 
             // activate scan mode by setting --scan-blocks, so num future keys
             // will assume its default value
-            let mut cli_args = Args::default();
-            cli_args.scan_blocks = Some(0u64..=10);
+            let cli_args = Args {
+                scan_blocks: Some(0u64..=10),
+                ..Default::default()
+            };
             let wallet_state = WalletState::new_from_wallet_secret_and_database(
                 rusty_wallet_database,
                 &data_dir,
@@ -4050,8 +4060,10 @@ mod tests {
 
             // activate scan mode by setting --scan-blocks, so num future keys
             // will assume its default value
-            let mut cli_args = Args::default();
-            cli_args.scan_blocks = Some(lb..=ub);
+            let cli_args = Args {
+                scan_blocks: Some(lb..=ub),
+                ..Default::default()
+            };
             let wallet_state = WalletState::new_from_wallet_secret_and_database(
                 rusty_wallet_database,
                 &data_dir,

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -1161,7 +1161,7 @@ impl WalletState {
             new_block.header().height
         );
 
-        for (key_type, derivation_index) in max_counters.into_iter() {
+        for (key_type, derivation_index) in max_counters {
             self.bump_derivation_counter(key_type, derivation_index)
                 .await;
         }

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -36,6 +36,7 @@ use super::expected_utxo::ExpectedUtxo;
 use super::expected_utxo::UtxoNotifier;
 use super::incoming_utxo::IncomingUtxo;
 use super::rusty_wallet_database::RustyWalletDatabase;
+use super::scan_mode_configuration::ScanModeConfiguration;
 use super::sent_transaction::SentTransaction;
 use super::unlocked_utxo::UnlockedUtxo;
 use super::wallet_status::WalletStatus;
@@ -89,6 +90,10 @@ pub struct WalletState {
     // Cached from the database to avoid async cascades.
     // Contains guesser-preimages from miner PoW-guessing.
     known_raw_hash_lock_keys: Vec<SpendingKey>,
+
+    /// Whether we are in scan mode and, if so, how many future keys to scan
+    /// with and the range of block heights where the scanning step is done.
+    pub(crate) scan_mode: Option<ScanModeConfiguration>,
 }
 
 /// Contains the cryptographic (non-public) data that is needed to recover the mutator set
@@ -229,10 +234,13 @@ impl WalletState {
         data_dir: &DataDirectory,
         wallet_secret: WalletSecret,
         cli_args: &Args,
+        wallet_was_new: bool,
     ) -> Self {
         // Create or connect to wallet block DB
 
-        DataDirectory::create_dir_if_not_exists(&data_dir.wallet_database_dir_path())
+        let wallet_database_path = data_dir.wallet_database_dir_path();
+        let database_is_new = tokio::fs::try_exists(&wallet_database_path).await.unwrap();
+        DataDirectory::create_dir_if_not_exists(&wallet_database_path)
             .await
             .unwrap();
         let wallet_db = NeptuneLevelDb::new(
@@ -249,6 +257,26 @@ impl WalletState {
         };
 
         let rusty_wallet_database = RustyWalletDatabase::connect(wallet_db).await;
+
+        Self::new_from_wallet_secret_and_database(
+            rusty_wallet_database,
+            data_dir,
+            wallet_secret,
+            cli_args,
+            wallet_was_new,
+            database_is_new,
+        )
+        .await
+    }
+
+    async fn new_from_wallet_secret_and_database(
+        rusty_wallet_database: RustyWalletDatabase,
+        data_dir: &DataDirectory,
+        wallet_secret: WalletSecret,
+        cli_args: &Args,
+        wallet_was_new: bool,
+        database_was_new: bool,
+    ) -> Self {
         let sync_label = rusty_wallet_database.get_sync_label().await;
 
         // generate and cache all used generation keys
@@ -270,6 +298,33 @@ impl WalletState {
             .map(SpendingKey::RawHashLock)
             .collect_vec();
 
+        let scan_mode = match (&cli_args.scan_blocks, cli_args.scan_keys) {
+            (None, None) => {
+                if !wallet_was_new && database_was_new {
+                    info!("Activating scan mode: wallet file present but databse absent; wallet may have been imported.");
+                    Some(ScanModeConfiguration::default())
+                } else {
+                    None
+                }
+            }
+            (None, Some(num_future_keys)) => {
+                info!("Activating scan mode: CLI argument `--scan-keys`.");
+                Some(ScanModeConfiguration::scan().for_future_keys(num_future_keys))
+            }
+            (Some(range), None) => {
+                info!("Activating scan mode: CLI argument `--scan-blocks`.");
+                Some(ScanModeConfiguration::scan().blocks(range.to_owned()))
+            }
+            (Some(range), Some(num_future_keys)) => {
+                info!("Activating scan mode: CLI arguments `--scan-keys` and `--scan-blocks`.");
+                Some(
+                    ScanModeConfiguration::scan()
+                        .blocks(range.to_owned())
+                        .for_future_keys(num_future_keys),
+                )
+            }
+        };
+
         let mut wallet_state = Self {
             wallet_db: rusty_wallet_database,
             wallet_secret,
@@ -280,6 +335,7 @@ impl WalletState {
             known_generation_keys,
             known_symmetric_keys,
             known_raw_hash_lock_keys,
+            scan_mode,
         };
 
         // Generation key 0 is reserved for composing and guessing rewards. The
@@ -3733,6 +3789,163 @@ mod tests {
                 .await;
             assert!(wallet_status_1b.synced_unspent_total_amount().is_zero());
             assert!(!wallet_status_1b.unsynced.is_empty());
+        }
+    }
+
+    pub(crate) mod scan_mode {
+        use crate::models::blockchain::block::block_height::BlockHeight;
+
+        use super::*;
+
+        async fn mock_rusty_wallet_database() -> RustyWalletDatabase {
+            let neptune_leveldb = NeptuneLevelDb::open_new_test_database(true, None, None, None)
+                .await
+                .unwrap();
+            RustyWalletDatabase::connect(neptune_leveldb).await
+        }
+
+        fn mock_data_dir() -> DataDirectory {
+            DataDirectory::get(None, Default::default()).unwrap()
+        }
+
+        #[tokio::test]
+        async fn scan_mode_is_off_by_default() {
+            let rusty_wallet_database = mock_rusty_wallet_database().await;
+            let wallet_state = WalletState::new_from_wallet_secret_and_database(
+                rusty_wallet_database,
+                &mock_data_dir(),
+                WalletSecret::new_random(),
+                &Args::default(),
+                false,
+                false,
+            )
+            .await;
+            assert!(wallet_state.scan_mode.is_none());
+        }
+
+        #[tokio::test]
+        async fn scan_mode_is_on_with_scan_blocks_or_scan_keys() {
+            let wallet_secret = WalletSecret::new_random();
+            let data_dir = mock_data_dir();
+            let rusty_wallet_database_1 = mock_rusty_wallet_database().await;
+            let rusty_wallet_database_2 = mock_rusty_wallet_database().await;
+            let rusty_wallet_database_3 = mock_rusty_wallet_database().await;
+
+            let mut cli_args = Args::default();
+            cli_args.scan_blocks = Some(0u64..=10);
+            let wallet_state = WalletState::new_from_wallet_secret_and_database(
+                rusty_wallet_database_1,
+                &data_dir,
+                wallet_secret.clone(),
+                &cli_args,
+                false,
+                false,
+            )
+            .await;
+            assert!(wallet_state.scan_mode.is_some());
+
+            cli_args = Args::default();
+            cli_args.scan_keys = Some(10);
+            let wallet_state = WalletState::new_from_wallet_secret_and_database(
+                rusty_wallet_database_2,
+                &data_dir,
+                wallet_secret.clone(),
+                &cli_args,
+                false,
+                false,
+            )
+            .await;
+            assert!(wallet_state.scan_mode.is_some());
+
+            cli_args = Args::default();
+            cli_args.scan_blocks = Some(0u64..=10);
+            cli_args.scan_keys = Some(10);
+            let wallet_state = WalletState::new_from_wallet_secret_and_database(
+                rusty_wallet_database_3,
+                &data_dir,
+                wallet_secret,
+                &cli_args,
+                false,
+                false,
+            )
+            .await;
+            assert!(wallet_state.scan_mode.is_some());
+        }
+
+        #[tokio::test]
+        async fn scan_mode_is_on_if_wallet_was_imported() {
+            let wallet_secret = WalletSecret::new_random();
+            let data_dir = mock_data_dir();
+            let rusty_wallet_database = mock_rusty_wallet_database().await;
+
+            let mut cli_args = Args::default();
+            cli_args.scan_blocks = Some(0u64..=10);
+            let wallet_state = WalletState::new_from_wallet_secret_and_database(
+                rusty_wallet_database,
+                &data_dir,
+                wallet_secret.clone(),
+                &cli_args,
+                false,
+                true,
+            )
+            .await;
+            assert!(wallet_state.scan_mode.is_some());
+        }
+
+        #[tokio::test]
+        async fn num_future_keys_default_is_sane() {
+            let wallet_secret = WalletSecret::new_random();
+            let data_dir = mock_data_dir();
+            let rusty_wallet_database = mock_rusty_wallet_database().await;
+
+            // activate scan mode by setting --scan-blocks, so num future keys
+            // will assume its default value
+            let mut cli_args = Args::default();
+            cli_args.scan_blocks = Some(0u64..=10);
+            let wallet_state = WalletState::new_from_wallet_secret_and_database(
+                rusty_wallet_database,
+                &data_dir,
+                wallet_secret.clone(),
+                &cli_args,
+                false,
+                false,
+            )
+            .await;
+            let scan_mode = wallet_state.scan_mode.unwrap();
+            assert!(scan_mode.num_future_keys() > 0);
+            assert!(scan_mode.num_future_keys() < 1_000_000);
+        }
+
+        #[tokio::test]
+        async fn block_height_range_check_agrees_with_interval_membership() {
+            let wallet_secret = WalletSecret::new_random();
+            let data_dir = mock_data_dir();
+            let rusty_wallet_database = mock_rusty_wallet_database().await;
+
+            let lb = 10;
+            let ub = 20;
+
+            // activate scan mode by setting --scan-blocks, so num future keys
+            // will assume its default value
+            let mut cli_args = Args::default();
+            cli_args.scan_blocks = Some(lb..=ub);
+            let wallet_state = WalletState::new_from_wallet_secret_and_database(
+                rusty_wallet_database,
+                &data_dir,
+                wallet_secret.clone(),
+                &cli_args,
+                false,
+                false,
+            )
+            .await;
+            let scan_mode = wallet_state.scan_mode.unwrap();
+
+            for h in (lb - 5)..(ub + 5) {
+                assert_eq!(
+                    (lb..=ub).contains(&h),
+                    scan_mode.block_height_is_in_range(BlockHeight::from(h)),
+                );
+            }
         }
     }
 }

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -465,7 +465,7 @@ impl WalletState {
 
                 // scan tx for utxo with public-announcements we can claim
                 let announced_utxos_from_public_announcements =
-                    self.scan_for_announced_utxos(&tx.kernel);
+                    self.scan_for_utxos_announced_to_known_keys(&tx.kernel);
 
                 let own_utxos = announced_utxos_from_public_announcements
                     .chain(own_utxos_from_expected_utxos)
@@ -720,25 +720,42 @@ impl WalletState {
     /// Scan the given transaction for announced UTXOs as recognized by owned
     /// `SpendingKey`s, and then verify those announced UTXOs are actually
     /// present.
-    fn scan_for_announced_utxos<'a>(
+    fn scan_for_utxos_announced_to_known_keys<'a>(
         &'a self,
         tx_kernel: &'a TransactionKernel,
     ) -> impl Iterator<Item = IncomingUtxo> + 'a {
         // scan for announced utxos for every known key of every key type.
-        self.get_all_known_spending_keys()
-            .flat_map(|key| key.scan_for_announced_utxos(tx_kernel))
+        self.get_all_known_spending_keys().flat_map(|key| key.scan_for_announced_utxos(tx_kernel))
 
-            // filter for presence in transaction
-            //
-            // note: this is a nice sanity check, but probably is un-necessary
-            //       work that can eventually be removed.
-            .filter(|au| match tx_kernel.outputs.contains(&au.addition_record()) {
+        // filter for presence in transaction
+        //
+        // note: this is a nice sanity check, but probably is un-necessary
+        //       work that can eventually be removed.
+        .filter(|au| match tx_kernel.outputs.contains(&au.addition_record()) {
+            true => true,
+            false => {
+                warn!("Transaction does not contain announced UTXO encrypted to own receiving address. Announced UTXO was: {:#?}", au.utxo);
+                false
+            }
+        })
+    }
+
+    /// Scan the given transaction for announced UTXOs as recognized by *future*
+    /// keys, *.i.e.*, keys that will be derived by the next n derivation
+    /// indices.
+    async fn scan_for_utxos_announced_to_future_keys<'a>(
+        &'a self,
+        num_future_keys: usize,
+        tx_kernel: &'a TransactionKernel,
+    ) -> impl Iterator<Item = (KeyType, u64, SpendingKey, IncomingUtxo)> + 'a {
+        self.get_future_spending_keys(num_future_keys).await
+            .flat_map(|(key_type, derivation_index, key)| key.scan_for_announced_utxos(tx_kernel).into_iter().filter(|au| match tx_kernel.outputs.contains(&au.addition_record()) {
                 true => true,
                 false => {
                     warn!("Transaction does not contain announced UTXO encrypted to own receiving address. Announced UTXO was: {:#?}", au.utxo);
                     false
                 }
-            })
+            }).map(move |au| (key_type, derivation_index, key, au)))
     }
 
     /// Scan the given list of addition records for items that match with list
@@ -932,6 +949,26 @@ impl WalletState {
             .flat_map(|key_type| self.get_known_spending_keys(key_type))
     }
 
+    /// Return an iterator over the next n spending keys of all applicably key
+    /// types, with derivation info.
+    ///
+    /// Specifically, return an iterator over tuples (key type, derivation
+    /// index, spending key) for the next `num_future_keys` to be derived, for
+    /// key types "Generation" and "Symmetric Key".
+    pub(crate) async fn get_future_spending_keys(
+        &self,
+        num_future_keys: usize,
+    ) -> impl Iterator<Item = (KeyType, u64, SpendingKey)> + '_ {
+        self.get_future_generation_spending_keys(num_future_keys)
+            .await
+            .map(|(i, gsk)| (KeyType::Generation, i, SpendingKey::from(gsk)))
+            .chain(
+                self.get_future_symmetric_keys(num_future_keys)
+                    .await
+                    .map(|(i, sk)| (KeyType::Symmetric, i, SpendingKey::from(sk))),
+            )
+    }
+
     /// returns all spending keys of `key_type` with derivation index less than current counter
     pub fn get_known_spending_keys(
         &self,
@@ -1037,6 +1074,28 @@ impl WalletState {
         let key = self.wallet_secret.nth_symmetric_key(index);
         self.known_symmetric_keys.push(key.into());
         key
+    }
+
+    /// Get the next n generation spending keys (with derivation indices)
+    /// without modifying the counter.
+    pub(crate) async fn get_future_generation_spending_keys(
+        &self,
+        num_future_keys: usize,
+    ) -> impl Iterator<Item = (u64, generation_address::GenerationSpendingKey)> + use<'_> {
+        let index = self.wallet_db.get_generation_key_counter().await;
+        (index..index + (num_future_keys as u64))
+            .map(|i| (i, self.wallet_secret.nth_generation_spending_key(i)))
+    }
+
+    /// Get the next n symmetric spending keys (with derivation indices)
+    /// without modifying the counter.
+    pub(crate) async fn get_future_symmetric_keys(
+        &self,
+        num_future_keys: usize,
+    ) -> impl Iterator<Item = (u64, symmetric_key::SymmetricKey)> + use<'_> {
+        let index = self.wallet_db.get_symmetric_key_counter().await;
+        (index..index + (num_future_keys as u64))
+            .map(|i| (i, self.wallet_secret.nth_symmetric_key(i)))
     }
 
     pub(crate) async fn claim_utxo(&mut self, utxo_claim_data: ClaimUtxoData) -> Result<()> {
@@ -1145,12 +1204,13 @@ impl WalletState {
         let spent_inputs: Vec<(Utxo, AbsoluteIndexSet, u64)> =
             self.scan_for_spent_utxos(&tx_kernel).await;
 
+        let onchain_received_outputs = self.scan_for_utxos_announced_to_known_keys(&tx_kernel);
+
         let MutatorSetUpdate {
             additions: addition_records,
             removals: _removal_records,
         } = new_block.mutator_set_update();
 
-        let onchain_received_outputs = self.scan_for_announced_utxos(&tx_kernel);
         let offchain_received_outputs = self
             .scan_for_expected_utxos(&addition_records)
             .await

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::error::Error;
 use std::fmt::Debug;
-use std::path::PathBuf;
 
 use anyhow::bail;
 use anyhow::Result;
@@ -36,12 +35,11 @@ use super::expected_utxo::ExpectedUtxo;
 use super::expected_utxo::UtxoNotifier;
 use super::incoming_utxo::IncomingUtxo;
 use super::rusty_wallet_database::RustyWalletDatabase;
-use super::scan_mode_configuration::ScanModeConfiguration;
 use super::sent_transaction::SentTransaction;
 use super::unlocked_utxo::UnlockedUtxo;
+use super::wallet_configuration::WalletConfiguration;
 use super::wallet_entropy::WalletEntropy;
 use super::wallet_file::WalletFileContext;
-use super::wallet_file::WALLET_INCOMING_SECRETS_FILE_NAME;
 use super::wallet_status::WalletStatus;
 use super::wallet_status::WalletStatusElement;
 use crate::config_models::cli_args::Args;
@@ -74,8 +72,6 @@ use crate::Hash;
 pub struct WalletState {
     pub wallet_db: RustyWalletDatabase,
     pub wallet_entropy: WalletEntropy,
-    pub number_of_mps_per_utxo: usize,
-    wallet_directory_path: PathBuf,
 
     /// these two fields are for monitoring wallet-affecting utxos in the mempool.
     /// key is Tx hash.  for removing watched utxos when a tx is removed from mempool.
@@ -92,9 +88,8 @@ pub struct WalletState {
     // Contains guesser-preimages from miner PoW-guessing.
     known_raw_hash_lock_keys: Vec<SpendingKey>,
 
-    /// Whether we are in scan mode and, if so, how many future keys to scan
-    /// with and the range of block heights where the scanning step is done.
-    pub(crate) scan_mode: Option<ScanModeConfiguration>,
+    /// Tunable options for configuring how the wallet state operates.
+    pub(crate) configuration: WalletConfiguration,
 }
 
 /// Contains the cryptographic (non-public) data that is needed to recover the mutator set
@@ -156,20 +151,21 @@ impl Debug for WalletState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("WalletState")
             .field("wallet_secret", &self.wallet_entropy)
-            .field("number_of_mps_per_utxo", &self.number_of_mps_per_utxo)
-            .field("wallet_directory_path", &self.wallet_directory_path)
+            .field(
+                "number_of_mps_per_utxo",
+                &self.configuration.num_mps_per_utxo,
+            )
+            .field(
+                "wallet_directory_path",
+                &self.configuration.wallet_files_directory_path(),
+            )
             .finish()
     }
 }
 
 impl WalletState {
-    fn incoming_secrets_path(&self) -> PathBuf {
-        self.wallet_directory_path
-            .join(WALLET_INCOMING_SECRETS_FILE_NAME)
-    }
-
-    /// Store information needed to recover mutator set membership proof of a UTXO, in case
-    /// the wallet database is deleted.
+    /// Store information needed to recover mutator set membership proof of a
+    /// UTXO, in case the wallet database is deleted.
     ///
     /// Uses non-blocking I/O via tokio.
     async fn store_utxo_ms_recovery_data(
@@ -178,14 +174,14 @@ impl WalletState {
     ) -> Result<()> {
         #[cfg(test)]
         {
-            tokio::fs::create_dir_all(self.wallet_directory_path.clone()).await?;
+            tokio::fs::create_dir_all(self.configuration.wallet_files_directory_path()).await?;
         }
 
         // Open file
         let incoming_secrets_file = OpenOptions::new()
             .append(true)
             .create(true)
-            .open(self.incoming_secrets_path())
+            .open(self.configuration.incoming_secrets_path())
             .await?;
         let mut incoming_secrets_file = BufWriter::new(incoming_secrets_file);
 
@@ -207,8 +203,9 @@ impl WalletState {
         Ok(())
     }
 
-    /// Read recovery-information for mutator set membership proof of a UTXO. Returns all lines in the files,
-    /// where each line represents an incoming UTXO.
+    /// Read recovery-information for mutator set membership proof of a UTXO.
+    /// Returns all lines in the files, where each line represents an incoming
+    /// UTXO.
     ///
     /// Uses non-blocking I/O via tokio.
     pub(crate) async fn read_utxo_ms_recovery_data(&self) -> Result<Vec<IncomingUtxoRecoveryData>> {
@@ -216,7 +213,7 @@ impl WalletState {
         let incoming_secrets_file = OpenOptions::new()
             .read(true)
             .write(false)
-            .open(self.incoming_secrets_path())
+            .open(self.configuration.incoming_secrets_path())
             .await?;
 
         let file_reader = BufReader::new(incoming_secrets_file);
@@ -231,21 +228,37 @@ impl WalletState {
         Ok(ret)
     }
 
-    async fn new_from_wallet_entropy_and_new_bool(
+    /// Create a `WalletState` object from related data.
+    ///
+    /// Convenience method to extract required data prior to calling the
+    /// canonical constructor, [`Self::new`].
+    pub(crate) async fn new_from_context(
         data_dir: &DataDirectory,
-        wallet_entropy: WalletEntropy,
+        wallet_file_context: WalletFileContext,
         cli_args: &Args,
-        wallet_was_new: bool,
     ) -> Self {
-        // Create or connect to wallet block DB
+        let database_is_new = tokio::fs::try_exists(&data_dir.wallet_database_dir_path())
+            .await
+            .unwrap();
+        let configuration = WalletConfiguration::new(data_dir)
+            .absorb_options(cli_args)
+            .with_scan_mode_if_necessary(wallet_file_context.wallet_is_new, database_is_new);
+        Self::new(configuration, wallet_file_context.entropy()).await
+    }
 
-        let wallet_database_path = data_dir.wallet_database_dir_path();
-        let database_is_new = tokio::fs::try_exists(&wallet_database_path).await.unwrap();
+    /// Construct a `WalletState` object.
+    ///
+    /// Canonical constructor.
+    pub(crate) async fn new(
+        configuration: WalletConfiguration,
+        wallet_entropy: WalletEntropy,
+    ) -> Self {
+        let wallet_database_path = configuration.wallet_database_directory_path();
         DataDirectory::create_dir_if_not_exists(&wallet_database_path)
             .await
             .unwrap();
         let wallet_db = NeptuneLevelDb::new(
-            &data_dir.wallet_database_dir_path(),
+            &wallet_database_path,
             &crate::database::create_db_if_missing(),
         )
         .await;
@@ -259,49 +272,16 @@ impl WalletState {
 
         let rusty_wallet_database = RustyWalletDatabase::connect(wallet_db).await;
 
-        Self::new_from_wallet_secret_and_database(
-            rusty_wallet_database,
-            data_dir,
-            wallet_entropy,
-            cli_args,
-            wallet_was_new,
-            database_is_new,
-        )
-        .await
-    }
-
-    pub async fn new_from_wallet_file_context(
-        data_dir: &DataDirectory,
-        wallet_file_context: WalletFileContext,
-        cli_args: &Args,
-    ) -> Self {
-        Self::new_from_wallet_entropy_and_new_bool(
-            data_dir,
-            wallet_file_context.entropy(),
-            cli_args,
-            wallet_file_context.wallet_is_new,
-        )
-        .await
-    }
-
-    async fn new_from_wallet_secret_and_database(
-        rusty_wallet_database: RustyWalletDatabase,
-        data_dir: &DataDirectory,
-        wallet_secret: WalletEntropy,
-        cli_args: &Args,
-        wallet_was_new: bool,
-        database_was_new: bool,
-    ) -> Self {
         let sync_label = rusty_wallet_database.get_sync_label().await;
 
         // generate and cache all used generation keys
         let known_generation_keys = (0..rusty_wallet_database.get_generation_key_counter().await)
-            .map(|idx| wallet_secret.nth_generation_spending_key(idx).into())
+            .map(|idx| wallet_entropy.nth_generation_spending_key(idx).into())
             .collect_vec();
 
         // generate and cache all used symmetric keys
         let known_symmetric_keys = (0..rusty_wallet_database.get_symmetric_key_counter().await)
-            .map(|idx| wallet_secret.nth_symmetric_key(idx).into())
+            .map(|idx| wallet_entropy.nth_symmetric_key(idx).into())
             .collect_vec();
 
         let known_raw_hash_lock_keys = rusty_wallet_database
@@ -313,50 +293,15 @@ impl WalletState {
             .map(SpendingKey::RawHashLock)
             .collect_vec();
 
-        let scan_mode = match (&cli_args.scan_blocks, cli_args.scan_keys) {
-            (None, None) => {
-                if !wallet_was_new && database_was_new {
-                    info!(
-                        "Activating scan mode: wallet file present but \
-                    databse absent; wallet may have been imported."
-                    );
-                    Some(ScanModeConfiguration::default())
-                } else {
-                    None
-                }
-            }
-            (None, Some(num_future_keys)) => {
-                info!("Activating scan mode: CLI argument `--scan-keys`.");
-                Some(ScanModeConfiguration::scan().for_many_future_keys(num_future_keys))
-            }
-            (Some(range), None) => {
-                info!("Activating scan mode: CLI argument `--scan-blocks`.");
-                Some(ScanModeConfiguration::scan().blocks(range.to_owned()))
-            }
-            (Some(range), Some(num_future_keys)) => {
-                info!(
-                    "Activating scan mode: CLI arguments `--scan-keys` and \
-                `--scan-blocks`."
-                );
-                Some(
-                    ScanModeConfiguration::scan()
-                        .blocks(range.to_owned())
-                        .for_many_future_keys(num_future_keys),
-                )
-            }
-        };
-
         let mut wallet_state = Self {
             wallet_db: rusty_wallet_database,
-            wallet_entropy: wallet_secret,
-            number_of_mps_per_utxo: cli_args.number_of_mps_per_utxo,
-            wallet_directory_path: data_dir.wallet_directory_path(),
+            wallet_entropy,
             mempool_spent_utxos: Default::default(),
             mempool_unspent_utxos: Default::default(),
             known_generation_keys,
             known_symmetric_keys,
             known_raw_hash_lock_keys,
-            scan_mode,
+            configuration: configuration.clone(),
         };
 
         // Generation key 0 is reserved for composing and guessing rewards. The
@@ -401,12 +346,12 @@ impl WalletState {
                 let own_receiving_address = premine_key
                     .to_address()
                     .expect("premine keys should have associated addresses");
-                for utxo in Block::premine_utxos(cli_args.network) {
+                for utxo in Block::premine_utxos(configuration.network()) {
                     if utxo.lock_script_hash() == own_receiving_address.lock_script().hash() {
                         wallet_state
                             .add_expected_utxo(ExpectedUtxo::new(
                                 utxo,
-                                Block::premine_sender_randomness(cli_args.network),
+                                Block::premine_sender_randomness(configuration.network()),
                                 premine_key
                                     .privacy_preimage()
                                     .expect("premine keys should have associated privacy preimage"),
@@ -420,7 +365,7 @@ impl WalletState {
             wallet_state
                 .update_wallet_state_with_new_block(
                     &MutatorSetAccumulator::default(),
-                    &Block::genesis(cli_args.network),
+                    &Block::genesis(configuration.network()),
                 )
                 .await
                 .expect("Updating wallet state with genesis block must succeed");
@@ -1254,7 +1199,7 @@ impl WalletState {
         // if scan mode is active, scan the block with keys that will be
         // derived in the future
         let mut outputs_recovered_through_scan_mode = vec![];
-        if let Some(scan_mode_configuration) = self.scan_mode {
+        if let Some(scan_mode_configuration) = self.configuration.scan_mode {
             if scan_mode_configuration.block_is_in_range(new_block) {
                 let mut max_counters = HashMap::<KeyType, u64>::new();
                 for (key_type, derivation_index, incoming_utxo) in self
@@ -1411,7 +1356,8 @@ impl WalletState {
                 let strong_key = StrongUtxoKey::new(*addition_record, aocl_index);
 
                 // Add the new UTXO to the list of monitored UTXOs
-                let mut mutxo = MonitoredUtxo::new(utxo.clone(), self.number_of_mps_per_utxo);
+                let mut mutxo =
+                    MonitoredUtxo::new(utxo.clone(), self.configuration.num_mps_per_utxo);
                 mutxo.confirmed_in_block = Some((
                     new_block.hash(),
                     new_block.kernel.header.timestamp,
@@ -1805,12 +1751,13 @@ impl WalletState {
         wallet_entropy: WalletEntropy,
         cli_args: &Args,
     ) -> Self {
-        Self::new_from_wallet_entropy_and_new_bool(data_dir, wallet_entropy, cli_args, false).await
+        let configuration = WalletConfiguration::new(data_dir).absorb_options(cli_args);
+        Self::new(configuration, wallet_entropy).await
     }
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use generation_address::GenerationSpendingKey;
     use rand::random;
     use rand::Rng;
@@ -3962,173 +3909,9 @@ mod tests {
         use rand::{rng, SeedableRng};
 
         use crate::job_queue::JobQueue;
-        use crate::models::blockchain::block::block_height::BlockHeight;
         use crate::tests::shared::unit_test_data_directory;
 
         use super::*;
-
-        async fn mock_rusty_wallet_database() -> RustyWalletDatabase {
-            let neptune_leveldb = NeptuneLevelDb::open_new_test_database(true, None, None, None)
-                .await
-                .unwrap();
-            RustyWalletDatabase::connect(neptune_leveldb).await
-        }
-
-        fn mock_data_dir() -> DataDirectory {
-            DataDirectory::get(None, Default::default()).unwrap()
-        }
-
-        #[tokio::test]
-        async fn scan_mode_is_off_by_default() {
-            let rusty_wallet_database = mock_rusty_wallet_database().await;
-            let wallet_state = WalletState::new_from_wallet_secret_and_database(
-                rusty_wallet_database,
-                &mock_data_dir(),
-                WalletEntropy::new_random(),
-                &Args::default(),
-                false,
-                false,
-            )
-            .await;
-            assert!(wallet_state.scan_mode.is_none());
-        }
-
-        #[tokio::test]
-        async fn scan_mode_is_on_with_scan_blocks_or_scan_keys() {
-            let wallet_secret = WalletEntropy::new_random();
-            let data_dir = mock_data_dir();
-            let rusty_wallet_database_1 = mock_rusty_wallet_database().await;
-            let rusty_wallet_database_2 = mock_rusty_wallet_database().await;
-            let rusty_wallet_database_3 = mock_rusty_wallet_database().await;
-
-            let cli_args_1 = Args {
-                scan_blocks: Some(0u64..=10),
-                ..Default::default()
-            };
-            let wallet_state_1 = WalletState::new_from_wallet_secret_and_database(
-                rusty_wallet_database_1,
-                &data_dir,
-                wallet_secret.clone(),
-                &cli_args_1,
-                false,
-                false,
-            )
-            .await;
-            assert!(wallet_state_1.scan_mode.is_some());
-
-            let cli_args_2 = Args {
-                scan_keys: Some(10),
-                ..Default::default()
-            };
-            let wallet_state_2 = WalletState::new_from_wallet_secret_and_database(
-                rusty_wallet_database_2,
-                &data_dir,
-                wallet_secret.clone(),
-                &cli_args_2,
-                false,
-                false,
-            )
-            .await;
-            assert!(wallet_state_2.scan_mode.is_some());
-
-            let cli_args_3 = Args {
-                scan_blocks: Some(0u64..=10),
-                scan_keys: Some(10),
-                ..Default::default()
-            };
-            let wallet_state_3 = WalletState::new_from_wallet_secret_and_database(
-                rusty_wallet_database_3,
-                &data_dir,
-                wallet_secret,
-                &cli_args_3,
-                false,
-                false,
-            )
-            .await;
-            assert!(wallet_state_3.scan_mode.is_some());
-        }
-
-        #[tokio::test]
-        async fn scan_mode_is_on_if_wallet_was_imported() {
-            let wallet_secret = WalletEntropy::new_random();
-            let data_dir = mock_data_dir();
-            let rusty_wallet_database = mock_rusty_wallet_database().await;
-
-            let cli_args = Args {
-                scan_blocks: Some(0u64..=10),
-                ..Default::default()
-            };
-            let wallet_state = WalletState::new_from_wallet_secret_and_database(
-                rusty_wallet_database,
-                &data_dir,
-                wallet_secret.clone(),
-                &cli_args,
-                false,
-                true,
-            )
-            .await;
-            assert!(wallet_state.scan_mode.is_some());
-        }
-
-        #[tokio::test]
-        async fn num_future_keys_default_is_sane() {
-            let wallet_secret = WalletEntropy::new_random();
-            let data_dir = mock_data_dir();
-            let rusty_wallet_database = mock_rusty_wallet_database().await;
-
-            // activate scan mode by setting --scan-blocks, so num future keys
-            // will assume its default value
-            let cli_args = Args {
-                scan_blocks: Some(0u64..=10),
-                ..Default::default()
-            };
-            let wallet_state = WalletState::new_from_wallet_secret_and_database(
-                rusty_wallet_database,
-                &data_dir,
-                wallet_secret.clone(),
-                &cli_args,
-                false,
-                false,
-            )
-            .await;
-            let scan_mode = wallet_state.scan_mode.unwrap();
-            assert!(scan_mode.num_future_keys() > 0);
-            assert!(scan_mode.num_future_keys() < 10_000);
-        }
-
-        #[tokio::test]
-        async fn block_height_range_check_agrees_with_interval_membership() {
-            let wallet_secret = WalletEntropy::new_random();
-            let data_dir = mock_data_dir();
-            let rusty_wallet_database = mock_rusty_wallet_database().await;
-
-            let lb = 10;
-            let ub = 20;
-
-            // activate scan mode by setting --scan-blocks, so num future keys
-            // will assume its default value
-            let cli_args = Args {
-                scan_blocks: Some(lb..=ub),
-                ..Default::default()
-            };
-            let wallet_state = WalletState::new_from_wallet_secret_and_database(
-                rusty_wallet_database,
-                &data_dir,
-                wallet_secret.clone(),
-                &cli_args,
-                false,
-                false,
-            )
-            .await;
-            let scan_mode = wallet_state.scan_mode.unwrap();
-
-            for h in (lb - 5)..(ub + 5) {
-                assert_eq!(
-                    (lb..=ub).contains(&h),
-                    scan_mode.block_height_is_in_range(BlockHeight::from(h)),
-                );
-            }
-        }
 
         /// Test scan mode.
         ///

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -150,7 +150,7 @@ impl StrongUtxoKey {
 impl Debug for WalletState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("WalletState")
-            .field("wallet_secret", &self.wallet_entropy)
+            .field("wallet_entropy", &self.wallet_entropy)
             .field(
                 "number_of_mps_per_utxo",
                 &self.configuration.num_mps_per_utxo,
@@ -240,9 +240,17 @@ impl WalletState {
         let database_is_new = tokio::fs::try_exists(&data_dir.wallet_database_dir_path())
             .await
             .unwrap();
-        let configuration = WalletConfiguration::new(data_dir)
-            .absorb_options(cli_args)
-            .with_scan_mode_if_necessary(wallet_file_context.wallet_is_new, database_is_new);
+        let mut configuration = WalletConfiguration::new(data_dir).absorb_options(cli_args);
+
+        // if wallet was imported, ensure scan mode is enabled
+        if !wallet_file_context.wallet_is_new && database_is_new {
+            info!(
+                "Activating scan mode: wallet file present but \
+                databse absent; wallet may have been imported."
+            );
+            configuration.enable_scan_mode();
+        }
+
         Self::new(configuration, wallet_file_context.entropy()).await
     }
 
@@ -691,16 +699,20 @@ impl WalletState {
         tx_kernel: &'a TransactionKernel,
     ) -> impl Iterator<Item = IncomingUtxo> + 'a {
         // scan for announced utxos for every known key of every key type.
-        self.get_all_known_spending_keys().flat_map(|key| key.scan_for_announced_utxos(tx_kernel))
-
-        // filter for presence in transaction
-        .filter(|au| match tx_kernel.outputs.contains(&au.addition_record()) {
-            true => true,
-            false => {
-                warn!("Transaction does not contain announced UTXO encrypted to own receiving address. Announced UTXO was: {:#?}", au.utxo);
-                false
-            }
-        })
+        self.get_all_known_spending_keys()
+            .flat_map(|key| key.scan_for_announced_utxos(tx_kernel))
+            .filter(|au| {
+                let transaction_contains_addition_record =
+                    tx_kernel.outputs.contains(&au.addition_record());
+                if !transaction_contains_addition_record {
+                    warn!(
+                        "Transaction does not contain announced UTXO encrypted \
+                        to own receiving address. Announced UTXO was: {:#?}",
+                        au.utxo
+                    );
+                }
+                transaction_contains_addition_record
+            })
     }
 
     /// Scan the given transaction for announced UTXOs as recognized by *future*
@@ -923,14 +935,15 @@ impl WalletState {
         &self,
         num_future_keys: usize,
     ) -> impl Iterator<Item = (KeyType, u64, SpendingKey)> + '_ {
-        self.get_future_generation_spending_keys(num_future_keys)
+        let future_generation_keys = self
+            .get_future_generation_spending_keys(num_future_keys)
             .await
-            .map(|(i, gsk)| (KeyType::Generation, i, SpendingKey::from(gsk)))
-            .chain(
-                self.get_future_symmetric_keys(num_future_keys)
-                    .await
-                    .map(|(i, sk)| (KeyType::Symmetric, i, SpendingKey::from(sk))),
-            )
+            .map(|(i, gsk)| (KeyType::Generation, i, SpendingKey::from(gsk)));
+        let future_symmetric_keys = self
+            .get_future_symmetric_keys(num_future_keys)
+            .await
+            .map(|(i, sk)| (KeyType::Symmetric, i, SpendingKey::from(sk)));
+        future_generation_keys.chain(future_symmetric_keys)
     }
 
     /// returns all spending keys of `key_type` with derivation index less than current counter
@@ -989,23 +1002,16 @@ impl WalletState {
     }
 
     pub(crate) async fn bump_derivation_counter(&mut self, key_type: KeyType, max_used_index: u64) {
+        let new_counter = max_used_index + 1;
         if self
             .spending_key_counter(key_type)
             .await
-            .is_some_and(|current_counter| max_used_index + 1 > current_counter)
+            .is_some_and(|current_counter| new_counter > current_counter)
         {
             match key_type {
                 KeyType::RawHashLock => (),
-                KeyType::Generation => {
-                    self.wallet_db
-                        .set_generation_key_counter(max_used_index + 1)
-                        .await
-                }
-                KeyType::Symmetric => {
-                    self.wallet_db
-                        .set_symmetric_key_counter(max_used_index + 1)
-                        .await
-                }
+                KeyType::Generation => self.wallet_db.set_generation_key_counter(new_counter).await,
+                KeyType::Symmetric => self.wallet_db.set_symmetric_key_counter(new_counter).await,
             }
         }
     }
@@ -1104,6 +1110,51 @@ impl WalletState {
         Ok(())
     }
 
+    /// If scan mode is active and block is in range, scan the block with keys
+    /// that will be derived in the future
+    async fn recover_by_scanning(&mut self, new_block: &Block) -> Vec<IncomingUtxo> {
+        let Some(scan_mode_configuration) = self.configuration.scan_mode else {
+            return Vec::new();
+        };
+        if !scan_mode_configuration.block_is_in_range(new_block) {
+            return Vec::new();
+        }
+
+        let mut recovered_outputs = vec![];
+
+        let mut max_counters = HashMap::<KeyType, u64>::new();
+        for (key_type, derivation_index, incoming_utxo) in self
+            .scan_for_utxos_announced_to_future_keys(
+                scan_mode_configuration.num_future_keys(),
+                &new_block.body().transaction_kernel,
+            )
+            .await
+        {
+            if max_counters
+                .get(&key_type)
+                .is_none_or(|&current_max_derivation_index| {
+                    current_max_derivation_index < derivation_index
+                })
+            {
+                max_counters.insert(key_type, derivation_index);
+            }
+            recovered_outputs.push(incoming_utxo);
+        }
+
+        info!(
+            "Scan Mode: recovered {} UTXOs in block {}",
+            recovered_outputs.len(),
+            new_block.header().height
+        );
+
+        for (key_type, derivation_index) in max_counters.into_iter() {
+            self.bump_derivation_counter(key_type, derivation_index)
+                .await;
+        }
+
+        recovered_outputs
+    }
+
     /// Update wallet state with new block.
     ///
     /// Assume the given block is valid and that the wallet state is not synced
@@ -1196,42 +1247,7 @@ impl WalletState {
             .scan_for_utxos_announced_to_known_keys(&tx_kernel)
             .collect_vec(); // drop immutable borrow of self, for (maybe) bumping below
 
-        // if scan mode is active, scan the block with keys that will be
-        // derived in the future
-        let mut outputs_recovered_through_scan_mode = vec![];
-        if let Some(scan_mode_configuration) = self.configuration.scan_mode {
-            if scan_mode_configuration.block_is_in_range(new_block) {
-                let mut max_counters = HashMap::<KeyType, u64>::new();
-                for (key_type, derivation_index, incoming_utxo) in self
-                    .scan_for_utxos_announced_to_future_keys(
-                        scan_mode_configuration.num_future_keys(),
-                        &tx_kernel,
-                    )
-                    .await
-                {
-                    if max_counters
-                        .get(&key_type)
-                        .is_none_or(|&current_max_derivation_index| {
-                            current_max_derivation_index < derivation_index
-                        })
-                    {
-                        max_counters.insert(key_type, derivation_index);
-                    }
-                    outputs_recovered_through_scan_mode.push(incoming_utxo);
-                }
-
-                info!(
-                    "Scan Mode: recovered {} UTXOs in block {}",
-                    outputs_recovered_through_scan_mode.len(),
-                    new_block.header().height
-                );
-
-                for (key_type, derivation_index) in max_counters.into_iter() {
-                    self.bump_derivation_counter(key_type, derivation_index)
-                        .await;
-                }
-            }
-        }
+        let outputs_recovered_through_scan_mode = self.recover_by_scanning(new_block).await;
 
         let MutatorSetUpdate {
             additions: addition_records,
@@ -1744,16 +1760,6 @@ impl WalletState {
         }
         own_coins
     }
-
-    #[cfg(test)]
-    pub(crate) async fn new_from_wallet_entropy(
-        data_dir: &DataDirectory,
-        wallet_entropy: WalletEntropy,
-        cli_args: &Args,
-    ) -> Self {
-        let configuration = WalletConfiguration::new(data_dir).absorb_options(cli_args);
-        Self::new(configuration, wallet_entropy).await
-    }
 }
 
 #[cfg(test)]
@@ -1786,6 +1792,16 @@ pub(crate) mod tests {
         pub(crate) async fn clear_raw_hash_keys(&mut self) {
             self.known_raw_hash_lock_keys.clear();
             self.wallet_db.guesser_preimages_mut().clear().await;
+        }
+
+        #[cfg(test)]
+        pub(crate) async fn new_from_wallet_entropy(
+            data_dir: &DataDirectory,
+            wallet_entropy: WalletEntropy,
+            cli_args: &Args,
+        ) -> Self {
+            let configuration = WalletConfiguration::new(data_dir).absorb_options(cli_args);
+            Self::new(configuration, wallet_entropy).await
         }
     }
 
@@ -3905,8 +3921,8 @@ pub(crate) mod tests {
     pub(crate) mod scan_mode {
         use std::hint::black_box;
 
-        use rand::rngs::StdRng;
-        use rand::{rng, SeedableRng};
+        use rand::prelude::*;
+        use rand::rng;
 
         use crate::job_queue::JobQueue;
         use crate::tests::shared::unit_test_data_directory;
@@ -3930,8 +3946,7 @@ pub(crate) mod tests {
         #[tokio::test]
         async fn test_recovery_on_imported_wallet() {
             let network = Network::Main;
-            let mut rng = StdRng::from_rng(&mut rng());
-            let alice_secret = WalletEntropy::new_pseudorandom(rng.random());
+            let alice_secret = WalletEntropy::new_random();
             let data_dir = unit_test_data_directory(network).unwrap();
 
             // generate events
@@ -3951,7 +3966,7 @@ pub(crate) mod tests {
                 .expect("wallet should be capable of generating symmetric spending keys");
             let now =
                 genesis_block.header().timestamp + Timestamp::months(6) + Timestamp::minutes(5);
-            let sender_randomness = rng.random();
+            let sender_randomness = rng().random();
             let alice_future_spending_key = alice_secret.nth_generation_spending_key(20);
             let tx_output = TxOutput::onchain_native_currency(
                 NativeCurrencyAmount::coins(1),
@@ -3996,13 +4011,12 @@ pub(crate) mod tests {
                 ..Default::default()
             };
 
-            for (case, cli_args, should_catch_utxo) in [
-                (0, cli_default, false),
-                (1, cli_wrong_range, false),
-                (2, cli_too_few_keys, false),
-                (3, cli_well_configured, true),
+            for (cli_args, should_catch_utxo) in [
+                (cli_default, false),
+                (cli_wrong_range, false),
+                (cli_too_few_keys, false),
+                (cli_well_configured, true),
             ] {
-                println!("testing case {case} ...");
                 let mut alice_wallet_state = WalletState::new_from_wallet_entropy(
                     &data_dir,
                     alice_secret.clone(),

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -1278,6 +1278,15 @@ impl WalletState {
             .collect_vec();
         let guesser_fee_outputs = self.scan_for_guesser_fee_utxos(new_block);
 
+        debug!(
+            "Scanned block for incoming UTXOs; received {} onchain \
+            notifications, {} onchain through scan mode, {} offchain \
+            notifications",
+            onchain_received_outputs.len(),
+            outputs_recovered_through_scan_mode.len(),
+            offchain_received_outputs.len()
+        );
+
         let all_spendable_received_outputs = onchain_received_outputs
             .into_iter()
             .chain(outputs_recovered_through_scan_mode)
@@ -3916,7 +3925,12 @@ mod tests {
     }
 
     pub(crate) mod scan_mode {
+        use rand::rngs::StdRng;
+        use rand::{rng, SeedableRng};
+
+        use crate::job_queue::JobQueue;
         use crate::models::blockchain::block::block_height::BlockHeight;
+        use crate::tests::shared::unit_test_data_directory;
 
         use super::*;
 
@@ -4080,6 +4094,144 @@ mod tests {
                     (lb..=ub).contains(&h),
                     scan_mode.block_height_is_in_range(BlockHeight::from(h)),
                 );
+            }
+        }
+
+        /// Test scan mode.
+        ///
+        /// In rough terms, this test verifies that importing a wallet followed
+        /// by booting the node in scan mode will recover UTXOs sent to it.
+        ///
+        /// Specifically:
+        ///  - Alice is recipient of a transaction in block 1, but the address
+        ///    for this transaction uses derivation index 20, which is in the
+        ///    future.
+        ///  - If Alice does nothing special, she does not catch the UTXO.
+        ///  - If Alice activates scan mode with the right parameters, she does
+        ///    catch the UTXO.
+        ///  - In the last case, her derivation counter is updated accordingly.
+        #[traced_test]
+        #[tokio::test]
+        async fn test_recovery_on_imported_wallet() {
+            let network = Network::Main;
+            let mut rng = StdRng::from_rng(&mut rng());
+            let alice_secret = WalletSecret::new_pseudorandom(rng.random());
+            let data_dir = unit_test_data_directory(network).unwrap();
+
+            // generate events
+            let genesis_block = Block::genesis(network);
+            let premine_receiver = mock_genesis_global_state(
+                network,
+                0,
+                WalletSecret::devnet_wallet(),
+                cli_args::Args::default(),
+            )
+            .await;
+            let premine_change_key = premine_receiver
+                .lock_guard()
+                .await
+                .wallet_state
+                .nth_spending_key(KeyType::Symmetric, 0)
+                .expect("wallet should be capable of generating symmetric spending keys");
+            let now =
+                genesis_block.header().timestamp + Timestamp::months(6) + Timestamp::minutes(5);
+            let sender_randomness = rng.random();
+            let alice_future_spending_key = alice_secret.nth_generation_spending_key(20);
+            let tx_output = TxOutput::onchain_native_currency(
+                NativeCurrencyAmount::coins(1),
+                sender_randomness,
+                alice_future_spending_key.to_address().into(),
+                false,
+            );
+            let (transaction, _, _) = premine_receiver
+                .lock_guard()
+                .await
+                .create_transaction_with_prover_capability(
+                    vec![tx_output].into(),
+                    premine_change_key,
+                    UtxoNotificationMedium::OffChain,
+                    NativeCurrencyAmount::coins(0),
+                    now,
+                    TxProvingCapability::PrimitiveWitness,
+                    &JobQueue::dummy(),
+                )
+                .await
+                .unwrap();
+            let block_1 = invalid_block_with_transaction(&genesis_block, transaction);
+
+            // some possible CLI configurations:
+            // scan mode is inactive
+            let cli_default = cli_args::Args::default();
+            // scan mode is active but looking in the wrong blocks
+            let cli_wrong_range = cli_args::Args {
+                scan_blocks: Some(10..=100),
+                ..Default::default()
+            };
+            // scan mode is active but scanning for too few keys
+            let cli_too_few_keys = cli_args::Args {
+                scan_keys: Some(5),
+                ..Default::default()
+            };
+            // scan mode is active and scanning for the right keys in the right
+            // blocks
+            let cli_well_configured = cli_args::Args {
+                scan_blocks: Some(0..=u64::MAX),
+                scan_keys: Some(25),
+                ..Default::default()
+            };
+
+            for (case, cli_args, should_catch_utxo) in [
+                (0, cli_default, false),
+                (1, cli_wrong_range, false),
+                (2, cli_too_few_keys, false),
+                (3, cli_well_configured, true),
+            ] {
+                println!("testing case {case} ...");
+                let mut alice_wallet_state = WalletState::new_from_wallet_secret(
+                    &data_dir,
+                    alice_secret.clone(),
+                    &cli_args,
+                    false,
+                )
+                .await;
+
+                let wallet_status_ = alice_wallet_state
+                    .get_wallet_status(block_1.hash(), &block_1.mutator_set_accumulator_after())
+                    .await;
+                let balance_ = alice_wallet_state.confirmed_available_balance(&wallet_status_, now);
+                assert_eq!(NativeCurrencyAmount::coins(0), balance_);
+
+                alice_wallet_state
+                    .update_wallet_state_with_new_block(
+                        &genesis_block.mutator_set_accumulator_after(),
+                        &block_1,
+                    )
+                    .await
+                    .unwrap();
+
+                let wallet_status = alice_wallet_state
+                    .get_wallet_status(block_1.hash(), &block_1.mutator_set_accumulator_after())
+                    .await;
+                let balance = alice_wallet_state.confirmed_available_balance(&wallet_status, now);
+                if should_catch_utxo {
+                    assert_eq!(NativeCurrencyAmount::coins(1), balance);
+                    assert_eq!(
+                        21,
+                        alice_wallet_state
+                            .wallet_db
+                            .get_generation_key_counter()
+                            .await
+                    );
+                } else {
+                    assert_eq!(NativeCurrencyAmount::coins(0), balance);
+                    assert_eq!(
+                        1,
+                        alice_wallet_state
+                            .wallet_db
+                            .get_generation_key_counter()
+                            .await
+                    );
+                }
             }
         }
     }

--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -1927,7 +1927,7 @@ mod peer_loop_tests {
     use crate::models::state::mempool::TransactionOrigin;
     use crate::models::state::tx_proving_capability::TxProvingCapability;
     use crate::models::state::wallet::utxo_notification::UtxoNotificationMedium;
-    use crate::models::state::wallet::WalletSecret;
+    use crate::models::state::wallet::wallet_entropy::WalletEntropy;
     use crate::tests::shared::fake_valid_block_for_tests;
     use crate::tests::shared::fake_valid_sequence_of_blocks_for_tests;
     use crate::tests::shared::get_dummy_handshake_data_for_genesis;
@@ -3337,7 +3337,7 @@ mod peer_loop_tests {
             .lock_guard()
             .await
             .wallet_state
-            .wallet_secret
+            .wallet_entropy
             .nth_symmetric_key_for_tests(0);
         let genesis_block = Block::genesis(network);
         let now = genesis_block.kernel.header.timestamp;
@@ -3419,7 +3419,7 @@ mod peer_loop_tests {
             .lock_guard()
             .await
             .wallet_state
-            .wallet_secret
+            .wallet_entropy
             .nth_symmetric_key_for_tests(0);
 
         let genesis_block = Block::genesis(network);
@@ -3620,7 +3620,7 @@ mod peer_loop_tests {
             network: Network,
             quality: TransactionProofQuality,
         ) -> Transaction {
-            let wallet_secret = WalletSecret::devnet_wallet();
+            let wallet_secret = WalletEntropy::devnet_wallet();
             let alice_key = wallet_secret.nth_generation_spending_key_for_tests(0);
             let alice =
                 mock_genesis_global_state(network, 1, wallet_secret, cli_args::Args::default())

--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -3393,7 +3393,7 @@ mod rpc_server_tests {
     use crate::models::peer::NegativePeerSanction;
     use crate::models::peer::PeerSanction;
     use crate::models::state::wallet::address::generation_address::GenerationSpendingKey;
-    use crate::models::state::wallet::WalletSecret;
+    use crate::models::state::wallet::wallet_entropy::WalletEntropy;
     use crate::rpc_server::NeptuneRPCServer;
     use crate::tests::shared::make_mock_block;
     use crate::tests::shared::mock_genesis_global_state;
@@ -3403,7 +3403,7 @@ mod rpc_server_tests {
 
     async fn test_rpc_server(
         network: Network,
-        wallet_secret: WalletSecret,
+        wallet_secret: WalletEntropy,
         peer_count: u8,
         cli: cli_args::Args,
     ) -> NeptuneRPCServer {
@@ -3441,7 +3441,7 @@ mod rpc_server_tests {
         for network in Network::iter() {
             let rpc_server = test_rpc_server(
                 network,
-                WalletSecret::new_random(),
+                WalletEntropy::new_random(),
                 2,
                 cli_args::Args {
                     network,
@@ -3466,7 +3466,7 @@ mod rpc_server_tests {
 
         let rpc_server = test_rpc_server(
             network,
-            WalletSecret::new_pseudorandom(rng.random()),
+            WalletEntropy::new_pseudorandom(rng.random()),
             2,
             cli_args::Args::default(),
         )
@@ -3587,7 +3587,7 @@ mod rpc_server_tests {
         // Verify that a wallet not receiving a premine is empty at startup
         let rpc_server = test_rpc_server(
             Network::Alpha,
-            WalletSecret::new_random(),
+            WalletEntropy::new_random(),
             2,
             cli_args::Args::default(),
         )
@@ -3607,7 +3607,7 @@ mod rpc_server_tests {
     async fn clear_ip_standing_test() -> Result<()> {
         let mut rpc_server = test_rpc_server(
             Network::Alpha,
-            WalletSecret::new_random(),
+            WalletEntropy::new_random(),
             2,
             cli_args::Args::default(),
         )
@@ -3766,7 +3766,7 @@ mod rpc_server_tests {
         // Create initial conditions
         let mut rpc_server = test_rpc_server(
             Network::Alpha,
-            WalletSecret::new_random(),
+            WalletEntropy::new_random(),
             2,
             cli_args::Args::default(),
         )
@@ -3895,7 +3895,7 @@ mod rpc_server_tests {
     async fn utxo_digest_test() {
         let rpc_server = test_rpc_server(
             Network::Alpha,
-            WalletSecret::new_random(),
+            WalletEntropy::new_random(),
             2,
             cli_args::Args::default(),
         )
@@ -3935,7 +3935,7 @@ mod rpc_server_tests {
         let network = Network::RegTest;
         let rpc_server = test_rpc_server(
             network,
-            WalletSecret::new_random(),
+            WalletEntropy::new_random(),
             2,
             cli_args::Args::default(),
         )
@@ -4042,7 +4042,7 @@ mod rpc_server_tests {
         let network = Network::RegTest;
         let rpc_server = test_rpc_server(
             network,
-            WalletSecret::new_random(),
+            WalletEntropy::new_random(),
             2,
             cli_args::Args::default(),
         )
@@ -4126,7 +4126,7 @@ mod rpc_server_tests {
         // crash the host machine, we don't verify that any value is returned.
         let rpc_server = test_rpc_server(
             Network::Alpha,
-            WalletSecret::new_random(),
+            WalletEntropy::new_random(),
             2,
             cli_args::Args::default(),
         )
@@ -4153,7 +4153,7 @@ mod rpc_server_tests {
             ..Default::default()
         };
 
-        let rpc_server = test_rpc_server(network, WalletSecret::new_random(), 2, cli_on).await;
+        let rpc_server = test_rpc_server(network, WalletEntropy::new_random(), 2, cli_on).await;
         let token = cookie_token(&rpc_server).await;
 
         assert!(rpc_server
@@ -4234,7 +4234,7 @@ mod rpc_server_tests {
                 // bob's node
                 let (pay_to_bob_outputs, bob_rpc_server, bob_token) = {
                     let rpc_server =
-                        test_rpc_server(network, WalletSecret::new_random(), 2, Args::default())
+                        test_rpc_server(network, WalletEntropy::new_random(), 2, Args::default())
                             .await;
                     let token = cookie_token(&rpc_server).await;
 
@@ -4259,7 +4259,7 @@ mod rpc_server_tests {
 
                 // alice's node
                 let (blocks, alice_to_bob_utxo_notifications, bob_amount) = {
-                    let wallet_secret = WalletSecret::new_random();
+                    let wallet_secret = WalletEntropy::new_random();
                     let mut rpc_server =
                         test_rpc_server(network, wallet_secret.clone(), 2, Args::default()).await;
 
@@ -4394,7 +4394,7 @@ mod rpc_server_tests {
                     "If UTXO is spent, it must also be mined"
                 );
                 let network = Network::Main;
-                let bob_wallet = WalletSecret::new_random();
+                let bob_wallet = WalletEntropy::new_random();
                 let mut bob =
                     test_rpc_server(network, bob_wallet.clone(), 2, Args::default()).await;
                 let bob_token = cookie_token(&bob).await;
@@ -4453,7 +4453,7 @@ mod rpc_server_tests {
 
                     if spent {
                         // Send entire liquid balance somewhere else
-                        let another_address = WalletSecret::new_random()
+                        let another_address = WalletEntropy::new_random()
                             .nth_generation_spending_key(0)
                             .to_address();
                         let (spending_tx, _) = bob
@@ -4552,7 +4552,7 @@ mod rpc_server_tests {
             let network = Network::Main;
             let rpc_server = test_rpc_server(
                 network,
-                WalletSecret::new_pseudorandom(rng.random()),
+                WalletEntropy::new_pseudorandom(rng.random()),
                 2,
                 cli_args::Args::default(),
             )
@@ -4613,7 +4613,7 @@ mod rpc_server_tests {
             let network = Network::Main;
             let rpc_server = test_rpc_server(
                 network,
-                WalletSecret::devnet_wallet(),
+                WalletEntropy::devnet_wallet(),
                 2,
                 cli_args::Args::default(),
             )
@@ -4686,7 +4686,7 @@ mod rpc_server_tests {
                 let network = Network::Main;
                 let mut rpc_server = test_rpc_server(
                     network,
-                    WalletSecret::new_pseudorandom(rng.random()),
+                    WalletEntropy::new_pseudorandom(rng.random()),
                     2,
                     cli_args::Args::default(),
                 )

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -105,8 +105,8 @@ use crate::models::state::wallet::address::generation_address::GenerationReceivi
 use crate::models::state::wallet::expected_utxo::ExpectedUtxo;
 use crate::models::state::wallet::expected_utxo::UtxoNotifier;
 use crate::models::state::wallet::transaction_output::TxOutputList;
+use crate::models::state::wallet::wallet_entropy::WalletEntropy;
 use crate::models::state::wallet::wallet_state::WalletState;
-use crate::models::state::wallet::WalletSecret;
 use crate::models::state::GlobalStateLock;
 use crate::prelude::twenty_first;
 use crate::util_types::mutator_set::addition_record::AdditionRecord;
@@ -211,7 +211,7 @@ pub(crate) async fn mock_genesis_global_state(
     // TODO: Remove network and read it from CLI arguments instead
     network: Network,
     peer_count: u8,
-    wallet: WalletSecret,
+    wallet: WalletEntropy,
     cli: cli_args::Args,
 ) -> GlobalStateLock {
     let (archival_state, peer_db, _data_dir) = mock_genesis_archival_state(network).await;
@@ -276,7 +276,7 @@ pub(crate) async fn get_test_genesis_setup(
     let (to_main_tx, mut _to_main_rx1) = mpsc::channel::<PeerTaskToMain>(PEER_CHANNEL_CAPACITY);
     let from_main_rx_clone = peer_broadcast_tx.subscribe();
 
-    let devnet_wallet = WalletSecret::devnet_wallet();
+    let devnet_wallet = WalletEntropy::devnet_wallet();
     let state = mock_genesis_global_state(network, peer_count, devnet_wallet, cli).await;
     Ok((
         peer_broadcast_tx,
@@ -760,7 +760,7 @@ pub(crate) async fn make_mock_block(
 /// Return a dummy-wallet used for testing. The returned wallet is populated with
 /// whatever UTXOs are present in the genesis block.
 pub async fn mock_genesis_wallet_state(
-    wallet_secret: WalletSecret,
+    wallet_secret: WalletEntropy,
     network: Network,
 ) -> WalletState {
     let data_dir = unit_test_data_directory(network).unwrap();
@@ -768,7 +768,7 @@ pub async fn mock_genesis_wallet_state(
 }
 
 pub async fn mock_genesis_wallet_state_with_data_dir(
-    wallet_secret: WalletSecret,
+    wallet_entropy: WalletEntropy,
     network: Network,
     data_dir: &DataDirectory,
 ) -> WalletState {
@@ -777,7 +777,7 @@ pub async fn mock_genesis_wallet_state_with_data_dir(
         network,
         ..Default::default()
     };
-    WalletState::new_from_wallet_secret(data_dir, wallet_secret, &cli_args, false).await
+    WalletState::new_from_wallet_entropy(data_dir, wallet_entropy, &cli_args).await
 }
 
 /// Return an archival state populated with the genesis block
@@ -835,7 +835,7 @@ pub(crate) async fn mine_block_to_wallet_invalid_block_proof(
         .lock_guard()
         .await
         .wallet_state
-        .wallet_secret
+        .wallet_entropy
         .guesser_preimage(prev_block_digest);
     let mut block = Block::block_template_invalid_proof(&tip_block, transaction, timestamp, None);
     block.set_header_guesser_digest(guesser_preimage.hash());

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -777,7 +777,7 @@ pub async fn mock_genesis_wallet_state_with_data_dir(
         network,
         ..Default::default()
     };
-    WalletState::new_from_wallet_secret(data_dir, wallet_secret, &cli_args).await
+    WalletState::new_from_wallet_secret(data_dir, wallet_secret, &cli_args, false).await
 }
 
 /// Return an archival state populated with the genesis block


### PR DESCRIPTION
Scan Mode is a possible configuration on the `WalletState` which activates a new step in the main wallet state updater function: if the block is in range, it is also scanned for encrypted public announcements decryptable by *future* spending keys. The situation occurs frequently in practice when users import their wallet seed onto a new machine -- losing all wallet information but the seed. By configuring (through CLI arguments) the range of blocks and the number of future keys to scan with, such users can recover UTXOs bound for them provided that there is an on-chain announcement. Scan mode is also activated (with default parameters) when, at boot, the client finds a `wallet.dat` file but no matching wallet database directory -- a strong indicator that the wallet seed was imported.

Addresses (together with a future PR for #443) #441.
Closes #442.