### PR TITLE
Leave bootstrap nodes alone if well connected

### DIFF
--- a/src/config_models/cli_args.rs
+++ b/src/config_models/cli_args.rs
@@ -82,13 +82,21 @@ pub struct Args {
     #[clap(long)]
     pub(crate) max_connections_per_ip: Option<usize>,
 
-    /// Whether to act as bootstrapper node.
+    /// Whether to act as a bootstrap node.
     ///
-    /// Bootstrapper nodes ensure that the maximum number of peers is never
-    /// reached by disconnecting from existing peers when the maximum is about
-    /// to be reached. As a result, they will respond with high likelihood to
-    /// incoming connection requests -- in contrast to regular nodes, which
-    /// refuse incoming connections when the max is reached.
+    /// Bootstrap nodes almost always accept new connections. This gives newcomers
+    /// to the network a chance to discover other nodes on the network through the
+    /// automatic peer discovery process.
+    ///
+    /// The differences between bootstrap nodes and non-bootstrap nodes are:
+    ///
+    /// - If the maximum number of peers is reached, non-bootstrap nodes refuse
+    ///   additional connection attempts, while bootstrap nodes terminate the
+    ///   longest-standing connection and accept the new connection.
+    /// - If a node that got disconnected recently tries to re-establish the same
+    ///   connection immediately, a non-bootstrap node might accept (depending on
+    ///   its current and maximum number of peers), while a bootstrap node will
+    ///   certainly refuse until the reconnect cooldown has expired.
     #[clap(long)]
     pub(crate) bootstrap: bool,
 

--- a/src/config_models/cli_args.rs
+++ b/src/config_models/cli_args.rs
@@ -97,6 +97,9 @@ pub struct Args {
     ///   connection immediately, a non-bootstrap node might accept (depending on
     ///   its current and maximum number of peers), while a bootstrap node will
     ///   certainly refuse until the reconnect cooldown has expired.
+    /// - If a node is well-connected, it will stop trying to connect to known
+    ///   bootstrap nodes, even if this node's address is passed as an explicit peer
+    ///   via the corresponding command line argument.
     #[clap(long)]
     pub(crate) bootstrap: bool,
 
@@ -206,6 +209,10 @@ pub struct Args {
     pub(crate) sync_mode_threshold: usize,
 
     /// IPs of nodes to connect to, e.g.: --peers 8.8.8.8:9798 --peers 8.8.4.4:1337.
+    ///
+    /// Connection attempts to bootstrap nodes will only be made if the own node is
+    /// not well-connected yet. Once enough connections to non-bootstrap peers have
+    /// been established, bootstrap nodes will not be bothered anymore.
     #[structopt(long)]
     pub(crate) peers: Vec<SocketAddr>,
 

--- a/src/connect_to_peers.rs
+++ b/src/connect_to_peers.rs
@@ -23,6 +23,7 @@ use tracing::warn;
 
 use crate::models::channel::MainToPeerTask;
 use crate::models::channel::PeerTaskToMain;
+use crate::models::peer::bootstrap_info::BootstrapStatus;
 use crate::models::peer::ConnectionRefusedReason;
 use crate::models::peer::InternalConnectionStatus;
 use crate::models::peer::NegativePeerSanction;
@@ -309,12 +310,23 @@ where
     info!("Connection accepted from {peer_address}");
 
     // If necessary, disconnect from another, existing peer.
-    if connection_status == InternalConnectionStatus::AcceptedMaxReached && state.cli().bootstrap {
+    let self_is_bootstrap = state.cli().bootstrap;
+    if connection_status == InternalConnectionStatus::AcceptedMaxReached && self_is_bootstrap {
         info!("Maximum # peers reached, so disconnecting from an existing peer.");
         peer_task_to_main_tx
             .send(PeerTaskToMain::DisconnectFromLongestLivedPeer)
             .await?;
     }
+
+    // inform the new peer about our bootstrap status
+    let bootstrap_status = if self_is_bootstrap {
+        BootstrapStatus::Bootstrap
+    } else {
+        BootstrapStatus::Ordinary
+    };
+    peer.send(PeerMessage::BootstrapStatus(bootstrap_status))
+        .await?;
+    debug!("Informing {peer_address} of our bootstrap status: {bootstrap_status}");
 
     let peer_distance = 1; // All incoming connections have distance 1
     let mut peer_loop_handler = PeerLoopHandler::new(
@@ -557,6 +569,9 @@ mod connect_tests {
 
     use anyhow::bail;
     use anyhow::Result;
+    use bytes::Bytes;
+    use proptest::prelude::*;
+    use test_strategy::proptest;
     use tokio_test::io::Builder;
     use tracing_test::traced_test;
     use twenty_first::math::digest::Digest;
@@ -583,9 +598,12 @@ mod connect_tests {
     #[traced_test]
     #[tokio::test]
     async fn test_outgoing_connection_succeed() -> Result<()> {
-        let network = Network::Alpha;
-        let other_handshake = get_dummy_handshake_data_for_genesis(network);
-        let own_handshake = get_dummy_handshake_data_for_genesis(network);
+        let network = Network::Main;
+        let (_tx, main_to_peer_rx, peer_to_main_tx, _rx, state, own_handshake) =
+            get_test_genesis_setup(network, 0, cli_args::Args::default()).await?;
+        let (peer_handshake, peer_socket_address) =
+            get_dummy_peer_connection_data_genesis(network, 0);
+
         let mock = Builder::new()
             .write(&to_bytes(&PeerMessage::Handshake(Box::new((
                 MAGIC_STRING_REQUEST.to_vec(),
@@ -593,7 +611,7 @@ mod connect_tests {
             ))))?)
             .read(&to_bytes(&PeerMessage::Handshake(Box::new((
                 MAGIC_STRING_RESPONSE.to_vec(),
-                other_handshake,
+                peer_handshake,
             ))))?)
             .read(&to_bytes(&PeerMessage::ConnectionStatus(
                 TransferConnectionStatus::Accepted,
@@ -601,25 +619,20 @@ mod connect_tests {
             .write(&to_bytes(&PeerMessage::PeerListRequest)?)
             .read(&to_bytes(&PeerMessage::Bye)?)
             .build();
-
-        let (_peer_broadcast_tx, from_main_rx_clone, to_main_tx, _to_main_rx1, state, _hsd) =
-            get_test_genesis_setup(Network::Alpha, 0, cli_args::Args::default()).await?;
         call_peer_inner(
             mock,
             state.clone(),
-            get_dummy_socket_address(0),
-            from_main_rx_clone,
-            to_main_tx,
+            peer_socket_address,
+            main_to_peer_rx,
+            peer_to_main_tx,
             &own_handshake,
             1,
         )
         .await?;
 
-        // Verify that peer map is empty after connection has been closed
-        match state.lock(|s| s.net.peer_map.keys().len()).await {
-            0 => (),
-            _ => bail!("Incorrect number of maps in peer map"),
-        };
+        if !state.lock_guard().await.net.peer_map.is_empty() {
+            bail!("peer map must be empty after connection has been closed");
+        }
 
         Ok(())
     }
@@ -856,6 +869,9 @@ mod connect_tests {
             .write(&to_bytes(&PeerMessage::ConnectionStatus(
                 TransferConnectionStatus::Accepted,
             ))?)
+            .write(&to_bytes(&PeerMessage::BootstrapStatus(
+                BootstrapStatus::Ordinary,
+            ))?)
             .read(&to_bytes(&PeerMessage::Bye)?)
             .build();
         answer_peer_inner(
@@ -896,6 +912,9 @@ mod connect_tests {
             ))))?)
             .write(&to_bytes(&PeerMessage::ConnectionStatus(
                 TransferConnectionStatus::Accepted,
+            ))?)
+            .write(&to_bytes(&PeerMessage::BootstrapStatus(
+                BootstrapStatus::Ordinary,
             ))?)
             .read(&to_bytes(&PeerMessage::Bye)?)
             .build();
@@ -1250,5 +1269,102 @@ mod connect_tests {
         };
 
         Ok(())
+    }
+
+    #[proptest(cases = 20, async = "tokio")]
+    async fn bootstrap_status_message_propagates_to_state(
+        connection_is_incoming: bool,
+        own_bootstrap_status: BootstrapStatus,
+        peer_bootstrap_status: BootstrapStatus,
+    ) {
+        // convenience wrapper for `to_bytes`
+        fn serialize(message: &PeerMessage) -> Bytes {
+            to_bytes(message).unwrap()
+        }
+
+        let network = Network::Main;
+        let args = cli_args::Args {
+            network,
+            bootstrap: own_bootstrap_status == BootstrapStatus::Bootstrap,
+            ..Default::default()
+        };
+        let (_tx, main_to_peer_rx, peer_to_main_tx, _rx, state, own_handshake) =
+            get_test_genesis_setup(network, 0, args).await.unwrap();
+
+        // sanity check: no bootstrap status is known after startup
+        prop_assert!(state.lock_guard().await.net.bootstrap_status.is_empty());
+
+        // simulate connection
+        let (peer_handshake, peer_socket_address) =
+            get_dummy_peer_connection_data_genesis(network, 1);
+        let mut stream_builder = Builder::new();
+
+        if connection_is_incoming {
+            stream_builder
+                .read(&serialize(&PeerMessage::Handshake(Box::new((
+                    MAGIC_STRING_REQUEST.to_vec(),
+                    peer_handshake.clone(),
+                )))))
+                .write(&serialize(&PeerMessage::Handshake(Box::new((
+                    MAGIC_STRING_RESPONSE.to_vec(),
+                    own_handshake.clone(),
+                )))))
+                .write(&serialize(&PeerMessage::ConnectionStatus(
+                    TransferConnectionStatus::Accepted,
+                )))
+                .write(&serialize(&PeerMessage::BootstrapStatus(
+                    own_bootstrap_status,
+                )));
+        } else {
+            stream_builder
+                .write(&serialize(&PeerMessage::Handshake(Box::new((
+                    MAGIC_STRING_REQUEST.to_vec(),
+                    own_handshake.clone(),
+                )))))
+                .read(&serialize(&PeerMessage::Handshake(Box::new((
+                    MAGIC_STRING_RESPONSE.to_vec(),
+                    peer_handshake.clone(),
+                )))))
+                .read(&serialize(&PeerMessage::ConnectionStatus(
+                    TransferConnectionStatus::Accepted,
+                )))
+                .write(&serialize(&PeerMessage::PeerListRequest));
+        }
+        let mock_stream = stream_builder
+            .read(&serialize(&PeerMessage::BootstrapStatus(
+                peer_bootstrap_status,
+            )))
+            .read(&serialize(&PeerMessage::Bye))
+            .build();
+
+        if connection_is_incoming {
+            answer_peer_inner(
+                mock_stream,
+                state.clone(),
+                peer_socket_address,
+                main_to_peer_rx,
+                peer_to_main_tx,
+                own_handshake,
+            )
+            .await
+            .unwrap();
+        } else {
+            call_peer_inner(
+                mock_stream,
+                state.clone(),
+                peer_socket_address,
+                main_to_peer_rx,
+                peer_to_main_tx,
+                &own_handshake,
+                1,
+            )
+            .await
+            .unwrap();
+        }
+
+        let bootstrap_status = &state.lock_guard().await.net.bootstrap_status;
+        prop_assert_eq!(1, bootstrap_status.len());
+        let peer_status = bootstrap_status.get(&peer_socket_address).unwrap();
+        prop_assert_eq!(peer_bootstrap_status, peer_status.status);
     }
 }

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -2403,8 +2403,8 @@ mod test {
             instants.iter().copied().min_by(|l, r| l.cmp(r)).unwrap()
         );
     }
-    mod bootstrapper_mode {
 
+    mod bootstrap_mode {
         use rand::Rng;
 
         use super::*;
@@ -2416,7 +2416,7 @@ mod test {
         #[tokio::test]
         #[traced_test]
         async fn disconnect_from_oldest_peer_upon_connection_request() {
-            // Set up a node in bootstrapper mode and connected to a given
+            // Set up a node in bootstrap mode and connected to a given
             // number of peers, which is one less than the maximum. Initiate a
             // connection request. Verify that the oldest of the existing
             // connections is dropped.
@@ -2427,11 +2427,10 @@ mod test {
             let test_setup = setup(num_init_peers_outgoing, num_init_peers_incoming).await;
             let TestSetup {
                 mut peer_to_main_rx,
-                miner_to_main_rx: _,
-                rpc_server_to_main_rx: _,
                 task_join_handles,
                 mut main_loop_handler,
                 mut main_to_peer_rx,
+                ..
             } = test_setup;
 
             let mocked_cli = cli_args::Args {
@@ -2460,9 +2459,13 @@ mod test {
             );
 
             // randomize "connection established" timestamps
-            let mut rng = rand::rng();
-            let now = SystemTime::now();
-            let now_as_unix_timestamp = now.duration_since(UNIX_EPOCH).unwrap();
+            let random_offset = || {
+                let unix_epoch_to_now_in_millis = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_millis() as u64;
+                Duration::from_millis(rand::rng().random_range(0..unix_epoch_to_now_in_millis))
+            };
             main_loop_handler
                 .global_state_lock
                 .lock_guard_mut()
@@ -2470,13 +2473,8 @@ mod test {
                 .net
                 .peer_map
                 .iter_mut()
-                .for_each(|(_socket_address, peer_info)| {
-                    peer_info.set_connection_established(
-                        UNIX_EPOCH
-                            + Duration::from_millis(
-                                rng.random_range(0..(now_as_unix_timestamp.as_millis() as u64)),
-                            ),
-                    );
+                .for_each(|(_, peer_info)| {
+                    peer_info.set_connection_established(UNIX_EPOCH + random_offset());
                 });
 
             // compute which peer will be dropped, for later reference
@@ -2487,11 +2485,11 @@ mod test {
                 .net
                 .peer_map
                 .iter()
-                .min_by(|l, r| {
-                    l.1.connection_established()
-                        .cmp(&r.1.connection_established())
+                .min_by(|(_, left), (_, right)| {
+                    left.connection_established()
+                        .cmp(&right.connection_established())
                 })
-                .map(|(socket_address, _peer_info)| socket_address)
+                .map(|(socket_address, _)| socket_address)
                 .copied()
                 .unwrap();
 
@@ -2503,8 +2501,8 @@ mod test {
                 .lock_guard()
                 .await
                 .get_own_handshakedata();
-            assert_eq!(peer_handshake_data.network, own_handshake_data.network,);
-            assert_eq!(peer_handshake_data.version, own_handshake_data.version,);
+            assert_eq!(peer_handshake_data.network, own_handshake_data.network);
+            assert_eq!(peer_handshake_data.version, own_handshake_data.version);
             let mock_stream = tokio_test::io::Builder::new()
                 .read(
                     &to_bytes(&PeerMessage::Handshake(Box::new((
@@ -2529,23 +2527,20 @@ mod test {
                 .build();
             let peer_to_main_tx_clone = main_loop_handler.peer_task_to_main_tx.clone();
             let global_state_lock_clone = main_loop_handler.global_state_lock.clone();
-            let (_main_to_peer_tx_mock, main_to_peer_rx_mock) = tokio::sync::broadcast::channel(10);
+            let main_to_peer_rx_clone = main_loop_handler.main_to_peer_broadcast_tx.subscribe();
             let incoming_peer_task_handle = tokio::task::Builder::new()
                 .name("answer_peer_wrapper")
                 .spawn(async move {
-                    match answer_peer(
+                    answer_peer(
                         mock_stream,
                         global_state_lock_clone,
                         peer_socket_address,
-                        main_to_peer_rx_mock,
+                        main_to_peer_rx_clone,
                         peer_to_main_tx_clone,
                         own_handshake_data,
                     )
                     .await
-                    {
-                        Ok(()) => (),
-                        Err(err) => error!("Got error: {:?}", err),
-                    }
+                    .unwrap();
                 })
                 .unwrap();
 

--- a/src/models/channel.rs
+++ b/src/models/channel.rs
@@ -14,6 +14,7 @@ use super::peer::transaction_notification::TransactionNotification;
 use super::proof_abstractions::mast_hash::MastHash;
 use super::state::wallet::expected_utxo::ExpectedUtxo;
 use super::state::wallet::monitored_utxo::MonitoredUtxo;
+use crate::models::peer::InstanceId;
 
 #[derive(Clone, Debug)]
 pub(crate) enum MainToMiner {
@@ -162,8 +163,8 @@ pub(crate) enum PeerTaskToMain {
     },
     RemovePeerMaxBlockHeight(SocketAddr),
 
-    /// (\[(peer_listen_address)\], reported_by, distance)
-    PeerDiscoveryAnswer((Vec<(SocketAddr, u128)>, SocketAddr, u8)),
+    /// list of peer's peers, and their distance from “self”
+    PeerDiscoveryAnswer(Vec<(SocketAddr, InstanceId)>, u8),
 
     Transaction(Box<PeerTaskToMainTransaction>),
     BlockProposal(Box<Block>),
@@ -182,7 +183,7 @@ impl PeerTaskToMain {
             PeerTaskToMain::NewBlocks(_) => "new blocks",
             PeerTaskToMain::AddPeerMaxBlockHeight { .. } => "add peer max block height",
             PeerTaskToMain::RemovePeerMaxBlockHeight(_) => "remove peer max block height",
-            PeerTaskToMain::PeerDiscoveryAnswer(_) => "peer discovery answer",
+            PeerTaskToMain::PeerDiscoveryAnswer(..) => "peer discovery answer",
             PeerTaskToMain::Transaction(_) => "transaction",
             PeerTaskToMain::BlockProposal(_) => "block proposal",
             PeerTaskToMain::DisconnectFromLongestLivedPeer => "disconnect from longest lived peer",

--- a/src/models/peer/bootstrap_info.rs
+++ b/src/models/peer/bootstrap_info.rs
@@ -1,0 +1,49 @@
+use std::fmt::Display;
+use std::time::SystemTime;
+
+use serde_derive::Deserialize;
+use serde_derive::Serialize;
+
+/// A node's [BootstrapStatus] and some metadata.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub(crate) struct BootstrapInfo {
+    pub status: BootstrapStatus,
+
+    /// The time when the status was last set.
+    pub last_set: SystemTime,
+}
+
+/// Does the node help bootstrapping the network?
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub(crate) enum BootstrapStatus {
+    /// The node is not a bootstrap node.
+    ///
+    /// If no further information is known about a peer, it is assumed that it is an
+    /// ordinary node.
+    #[default]
+    Ordinary,
+
+    /// The node _is_ a bootstrap node.
+    Bootstrap,
+}
+
+impl Display for BootstrapStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let display = match self {
+            Self::Ordinary => "ordinary node",
+            Self::Bootstrap => "bootstrap node",
+        };
+
+        write!(f, "{display}")
+    }
+}
+
+impl BootstrapInfo {
+    /// Create new [BootstrapInfo] right [now](SystemTime::now).
+    pub fn new(status: BootstrapStatus) -> Self {
+        Self {
+            status,
+            last_set: SystemTime::now(),
+        }
+    }
+}

--- a/src/models/peer/bootstrap_info.rs
+++ b/src/models/peer/bootstrap_info.rs
@@ -15,6 +15,7 @@ pub(crate) struct BootstrapInfo {
 
 /// Does the node help bootstrapping the network?
 #[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[cfg_attr(test, derive(test_strategy::Arbitrary))]
 pub(crate) enum BootstrapStatus {
     /// The node is not a bootstrap node.
     ///

--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -689,12 +689,10 @@ impl PeerLoopHandler {
                         .await?;
                 }
                 self.to_main_tx
-                    .send(PeerTaskToMain::PeerDiscoveryAnswer((
+                    .send(PeerTaskToMain::PeerDiscoveryAnswer(
                         peers,
-                        self.peer_address,
-                        // The distance to the revealed peers is 1 + this peer's distance
                         self.distance + 1,
-                    )))
+                    ))
                     .await?;
                 Ok(KEEP_CONNECTION_ALIVE)
             }


### PR DESCRIPTION
In order to help newcomers to connect to peers on the network, certain nodes act as bootstrap nodes. Those nodes tend to be well known, and users tend to specify them as potential peers via command line arguments.

Previously, connections to potential peers specified as command line arguments were always re-initiated when dropped. This can cause an involuntary denial-of-service of those well-known bootstrap nodes.

With this PR, a well-connected node does not initiate connections with bootstrap nodes.