### PR TITLE
Remove timestamps from `PeerStanding`

### DIFF
--- a/src/bin/dashboard_src/peers_screen.rs
+++ b/src/bin/dashboard_src/peers_screen.rs
@@ -361,11 +361,11 @@ impl Widget for PeersScreen {
                 self.sort_order.compare(
                     a.standing()
                         .latest_punishment
-                        .map(|p| p.0.to_string())
+                        .map(|p| p.to_string())
                         .unwrap_or_default(),
                     b.standing()
                         .latest_punishment
-                        .map(|p| p.0.to_string())
+                        .map(|p| p.to_string())
                         .unwrap_or_default(),
                 )
             }),
@@ -373,11 +373,11 @@ impl Widget for PeersScreen {
                 self.sort_order.compare(
                     a.standing()
                         .latest_reward
-                        .map(|r| r.0.to_string())
+                        .map(|r| r.to_string())
                         .unwrap_or_default(),
                     b.standing()
                         .latest_reward
-                        .map(|r| r.0.to_string())
+                        .map(|r| r.to_string())
                         .unwrap_or_default(),
                 )
             }),
@@ -386,14 +386,8 @@ impl Widget for PeersScreen {
         let matrix = pi
             .iter()
             .map(|pi| {
-                let latest_punishment: Option<String> = pi
-                    .standing()
-                    .latest_punishment
-                    .map(|(peer_sanction, _timestamp)| peer_sanction.to_string());
-                let latest_reward: Option<String> = pi
-                    .standing()
-                    .latest_reward
-                    .map(|(peer_sanction, _timestamp)| peer_sanction.to_string());
+                let latest_punishment = pi.standing().latest_punishment.map(|p| p.to_string());
+                let latest_reward = pi.standing().latest_reward.map(|r| r.to_string());
                 let connection_established = pi
                     .connection_established()
                     .duration_since(std::time::UNIX_EPOCH)

--- a/src/bin/neptune-cli.rs
+++ b/src/bin/neptune-cli.rs
@@ -807,14 +807,11 @@ async fn main() -> Result<()> {
             let peer_sanctions = client.all_punished_peers(ctx, token).await??;
             for (ip, sanction) in peer_sanctions {
                 let standing = sanction.standing;
-                let latest_sanction_str = match sanction.latest_punishment {
-                    Some((sanction, _timestamp)) => sanction.to_string(),
-                    None => String::default(),
-                };
-                println!(
-                    "{ip}\nstanding: {standing}\nlatest sanction: {} \n\n",
-                    latest_sanction_str
-                );
+                let sanction_str = sanction
+                    .latest_punishment
+                    .map(|p| p.to_string())
+                    .unwrap_or_default();
+                println!("{ip}\nstanding: {standing}\nlatest sanction: {sanction_str}\n\n");
             }
         }
         Command::TipDigest => {

--- a/src/config_models/cli_args.rs
+++ b/src/config_models/cli_args.rs
@@ -43,13 +43,18 @@ pub struct Args {
     #[clap(long, value_name = "IP")]
     pub(crate) ban: Vec<IpAddr>,
 
-    /// Refuse connection if peer is in bad standing.
+    /// The threshold at which a peer's standing is considered “bad”. Current
+    /// connections to peers in bad standing are terminated. Connection attempts
+    /// from peers in bad standing are refused.
     ///
-    /// This sets the threshold for when a peer should be automatically refused.
-    /// The default is set to 1000.
-    ///
-    /// For a list of reasons that cause bad standing, see [PeerSanctionReason](crate::models::peer::PeerSanctionReason).
-    #[clap(long, default_value = "1000", value_name = "VALUE")]
+    /// For a list of reasons that cause bad standing, see
+    /// [NegativePeerSanction](crate::models::peer::NegativePeerSanction).
+    #[clap(
+        long,
+        default_value = "1000",
+        value_name = "VALUE",
+        value_parser = clap::value_parser!(u16).range(1..),
+    )]
     pub(crate) peer_tolerance: u16,
 
     /// Maximum number of peers to accept connections from.

--- a/src/connect_to_peers.rs
+++ b/src/connect_to_peers.rs
@@ -514,8 +514,6 @@ pub(crate) async fn close_peer_connected_callback(
 
 #[cfg(test)]
 mod connect_tests {
-    use std::time::SystemTime;
-
     use anyhow::bail;
     use anyhow::Result;
     use tokio_test::io::Builder;
@@ -728,10 +726,10 @@ mod connect_tests {
         // Then check that peers can be banned by bad behavior
         let bad_standing: PeerStanding = PeerStanding::init(
             i32::MIN,
-            Some((
-                NegativePeerSanction::InvalidBlock((7u64.into(), Digest::default())),
-                SystemTime::now(),
-            )),
+            Some(NegativePeerSanction::InvalidBlock((
+                7u64.into(),
+                Digest::default(),
+            ))),
             None,
             i32::from(cli.peer_tolerance),
         );
@@ -1023,10 +1021,10 @@ mod connect_tests {
         .await?;
         let bad_standing: PeerStanding = PeerStanding::init(
             i32::MIN,
-            Some((
-                NegativePeerSanction::InvalidBlock((7u64.into(), Digest::default())),
-                SystemTime::now(),
-            )),
+            Some(NegativePeerSanction::InvalidBlock((
+                7u64.into(),
+                Digest::default(),
+            ))),
             None,
             i32::from(cli_args::Args::default().peer_tolerance),
         );

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -956,14 +956,15 @@ impl MainLoopHandler {
                 .get_peer_standing_from_database(peer_with_lost_connection.ip())
                 .await;
 
-            if standing.is_some()
-                && standing.unwrap().standing
-                    < -(self.global_state_lock.cli().peer_tolerance as i32)
-            {
-                info!("Not reconnecting to peer with lost connection because it was banned: {peer_with_lost_connection}");
+            if standing.is_some_and(|standing| standing.is_bad()) {
+                info!(
+                    "Not reconnecting to peer with lost connection because it was banned: \
+                    {peer_with_lost_connection}"
+                );
             } else {
                 info!(
-                    "Attempting to reconnect to peer with lost connection: {peer_with_lost_connection}"
+                    "Attempting to reconnect to peer with lost connection: \
+                    {peer_with_lost_connection}"
                 );
             }
 

--- a/src/models/peer.rs
+++ b/src/models/peer.rs
@@ -113,7 +113,7 @@ pub enum PositivePeerSanction {
 }
 
 impl Display for NegativePeerSanction {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let string = match self {
             NegativePeerSanction::InvalidBlock(_) => "invalid block",
             NegativePeerSanction::DifferentGenesis => "different genesis",
@@ -171,7 +171,7 @@ impl Display for NegativePeerSanction {
 }
 
 impl Display for PositivePeerSanction {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let string = match self {
             PositivePeerSanction::ValidBlocks(_) => "valid blocks",
             PositivePeerSanction::NewBlockProposal => "new block proposal",
@@ -278,10 +278,11 @@ impl Sanction for PeerSanction {
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct PeerStanding {
     pub standing: i32,
-    pub latest_punishment: Option<(NegativePeerSanction, SystemTime)>,
-    pub latest_reward: Option<(PositivePeerSanction, SystemTime)>,
+    pub latest_punishment: Option<NegativePeerSanction>,
+    pub latest_reward: Option<PositivePeerSanction>,
     peer_tolerance: i32,
 }
+
 #[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct StandingExceedsBanThreshold;
 
@@ -318,10 +319,9 @@ impl PeerStanding {
             self.standing,
             self.peer_tolerance
         );
-        let now = SystemTime::now();
         match sanction {
-            PeerSanction::Negative(sanction) => self.latest_punishment = Some((sanction, now)),
-            PeerSanction::Positive(sanction) => self.latest_reward = Some((sanction, now)),
+            PeerSanction::Negative(sanction) => self.latest_punishment = Some(sanction),
+            PeerSanction::Positive(sanction) => self.latest_reward = Some(sanction),
         }
 
         self.is_good()
@@ -350,7 +350,7 @@ impl PeerStanding {
 }
 
 impl Display for PeerStanding {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.standing)
     }
 }
@@ -908,8 +908,8 @@ mod tests {
     impl PeerStanding {
         pub fn init(
             standing: i32,
-            latest_punishment: Option<(NegativePeerSanction, SystemTime)>,
-            latest_reward: Option<(PositivePeerSanction, SystemTime)>,
+            latest_punishment: Option<NegativePeerSanction>,
+            latest_reward: Option<PositivePeerSanction>,
             peer_tolerance: i32,
         ) -> PeerStanding {
             Self {

--- a/src/models/peer.rs
+++ b/src/models/peer.rs
@@ -6,6 +6,7 @@ pub mod transfer_block;
 pub mod transfer_transaction;
 
 use std::fmt::Display;
+use std::fmt::Formatter;
 use std::net::SocketAddr;
 use std::time::SystemTime;
 
@@ -284,23 +285,17 @@ pub struct PeerStanding {
 #[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct StandingExceedsBanThreshold;
 
-impl PeerStanding {
-    #[cfg(test)]
-    pub(crate) fn init(
-        standing: i32,
-        latest_punishment: Option<(NegativePeerSanction, SystemTime)>,
-        latest_reward: Option<(PositivePeerSanction, SystemTime)>,
-        peer_tolerance: i32,
-    ) -> PeerStanding {
-        Self {
-            standing,
-            latest_punishment,
-            latest_reward,
-            peer_tolerance,
-        }
+impl Display for StandingExceedsBanThreshold {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "standing exceeds ban threshold")
     }
+}
 
+impl std::error::Error for StandingExceedsBanThreshold {}
+
+impl PeerStanding {
     pub(crate) fn new(peer_tolerance: u16) -> Self {
+        assert!(peer_tolerance > 0, "peer tolerance must be positive");
         Self {
             peer_tolerance: i32::from(peer_tolerance),
             standing: 0,
@@ -312,30 +307,26 @@ impl PeerStanding {
     /// Sanction peer and return latest standing score
     pub(crate) fn sanction(
         &mut self,
-        reason: PeerSanction,
-    ) -> Result<i32, StandingExceedsBanThreshold> {
+        sanction: PeerSanction,
+    ) -> Result<(), StandingExceedsBanThreshold> {
         self.standing = self
             .standing
-            .saturating_add(reason.severity())
+            .saturating_add(sanction.severity())
             .clamp(-self.peer_tolerance, self.peer_tolerance);
         trace!(
             "new standing: {}, peer tolerance: {}",
             self.standing,
             self.peer_tolerance
         );
-        match reason {
-            PeerSanction::Negative(negative_peer_sanction) => {
-                self.latest_punishment = Some((negative_peer_sanction, SystemTime::now()))
-            }
-            PeerSanction::Positive(positive_peer_sanction) => {
-                self.latest_reward = Some((positive_peer_sanction, SystemTime::now()))
-            }
+        let now = SystemTime::now();
+        match sanction {
+            PeerSanction::Negative(sanction) => self.latest_punishment = Some((sanction, now)),
+            PeerSanction::Positive(sanction) => self.latest_reward = Some((sanction, now)),
         }
-        if self.standing == -self.peer_tolerance {
-            Err(StandingExceedsBanThreshold)
-        } else {
-            Ok(self.standing)
-        }
+
+        self.is_good()
+            .then_some(())
+            .ok_or(StandingExceedsBanThreshold)
     }
 
     /// Clear peer standing record
@@ -349,23 +340,12 @@ impl PeerStanding {
         self.standing.is_negative()
     }
 
-    /// Should only be used if peer was expected to be found in the peer map
-    /// but, for some reason, was not there. Please only use this function for
-    /// that purpose.
-    pub fn new_on_no_standing_found(peer_tolerance: u16) -> Self {
-        assert!(
-            peer_tolerance > 0,
-            " peer tolerance must be greater than zero"
-        );
-        Self {
-            standing: NegativePeerSanction::NoStandingFoundMaybeCrash.severity(),
-            latest_punishment: Some((
-                NegativePeerSanction::NoStandingFoundMaybeCrash,
-                SystemTime::now(),
-            )),
-            latest_reward: None,
-            peer_tolerance: peer_tolerance.into(),
-        }
+    pub(crate) fn is_bad(&self) -> bool {
+        self.standing <= -self.peer_tolerance
+    }
+
+    pub(crate) fn is_good(&self) -> bool {
+        !self.is_bad()
     }
 }
 
@@ -924,6 +904,22 @@ mod tests {
     use crate::models::blockchain::block::block_header::HeaderToBlockHashWitness;
     use crate::models::blockchain::block::Block;
     use crate::tests::shared::fake_valid_sequence_of_blocks_for_tests;
+
+    impl PeerStanding {
+        pub fn init(
+            standing: i32,
+            latest_punishment: Option<(NegativePeerSanction, SystemTime)>,
+            latest_reward: Option<(PositivePeerSanction, SystemTime)>,
+            peer_tolerance: i32,
+        ) -> PeerStanding {
+            Self {
+                standing,
+                latest_punishment,
+                latest_reward,
+                peer_tolerance,
+            }
+        }
+    }
 
     #[tokio::test]
     async fn sync_challenge_response_pow_witnesses_must_be_a_chain() {

--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -2066,7 +2066,7 @@ mod peer_loop_tests {
         );
         assert_eq!(
             NegativePeerSanction::DifferentGenesis,
-            peer_standing.unwrap().latest_punishment.unwrap().0
+            peer_standing.unwrap().latest_punishment.unwrap(),
         );
 
         Ok(())
@@ -3758,7 +3758,6 @@ mod peer_loop_tests {
                 latest_sanction
                     .latest_punishment
                     .expect("peer must be sanctioned")
-                    .0
             );
         }
 
@@ -3819,7 +3818,6 @@ mod peer_loop_tests {
                 latest_sanction
                     .latest_punishment
                     .expect("peer must be sanctioned")
-                    .0
             );
         }
 

--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -169,21 +169,16 @@ impl PeerLoopHandler {
                 .unwrap()
                 .standing
         );
-        match global_state_mut
-            .net
-            .peer_map
-            .get_mut(&self.peer_address)
-            .map(|p: &mut PeerInfo| p.standing.sanction(PeerSanction::Negative(reason)))
-        {
-            Some(Ok(_standing)) => Ok(()),
-            Some(Err(_banned)) => {
-                warn!("Banning peer");
-                bail!("Banning peer");
-            }
-            None => {
-                bail!("Could not read peer map.");
-            }
+
+        let Some(peer_info) = global_state_mut.net.peer_map.get_mut(&self.peer_address) else {
+            bail!("Could not read peer map.");
+        };
+        let sanction_result = peer_info.standing.sanction(PeerSanction::Negative(reason));
+        if let Err(err) = sanction_result {
+            warn!("Banning peer: {err}");
         }
+
+        sanction_result.map_err(|err| anyhow::anyhow!("Banning peer: {err}"))
     }
 
     /// Reward a peer for good behavior.
@@ -195,22 +190,16 @@ impl PeerLoopHandler {
     async fn reward(&mut self, reason: PositivePeerSanction) -> Result<()> {
         let mut global_state_mut = self.global_state_lock.lock_guard_mut().await;
         info!("Rewarding peer {} for {:?}", self.peer_address.ip(), reason);
-        match global_state_mut
-            .net
-            .peer_map
-            .get_mut(&self.peer_address)
-            .map(|p| p.standing.sanction(PeerSanction::Positive(reason)))
-        {
-            Some(Ok(_standing)) => Ok(()),
-            Some(Err(_banned)) => {
-                error!("Cannot reward banned peer");
-                bail!("Cannot reward banned peer");
-            }
-            None => {
-                error!("Could not read peer map.");
-                Ok(())
-            }
+        let Some(peer_info) = global_state_mut.net.peer_map.get_mut(&self.peer_address) else {
+            error!("Could not read peer map.");
+            return Ok(());
+        };
+        let sanction_result = peer_info.standing.sanction(PeerSanction::Positive(reason));
+        if sanction_result.is_err() {
+            error!("Cannot reward banned peer");
         }
+
+        sanction_result.map_err(|err| anyhow::anyhow!("Cannot reward banned peer: {err}"))
     }
 
     /// Construct a batch response, with blocks and their MMR membership proofs


### PR DESCRIPTION
The struct `PeerStanding` records the most recent reward and the most recent punishment. Previously, it recorded the time of the respective event. This time was never used. Now, the time is no longer recorded.

This is a breaking change because struct `PeerStanding` is public, and so are the modified fields.

Note that this PR builds on top of #469.