### PR TITLE
Make `max_num_peers` a `usize`

### DIFF
--- a/src/config_models/cli_args.rs
+++ b/src/config_models/cli_args.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 
 use bytesize::ByteSize;
 use clap::builder::RangedI64ValueParser;
+use clap::builder::TypedValueParser;
 use clap::Parser;
 use num_traits::Zero;
 use sysinfo::System;
@@ -61,8 +62,13 @@ pub struct Args {
     ///
     /// Will not prevent outgoing connections made with `--peers`.
     /// Set this value to 0 to refuse all incoming connections.
-    #[clap(long, default_value = "10", value_name = "COUNT")]
-    pub(crate) max_num_peers: u16,
+    #[clap(
+        long,
+        default_value = "10",
+        value_name = "COUNT",
+        value_parser = clap::value_parser!(u16).map(|u| usize::from(u)),
+    )]
+    pub(crate) max_num_peers: usize,
 
     /// Whether to act as bootstrapper node.
     ///

--- a/src/connect_to_peers.rs
+++ b/src/connect_to_peers.rs
@@ -117,9 +117,7 @@ async fn check_if_connection_is_allowed(
     // `DisconnectFromLongestLivedPeer` message should have been sent to
     // the main loop already but that message need not have been processed by
     // the time we get here.
-    if (cli_arguments.max_num_peers as usize) <= global_state.net.peer_map.len()
-        && !cli_arguments.bootstrap
-    {
+    if cli_arguments.max_num_peers <= global_state.net.peer_map.len() && !cli_arguments.bootstrap {
         return InternalConnectionStatus::Refused(ConnectionRefusedReason::MaxPeerNumberExceeded);
     }
 
@@ -147,7 +145,7 @@ async fn check_if_connection_is_allowed(
 
     // If this connection touches the maximum number of peer connections, say
     // so with special OK code.
-    if cli_arguments.max_num_peers as usize == global_state.net.peer_map.len() + 1 {
+    if cli_arguments.max_num_peers == global_state.net.peer_map.len() + 1 {
         info!("ConnectionStatus::Accepted, but max # connections is now reached");
         return InternalConnectionStatus::AcceptedMaxReached;
     }

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -773,7 +773,7 @@ impl MainLoopHandler {
                     main_loop_state.potential_peers.add(
                         reported_by,
                         pot_peer,
-                        max_peers as usize,
+                        max_peers,
                         distance,
                         self.now(),
                     );
@@ -895,7 +895,7 @@ impl MainLoopHandler {
         let connected_peers: Vec<PeerInfo> = global_state.net.peer_map.values().cloned().collect();
 
         // Check if we are connected to too many peers
-        if connected_peers.len() > cli_args.max_num_peers as usize {
+        if connected_peers.len() > cli_args.max_num_peers {
             // If *all* peer connections were outgoing, then it's OK to exceed
             // the max-peer count. But in that case we don't want to connect to
             // more peers, so we should just stop execution of this scheduled
@@ -992,9 +992,8 @@ impl MainLoopHandler {
 
         // We don't make an outgoing connection if we've reached the peer limit, *or* if we are
         // one below the peer limit as we reserve this last slot for an ingoing connection.
-        if connected_peers.len() == cli_args.max_num_peers as usize
-            || connected_peers.len() > 2
-                && connected_peers.len() - 1 == cli_args.max_num_peers as usize
+        if connected_peers.len() == cli_args.max_num_peers
+            || connected_peers.len() > 2 && connected_peers.len() - 1 == cli_args.max_num_peers
         {
             return Ok(());
         }
@@ -2288,7 +2287,7 @@ mod test {
             } = test_setup;
 
             let mocked_cli = cli_args::Args {
-                max_num_peers: num_init_peers_outgoing as u16 + 1,
+                max_num_peers: usize::from(num_init_peers_outgoing) + 1,
                 bootstrap: true,
                 network,
                 ..Default::default()
@@ -2302,7 +2301,7 @@ mod test {
 
             // check sanity: at startup, we are connected to the initial number of peers
             assert_eq!(
-                num_init_peers_outgoing as usize,
+                usize::from(num_init_peers_outgoing),
                 main_loop_handler
                     .global_state_lock
                     .lock_guard()

--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -1831,7 +1831,7 @@ impl PeerLoopHandler {
             bail!("Attempted to connect to already connected peer. Aborting connection.");
         }
 
-        if global_state.net.peer_map.len() >= cli_args.max_num_peers as usize {
+        if global_state.net.peer_map.len() >= cli_args.max_num_peers {
             bail!("Attempted to connect to more peers than allowed. Aborting connection.");
         }
 

--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -2780,7 +2780,7 @@ impl RPC for NeptuneRPCServer {
         info!("proving capability: {proving_capability}");
 
         let peer_count = Some(state.net.peer_map.len());
-        let max_num_peers = self.state.cli().max_num_peers as usize;
+        let max_num_peers = self.state.cli().max_num_peers;
 
         let mining_status = Some(state.mining_status.clone());
 


### PR DESCRIPTION
Remove various casts from `u16` to `usize`.

The command line argument `max_num_peers` is almost always used as a `usize`. The only exception is a single test.