### PR TITLE
Thv/ 481 pw to pc upgrade race condition

### DIFF
--- a/src/main_loop/proof_upgrader.rs
+++ b/src/main_loop/proof_upgrader.rs
@@ -330,9 +330,7 @@ impl UpgradeJob {
             upgrade_job = {
                 let mut global_state = global_state_lock.lock_guard_mut().await;
                 // Did we receive a new block while proving? If so, perform an
-                // update also, if this was requested (and we have a single proof)
-                // if we only have a ProofCollection, then we throw away the work
-                // regardless.
+                // update also, if this was requested.
 
                 let transaction_is_deprecated = upgraded.kernel.mutator_set_hash
                     != global_state
@@ -718,9 +716,10 @@ mod test {
     use crate::tests::shared::get_test_genesis_setup;
     use crate::tests::shared::invalid_empty_block_with_timestamp;
 
-    /// Returns a PrimitiveWitness-backed transaction initiated by the global state provided as
-    /// argument. Assumes balance is sufficient to make this transaction.
-    async fn pw_backed_tx(mut state: GlobalStateLock, seed: u64) -> Transaction {
+    /// Returns a PrimitiveWitness-backed transaction initiated by the global
+    /// state provided as argument. Assumes balance is sufficient to make this
+    /// transaction.
+    async fn primitive_witness_backed_tx(mut state: GlobalStateLock, seed: u64) -> Transaction {
         let mut rng: StdRng = SeedableRng::seed_from_u64(seed);
         let receiving_address = GenerationReceivingAddress::derive_from_seed(rng.random());
         let tx_outputs = vec![TxOutput::onchain_native_currency(
@@ -760,7 +759,7 @@ mod test {
             get_test_genesis_setup(network, 2, cli_args::Args::default_with_network(network))
                 .await
                 .unwrap();
-        let pwtx = pw_backed_tx(alice.clone(), 512777439428).await;
+        let pwtx = primitive_witness_backed_tx(alice.clone(), 512777439428).await;
         alice
             .lock_guard_mut()
             .await
@@ -818,7 +817,7 @@ mod test {
             get_test_genesis_setup(network, 2, cli_args::Args::default_with_network(network))
                 .await
                 .unwrap();
-        let pwtx = pw_backed_tx(alice.clone(), 512777439429).await;
+        let pwtx = primitive_witness_backed_tx(alice.clone(), 512777439429).await;
         alice
             .lock_guard_mut()
             .await

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -1725,6 +1725,7 @@ pub(crate) mod block_tests {
                 .apply_to_accumulator_and_records(
                     &mut ms,
                     &mut mutator_set_update_tx.removals.iter_mut().collect_vec(),
+                    &mut [],
                 )
                 .expect(reason);
             mutator_set_update_tx

--- a/src/models/blockchain/block/mutator_set_update.rs
+++ b/src/models/blockchain/block/mutator_set_update.rs
@@ -4,6 +4,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::util_types::mutator_set::addition_record::AdditionRecord;
+use crate::util_types::mutator_set::authenticated_item::AuthenticatedItem;
 use crate::util_types::mutator_set::mutator_set_accumulator::MutatorSetAccumulator;
 use crate::util_types::mutator_set::removal_record::RemovalRecord;
 
@@ -28,7 +29,7 @@ impl MutatorSetUpdate {
     /// happening.
     pub(crate) fn apply_to_accumulator_unsafe(&self, ms_accumulator: &mut MutatorSetAccumulator) {
         let _valid_removal_records =
-            self.apply_to_accumulator_and_records_inner(ms_accumulator, &mut []);
+            self.apply_to_accumulator_and_records_inner(ms_accumulator, &mut [], &mut []);
     }
 
     /// Apply a mutator-set-update to a mutator-set-accumulator.
@@ -41,7 +42,7 @@ impl MutatorSetUpdate {
     /// Returns an error if some removal record could not be removed.
     pub fn apply_to_accumulator(&self, ms_accumulator: &mut MutatorSetAccumulator) -> Result<()> {
         let valid_removal_records =
-            self.apply_to_accumulator_and_records_inner(ms_accumulator, &mut []);
+            self.apply_to_accumulator_and_records_inner(ms_accumulator, &mut [], &mut []);
         if valid_removal_records {
             Ok(())
         } else {
@@ -62,13 +63,17 @@ impl MutatorSetUpdate {
     /// Returns an error if some removal record could not be removed. This
     /// return value **must** be verified to be OK. If it is not, then the
     /// mutator set will be in an invalid state.
-    pub fn apply_to_accumulator_and_records(
+    pub(crate) fn apply_to_accumulator_and_records(
         &self,
         ms_accumulator: &mut MutatorSetAccumulator,
         removal_records: &mut [&mut RemovalRecord],
+        authenticated_items: &mut [&mut AuthenticatedItem],
     ) -> Result<()> {
-        let valid_removal_records =
-            self.apply_to_accumulator_and_records_inner(ms_accumulator, removal_records);
+        let valid_removal_records = self.apply_to_accumulator_and_records_inner(
+            ms_accumulator,
+            removal_records,
+            authenticated_items,
+        );
         if valid_removal_records {
             Ok(())
         } else {
@@ -91,6 +96,7 @@ impl MutatorSetUpdate {
         &self,
         ms_accumulator: &mut MutatorSetAccumulator,
         removal_records: &mut [&mut RemovalRecord],
+        authenticated_items: &mut [&mut AuthenticatedItem],
     ) -> bool {
         let mut cloned_removals = self.removals.clone();
         let mut applied_removal_records = cloned_removals.iter_mut().rev().collect::<Vec<_>>();
@@ -98,6 +104,12 @@ impl MutatorSetUpdate {
             RemovalRecord::batch_update_from_addition(&mut applied_removal_records, ms_accumulator);
 
             RemovalRecord::batch_update_from_addition(removal_records, ms_accumulator);
+
+            AuthenticatedItem::batch_update_from_addition(
+                authenticated_items,
+                ms_accumulator,
+                *addition_record,
+            );
 
             ms_accumulator.add(addition_record);
         }
@@ -110,6 +122,11 @@ impl MutatorSetUpdate {
             );
 
             RemovalRecord::batch_update_from_remove(removal_records, applied_removal_record);
+
+            AuthenticatedItem::batch_update_from_remove(
+                authenticated_items,
+                applied_removal_record,
+            );
 
             if !ms_accumulator.can_remove(applied_removal_record) {
                 removal_records_are_valid = false;

--- a/src/models/blockchain/transaction/lock_script.rs
+++ b/src/models/blockchain/transaction/lock_script.rs
@@ -99,6 +99,11 @@ impl LockScriptAndWitness {
         }
     }
 
+    #[cfg(test)]
+    pub(crate) fn set_nd_tokens(&mut self, tokens: Vec<BFieldElement>) {
+        self.nd_tokens = tokens;
+    }
+
     pub fn new(program: Program) -> Self {
         Self {
             program,

--- a/src/models/blockchain/transaction/mod.rs
+++ b/src/models/blockchain/transaction/mod.rs
@@ -160,6 +160,7 @@ impl Transaction {
             .apply_to_accumulator_and_records(
                 &mut calculated_new_mutator_set,
                 &mut new_inputs.iter_mut().collect_vec(),
+                &mut [],
             )
             .unwrap_or_else(|_| panic!("Could not apply mutator set update."));
 

--- a/src/models/blockchain/transaction/transaction_kernel.rs
+++ b/src/models/blockchain/transaction/transaction_kernel.rs
@@ -522,6 +522,7 @@ pub mod transaction_kernel_tests {
             .apply_to_accumulator_and_records(
                 &mut msa,
                 &mut removal_records.iter_mut().collect_vec(),
+                &mut [],
             )
             .unwrap();
         let new_tx = TransactionKernelModifier::default()

--- a/src/models/blockchain/type_scripts/mod.rs
+++ b/src/models/blockchain/type_scripts/mod.rs
@@ -143,6 +143,10 @@ impl std::hash::Hash for TypeScriptAndWitness {
 
 #[cfg(test)]
 pub(crate) mod test {
+    use rand::rngs::StdRng;
+    use rand::Rng;
+    use rand::SeedableRng;
+
     use super::*;
 
     impl TypeScriptAndWitness {
@@ -159,6 +163,28 @@ pub(crate) mod test {
             let public_input = PublicInput::new(standard_input);
 
             VM::run(self.program.clone(), public_input, self.nondeterminism()).is_ok()
+        }
+
+        /// Scramble witness data without affecting program. For negative
+        /// tests.
+        pub(crate) fn scramble_non_determinism(&mut self, seed: u64) {
+            let mut rng: StdRng = SeedableRng::seed_from_u64(seed);
+
+            if !self.nd_tokens.is_empty() {
+                let idx = rng.random_range(0..self.nd_tokens.len());
+                self.nd_tokens[idx] = rng.random();
+            }
+
+            if !self.nd_memory.is_empty() {
+                let idx = rng.random_range(0..self.nd_memory.len());
+                let (address, _value) = self.nd_memory[idx];
+                self.nd_memory[idx] = (address, rng.random());
+            }
+
+            if !self.nd_digests.is_empty() {
+                let idx = rng.random_range(0..self.nd_digests.len());
+                self.nd_digests[idx] = rng.random();
+            }
         }
     }
 }

--- a/src/models/blockchain/type_scripts/time_lock.rs
+++ b/src/models/blockchain/type_scripts/time_lock.rs
@@ -1250,12 +1250,14 @@ mod test {
     }
 
     #[proptest(cases = 5)]
-    fn primitive_witness_with_timelocks_is_valid(
+    fn primitive_witness_with_active_timelocks_is_invalid(
         #[strategy(arb::<Timestamp>())] _now: Timestamp,
         #[strategy(arbitrary_primitive_witness_with_active_timelocks(2, 2, 2, #_now))]
         primitive_witness: PrimitiveWitness,
     ) {
-        prop_assert!(Runtime::new()
+        // Negative test: Primitive witness spending inputs that are timelocked
+        // must fail to validate.
+        prop_assert!(!Runtime::new()
             .unwrap()
             .block_on(primitive_witness.validate()));
     }

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -527,13 +527,12 @@ pub fn make_mock_transaction(
     make_mock_transaction_with_mutator_set_hash(inputs, outputs, Digest::default())
 }
 
-pub(crate) fn make_mock_transaction_with_mutator_set_hash(
+pub(crate) fn make_mock_transaction_with_mutator_set_hash_and_timestamp(
     inputs: Vec<RemovalRecord>,
     outputs: Vec<AdditionRecord>,
     mutator_set_hash: Digest,
+    timestamp: Timestamp,
 ) -> Transaction {
-    let timestamp = Timestamp::now();
-
     Transaction {
         kernel: TransactionKernelProxy {
             inputs,
@@ -548,6 +547,21 @@ pub(crate) fn make_mock_transaction_with_mutator_set_hash(
         .into_kernel(),
         proof: TransactionProof::invalid(),
     }
+}
+
+pub(crate) fn make_mock_transaction_with_mutator_set_hash(
+    inputs: Vec<RemovalRecord>,
+    outputs: Vec<AdditionRecord>,
+    mutator_set_hash: Digest,
+) -> Transaction {
+    let timestamp = Timestamp::now();
+
+    make_mock_transaction_with_mutator_set_hash_and_timestamp(
+        inputs,
+        outputs,
+        mutator_set_hash,
+        timestamp,
+    )
 }
 
 pub(crate) fn dummy_expected_utxo() -> ExpectedUtxo {
@@ -854,6 +868,19 @@ pub(crate) fn invalid_empty_block(predecessor: &Block) -> Block {
         predecessor.mutator_set_accumulator_after().hash(),
     );
     let timestamp = predecessor.header().timestamp + Timestamp::hours(1);
+    Block::block_template_invalid_proof(predecessor, tx, timestamp, None)
+}
+
+pub(crate) fn invalid_empty_block_with_timestamp(
+    predecessor: &Block,
+    timestamp: Timestamp,
+) -> Block {
+    let tx = make_mock_transaction_with_mutator_set_hash_and_timestamp(
+        vec![],
+        vec![],
+        predecessor.mutator_set_accumulator_after().hash(),
+        timestamp,
+    );
     Block::block_template_invalid_proof(predecessor, tx, timestamp, None)
 }
 

--- a/src/util_types/mutator_set.rs
+++ b/src/util_types/mutator_set.rs
@@ -16,6 +16,7 @@ use crate::models::blockchain::shared::Hash;
 pub mod active_window;
 pub mod addition_record;
 pub mod archival_mutator_set;
+pub mod authenticated_item;
 pub mod chunk;
 pub mod chunk_dictionary;
 pub mod mmra_and_membership_proofs;

--- a/src/util_types/mutator_set/authenticated_item.rs
+++ b/src/util_types/mutator_set/authenticated_item.rs
@@ -1,0 +1,51 @@
+use itertools::Itertools;
+use tasm_lib::prelude::Digest;
+
+use super::addition_record::AdditionRecord;
+use super::ms_membership_proof::MsMembershipProof;
+use super::mutator_set_accumulator::MutatorSetAccumulator;
+use super::removal_record::RemovalRecord;
+
+#[derive(Debug, Clone)]
+pub(crate) struct AuthenticatedItem {
+    pub(crate) item: Digest,
+    pub(crate) ms_membership_proof: MsMembershipProof,
+}
+
+impl AuthenticatedItem {
+    /// Update the membership proofs of a list of authenticated items in
+    /// anticipation of an addition.
+    ///
+    /// Does not verify that the membership proofs are valid.
+    pub(crate) fn batch_update_from_addition(
+        authenticated_items: &mut [&mut Self],
+        mutator_set: &MutatorSetAccumulator,
+        addition_record: AdditionRecord,
+    ) {
+        let items = authenticated_items.iter().map(|x| x.item).collect_vec();
+        let mut ms_membership_proofs = authenticated_items
+            .iter_mut()
+            .map(|authenticated_item| &mut authenticated_item.ms_membership_proof)
+            .collect_vec();
+        let _ = MsMembershipProof::batch_update_from_addition(
+            &mut ms_membership_proofs,
+            &items,
+            mutator_set,
+            &addition_record,
+        );
+    }
+
+    /// Update the membership proofs of a list of authenticated items in
+    /// anticipation of one remove operation.
+    pub(crate) fn batch_update_from_remove(
+        authenticated_items: &mut [&mut Self],
+        removal_record: &RemovalRecord,
+    ) {
+        let mut ms_membership_proofs = authenticated_items
+            .iter_mut()
+            .map(|authenticated_item| &mut authenticated_item.ms_membership_proof)
+            .collect_vec();
+        let _ =
+            MsMembershipProof::batch_update_from_remove(&mut ms_membership_proofs, removal_record);
+    }
+}


### PR DESCRIPTION
Close #481 by way of (1): "Transaction initiator retains the original PritmitiveWitness, upgrades it to the new block, and then attempts to make a new ProofCollection that can then be shared."

Fixes broken `PrimitiveWitness::validate`.