### PR TITLE
Work around deprecation of ubuntu runner image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.25.1/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.28.0/cargo-dist-installer.sh | sh"
       - name: Cache dist
         uses: actions/upload-artifact@v4
         with:
@@ -109,6 +109,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
@@ -119,6 +120,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
       - name: "Update RUSTFLAGS with --cfg tokio_unstable (Linux/MacOS)"
         if: "runner.os != 'Windows'"
         run: "echo RUSTFLAGS=\"$RUSTFLAGS --cfg tokio_unstable\" >> \"$GITHUB_ENV\""
@@ -127,7 +135,7 @@ jobs:
         run: "echo \"RUSTFLAGS=$Env:RUSTFLAGS --cfg tokio_unstable\" >> $Env:GITHUB_ENV"
         shell: "pwsh"
       - name: Install dist
-        run: ${{ matrix.install_dist }}
+        run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
       - name: Fetch local artifacts
         uses: actions/download-artifact@v4
@@ -156,7 +164,7 @@ jobs:
         run: |
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -4,7 +4,7 @@ members = ["cargo:."]
 # Config for 'dist'
 [dist]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.25.1"
+cargo-dist-version = "0.28.0"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
@@ -18,3 +18,11 @@ install-updater = true
 # Whether to enable GitHub Attestations
 github-attestations = true
 github-build-setup = "build-workaround"
+
+# Work around the brownout and eventual removal of ubuntu runner image `20.04`
+# until the next upgrade of `dist`.
+# See also:
+# https://github.com/actions/runner-images/issues/11101
+# https://github.com/axodotdev/cargo-dist/issues/1760
+[dist.github-custom-runners]
+x86_64-unknown-linux-gnu = "ubuntu-22.04"


### PR DESCRIPTION
Work around the brownout and eventual removal of ubuntu runner image `20.04` until the next upgrade of `dist`.

See also:
- https://github.com/actions/runner-images/issues/11101
- https://github.com/axodotdev/cargo-dist/issues/1760