### PR TITLE
style: Factor out common logic

### DIFF
--- a/src/config_models/cli_args.rs
+++ b/src/config_models/cli_args.rs
@@ -43,13 +43,18 @@ pub struct Args {
     #[clap(long, value_name = "IP")]
     pub(crate) ban: Vec<IpAddr>,
 
-    /// Refuse connection if peer is in bad standing.
+    /// The threshold at which a peer's standing is considered “bad”. Current
+    /// connections to peers in bad standing are terminated. Connection attempts
+    /// from peers in bad standing are refused.
     ///
-    /// This sets the threshold for when a peer should be automatically refused.
-    /// The default is set to 1000.
-    ///
-    /// For a list of reasons that cause bad standing, see [PeerSanctionReason](crate::models::peer::PeerSanctionReason).
-    #[clap(long, default_value = "1000", value_name = "VALUE")]
+    /// For a list of reasons that cause bad standing, see
+    /// [NegativePeerSanction](crate::models::peer::NegativePeerSanction).
+    #[clap(
+        long,
+        default_value = "1000",
+        value_name = "VALUE",
+        value_parser = clap::value_parser!(u16).range(1..),
+    )]
     pub(crate) peer_tolerance: u16,
 
     /// Maximum number of peers to accept connections from.

--- a/src/connect_to_peers.rs
+++ b/src/connect_to_peers.rs
@@ -24,7 +24,9 @@ use crate::models::channel::MainToPeerTask;
 use crate::models::channel::PeerTaskToMain;
 use crate::models::peer::ConnectionRefusedReason;
 use crate::models::peer::InternalConnectionStatus;
+use crate::models::peer::NegativePeerSanction;
 use crate::models::peer::PeerMessage;
+use crate::models::peer::PeerSanction;
 use crate::models::peer::PeerStanding;
 use crate::models::peer::TransferConnectionStatus;
 use crate::models::state::GlobalStateLock;
@@ -100,7 +102,7 @@ async fn check_if_connection_is_allowed(
         .get_peer_standing_from_database(peer_address.ip())
         .await;
 
-    if standing.is_some() && standing.unwrap().standing <= -(cli_arguments.peer_tolerance as i32) {
+    if standing.is_some_and(|standing| standing.is_bad()) {
         let ip = peer_address.ip();
         warn!("Peer {ip}, banned because of bad standing, attempted to connect. Disallowing.");
         return InternalConnectionStatus::Refused(ConnectionRefusedReason::BadStanding);
@@ -192,7 +194,7 @@ where
         Ok(_) => (),
         Err(_err) => {
             error!("Peer task (incoming) for {peer_address} panicked. Invoking close connection callback");
-            let _ret = close_peer_connected_callback(
+            close_peer_connected_callback(
                 state_lock.clone(),
                 peer_address,
                 &peer_task_to_main_tx_clone,
@@ -359,12 +361,8 @@ pub(crate) async fn call_peer(
         Ok(_) => (),
         Err(_) => {
             error!("Peer task (outgoing) for {peer_address} panicked. Invoking close connection callback");
-            let _ret = close_peer_connected_callback(
-                state_clone,
-                peer_address,
-                &peer_task_to_main_tx_clone,
-            )
-            .await;
+            close_peer_connected_callback(state_clone, peer_address, &peer_task_to_main_tx_clone)
+                .await;
         }
     }
 }
@@ -478,41 +476,40 @@ pub(crate) async fn close_peer_connected_callback(
     mut global_state_lock: GlobalStateLock,
     peer_address: SocketAddr,
     to_main_tx: &mpsc::Sender<PeerTaskToMain>,
-) -> Result<()> {
+) {
     let cli_arguments = global_state_lock.cli().clone();
     let mut global_state_mut = global_state_lock.lock_guard_mut().await;
+
     // Store any new peer-standing to database
     let peer_info_writeback = global_state_mut.net.peer_map.remove(&peer_address);
+    let new_standing = if let Some(new) = peer_info_writeback {
+        new.standing()
+    } else {
+        error!("Could not find peer standing for {peer_address}");
+        let mut standing = PeerStanding::new(cli_arguments.peer_tolerance);
+        let sanction = NegativePeerSanction::NoStandingFoundMaybeCrash;
 
-    let peer_tolerance = cli_arguments.peer_tolerance;
-    let new_standing = match peer_info_writeback {
-        Some(new) => new.standing(),
-        None => {
-            error!("Could not find peer standing for {peer_address}");
-            PeerStanding::new_on_no_standing_found(peer_tolerance)
-        }
+        // Don't return early: _must_ send message to main loop at the end of this
+        // function.
+        // If the peer has now reached bad standing, the connection to it should be
+        // dropped, which is currently happening anyway.
+        let _ = standing.sanction(PeerSanction::Negative(sanction));
+        standing
     };
-    debug!(
-        "Fetched peer info standing {} for peer {}",
-        new_standing, peer_address
-    );
+    debug!("Fetched peer info standing {new_standing} for peer {peer_address}");
+
     global_state_mut
         .net
         .write_peer_standing_on_decrease(peer_address.ip(), new_standing)
         .await;
     drop(global_state_mut); // avoid holding across mpsc::Sender::send()
-
-    debug!(
-        "Stored peer info standing {} for peer {}",
-        new_standing, peer_address
-    );
+    debug!("Stored peer info standing {new_standing} for peer {peer_address}");
 
     // This message is used to determine if we are to exit synchronization mode
     to_main_tx
         .send(PeerTaskToMain::RemovePeerMaxBlockHeight(peer_address))
-        .await?;
-
-    Ok(())
+        .await
+        .expect("channel to main task should exist");
 }
 
 #[cfg(test)]

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -956,14 +956,15 @@ impl MainLoopHandler {
                 .get_peer_standing_from_database(peer_with_lost_connection.ip())
                 .await;
 
-            if standing.is_some()
-                && standing.unwrap().standing
-                    < -(self.global_state_lock.cli().peer_tolerance as i32)
-            {
-                info!("Not reconnecting to peer with lost connection because it was banned: {peer_with_lost_connection}");
+            if standing.is_some_and(|standing| standing.is_bad()) {
+                info!(
+                    "Not reconnecting to peer with lost connection because it was banned: \
+                    {peer_with_lost_connection}"
+                );
             } else {
                 info!(
-                    "Attempting to reconnect to peer with lost connection: {peer_with_lost_connection}"
+                    "Attempting to reconnect to peer with lost connection: \
+                    {peer_with_lost_connection}"
                 );
             }
 


### PR DESCRIPTION
Don't repeat the logic for testing whether peer standing is bad. Use one canonical method instead. Also:

- improve documentation of command line argument `peer_tolerance`
- prevent non-sensical peer tolerances from entering the application
- improve code flow by staying on the happy path more
- adhere to max line length more often
- move test code into test module