### PR TITLE
Streamline Transaction Creation Interface

### DIFF
--- a/src/bin/neptune-cli.rs
+++ b/src/bin/neptune-cli.rs
@@ -1322,8 +1322,7 @@ fn enter_seed_phrase_dialog() -> Result<SecretKeyMaterial> {
         if bip39::Language::English
             .wordlist()
             .get_words_by_prefix("")
-            .iter()
-            .any(|s| *s == word)
+            .contains(&word)
         {
             phrase.push(word.to_string());
             i += 1;

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -1963,7 +1963,7 @@ mod test {
                 .use_job_queue(&dummy_queue);
             let global_state = global_state_lock.lock_guard().await;
             global_state
-                .create_transaction_with_config(
+                .create_transaction(
                     vec![].into(),
                     fee,
                     in_seven_months,

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -1963,7 +1963,7 @@ mod test {
                 .use_job_queue(&dummy_queue);
             let global_state = global_state_lock.lock_guard().await;
             global_state
-                .create_transaction_with_prover_capability(
+                .create_transaction_with_config(
                     vec![].into(),
                     fee,
                     in_seven_months,

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -1963,14 +1963,10 @@ mod test {
                 .use_job_queue(&dummy_queue);
             let global_state = global_state_lock.lock_guard().await;
             global_state
-                .create_transaction(
-                    vec![].into(),
-                    fee,
-                    in_seven_months,
-                    &config,
-                )
+                .create_transaction(vec![].into(), fee, in_seven_months, &config)
                 .await
                 .unwrap()
+                .transaction
         }
 
         #[tokio::test]

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -1934,7 +1934,7 @@ mod test {
         use crate::models::blockchain::type_scripts::native_currency_amount::NativeCurrencyAmount;
         use crate::models::peer::transfer_transaction::TransactionProofQuality;
         use crate::models::proof_abstractions::timestamp::Timestamp;
-        use crate::models::state::wallet::utxo_notification::UtxoNotificationMedium;
+        use crate::models::state::tx_initiation_config::TxInitiationConfig;
 
         async fn tx_no_outputs(
             global_state_lock: &GlobalStateLock,
@@ -1956,20 +1956,21 @@ mod test {
                 .timestamp
                 + Timestamp::months(7);
 
+            let dummy_queue = TritonVmJobQueue::dummy();
+            let config = TxInitiationConfig::default()
+                .recover_change_off_chain(change_key.into())
+                .with_prover_capability(tx_proof_type)
+                .use_job_queue(&dummy_queue);
             let global_state = global_state_lock.lock_guard().await;
             global_state
                 .create_transaction_with_prover_capability(
                     vec![].into(),
-                    change_key.into(),
-                    UtxoNotificationMedium::OffChain,
                     fee,
                     in_seven_months,
-                    tx_proof_type,
-                    &TritonVmJobQueue::dummy(),
+                    &config,
                 )
                 .await
                 .unwrap()
-                .0
         }
 
         #[tokio::test]

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -1934,7 +1934,7 @@ mod test {
         use crate::models::blockchain::type_scripts::native_currency_amount::NativeCurrencyAmount;
         use crate::models::peer::transfer_transaction::TransactionProofQuality;
         use crate::models::proof_abstractions::timestamp::Timestamp;
-        use crate::models::state::tx_initiation_config::TxInitiationConfig;
+        use crate::models::state::tx_creation_config::TxCreationConfig;
 
         async fn tx_no_outputs(
             global_state_lock: &GlobalStateLock,
@@ -1957,7 +1957,7 @@ mod test {
                 + Timestamp::months(7);
 
             let dummy_queue = TritonVmJobQueue::dummy();
-            let config = TxInitiationConfig::default()
+            let config = TxCreationConfig::default()
                 .recover_change_off_chain(change_key.into())
                 .with_prover_capability(tx_proof_type)
                 .use_job_queue(&dummy_queue);

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -1963,7 +1963,7 @@ mod test {
                 .use_job_queue(&dummy_queue);
             let global_state = global_state_lock.lock_guard().await;
             global_state
-                .create_transaction(vec![].into(), fee, in_seven_months, &config)
+                .create_transaction(vec![].into(), fee, in_seven_months, config)
                 .await
                 .unwrap()
                 .transaction

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -180,7 +180,7 @@ fn precalculate_kernel_ap(block_kernel: &BlockKernel) -> [Digest; BlockKernel::M
 ///
 /// Returns those MAST nodes that can be precalculated prior to PoW-guessing.
 /// This vastly reduces the amount of hashing needed for each PoW-guess.
-fn precalculate_block_auth_paths(
+pub(crate) fn precalculate_block_auth_paths(
     block_template: &Block,
 ) -> (
     [Digest; BlockKernel::MAST_HEIGHT],

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -958,7 +958,7 @@ pub(crate) mod mine_loop_tests {
     use crate::models::proof_abstractions::timestamp::Timestamp;
     use crate::models::proof_abstractions::verifier::verify;
     use crate::models::state::mempool::TransactionOrigin;
-    use crate::models::state::tx_initiation_config::TxInitiationConfig;
+    use crate::models::state::tx_creation_config::TxCreationConfig;
     use crate::models::state::wallet::transaction_output::TxOutput;
     use crate::tests::shared::dummy_expected_utxo;
     use crate::tests::shared::invalid_empty_block;
@@ -1191,7 +1191,7 @@ pub(crate) mod mine_loop_tests {
             false,
         );
         let dummy_queue = TritonVmJobQueue::dummy();
-        let config = TxInitiationConfig::default()
+        let config = TxCreationConfig::default()
             .recover_change_off_chain(alice_key.into())
             .with_prover_capability(TxProvingCapability::SingleProof)
             .use_job_queue(&dummy_queue);

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -1202,7 +1202,7 @@ pub(crate) mod mine_loop_tests {
                 vec![output_to_alice].into(),
                 NativeCurrencyAmount::coins(1),
                 now,
-                &config,
+                config,
             )
             .await
             .unwrap()

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -1198,7 +1198,7 @@ pub(crate) mod mine_loop_tests {
         let tx_from_alice = alice
             .lock_guard()
             .await
-            .create_transaction_with_config(
+            .create_transaction(
                 vec![output_to_alice].into(),
                 NativeCurrencyAmount::coins(1),
                 now,

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -1198,7 +1198,7 @@ pub(crate) mod mine_loop_tests {
         let tx_from_alice = alice
             .lock_guard()
             .await
-            .create_transaction_with_prover_capability(
+            .create_transaction_with_config(
                 vec![output_to_alice].into(),
                 NativeCurrencyAmount::coins(1),
                 now,

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -387,7 +387,7 @@ pub(crate) async fn make_coinbase_transaction_stateless(
     info!("Start: generate single proof for coinbase transaction");
     let config = TxCreationConfig::default()
         .use_job_queue(vm_job_queue)
-        .with_prover_job_options(job_options.job_priority, 11)
+        .with_proof_job_options(job_options)
         .with_prover_capability(proving_power);
     let transaction = GlobalState::create_raw_transaction(&transaction_details, config).await?;
     info!("Done: generating single proof for coinbase transaction");

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -1205,7 +1205,8 @@ pub(crate) mod mine_loop_tests {
                 &config,
             )
             .await
-            .unwrap();
+            .unwrap()
+            .transaction;
 
         let mut cli = cli_args::Args::default();
         for guesser_fee_fraction in [0f64, 0.5, 1.0] {

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -1911,10 +1911,14 @@ pub(crate) mod block_tests {
             print_block_size_statistics(block_size_statistics(&block));
             println!();
 
+            let block_is_valid = block
+                .is_valid_internal(blocks.last().unwrap(), now, None, None)
+                .await;
             println!(
-                "block is valid? {}",
-                block.is_valid(blocks.last().unwrap(), now).await
+                "block is valid? {:?}",
+                block_is_valid.map(|_| "yes".to_string())
             );
+            assert!(block_is_valid.is_ok());
 
             // update state with new block
             alice.set_new_tip(block.clone()).await.unwrap();

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -1327,12 +1327,7 @@ pub(crate) mod block_tests {
                 let tx2 = alice
                     .lock_guard_mut()
                     .await
-                    .create_transaction_with_config(
-                        outputs.into(),
-                        fee,
-                        plus_eight_months,
-                        &config2,
-                    )
+                    .create_transaction(outputs.into(), fee, plus_eight_months, &config2)
                     .await
                     .unwrap();
                 let block2_tx = coinbase_for_block2
@@ -1384,7 +1379,7 @@ pub(crate) mod block_tests {
                 let tx3 = alice
                     .lock_guard_mut()
                     .await
-                    .create_transaction_with_config(
+                    .create_transaction(
                         vec![output_to_self.clone()].into(),
                         fee,
                         plus_nine_months,
@@ -1668,12 +1663,7 @@ pub(crate) mod block_tests {
             let tx1 = alice
                 .lock_guard()
                 .await
-                .create_transaction_with_config(
-                    vec![output.clone()].into(),
-                    fee,
-                    in_seven_months,
-                    &config,
-                )
+                .create_transaction(vec![output.clone()].into(), fee, in_seven_months, &config)
                 .await
                 .unwrap();
 
@@ -1688,7 +1678,7 @@ pub(crate) mod block_tests {
             let tx2 = alice
                 .lock_guard()
                 .await
-                .create_transaction_with_config(vec![output].into(), fee, in_eight_months, &config2)
+                .create_transaction(vec![output].into(), fee, in_eight_months, &config2)
                 .await
                 .unwrap();
 
@@ -1867,12 +1857,7 @@ pub(crate) mod block_tests {
                 let self_spending_transaction = alice
                     .lock_guard_mut()
                     .await
-                    .create_transaction_with_config(
-                        tx_outputs,
-                        NativeCurrencyAmount::coins(0),
-                        now,
-                        &config,
-                    )
+                    .create_transaction(tx_outputs, NativeCurrencyAmount::coins(0), now, &config)
                     .await
                     .unwrap();
 

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -1863,7 +1863,7 @@ pub(crate) mod block_tests {
                     .create_transaction_with_prover_capability(
                         tx_outputs,
                         change_key.into(),
-                        UtxoNotificationMedium::OffChain,
+                        UtxoNotificationMedium::OnChain,
                         NativeCurrencyAmount::coins(0),
                         now,
                         TxProvingCapability::SingleProof,

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -1329,7 +1329,8 @@ pub(crate) mod block_tests {
                     .await
                     .create_transaction(outputs.into(), fee, plus_eight_months, &config2)
                     .await
-                    .unwrap();
+                    .unwrap()
+                    .transaction;
                 let block2_tx = coinbase_for_block2
                     .clone()
                     .merge_with(
@@ -1386,7 +1387,8 @@ pub(crate) mod block_tests {
                         &config3,
                     )
                     .await
-                    .unwrap();
+                    .unwrap()
+                    .transaction;
                 let block3_tx = coinbase_for_block3
                     .clone()
                     .merge_with(
@@ -1665,7 +1667,8 @@ pub(crate) mod block_tests {
                 .await
                 .create_transaction(vec![output.clone()].into(), fee, in_seven_months, &config)
                 .await
-                .unwrap();
+                .unwrap()
+                .transaction;
 
             let block1 =
                 Block::block_template_invalid_proof(&genesis_block, tx1, in_seven_months, None);
@@ -1680,7 +1683,8 @@ pub(crate) mod block_tests {
                 .await
                 .create_transaction(vec![output].into(), fee, in_eight_months, &config2)
                 .await
-                .unwrap();
+                .unwrap()
+                .transaction;
 
             let block2 = Block::block_template_invalid_proof(&block1, tx2, in_eight_months, None);
 
@@ -1860,7 +1864,8 @@ pub(crate) mod block_tests {
                     .await
                     .create_transaction(tx_outputs, NativeCurrencyAmount::coins(0), now, &config)
                     .await
-                    .unwrap();
+                    .unwrap()
+                    .transaction;
 
                 // merge that transaction in
                 transaction = transaction

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -1327,7 +1327,7 @@ pub(crate) mod block_tests {
                 let tx2 = alice
                     .lock_guard_mut()
                     .await
-                    .create_transaction(outputs.into(), fee, plus_eight_months, &config2)
+                    .create_transaction(outputs.into(), fee, plus_eight_months, config2)
                     .await
                     .unwrap()
                     .transaction;
@@ -1384,7 +1384,7 @@ pub(crate) mod block_tests {
                         vec![output_to_self.clone()].into(),
                         fee,
                         plus_nine_months,
-                        &config3,
+                        config3,
                     )
                     .await
                     .unwrap()
@@ -1658,14 +1658,14 @@ pub(crate) mod block_tests {
             );
             let fee = NativeCurrencyAmount::coins(1);
             let dummy_queue = TritonVmJobQueue::dummy();
-            let config = TxCreationConfig::default()
+            let config1 = TxCreationConfig::default()
                 .recover_change_on_chain(alice_key.into())
                 .with_prover_capability(TxProvingCapability::PrimitiveWitness)
                 .use_job_queue(&dummy_queue);
             let tx1 = alice
                 .lock_guard()
                 .await
-                .create_transaction(vec![output.clone()].into(), fee, in_seven_months, &config)
+                .create_transaction(vec![output.clone()].into(), fee, in_seven_months, config1)
                 .await
                 .unwrap()
                 .transaction;
@@ -1681,7 +1681,7 @@ pub(crate) mod block_tests {
             let tx2 = alice
                 .lock_guard()
                 .await
-                .create_transaction(vec![output].into(), fee, in_eight_months, &config2)
+                .create_transaction(vec![output].into(), fee, in_eight_months, config2)
                 .await
                 .unwrap()
                 .transaction;
@@ -1862,7 +1862,7 @@ pub(crate) mod block_tests {
                 let self_spending_transaction = alice
                     .lock_guard_mut()
                     .await
-                    .create_transaction(tx_outputs, NativeCurrencyAmount::coins(0), now, &config)
+                    .create_transaction(tx_outputs, NativeCurrencyAmount::coins(0), now, config)
                     .await
                     .unwrap()
                     .transaction;

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -1791,6 +1791,7 @@ pub(crate) mod block_tests {
     ///
     /// Create block i that spends i inputs. Do this indefinitely. Report on
     /// block size statistics.
+    #[ignore = "informational; not testing anything"]
     #[tokio::test]
     async fn block_size_limit() {
         let mut rng = StdRng::seed_from_u64(893423984854);

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -1013,6 +1013,7 @@ impl Block {
 #[cfg(test)]
 pub(crate) mod block_tests {
     use std::collections::HashMap;
+    use std::collections::HashSet;
 
     use bytesize::ByteSize;
     use rand::random;
@@ -1037,6 +1038,7 @@ pub(crate) mod block_tests {
     use crate::models::state::tx_proving_capability::TxProvingCapability;
     use crate::models::state::wallet::address::KeyType;
     use crate::models::state::wallet::transaction_output::TxOutput;
+    use crate::models::state::wallet::wallet_state::StrongUtxoKey;
     use crate::models::state::wallet::WalletSecret;
     use crate::tests::shared::fake_valid_successor_for_tests;
     use crate::tests::shared::invalid_block_with_transaction;
@@ -1831,6 +1833,7 @@ pub(crate) mod block_tests {
             .unwrap();
 
             // for all own UTXOs, spend to self
+            let mut avoidable_utxos = HashSet::new();
             for _ in 0..i {
                 // create a transaction spending it to self
                 let change_key = alice

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -1816,6 +1816,7 @@ pub(crate) mod block_tests {
 
         let mut blocks = vec![genesis_block];
 
+        now += Timestamp::months(6);
         for i in 1..100 {
             now += TARGET_BLOCK_INTERVAL;
 
@@ -1905,13 +1906,18 @@ pub(crate) mod block_tests {
             }
             block.set_header_nonce(nonce);
 
-            // update state with new block
-            alice.set_new_tip(block.clone()).await.unwrap();
-
             // report size statistics
             println!("Mined block {i} with {i} inputs and {i} outputs:");
             print_block_size_statistics(block_size_statistics(&block));
             println!();
+
+            println!(
+                "block is valid? {}",
+                block.is_valid(blocks.last().unwrap(), now).await
+            );
+
+            // update state with new block
+            alice.set_new_tip(block.clone()).await.unwrap();
 
             blocks.push(block);
         }

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -1033,7 +1033,7 @@ pub(crate) mod block_tests {
     use crate::mine_loop::fast_kernel_mast_hash;
     use crate::mine_loop::mine_loop_tests::make_coinbase_transaction_from_state;
     use crate::mine_loop::precalculate_block_auth_paths;
-    use crate::models::state::tx_initiation_config::TxInitiationConfig;
+    use crate::models::state::tx_creation_config::TxCreationConfig;
     use crate::models::state::tx_proving_capability::TxProvingCapability;
     use crate::models::state::wallet::address::KeyType;
     use crate::models::state::wallet::transaction_output::TxOutput;
@@ -1249,7 +1249,7 @@ pub(crate) mod block_tests {
         use super::*;
         use crate::job_queue::triton_vm::TritonVmJobPriority;
         use crate::mine_loop::mine_loop_tests::make_coinbase_transaction_from_state;
-        use crate::models::state::tx_initiation_config::TxInitiationConfig;
+        use crate::models::state::tx_creation_config::TxCreationConfig;
         use crate::models::state::wallet::address::KeyType;
         use crate::tests::shared::fake_valid_successor_for_tests;
 
@@ -1320,7 +1320,7 @@ pub(crate) mod block_tests {
                 alice.set_new_tip(block1.clone()).await.unwrap();
                 let outputs = vec![output_to_self.clone(); i];
                 let dummy_queue = TritonVmJobQueue::dummy();
-                let config2 = TxInitiationConfig::default()
+                let config2 = TxCreationConfig::default()
                     .recover_change_on_chain(alice_key)
                     .with_prover_capability(TxProvingCapability::SingleProof)
                     .use_job_queue(&dummy_queue);
@@ -1377,7 +1377,7 @@ pub(crate) mod block_tests {
                 )
                 .await
                 .unwrap();
-                let config3 = TxInitiationConfig::default()
+                let config3 = TxCreationConfig::default()
                     .recover_change_on_chain(alice_key)
                     .with_prover_capability(TxProvingCapability::SingleProof)
                     .use_job_queue(&dummy_queue);
@@ -1562,7 +1562,7 @@ pub(crate) mod block_tests {
 
     mod guesser_fee_utxos {
         use super::*;
-        use crate::models::state::tx_initiation_config::TxInitiationConfig;
+        use crate::models::state::tx_creation_config::TxCreationConfig;
         use crate::models::state::wallet::address::generation_address::GenerationSpendingKey;
         use crate::tests::shared::make_mock_block_guesser_preimage_and_guesser_fraction;
 
@@ -1661,7 +1661,7 @@ pub(crate) mod block_tests {
             );
             let fee = NativeCurrencyAmount::coins(1);
             let dummy_queue = TritonVmJobQueue::dummy();
-            let config = TxInitiationConfig::default()
+            let config = TxCreationConfig::default()
                 .recover_change_on_chain(alice_key.into())
                 .with_prover_capability(TxProvingCapability::PrimitiveWitness)
                 .use_job_queue(&dummy_queue);
@@ -1681,7 +1681,7 @@ pub(crate) mod block_tests {
                 Block::block_template_invalid_proof(&genesis_block, tx1, in_seven_months, None);
             alice.set_new_tip(block1.clone()).await.unwrap();
 
-            let config2 = TxInitiationConfig::default()
+            let config2 = TxCreationConfig::default()
                 .recover_change_on_chain(alice_key.into())
                 .with_prover_capability(TxProvingCapability::PrimitiveWitness)
                 .use_job_queue(&dummy_queue);
@@ -1865,7 +1865,7 @@ pub(crate) mod block_tests {
                     true,
                 )]
                 .into();
-                let config = TxInitiationConfig::default()
+                let config = TxCreationConfig::default()
                     .recover_change_on_chain(change_key.into())
                     .with_prover_capability(TxProvingCapability::SingleProof)
                     .use_job_queue(&job_queue);

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -1327,7 +1327,7 @@ pub(crate) mod block_tests {
                 let tx2 = alice
                     .lock_guard_mut()
                     .await
-                    .create_transaction_with_prover_capability(
+                    .create_transaction_with_config(
                         outputs.into(),
                         fee,
                         plus_eight_months,
@@ -1384,7 +1384,7 @@ pub(crate) mod block_tests {
                 let tx3 = alice
                     .lock_guard_mut()
                     .await
-                    .create_transaction_with_prover_capability(
+                    .create_transaction_with_config(
                         vec![output_to_self.clone()].into(),
                         fee,
                         plus_nine_months,
@@ -1668,7 +1668,7 @@ pub(crate) mod block_tests {
             let tx1 = alice
                 .lock_guard()
                 .await
-                .create_transaction_with_prover_capability(
+                .create_transaction_with_config(
                     vec![output.clone()].into(),
                     fee,
                     in_seven_months,
@@ -1688,12 +1688,7 @@ pub(crate) mod block_tests {
             let tx2 = alice
                 .lock_guard()
                 .await
-                .create_transaction_with_prover_capability(
-                    vec![output].into(),
-                    fee,
-                    in_eight_months,
-                    &config2,
-                )
+                .create_transaction_with_config(vec![output].into(), fee, in_eight_months, &config2)
                 .await
                 .unwrap();
 
@@ -1872,7 +1867,7 @@ pub(crate) mod block_tests {
                 let self_spending_transaction = alice
                     .lock_guard_mut()
                     .await
-                    .create_transaction_with_prover_capability(
+                    .create_transaction_with_config(
                         tx_outputs,
                         NativeCurrencyAmount::coins(0),
                         now,

--- a/src/models/blockchain/block/validity/block_program.rs
+++ b/src/models/blockchain/block/validity/block_program.rs
@@ -520,7 +520,7 @@ pub(crate) mod test {
         let tx = alice
             .lock_guard()
             .await
-            .create_transaction_with_prover_capability(vec![tx_output].into(), fee, now, &config)
+            .create_transaction_with_config(vec![tx_output].into(), fee, now, &config)
             .await
             .unwrap();
         let block1 = mine_tx(&alice, tx.clone(), &genesis_block, now).await;

--- a/src/models/blockchain/block/validity/block_program.rs
+++ b/src/models/blockchain/block/validity/block_program.rs
@@ -522,7 +522,8 @@ pub(crate) mod test {
             .await
             .create_transaction(vec![tx_output].into(), fee, now, &config)
             .await
-            .unwrap();
+            .unwrap()
+            .transaction;
         let block1 = mine_tx(&alice, tx.clone(), &genesis_block, now).await;
 
         // Update transaction, stick it into block 2, and verify that block 2

--- a/src/models/blockchain/block/validity/block_program.rs
+++ b/src/models/blockchain/block/validity/block_program.rs
@@ -351,9 +351,9 @@ pub(crate) mod test {
     use crate::models::proof_abstractions::tasm::program::test::ConsensusProgramSpecification;
     use crate::models::proof_abstractions::timestamp::Timestamp;
     use crate::models::proof_abstractions::SecretWitness;
+    use crate::models::state::tx_initiation_config::TxInitiationConfig;
     use crate::models::state::tx_proving_capability::TxProvingCapability;
     use crate::models::state::wallet::transaction_output::TxOutput;
-    use crate::models::state::wallet::utxo_notification::UtxoNotificationMedium;
     use crate::models::state::wallet::WalletSecret;
     use crate::tests::shared::mock_genesis_global_state;
     use crate::GlobalStateLock;
@@ -512,18 +512,15 @@ pub(crate) mod test {
 
         let genesis_block = Block::genesis(network);
         let now = genesis_block.header().timestamp + Timestamp::months(12);
-        let (tx, _, _) = alice
+        let dummy_queue = TritonVmJobQueue::dummy();
+        let config = TxInitiationConfig::default()
+            .recover_change_off_chain(alice_key.into())
+            .with_prover_capability(TxProvingCapability::SingleProof)
+            .use_job_queue(&dummy_queue);
+        let tx = alice
             .lock_guard()
             .await
-            .create_transaction_with_prover_capability(
-                vec![tx_output].into(),
-                alice_key.into(),
-                UtxoNotificationMedium::OffChain,
-                fee,
-                now,
-                TxProvingCapability::SingleProof,
-                &TritonVmJobQueue::dummy(),
-            )
+            .create_transaction_with_prover_capability(vec![tx_output].into(), fee, now, &config)
             .await
             .unwrap();
         let block1 = mine_tx(&alice, tx.clone(), &genesis_block, now).await;

--- a/src/models/blockchain/block/validity/block_program.rs
+++ b/src/models/blockchain/block/validity/block_program.rs
@@ -520,7 +520,7 @@ pub(crate) mod test {
         let tx = alice
             .lock_guard()
             .await
-            .create_transaction(vec![tx_output].into(), fee, now, &config)
+            .create_transaction(vec![tx_output].into(), fee, now, config)
             .await
             .unwrap()
             .transaction;

--- a/src/models/blockchain/block/validity/block_program.rs
+++ b/src/models/blockchain/block/validity/block_program.rs
@@ -520,7 +520,7 @@ pub(crate) mod test {
         let tx = alice
             .lock_guard()
             .await
-            .create_transaction_with_config(vec![tx_output].into(), fee, now, &config)
+            .create_transaction(vec![tx_output].into(), fee, now, &config)
             .await
             .unwrap();
         let block1 = mine_tx(&alice, tx.clone(), &genesis_block, now).await;

--- a/src/models/blockchain/block/validity/block_program.rs
+++ b/src/models/blockchain/block/validity/block_program.rs
@@ -351,7 +351,7 @@ pub(crate) mod test {
     use crate::models::proof_abstractions::tasm::program::test::ConsensusProgramSpecification;
     use crate::models::proof_abstractions::timestamp::Timestamp;
     use crate::models::proof_abstractions::SecretWitness;
-    use crate::models::state::tx_initiation_config::TxInitiationConfig;
+    use crate::models::state::tx_creation_config::TxCreationConfig;
     use crate::models::state::tx_proving_capability::TxProvingCapability;
     use crate::models::state::wallet::transaction_output::TxOutput;
     use crate::models::state::wallet::WalletSecret;
@@ -513,7 +513,7 @@ pub(crate) mod test {
         let genesis_block = Block::genesis(network);
         let now = genesis_block.header().timestamp + Timestamp::months(12);
         let dummy_queue = TritonVmJobQueue::dummy();
-        let config = TxInitiationConfig::default()
+        let config = TxCreationConfig::default()
             .recover_change_off_chain(alice_key.into())
             .with_prover_capability(TxProvingCapability::SingleProof)
             .use_job_queue(&dummy_queue);

--- a/src/models/state/archival_state.rs
+++ b/src/models/state/archival_state.rs
@@ -1162,7 +1162,7 @@ mod archival_state_tests {
     use crate::models::blockchain::type_scripts::native_currency_amount::NativeCurrencyAmount;
     use crate::models::proof_abstractions::timestamp::Timestamp;
     use crate::models::state::archival_state::ArchivalState;
-    use crate::models::state::tx_initiation_config::TxInitiationConfig;
+    use crate::models::state::tx_creation_config::TxCreationConfig;
     use crate::models::state::tx_proving_capability::TxProvingCapability;
     use crate::models::state::wallet::address::KeyType;
     use crate::models::state::wallet::expected_utxo::UtxoNotifier;
@@ -1355,7 +1355,7 @@ mod archival_state_tests {
         let tx_output_anyone_can_spend =
             TxOutput::no_notification(utxo, rng.random(), rng.random(), false);
         let dummy_queue = TritonVmJobQueue::dummy();
-        let config = TxInitiationConfig::default()
+        let config = TxCreationConfig::default()
             .recover_change_on_chain(alice_key.into())
             .with_prover_capability(TxProvingCapability::PrimitiveWitness)
             .use_job_queue(&dummy_queue);
@@ -1463,7 +1463,7 @@ mod archival_state_tests {
 
         let in_seven_months = Timestamp::now() + Timestamp::months(7);
         let dummy_queue = TritonVmJobQueue::dummy();
-        let config_1a = TxInitiationConfig::default()
+        let config_1a = TxCreationConfig::default()
             .recover_change_on_chain(alice_key.into())
             .with_prover_capability(TxProvingCapability::PrimitiveWitness)
             .use_job_queue(&dummy_queue);
@@ -1480,7 +1480,7 @@ mod archival_state_tests {
             .unwrap();
         let block_1a = invalid_block_with_transaction(&genesis_block, big_tx);
 
-        let config_1b = TxInitiationConfig::default()
+        let config_1b = TxCreationConfig::default()
             .recover_change_on_chain(alice_key.into())
             .with_prover_capability(TxProvingCapability::PrimitiveWitness)
             .use_job_queue(&dummy_queue);
@@ -1567,7 +1567,7 @@ mod archival_state_tests {
         let dummy_queue = TritonVmJobQueue::dummy();
         for _ in 0..num_blocks {
             let timestamp = previous_block.header().timestamp + Timestamp::months(7);
-            let config = TxInitiationConfig::default()
+            let config = TxCreationConfig::default()
                 .recover_change_on_chain(alice_key.into())
                 .with_prover_capability(TxProvingCapability::PrimitiveWitness)
                 .use_job_queue(&dummy_queue);
@@ -1813,7 +1813,7 @@ mod archival_state_tests {
             .await
             .unwrap();
         let dummy_queue = TritonVmJobQueue::dummy();
-        let config = TxInitiationConfig::default()
+        let config = TxCreationConfig::default()
             .recover_change_off_chain(change_key)
             .with_prover_capability(TxProvingCapability::SingleProof)
             .use_job_queue(&dummy_queue);
@@ -2020,7 +2020,7 @@ mod archival_state_tests {
             .wallet_secret
             .nth_symmetric_key_for_tests(0)
             .into();
-        let config_alice = TxInitiationConfig::default()
+        let config_alice = TxCreationConfig::default()
             .recover_change_off_chain(alice_change_key)
             .with_prover_capability(TxProvingCapability::SingleProof)
             .use_job_queue(&dummy_queue);
@@ -2067,7 +2067,7 @@ mod archival_state_tests {
             .wallet_secret
             .nth_symmetric_key_for_tests(0)
             .into();
-        let config_bob = TxInitiationConfig::default()
+        let config_bob = TxCreationConfig::default()
             .recover_change_off_chain(bob_change_key)
             .with_prover_capability(TxProvingCapability::SingleProof)
             .use_job_queue(&dummy_queue);

--- a/src/models/state/archival_state.rs
+++ b/src/models/state/archival_state.rs
@@ -1362,7 +1362,7 @@ mod archival_state_tests {
         let sender_tx = alice
             .lock_guard()
             .await
-            .create_transaction_with_prover_capability(
+            .create_transaction_with_config(
                 vec![tx_output_anyone_can_spend].into(),
                 NativeCurrencyAmount::coins(2),
                 in_seven_months,
@@ -1470,7 +1470,7 @@ mod archival_state_tests {
         let big_tx = alice
             .lock_guard()
             .await
-            .create_transaction_with_prover_capability(
+            .create_transaction_with_config(
                 outputs.clone().into(),
                 fee,
                 in_seven_months,
@@ -1487,12 +1487,7 @@ mod archival_state_tests {
         let empty_tx = alice
             .lock_guard()
             .await
-            .create_transaction_with_prover_capability(
-                vec![].into(),
-                fee,
-                in_seven_months,
-                &config_1b,
-            )
+            .create_transaction_with_config(vec![].into(), fee, in_seven_months, &config_1b)
             .await
             .unwrap();
         let block_1b = invalid_block_with_transaction(&genesis_block, empty_tx);
@@ -1574,12 +1569,7 @@ mod archival_state_tests {
             let tx = alice
                 .lock_guard()
                 .await
-                .create_transaction_with_prover_capability(
-                    outputs.clone().into(),
-                    fee,
-                    timestamp,
-                    &config,
-                )
+                .create_transaction_with_config(outputs.clone().into(), fee, timestamp, &config)
                 .await
                 .unwrap();
             let next_block = invalid_block_with_transaction(&previous_block, tx);
@@ -1820,7 +1810,7 @@ mod archival_state_tests {
         let tx_to_alice_and_bob = premine_rec
             .lock_guard()
             .await
-            .create_transaction_with_prover_capability(
+            .create_transaction_with_config(
                 [
                     receiver_data_for_alice.clone(),
                     receiver_data_for_bob.clone(),
@@ -2027,7 +2017,7 @@ mod archival_state_tests {
         let tx_from_alice = alice
             .lock_guard()
             .await
-            .create_transaction_with_prover_capability(
+            .create_transaction_with_config(
                 outputs_from_alice.clone(),
                 NativeCurrencyAmount::coins(1),
                 in_seven_months,
@@ -2074,7 +2064,7 @@ mod archival_state_tests {
         let tx_from_bob = bob
             .lock_guard()
             .await
-            .create_transaction_with_prover_capability(
+            .create_transaction_with_config(
                 outputs_from_bob.clone(),
                 NativeCurrencyAmount::coins(1),
                 in_seven_months,

--- a/src/models/state/archival_state.rs
+++ b/src/models/state/archival_state.rs
@@ -1366,7 +1366,7 @@ mod archival_state_tests {
                 vec![tx_output_anyone_can_spend].into(),
                 NativeCurrencyAmount::coins(2),
                 in_seven_months,
-                &config,
+                config,
             )
             .await
             .unwrap()
@@ -1471,7 +1471,7 @@ mod archival_state_tests {
         let big_tx = alice
             .lock_guard()
             .await
-            .create_transaction(outputs.clone().into(), fee, in_seven_months, &config_1a)
+            .create_transaction(outputs.clone().into(), fee, in_seven_months, config_1a)
             .await
             .unwrap()
             .transaction;
@@ -1484,7 +1484,7 @@ mod archival_state_tests {
         let empty_tx = alice
             .lock_guard()
             .await
-            .create_transaction(vec![].into(), fee, in_seven_months, &config_1b)
+            .create_transaction(vec![].into(), fee, in_seven_months, config_1b)
             .await
             .unwrap()
             .transaction;
@@ -1567,7 +1567,7 @@ mod archival_state_tests {
             let tx = alice
                 .lock_guard()
                 .await
-                .create_transaction(outputs.clone().into(), fee, timestamp, &config)
+                .create_transaction(outputs.clone().into(), fee, timestamp, config)
                 .await
                 .unwrap()
                 .transaction;
@@ -1818,7 +1818,7 @@ mod archival_state_tests {
                 .into(),
                 fee,
                 in_seven_months,
-                &config,
+                config,
             )
             .await
             .unwrap();
@@ -2021,7 +2021,7 @@ mod archival_state_tests {
                 outputs_from_alice.clone(),
                 NativeCurrencyAmount::coins(1),
                 in_seven_months,
-                &config_alice,
+                config_alice,
             )
             .await
             .unwrap();
@@ -2069,7 +2069,7 @@ mod archival_state_tests {
                 outputs_from_bob.clone(),
                 NativeCurrencyAmount::coins(1),
                 in_seven_months,
-                &config_bob,
+                config_bob,
             )
             .await
             .unwrap();

--- a/src/models/state/archival_state.rs
+++ b/src/models/state/archival_state.rs
@@ -1369,7 +1369,8 @@ mod archival_state_tests {
                 &config,
             )
             .await
-            .unwrap();
+            .unwrap()
+            .transaction;
 
         let mock_block_2 =
             Block::block_template_invalid_proof(&block1, sender_tx, in_seven_months, None);
@@ -1472,7 +1473,8 @@ mod archival_state_tests {
             .await
             .create_transaction(outputs.clone().into(), fee, in_seven_months, &config_1a)
             .await
-            .unwrap();
+            .unwrap()
+            .transaction;
         let block_1a = invalid_block_with_transaction(&genesis_block, big_tx);
 
         let config_1b = TxCreationConfig::default()
@@ -1484,7 +1486,8 @@ mod archival_state_tests {
             .await
             .create_transaction(vec![].into(), fee, in_seven_months, &config_1b)
             .await
-            .unwrap();
+            .unwrap()
+            .transaction;
         let block_1b = invalid_block_with_transaction(&genesis_block, empty_tx);
 
         alice.set_new_tip(block_1a.clone()).await.unwrap();
@@ -1566,7 +1569,8 @@ mod archival_state_tests {
                 .await
                 .create_transaction(outputs.clone().into(), fee, timestamp, &config)
                 .await
-                .unwrap();
+                .unwrap()
+                .transaction;
             let next_block = invalid_block_with_transaction(&previous_block, tx);
 
             // 2. Update archival-mutator set with produced block
@@ -1802,7 +1806,7 @@ mod archival_state_tests {
             .recover_change_off_chain(change_key)
             .with_prover_capability(TxProvingCapability::SingleProof)
             .use_job_queue(&dummy_queue);
-        let tx_to_alice_and_bob = premine_rec
+        let artifacts_alice_and_bob = premine_rec
             .lock_guard()
             .await
             .create_transaction(
@@ -1818,7 +1822,8 @@ mod archival_state_tests {
             )
             .await
             .unwrap();
-        let change_utxo = config.change_output();
+        let tx_to_alice_and_bob = artifacts_alice_and_bob.transaction;
+        let change_utxo = artifacts_alice_and_bob.change_output;
         println!("Generated transaction for Alice and Bob.");
 
         let guesser_fraction = 0f64;
@@ -2009,7 +2014,7 @@ mod archival_state_tests {
             .recover_change_off_chain(alice_change_key)
             .with_prover_capability(TxProvingCapability::SingleProof)
             .use_job_queue(&dummy_queue);
-        let tx_from_alice = alice
+        let artifacts_alice = alice
             .lock_guard()
             .await
             .create_transaction(
@@ -2020,8 +2025,9 @@ mod archival_state_tests {
             )
             .await
             .unwrap();
+        let tx_from_alice = artifacts_alice.transaction;
         assert!(
-            config_alice.change_output().is_none(),
+            artifacts_alice.change_output.is_none(),
             "no change when consuming entire balance"
         );
         let outputs_from_bob: TxOutputList = vec![
@@ -2056,7 +2062,7 @@ mod archival_state_tests {
             .recover_change_off_chain(bob_change_key)
             .with_prover_capability(TxProvingCapability::SingleProof)
             .use_job_queue(&dummy_queue);
-        let tx_from_bob = bob
+        let tx_creation_artifacts_bob = bob
             .lock_guard()
             .await
             .create_transaction(
@@ -2067,8 +2073,9 @@ mod archival_state_tests {
             )
             .await
             .unwrap();
+        let tx_from_bob = tx_creation_artifacts_bob.transaction;
         assert!(
-            config_bob.change_output().is_none(),
+            tx_creation_artifacts_bob.change_output.is_none(),
             "no change when consuming entire balance"
         );
 

--- a/src/models/state/archival_state.rs
+++ b/src/models/state/archival_state.rs
@@ -1362,7 +1362,7 @@ mod archival_state_tests {
         let sender_tx = alice
             .lock_guard()
             .await
-            .create_transaction_with_config(
+            .create_transaction(
                 vec![tx_output_anyone_can_spend].into(),
                 NativeCurrencyAmount::coins(2),
                 in_seven_months,
@@ -1470,12 +1470,7 @@ mod archival_state_tests {
         let big_tx = alice
             .lock_guard()
             .await
-            .create_transaction_with_config(
-                outputs.clone().into(),
-                fee,
-                in_seven_months,
-                &config_1a,
-            )
+            .create_transaction(outputs.clone().into(), fee, in_seven_months, &config_1a)
             .await
             .unwrap();
         let block_1a = invalid_block_with_transaction(&genesis_block, big_tx);
@@ -1487,7 +1482,7 @@ mod archival_state_tests {
         let empty_tx = alice
             .lock_guard()
             .await
-            .create_transaction_with_config(vec![].into(), fee, in_seven_months, &config_1b)
+            .create_transaction(vec![].into(), fee, in_seven_months, &config_1b)
             .await
             .unwrap();
         let block_1b = invalid_block_with_transaction(&genesis_block, empty_tx);
@@ -1569,7 +1564,7 @@ mod archival_state_tests {
             let tx = alice
                 .lock_guard()
                 .await
-                .create_transaction_with_config(outputs.clone().into(), fee, timestamp, &config)
+                .create_transaction(outputs.clone().into(), fee, timestamp, &config)
                 .await
                 .unwrap();
             let next_block = invalid_block_with_transaction(&previous_block, tx);
@@ -1810,7 +1805,7 @@ mod archival_state_tests {
         let tx_to_alice_and_bob = premine_rec
             .lock_guard()
             .await
-            .create_transaction_with_config(
+            .create_transaction(
                 [
                     receiver_data_for_alice.clone(),
                     receiver_data_for_bob.clone(),
@@ -2017,7 +2012,7 @@ mod archival_state_tests {
         let tx_from_alice = alice
             .lock_guard()
             .await
-            .create_transaction_with_config(
+            .create_transaction(
                 outputs_from_alice.clone(),
                 NativeCurrencyAmount::coins(1),
                 in_seven_months,
@@ -2064,7 +2059,7 @@ mod archival_state_tests {
         let tx_from_bob = bob
             .lock_guard()
             .await
-            .create_transaction_with_config(
+            .create_transaction(
                 outputs_from_bob.clone(),
                 NativeCurrencyAmount::coins(1),
                 in_seven_months,

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -835,7 +835,7 @@ mod tests {
     use crate::models::blockchain::transaction::Transaction;
     use crate::models::blockchain::type_scripts::native_currency_amount::NativeCurrencyAmount;
     use crate::models::shared::SIZE_20MB_IN_BYTES;
-    use crate::models::state::tx_initiation_config::TxInitiationConfig;
+    use crate::models::state::tx_creation_config::TxCreationConfig;
     use crate::models::state::tx_proving_capability::TxProvingCapability;
     use crate::models::state::wallet::expected_utxo::UtxoNotifier;
     use crate::models::state::wallet::transaction_output::TxOutput;
@@ -988,7 +988,7 @@ mod tests {
         let in_seven_months = genesis_block.kernel.header.timestamp + Timestamp::months(7);
         let high_fee = NativeCurrencyAmount::coins(15);
         let dummy_job_queue = TritonVmJobQueue::dummy();
-        let config = TxInitiationConfig::default()
+        let config = TxCreationConfig::default()
             .recover_change(bob_spending_key.into(), UtxoNotificationMedium::OnChain)
             .with_prover_capability(TxProvingCapability::ProofCollection)
             .use_job_queue(&dummy_job_queue);
@@ -1144,7 +1144,7 @@ mod tests {
         let in_seven_months = now + Timestamp::months(7);
         let in_eight_months = now + Timestamp::months(8);
         let dummy_queue = TritonVmJobQueue::dummy();
-        let config_bob = TxInitiationConfig::default()
+        let config_bob = TxCreationConfig::default()
             .recover_change(bob_spending_key.into(), UtxoNotificationMedium::OnChain)
             .with_prover_capability(TxProvingCapability::SingleProof)
             .use_job_queue(&dummy_queue);
@@ -1187,7 +1187,7 @@ mod tests {
             true,
         )];
         let dummy_job_queue = TritonVmJobQueue::dummy();
-        let config_alice = TxInitiationConfig::default()
+        let config_alice = TxCreationConfig::default()
             .recover_change(alice_key.into(), UtxoNotificationMedium::OffChain)
             .with_prover_capability(TxProvingCapability::SingleProof)
             .use_job_queue(&dummy_job_queue);
@@ -1482,7 +1482,7 @@ mod tests {
         let now = genesis_block.kernel.header.timestamp;
         let in_seven_years = now + Timestamp::months(7 * 12);
         let dummy_queue = TritonVmJobQueue::dummy();
-        let config = TxInitiationConfig::default()
+        let config = TxCreationConfig::default()
             .recover_change(alice_key.into(), UtxoNotificationMedium::OffChain)
             .with_prover_capability(proving_capability)
             .use_job_queue(&dummy_queue);
@@ -1612,7 +1612,7 @@ mod tests {
                 );
                 let tx_outputs: TxOutputList = vec![receiver_data.clone()].into();
                 let dummy_queue = TritonVmJobQueue::dummy();
-                let config = TxInitiationConfig::default()
+                let config = TxCreationConfig::default()
                     .recover_change_on_chain(premine_spending_key.into())
                     .with_prover_capability(TxProvingCapability::ProofCollection)
                     .use_job_queue(&dummy_queue);
@@ -1817,7 +1817,7 @@ mod tests {
             .await;
             let in_seven_months = genesis_block.kernel.header.timestamp + Timestamp::months(7);
             let dummy_queue = TritonVmJobQueue::dummy();
-            let config = TxInitiationConfig::default()
+            let config = TxCreationConfig::default()
                 .recover_change_on_chain(bob_spending_key.into())
                 .with_prover_capability(proof_type)
                 .use_job_queue(&dummy_queue);

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -995,7 +995,7 @@ mod tests {
         let tx_by_bob = bob
             .lock_guard()
             .await
-            .create_transaction(vec![].into(), high_fee, in_seven_months, &config)
+            .create_transaction(vec![].into(), high_fee, in_seven_months, config)
             .await
             .unwrap()
             .transaction;
@@ -1151,7 +1151,7 @@ mod tests {
                 utxos_from_bob.clone(),
                 NativeCurrencyAmount::coins(1),
                 in_seven_months,
-                &config_bob,
+                config_bob,
             )
             .await
             .unwrap();
@@ -1195,7 +1195,7 @@ mod tests {
                 utxos_from_alice.into(),
                 NativeCurrencyAmount::coins(1),
                 in_seven_months,
-                &config_alice,
+                config_alice,
             )
             .await
             .unwrap()
@@ -1491,7 +1491,7 @@ mod tests {
                 vec![tx_receiver_data].into(),
                 NativeCurrencyAmount::coins(1),
                 in_seven_years,
-                &config,
+                config,
             )
             .await
             .unwrap()
@@ -1619,7 +1619,7 @@ mod tests {
                     .clone()
                     .lock_guard()
                     .await
-                    .create_transaction(tx_outputs.clone(), fee, in_seven_months, &config)
+                    .create_transaction(tx_outputs.clone(), fee, in_seven_months, config)
                     .await
                     .expect("producing proof collection should succeed")
             };
@@ -1821,7 +1821,7 @@ mod tests {
             let tx = bob
                 .lock_guard()
                 .await
-                .create_transaction(vec![].into(), fee, in_seven_months, &config)
+                .create_transaction(vec![].into(), fee, in_seven_months, config)
                 .await
                 .unwrap()
                 .transaction;

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -995,7 +995,7 @@ mod tests {
         let tx_by_bob = bob
             .lock_guard()
             .await
-            .create_transaction_with_config(
+            .create_transaction(
                 vec![].into(),
                 high_fee,
                 in_seven_months,
@@ -1151,7 +1151,7 @@ mod tests {
         let tx_by_bob = bob
             .lock_guard()
             .await
-            .create_transaction_with_config(
+            .create_transaction(
                 utxos_from_bob.clone(),
                 NativeCurrencyAmount::coins(1),
                 in_seven_months,
@@ -1194,7 +1194,7 @@ mod tests {
         let tx_from_alice_original = alice
             .lock_guard()
             .await
-            .create_transaction_with_config(
+            .create_transaction(
                 utxos_from_alice.into(),
                 NativeCurrencyAmount::coins(1),
                 in_seven_months,
@@ -1489,7 +1489,7 @@ mod tests {
         let unmined_tx = alice
             .lock_guard()
             .await
-            .create_transaction_with_config(
+            .create_transaction(
                 vec![tx_receiver_data].into(),
                 NativeCurrencyAmount::coins(1),
                 in_seven_years,
@@ -1620,7 +1620,7 @@ mod tests {
                     .clone()
                     .lock_guard()
                     .await
-                    .create_transaction_with_config(
+                    .create_transaction(
                         tx_outputs.clone(),
                         fee,
                         in_seven_months,
@@ -1824,7 +1824,7 @@ mod tests {
             let tx_by_bob = bob
                 .lock_guard()
                 .await
-                .create_transaction_with_config(
+                .create_transaction(
                     vec![].into(),
                     fee,
                     in_seven_months,

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -995,7 +995,7 @@ mod tests {
         let tx_by_bob = bob
             .lock_guard()
             .await
-            .create_transaction_with_prover_capability(
+            .create_transaction_with_config(
                 vec![].into(),
                 high_fee,
                 in_seven_months,
@@ -1151,7 +1151,7 @@ mod tests {
         let tx_by_bob = bob
             .lock_guard()
             .await
-            .create_transaction_with_prover_capability(
+            .create_transaction_with_config(
                 utxos_from_bob.clone(),
                 NativeCurrencyAmount::coins(1),
                 in_seven_months,
@@ -1194,7 +1194,7 @@ mod tests {
         let tx_from_alice_original = alice
             .lock_guard()
             .await
-            .create_transaction_with_prover_capability(
+            .create_transaction_with_config(
                 utxos_from_alice.into(),
                 NativeCurrencyAmount::coins(1),
                 in_seven_months,
@@ -1489,7 +1489,7 @@ mod tests {
         let unmined_tx = alice
             .lock_guard()
             .await
-            .create_transaction_with_prover_capability(
+            .create_transaction_with_config(
                 vec![tx_receiver_data].into(),
                 NativeCurrencyAmount::coins(1),
                 in_seven_years,
@@ -1620,7 +1620,7 @@ mod tests {
                     .clone()
                     .lock_guard()
                     .await
-                    .create_transaction_with_prover_capability(
+                    .create_transaction_with_config(
                         tx_outputs.clone(),
                         fee,
                         in_seven_months,
@@ -1824,7 +1824,7 @@ mod tests {
             let tx_by_bob = bob
                 .lock_guard()
                 .await
-                .create_transaction_with_prover_capability(
+                .create_transaction_with_config(
                     vec![].into(),
                     fee,
                     in_seven_months,

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -1818,14 +1818,17 @@ mod tests {
                 .recover_change_on_chain(bob_spending_key.into())
                 .with_prover_capability(proof_type)
                 .use_job_queue(&dummy_queue);
-            let tx = bob
+
+            // Clippy is wrong here. You can *not* eliminate the binding.
+            #[allow(clippy::let_and_return)]
+            let x = bob
                 .lock_guard()
                 .await
                 .create_transaction(vec![].into(), fee, in_seven_months, config)
                 .await
                 .unwrap()
                 .transaction;
-            tx
+            x
         }
 
         #[traced_test]

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -766,6 +766,7 @@ impl GlobalState {
                 tip_digest,
                 &tip_mutator_set_accumulator,
                 timestamp,
+                config.utxo_selector(),
             )
             .await?;
 

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -819,10 +819,8 @@ impl GlobalState {
         };
 
         // 2. Create the transaction
-        let config = config.with_prover_job_options(
-            TritonVmJobPriority::High,
-            self.cli.max_log2_padded_height_for_proofs.unwrap_or(11),
-        );
+        let proof_job_options = self.cli.proof_job_options(TritonVmJobPriority::High);
+        let config = config.with_proof_job_options(proof_job_options);
         let transaction = Self::create_raw_transaction(&transaction_details, config).await?;
 
         let transaction_creation_artifacts = TxCreationArtifacts {
@@ -889,9 +887,7 @@ impl GlobalState {
             bail!("No job queue supplied.");
         };
 
-        let Some(job_options) = config.triton_vm_proof_job_options() else {
-            bail!("No job options supplied.")
-        };
+        let job_options = config.proof_job_options();
 
         info!(
             "Start: generate proof for {}-in {}-out transaction",

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -8,6 +8,7 @@ pub mod networking_state;
 pub mod shared;
 pub(crate) mod transaction_details;
 pub(crate) mod transaction_kernel_id;
+pub(crate) mod tx_initiation_config;
 pub mod tx_proving_capability;
 pub mod wallet;
 
@@ -715,7 +716,11 @@ impl GlobalState {
     /// let mut tx_outputs = state.generate_tx_outputs(outputs, change_notify_medium)?;
     ///
     /// // Create the transaction
-    /// let (transaction, maybe_change_utxo) = state
+    /// let (
+    ///         transaction,
+    ///         transaction_details,
+    ///         maybe_change_utxo
+    ///     ) = state
     ///     .create_transaction(
     ///         tx_outputs,                     // all outputs except `change`
     ///         change_key,                     // send `change` to this key

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -46,6 +46,7 @@ use tx_creation_config::TxCreationConfig;
 use tx_proving_capability::TxProvingCapability;
 use wallet::address::ReceivingAddress;
 use wallet::address::SpendingKey;
+use wallet::wallet_state::StrongUtxoKey;
 use wallet::wallet_state::WalletState;
 use wallet::wallet_status::WalletStatus;
 
@@ -801,6 +802,15 @@ impl GlobalState {
             }
         };
 
+        // if selection-tracking is enabled, store the keys in a hash map
+        let selection = config
+            .selection_is_tracked()
+            .then(|| tx_inputs.iter())
+            .into_iter()
+            .flatten()
+            .map(StrongUtxoKey::from)
+            .collect();
+
         let transaction_details = TransactionDetails::new_without_coinbase(
             tx_inputs,
             tx_outputs.to_owned(),
@@ -828,7 +838,7 @@ impl GlobalState {
             transaction,
             details: maybe_transaction_details,
             change_output: maybe_change_output,
-            selection: HashSet::new(),
+            selection,
         };
 
         Ok(transaction_creation_artifacts)

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -740,7 +740,7 @@ impl GlobalState {
     /// }
     /// ```
     #[allow(clippy::too_many_arguments)]
-    pub(crate) async fn create_transaction_with_config(
+    pub(crate) async fn create_transaction(
         &self,
         mut tx_outputs: TxOutputList,
         fee: NativeCurrencyAmount,
@@ -1853,7 +1853,7 @@ mod global_state_tests {
         assert!(bob
             .lock_guard()
             .await
-            .create_transaction_with_config(
+            .create_transaction(
                 tx_outputs.clone(),
                 NativeCurrencyAmount::coins(1),
                 launch + six_months - one_month,
@@ -1869,7 +1869,7 @@ mod global_state_tests {
         let tx = bob
             .lock_guard()
             .await
-            .create_transaction_with_config(
+            .create_transaction(
                 tx_outputs,
                 NativeCurrencyAmount::coins(1),
                 launch + six_months + one_month,
@@ -1909,7 +1909,7 @@ mod global_state_tests {
         let new_tx = bob
             .lock_guard()
             .await
-            .create_transaction_with_config(
+            .create_transaction(
                 output_utxos.into(),
                 NativeCurrencyAmount::coins(1),
                 launch + six_months + one_month,
@@ -2558,7 +2558,7 @@ mod global_state_tests {
         let tx_to_alice_and_bob = premine_receiver
             .lock_guard()
             .await
-            .create_transaction_with_config(
+            .create_transaction(
                 [tx_outputs_for_alice.clone(), tx_outputs_for_bob.clone()]
                     .concat()
                     .into(),
@@ -2739,7 +2739,7 @@ mod global_state_tests {
         let tx_from_alice = alice
             .lock_guard()
             .await
-            .create_transaction_with_config(
+            .create_transaction(
                 tx_outputs_from_alice.clone().into(),
                 NativeCurrencyAmount::coins(1),
                 in_seven_months,
@@ -2783,7 +2783,7 @@ mod global_state_tests {
         let tx_from_bob = bob
             .lock_guard()
             .await
-            .create_transaction_with_config(
+            .create_transaction(
                 tx_outputs_from_bob.clone().into(),
                 NativeCurrencyAmount::coins(1),
                 in_seven_months,
@@ -3701,7 +3701,7 @@ mod global_state_tests {
                 let alice_to_bob_tx = alice_state_lock
                     .lock_guard()
                     .await
-                    .create_transaction_with_config(
+                    .create_transaction(
                         tx_outputs.clone(),
                         alice_to_bob_fee,
                         seven_months_post_launch,

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -8,7 +8,7 @@ pub mod networking_state;
 pub mod shared;
 pub(crate) mod transaction_details;
 pub(crate) mod transaction_kernel_id;
-pub(crate) mod tx_initiation_config;
+pub(crate) mod tx_creation_config;
 pub mod tx_proving_capability;
 pub mod wallet;
 
@@ -38,8 +38,8 @@ use tracing::info;
 use tracing::warn;
 use transaction_details::TransactionDetails;
 use twenty_first::math::digest::Digest;
-use tx_initiation_config::ChangeKeyAndMedium;
-use tx_initiation_config::TxInitiationConfig;
+use tx_creation_config::ChangeKeyAndMedium;
+use tx_creation_config::TxCreationConfig;
 use tx_proving_capability::TxProvingCapability;
 use wallet::address::ReceivingAddress;
 use wallet::address::SpendingKey;
@@ -753,7 +753,7 @@ impl GlobalState {
         timestamp: Timestamp,
         triton_vm_job_queue: &TritonVmJobQueue,
     ) -> Result<(Transaction, Option<TxOutput>)> {
-        let config = TxInitiationConfig::default()
+        let config = TxCreationConfig::default()
             .recover_change(change_key, change_utxo_notify_medium)
             .use_job_queue(triton_vm_job_queue);
         let tx = self
@@ -771,7 +771,7 @@ impl GlobalState {
         mut tx_outputs: TxOutputList,
         fee: NativeCurrencyAmount,
         timestamp: Timestamp,
-        config: &TxInitiationConfig<'_>,
+        config: &TxCreationConfig<'_>,
     ) -> Result<Transaction> {
         let Some(ChangeKeyAndMedium {
             key: change_key,
@@ -1883,7 +1883,7 @@ mod global_state_tests {
                 tx_outputs.clone(),
                 NativeCurrencyAmount::coins(1),
                 launch + six_months - one_month,
-                &TxInitiationConfig::default()
+                &TxCreationConfig::default()
                     .recover_change(bob_spending_key.into(), UtxoNotificationMedium::OffChain,)
                     .with_prover_capability(TxProvingCapability::ProofCollection)
                     .use_job_queue(&TritonVmJobQueue::dummy()),
@@ -1899,7 +1899,7 @@ mod global_state_tests {
                 tx_outputs,
                 NativeCurrencyAmount::coins(1),
                 launch + six_months + one_month,
-                &TxInitiationConfig::default()
+                &TxCreationConfig::default()
                     .recover_change(bob_spending_key.into(), UtxoNotificationMedium::OffChain)
                     .with_prover_capability(TxProvingCapability::ProofCollection)
                     .use_job_queue(&TritonVmJobQueue::dummy()),
@@ -1939,7 +1939,7 @@ mod global_state_tests {
                 output_utxos.into(),
                 NativeCurrencyAmount::coins(1),
                 launch + six_months + one_month,
-                &TxInitiationConfig::default()
+                &TxCreationConfig::default()
                     .recover_change(bob_spending_key.into(), UtxoNotificationMedium::OffChain)
                     .with_prover_capability(TxProvingCapability::ProofCollection)
                     .use_job_queue(&TritonVmJobQueue::dummy()),
@@ -2577,7 +2577,7 @@ mod global_state_tests {
             .await
             .unwrap();
         let dummy_queue = TritonVmJobQueue::dummy();
-        let config_alice_and_bob = TxInitiationConfig::default()
+        let config_alice_and_bob = TxCreationConfig::default()
             .recover_change(genesis_key, UtxoNotificationMedium::OffChain)
             .with_prover_capability(TxProvingCapability::SingleProof)
             .use_job_queue(&dummy_queue);
@@ -2758,7 +2758,7 @@ mod global_state_tests {
         // state is being updated correctly with new blocks; not the
         // use-`ProofCollection`-instead-of-`SingleProof` functionality.
         // Weaker machines need to use the proof server.
-        let config_alice = TxInitiationConfig::default()
+        let config_alice = TxCreationConfig::default()
             .recover_change(alice_spending_key.into(), UtxoNotificationMedium::OffChain)
             .with_prover_capability(TxProvingCapability::SingleProof)
             .use_job_queue(&dummy_queue);
@@ -2802,7 +2802,7 @@ mod global_state_tests {
                 false,
             ),
         ];
-        let config_bob = TxInitiationConfig::default()
+        let config_bob = TxCreationConfig::default()
             .recover_change(bob_spending_key.into(), UtxoNotificationMedium::OffChain)
             .with_prover_capability(TxProvingCapability::SingleProof)
             .use_job_queue(&dummy_queue);
@@ -3720,7 +3720,7 @@ mod global_state_tests {
                 );
 
                 // create tx.  utxo_notify_method is a test param.
-                let config = TxInitiationConfig::default()
+                let config = TxCreationConfig::default()
                     .recover_change(alice_change_key, change_notification_medium)
                     .with_prover_capability(TxProvingCapability::SingleProof)
                     .use_job_queue(&vm_job_queue);

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -766,7 +766,7 @@ impl GlobalState {
     /// prover capability. [Self::create_transaction] is the preferred interface
     /// for anything but tests.
     #[allow(clippy::too_many_arguments)]
-    pub(crate) async fn create_transaction_with_prover_capability(
+    pub(crate) async fn create_transaction_with_config(
         &self,
         mut tx_outputs: TxOutputList,
         fee: NativeCurrencyAmount,
@@ -1879,7 +1879,7 @@ mod global_state_tests {
         assert!(bob
             .lock_guard()
             .await
-            .create_transaction_with_prover_capability(
+            .create_transaction_with_config(
                 tx_outputs.clone(),
                 NativeCurrencyAmount::coins(1),
                 launch + six_months - one_month,
@@ -1895,7 +1895,7 @@ mod global_state_tests {
         let tx = bob
             .lock_guard()
             .await
-            .create_transaction_with_prover_capability(
+            .create_transaction_with_config(
                 tx_outputs,
                 NativeCurrencyAmount::coins(1),
                 launch + six_months + one_month,
@@ -1935,7 +1935,7 @@ mod global_state_tests {
         let new_tx = bob
             .lock_guard()
             .await
-            .create_transaction_with_prover_capability(
+            .create_transaction_with_config(
                 output_utxos.into(),
                 NativeCurrencyAmount::coins(1),
                 launch + six_months + one_month,
@@ -2584,7 +2584,7 @@ mod global_state_tests {
         let tx_to_alice_and_bob = premine_receiver
             .lock_guard()
             .await
-            .create_transaction_with_prover_capability(
+            .create_transaction_with_config(
                 [tx_outputs_for_alice.clone(), tx_outputs_for_bob.clone()]
                     .concat()
                     .into(),
@@ -2765,7 +2765,7 @@ mod global_state_tests {
         let tx_from_alice = alice
             .lock_guard()
             .await
-            .create_transaction_with_prover_capability(
+            .create_transaction_with_config(
                 tx_outputs_from_alice.clone().into(),
                 NativeCurrencyAmount::coins(1),
                 in_seven_months,
@@ -2809,7 +2809,7 @@ mod global_state_tests {
         let tx_from_bob = bob
             .lock_guard()
             .await
-            .create_transaction_with_prover_capability(
+            .create_transaction_with_config(
                 tx_outputs_from_bob.clone().into(),
                 NativeCurrencyAmount::coins(1),
                 in_seven_months,
@@ -3727,7 +3727,7 @@ mod global_state_tests {
                 let alice_to_bob_tx = alice_state_lock
                     .lock_guard()
                     .await
-                    .create_transaction_with_prover_capability(
+                    .create_transaction_with_config(
                         tx_outputs.clone(),
                         alice_to_bob_fee,
                         seven_months_post_launch,

--- a/src/models/state/tx_creation_artifacts.rs
+++ b/src/models/state/tx_creation_artifacts.rs
@@ -1,0 +1,20 @@
+use std::collections::HashSet;
+
+use crate::models::blockchain::transaction::Transaction;
+use crate::models::state::transaction_details::TransactionDetails;
+use crate::models::state::wallet::transaction_output::TxOutput;
+use crate::models::state::wallet::wallet_state::StrongUtxoKey;
+
+#[derive(Debug, Clone)]
+pub(crate) struct TxCreationArtifacts {
+    pub(crate) transaction: Transaction,
+    pub(crate) details: Option<TransactionDetails>,
+    pub(crate) change_output: Option<TxOutput>,
+    pub(crate) selection: HashSet<StrongUtxoKey>,
+}
+
+impl From<TxCreationArtifacts> for Transaction {
+    fn from(value: TxCreationArtifacts) -> Self {
+        value.transaction
+    }
+}

--- a/src/models/state/tx_creation_config.rs
+++ b/src/models/state/tx_creation_config.rs
@@ -4,16 +4,16 @@ use std::fmt::Result;
 
 use crate::job_queue::triton_vm::TritonVmJobPriority;
 use crate::job_queue::triton_vm::TritonVmJobQueue;
-use crate::models::blockchain::transaction::utxo::Utxo;
 use crate::models::proof_abstractions::tasm::program::TritonVmProofJobOptions;
 
 use super::tx_proving_capability::TxProvingCapability;
 use super::wallet::address::SpendingKey;
+use super::wallet::unlocked_utxo::UnlockedUtxo;
 use super::wallet::utxo_notification::UtxoNotificationMedium;
 
 /// Custom trait capturing the closure for selecting UTXOs.
-pub(crate) trait UtxoSelector: Fn(&Utxo) -> bool + Send + Sync + 'static {}
-impl<T> UtxoSelector for T where T: Fn(&Utxo) -> bool + Send + Sync + 'static {}
+pub(crate) trait UtxoSelector: Fn(&UnlockedUtxo) -> bool + Send + Sync + 'static {}
+impl<T> UtxoSelector for T where T: Fn(&UnlockedUtxo) -> bool + Send + Sync + 'static {}
 
 /// Wrapper around the closure type for selecting UTXOs. Purpose: allow
 /// `derive(Debug)` and `derive(Clone)` on structs that have this closure as a
@@ -117,7 +117,7 @@ impl<'a> TxCreationConfig<'a> {
     /// When selecting UTXOs, filter them through the given closure.
     pub(crate) fn select_utxos<F>(mut self, selector: F) -> Self
     where
-        F: Fn(&Utxo) -> bool + Send + Sync + 'static,
+        F: Fn(&UnlockedUtxo) -> bool + Send + Sync + 'static,
     {
         self.select_utxos = Some(DebuggableUtxoSelector(Box::new(selector)));
         self

--- a/src/models/state/tx_creation_config.rs
+++ b/src/models/state/tx_creation_config.rs
@@ -12,7 +12,7 @@ use super::wallet::address::SpendingKey;
 use super::wallet::utxo_notification::UtxoNotificationMedium;
 
 /// Custom trait capturing the closure for selecting UTXOs.
-trait UtxoSelector: Fn(&Utxo) -> bool + Send + Sync + 'static {}
+pub(crate) trait UtxoSelector: Fn(&Utxo) -> bool + Send + Sync + 'static {}
 impl<T> UtxoSelector for T where T: Fn(&Utxo) -> bool + Send + Sync + 'static {}
 
 /// Wrapper around the closure type for selecting UTXOs. Purpose: allow

--- a/src/models/state/tx_creation_config.rs
+++ b/src/models/state/tx_creation_config.rs
@@ -40,9 +40,9 @@ pub(crate) struct ChangeKeyAndMedium {
     pub(crate) medium: UtxoNotificationMedium,
 }
 
-/// Options and configuration settings for initiating transactions
+/// Options and configuration settings for creating transactions
 #[derive(Debug, Clone, Default)]
-pub(crate) struct TxInitiationConfig<'a> {
+pub(crate) struct TxCreationConfig<'a> {
     change: Option<(ChangeKeyAndMedium, OnceLock<TxOutput>)>,
     prover_capability: TxProvingCapability,
     triton_vm_job_queue: Option<&'a TritonVmJobQueue>,
@@ -52,7 +52,7 @@ pub(crate) struct TxInitiationConfig<'a> {
     transaction_details: OnceLock<TransactionDetails>,
 }
 
-impl<'a> TxInitiationConfig<'a> {
+impl<'a> TxCreationConfig<'a> {
     /// Enable change-recovery and configure which key and notification medium
     /// to use for that purpose.
     pub(crate) fn recover_change(

--- a/src/models/state/tx_initiation_config.rs
+++ b/src/models/state/tx_initiation_config.rs
@@ -1,0 +1,179 @@
+use std::collections::HashSet;
+use std::fmt::Debug;
+use std::fmt::Formatter;
+use std::fmt::Result;
+use std::sync::OnceLock;
+
+use crate::job_queue::triton_vm::TritonVmJobQueue;
+use crate::models::blockchain::transaction::utxo::Utxo;
+
+use super::transaction_details::TransactionDetails;
+use super::tx_proving_capability::TxProvingCapability;
+use super::wallet::address::SpendingKey;
+use super::wallet::transaction_output::TxOutput;
+use super::wallet::utxo_notification::UtxoNotificationMedium;
+use super::wallet::wallet_state::StrongUtxoKey;
+
+/// Custom trait capturing the closure for selecting UTXOs.
+trait UtxoSelector: Fn(&Utxo) -> bool + Send + 'static {}
+impl<T> UtxoSelector for T where T: Fn(&Utxo) -> bool + Send + 'static {}
+
+/// Wrapper around the closure type for selecting UTXOs. Purpose: allow
+/// `derive(Debug)` and `derive(Clone)` on structs that have this closure as a
+/// field. (Note that these derive macros don't work for raw closure types.)
+struct DebuggableUtxoSelector(Box<dyn UtxoSelector>);
+impl Debug for DebuggableUtxoSelector {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "DebuggableUtxoSelector")
+    }
+}
+
+impl Clone for DebuggableUtxoSelector {
+    fn clone(&self) -> Self {
+        panic!("Cloning not supported for DebuggableUtxoSelector");
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ChangeKeyAndMedium {
+    pub(crate) key: SpendingKey,
+    pub(crate) medium: UtxoNotificationMedium,
+}
+
+/// Options and configuration settings for initiating transactions
+#[derive(Debug, Clone, Default)]
+pub(crate) struct TxInitiationConfig<'a> {
+    change: Option<(ChangeKeyAndMedium, OnceLock<TxOutput>)>,
+    prover_capability: TxProvingCapability,
+    triton_vm_job_queue: Option<&'a TritonVmJobQueue>,
+    select_utxos: Option<DebuggableUtxoSelector>,
+    track_selection: bool,
+    selection: OnceLock<HashSet<StrongUtxoKey>>,
+    transaction_details: OnceLock<TransactionDetails>,
+}
+
+impl<'a> TxInitiationConfig<'a> {
+    /// Enable change-recovery and configure which key and notification medium
+    /// to use for that purpose.
+    pub(crate) fn recover_change(
+        mut self,
+        change_key: SpendingKey,
+        notification_medium: UtxoNotificationMedium,
+    ) -> Self {
+        let change_key_and_medium = ChangeKeyAndMedium {
+            key: change_key,
+            medium: notification_medium,
+        };
+        self.change = Some((change_key_and_medium, OnceLock::default()));
+        self
+    }
+
+    /// Configure the proving capacity.
+    pub(crate) fn with_prover_capability(mut self, prover_capability: TxProvingCapability) -> Self {
+        self.prover_capability = prover_capability;
+        self
+    }
+
+    /// Configure which job queue to use.
+    pub(crate) fn use_job_queue(mut self, job_queue: &'a TritonVmJobQueue) -> Self {
+        self.triton_vm_job_queue = Some(job_queue);
+        self
+    }
+
+    /// When selecting UTXOs, filter them through the given closure.
+    pub(crate) fn select_utxos<F>(mut self, selector: F) -> Self
+    where
+        F: Fn(&Utxo) -> bool + Send + 'static,
+    {
+        self.select_utxos = Some(DebuggableUtxoSelector(Box::new(selector)));
+        self
+    }
+
+    /// Enable selection-tracking.
+    ///
+    /// When enabled, the a hash set of `StrongUtxoKey`s is stored, indicating
+    /// which UTXOs were selected for the transaction.
+    pub(crate) fn track_selection(mut self) -> Self {
+        self.track_selection = true;
+        self
+    }
+
+    /// Get the change key and notification medium, if any.
+    pub(crate) fn change(&self) -> Option<ChangeKeyAndMedium> {
+        self.change
+            .as_ref()
+            .map(|(change_key_and_medium, _)| change_key_and_medium)
+            .cloned()
+    }
+
+    /// Get the transaction proving capability.
+    pub(crate) fn prover_capability(&self) -> TxProvingCapability {
+        self.prover_capability
+    }
+
+    /// Get the job queue, if set.
+    pub(crate) fn job_queue(&self) -> Option<&'a TritonVmJobQueue> {
+        self.triton_vm_job_queue
+    }
+
+    /// Get the closure with which to filter out unsuitable UTXOs during UTXO
+    /// selection.
+    pub(crate) fn utxo_selector(&self) -> Option<&Box<dyn UtxoSelector>> {
+        self.select_utxos.as_ref().map(|dus| &dus.0)
+    }
+
+    /// Get the set of strong UTXO keys of selected UTXOs, if selection-tracking
+    /// is enabled.
+    pub(crate) fn selected_utxos(&self) -> Option<&HashSet<StrongUtxoKey>> {
+        self.selection.get()
+    }
+
+    /// Get the transaction details corresponding to the produced transaction.
+    pub(crate) fn transaction_details(&self) -> Option<&TransactionDetails> {
+        self.transaction_details.get()
+    }
+
+    /// Get the change output, if any.
+    pub(crate) fn change_output(&self) -> Option<TxOutput> {
+        self.change
+            .as_ref()
+            .and_then(|(_, output)| output.get())
+            .cloned()
+    }
+
+    /// Set the change output, if change-recovery is enabled and if it is not
+    /// already set. In case of failure, this function returns the given
+    /// `TxOutput` object, wrapped in the `Err` variant.
+    pub(crate) fn set_change_output(
+        &self,
+        output: TxOutput,
+    ) -> std::result::Result<(), Box<TxOutput>> {
+        let Some((_, change_output)) = &self.change else {
+            return std::result::Result::Err(Box::new(output));
+        };
+        change_output.set(output).map_err(Box::new)
+    }
+
+    /// Set the selection of UTXOs that are used as inputs in this transaction.
+    /// If the selection was already set, it will not be overwritten and this
+    /// function returns the given argument, wrapped in the `Err` variant.
+    pub(crate) fn set_selected_utxos(
+        &self,
+        selected_utxos: HashSet<StrongUtxoKey>,
+    ) -> std::result::Result<(), HashSet<StrongUtxoKey>> {
+        self.selection.set(selected_utxos)
+    }
+
+    /// Set the transaction details corresponding to the produced transaction.
+    /// If the transaction details were already set, they will not be
+    /// overwritten and this function returns the given argument, wrapped in the
+    /// `Err` variant.
+    pub(crate) fn set_transaction_details(
+        &self,
+        transaction_details: TransactionDetails,
+    ) -> std::result::Result<(), Box<TransactionDetails>> {
+        self.transaction_details
+            .set(transaction_details)
+            .map_err(Box::new)
+    }
+}

--- a/src/models/state/wallet/mod.rs
+++ b/src/models/state/wallet/mod.rs
@@ -721,7 +721,7 @@ mod wallet_tests {
                 .lock_guard()
                 .await
                 .wallet_state
-                .allocate_sufficient_input_funds(amount, tip_digest, &ms_acc, now)
+                .allocate_sufficient_input_funds_nofilter(amount, tip_digest, &ms_acc, now)
                 .await
         };
         let num_utxos_in_allocation = |alice_: GlobalStateLock, amount: NativeCurrencyAmount| async move {
@@ -823,7 +823,7 @@ mod wallet_tests {
             .lock_guard()
             .await
             .wallet_state
-            .allocate_sufficient_input_funds(
+            .allocate_sufficient_input_funds_nofilter(
                 liquid_mining_reward.scalar_mul(2),
                 next_block.hash(),
                 &next_block.mutator_set_accumulator_after(),

--- a/src/models/state/wallet/mod.rs
+++ b/src/models/state/wallet/mod.rs
@@ -469,7 +469,7 @@ mod wallet_tests {
     use crate::models::blockchain::transaction::utxo::Utxo;
     use crate::models::blockchain::type_scripts::native_currency_amount::NativeCurrencyAmount;
     use crate::models::proof_abstractions::timestamp::Timestamp;
-    use crate::models::state::tx_initiation_config::TxInitiationConfig;
+    use crate::models::state::tx_creation_config::TxCreationConfig;
     use crate::models::state::tx_proving_capability::TxProvingCapability;
     use crate::models::state::wallet::expected_utxo::UtxoNotifier;
     use crate::models::state::wallet::transaction_output::TxOutput;
@@ -964,7 +964,7 @@ mod wallet_tests {
             vec![receiver_data_12_to_alice, receiver_data_1_to_alice].into();
         let dummy_queue = TritonVmJobQueue::dummy();
         let bob_change_key = bob_wallet.nth_generation_spending_key_for_tests(0).into();
-        let config_1 = TxInitiationConfig::default()
+        let config_1 = TxCreationConfig::default()
             .recover_change_on_chain(bob_change_key)
             .with_prover_capability(TxProvingCapability::SingleProof)
             .use_job_queue(&dummy_queue);
@@ -1202,7 +1202,7 @@ mod wallet_tests {
             false,
         );
 
-        let config_2b = TxInitiationConfig::default()
+        let config_2b = TxCreationConfig::default()
             .recover_change_off_chain(bob_change_key)
             .with_prover_capability(TxProvingCapability::PrimitiveWitness)
             .use_job_queue(&dummy_queue);
@@ -1416,7 +1416,7 @@ mod wallet_tests {
             TxOutput::no_notification(anyone_can_spend_utxo, rng.random(), rng.random(), false);
         let change_key = WalletSecret::devnet_wallet().nth_symmetric_key_for_tests(0);
         let dummy_queue = TritonVmJobQueue::dummy();
-        let config = TxInitiationConfig::default()
+        let config = TxCreationConfig::default()
             .recover_change_on_chain(change_key.into())
             .with_prover_capability(TxProvingCapability::SingleProof)
             .use_job_queue(&dummy_queue);

--- a/src/models/state/wallet/mod.rs
+++ b/src/models/state/wallet/mod.rs
@@ -973,7 +973,7 @@ mod wallet_tests {
                 receiver_data_to_alice.clone(),
                 NativeCurrencyAmount::coins(2),
                 in_seven_months,
-                &config_1,
+                config_1,
             )
             .await
             .unwrap();
@@ -1211,7 +1211,7 @@ mod wallet_tests {
                 vec![receiver_data_1_to_alice_new.clone()].into(),
                 NativeCurrencyAmount::coins(4),
                 block_2_b.header().timestamp + MINIMUM_BLOCK_TIME,
-                &config_2b,
+                config_2b,
             )
             .await
             .unwrap();
@@ -1423,7 +1423,7 @@ mod wallet_tests {
         let sender_tx = bob
             .lock_guard()
             .await
-            .create_transaction(vec![tx_output].into(), one_money, in_seven_months, &config)
+            .create_transaction(vec![tx_output].into(), one_money, in_seven_months, config)
             .await
             .unwrap()
             .transaction;

--- a/src/models/state/wallet/mod.rs
+++ b/src/models/state/wallet/mod.rs
@@ -978,7 +978,7 @@ mod wallet_tests {
             .await
             .unwrap();
 
-        let block_1 = invalid_block_with_transaction(&genesis_block, tx_1);
+        let block_1 = invalid_block_with_transaction(&genesis_block, tx_1.into());
 
         // Update wallet state with block_1
         assert!(
@@ -1235,7 +1235,7 @@ mod wallet_tests {
         .unwrap();
         let merged_tx = coinbase_tx
             .merge_with(
-                tx_from_bob,
+                tx_from_bob.into(),
                 Default::default(),
                 &TritonVmJobQueue::dummy(),
                 TritonVmJobPriority::default().into(),
@@ -1423,14 +1423,10 @@ mod wallet_tests {
         let sender_tx = bob
             .lock_guard()
             .await
-            .create_transaction(
-                vec![tx_output].into(),
-                one_money,
-                in_seven_months,
-                &config,
-            )
+            .create_transaction(vec![tx_output].into(), one_money, in_seven_months, &config)
             .await
-            .unwrap();
+            .unwrap()
+            .transaction;
         let tx_for_block = sender_tx
             .merge_with(
                 cbtx,

--- a/src/models/state/wallet/mod.rs
+++ b/src/models/state/wallet/mod.rs
@@ -969,7 +969,7 @@ mod wallet_tests {
             .with_prover_capability(TxProvingCapability::SingleProof)
             .use_job_queue(&dummy_queue);
         let tx_1 = bob
-            .create_transaction_with_config(
+            .create_transaction(
                 receiver_data_to_alice.clone(),
                 NativeCurrencyAmount::coins(2),
                 in_seven_months,
@@ -1207,7 +1207,7 @@ mod wallet_tests {
             .with_prover_capability(TxProvingCapability::PrimitiveWitness)
             .use_job_queue(&dummy_queue);
         let tx_from_bob = bob
-            .create_transaction_with_config(
+            .create_transaction(
                 vec![receiver_data_1_to_alice_new.clone()].into(),
                 NativeCurrencyAmount::coins(4),
                 block_2_b.header().timestamp + MINIMUM_BLOCK_TIME,
@@ -1423,7 +1423,7 @@ mod wallet_tests {
         let sender_tx = bob
             .lock_guard()
             .await
-            .create_transaction_with_config(
+            .create_transaction(
                 vec![tx_output].into(),
                 one_money,
                 in_seven_months,

--- a/src/models/state/wallet/mod.rs
+++ b/src/models/state/wallet/mod.rs
@@ -969,7 +969,7 @@ mod wallet_tests {
             .with_prover_capability(TxProvingCapability::SingleProof)
             .use_job_queue(&dummy_queue);
         let tx_1 = bob
-            .create_transaction_with_prover_capability(
+            .create_transaction_with_config(
                 receiver_data_to_alice.clone(),
                 NativeCurrencyAmount::coins(2),
                 in_seven_months,
@@ -1207,7 +1207,7 @@ mod wallet_tests {
             .with_prover_capability(TxProvingCapability::PrimitiveWitness)
             .use_job_queue(&dummy_queue);
         let tx_from_bob = bob
-            .create_transaction_with_prover_capability(
+            .create_transaction_with_config(
                 vec![receiver_data_1_to_alice_new.clone()].into(),
                 NativeCurrencyAmount::coins(4),
                 block_2_b.header().timestamp + MINIMUM_BLOCK_TIME,
@@ -1423,7 +1423,7 @@ mod wallet_tests {
         let sender_tx = bob
             .lock_guard()
             .await
-            .create_transaction_with_prover_capability(
+            .create_transaction_with_config(
                 vec![tx_output].into(),
                 one_money,
                 in_seven_months,

--- a/src/models/state/wallet/unlocked_utxo.rs
+++ b/src/models/state/wallet/unlocked_utxo.rs
@@ -6,6 +6,8 @@ use super::address::SpendingKey;
 use crate::models::blockchain::transaction::lock_script::LockScriptAndWitness;
 use crate::models::blockchain::transaction::utxo::Utxo;
 use crate::tasm_lib::prelude::Digest;
+use crate::util_types::mutator_set::addition_record::AdditionRecord;
+use crate::util_types::mutator_set::commit;
 use crate::util_types::mutator_set::ms_membership_proof::MsMembershipProof;
 use crate::util_types::mutator_set::mutator_set_accumulator::MutatorSetAccumulator;
 use crate::util_types::mutator_set::removal_record::RemovalRecord;
@@ -47,5 +49,13 @@ impl UnlockedUtxo {
         let item = self.mutator_set_item();
         let msmp = &self.membership_proof;
         mutator_set.drop(item, msmp)
+    }
+
+    pub(crate) fn addition_record(&self) -> AdditionRecord {
+        commit(
+            self.mutator_set_item(),
+            self.membership_proof.sender_randomness,
+            self.membership_proof.receiver_preimage.hash(),
+        )
     }
 }

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -132,7 +132,7 @@ impl TryFrom<&MonitoredUtxo> for IncomingUtxoRecoveryData {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-struct StrongUtxoKey {
+pub(crate) struct StrongUtxoKey {
     addition_record: AdditionRecord,
     aocl_index: u64,
 }

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -1845,7 +1845,7 @@ mod tests {
         let tx_block2 = bob
             .lock_guard_mut()
             .await
-            .create_transaction_with_config(
+            .create_transaction(
                 tx_outputs.clone().into(),
                 fee,
                 network.launch_date() + Timestamp::minutes(11),
@@ -1890,7 +1890,7 @@ mod tests {
         let tx_block3 = bob
             .lock_guard_mut()
             .await
-            .create_transaction_with_config(
+            .create_transaction(
                 tx_outputs.into(),
                 fee,
                 network.launch_date() + Timestamp::minutes(22),
@@ -1952,7 +1952,7 @@ mod tests {
         let mut tx_block2 = bob
             .lock_guard_mut()
             .await
-            .create_transaction_with_config(
+            .create_transaction(
                 vec![txo.clone()].into(),
                 fee,
                 network.launch_date() + Timestamp::minutes(11),
@@ -2054,7 +2054,7 @@ mod tests {
         let mut tx_block2 = bob
             .lock_guard_mut()
             .await
-            .create_transaction_with_config(
+            .create_transaction(
                 vec![txo.clone()].into(),
                 fee,
                 network.launch_date() + Timestamp::minutes(11),
@@ -2771,7 +2771,7 @@ mod tests {
                 .global_state_lock
                 .lock_guard()
                 .await
-                .create_transaction_with_config(
+                .create_transaction(
                     vec![].into(),
                     fee,
                     block2_timestamp,
@@ -2952,7 +2952,7 @@ mod tests {
                     .recover_change_on_chain(change_key)
                     .with_prover_capability(TxProvingCapability::PrimitiveWitness)
                     .use_job_queue(&dummy_queue);
-                gs.create_transaction_with_config(
+                gs.create_transaction(
                     tx_outputs,
                     NativeCurrencyAmount::zero(),
                     timestamp,
@@ -3041,7 +3041,7 @@ mod tests {
                     .global_state_lock
                     .lock_guard()
                     .await
-                    .create_transaction_with_config(
+                    .create_transaction(
                         vec![tx_output].into(),
                         fee,
                         timestamp,
@@ -3548,7 +3548,7 @@ mod tests {
                     .global_state_lock
                     .lock_guard()
                     .await
-                    .create_transaction_with_config(
+                    .create_transaction(
                         vec![tx_output].into(),
                         fee,
                         timestamp,

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -1849,7 +1849,7 @@ mod tests {
                 tx_outputs.clone().into(),
                 fee,
                 network.launch_date() + Timestamp::minutes(11),
-                &config2,
+                config2,
             )
             .await
             .unwrap()
@@ -1895,7 +1895,7 @@ mod tests {
                 tx_outputs.into(),
                 fee,
                 network.launch_date() + Timestamp::minutes(22),
-                &config3,
+                config3,
             )
             .await
             .unwrap()
@@ -1958,7 +1958,7 @@ mod tests {
                 vec![txo.clone()].into(),
                 fee,
                 network.launch_date() + Timestamp::minutes(11),
-                &config,
+                config,
             )
             .await
             .unwrap()
@@ -2061,7 +2061,7 @@ mod tests {
                 vec![txo.clone()].into(),
                 fee,
                 network.launch_date() + Timestamp::minutes(11),
-                &config,
+                config,
             )
             .await
             .unwrap()
@@ -2775,7 +2775,7 @@ mod tests {
                 .global_state_lock
                 .lock_guard()
                 .await
-                .create_transaction(vec![].into(), fee, block2_timestamp, &config)
+                .create_transaction(vec![].into(), fee, block2_timestamp, config)
                 .await
                 .unwrap()
                 .transaction;
@@ -2952,7 +2952,7 @@ mod tests {
                     .recover_change_on_chain(change_key)
                     .with_prover_capability(TxProvingCapability::PrimitiveWitness)
                     .use_job_queue(&dummy_queue);
-                gs.create_transaction(tx_outputs, NativeCurrencyAmount::zero(), timestamp, &config)
+                gs.create_transaction(tx_outputs, NativeCurrencyAmount::zero(), timestamp, config)
                     .await?
                     .transaction
             };
@@ -3037,7 +3037,7 @@ mod tests {
                     .global_state_lock
                     .lock_guard()
                     .await
-                    .create_transaction(vec![tx_output].into(), fee, timestamp, &config)
+                    .create_transaction(vec![tx_output].into(), fee, timestamp, config)
                     .await
                     .map(|tx| tx.into())
             }
@@ -3540,7 +3540,7 @@ mod tests {
                     .global_state_lock
                     .lock_guard()
                     .await
-                    .create_transaction(vec![tx_output].into(), fee, timestamp, &config)
+                    .create_transaction(vec![tx_output].into(), fee, timestamp, config)
                     .await
                     .unwrap()
                     .transaction

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -146,6 +146,15 @@ impl StrongUtxoKey {
     }
 }
 
+impl From<&UnlockedUtxo> for StrongUtxoKey {
+    fn from(unlocked_utxo: &UnlockedUtxo) -> Self {
+        Self::new(
+            unlocked_utxo.addition_record(),
+            unlocked_utxo.mutator_set_mp().aocl_leaf_index,
+        )
+    }
+}
+
 impl Debug for WalletState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("WalletState")

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -1603,7 +1603,7 @@ mod tests {
     use crate::job_queue::triton_vm::TritonVmJobQueue;
     use crate::models::blockchain::transaction::transaction_kernel::TransactionKernelModifier;
     use crate::models::blockchain::transaction::utxo::Coin;
-    use crate::models::state::tx_initiation_config::TxInitiationConfig;
+    use crate::models::state::tx_creation_config::TxCreationConfig;
     use crate::models::state::tx_proving_capability::TxProvingCapability;
     use crate::models::state::wallet::expected_utxo::ExpectedUtxo;
     use crate::models::state::wallet::transaction_output::TxOutput;
@@ -1838,7 +1838,7 @@ mod tests {
         );
         let tx_outputs = vec![txoutput.clone(), txoutput.clone()];
         let dummy_queue = TritonVmJobQueue::dummy();
-        let config2 = TxInitiationConfig::default()
+        let config2 = TxCreationConfig::default()
             .recover_change_on_chain(bob_key.into())
             .with_prover_capability(TxProvingCapability::PrimitiveWitness)
             .use_job_queue(&dummy_queue);
@@ -1883,7 +1883,7 @@ mod tests {
 
         // Repeat the outputs to Alice in block 3 and verify correct new
         // balance.
-        let config3 = TxInitiationConfig::default()
+        let config3 = TxCreationConfig::default()
             .recover_change_on_chain(bob_key.into())
             .with_prover_capability(TxProvingCapability::PrimitiveWitness)
             .use_job_queue(&dummy_queue);
@@ -1945,7 +1945,7 @@ mod tests {
         );
         let fee = NativeCurrencyAmount::coins(10);
         let dummy_queue = TritonVmJobQueue::dummy();
-        let config = TxInitiationConfig::default()
+        let config = TxCreationConfig::default()
             .recover_change_on_chain(bob_key.into())
             .with_prover_capability(TxProvingCapability::PrimitiveWitness)
             .use_job_queue(&dummy_queue);
@@ -2047,7 +2047,7 @@ mod tests {
         );
         let fee = NativeCurrencyAmount::coins(10);
         let dummy_queue = TritonVmJobQueue::dummy();
-        let config = TxInitiationConfig::default()
+        let config = TxCreationConfig::default()
             .recover_change_on_chain(bob_key.into())
             .with_prover_capability(TxProvingCapability::PrimitiveWitness)
             .use_job_queue(&dummy_queue);
@@ -2763,7 +2763,7 @@ mod tests {
             let fee = NativeCurrencyAmount::coins(1);
             let dummy_queue = TritonVmJobQueue::dummy();
             let a_key = GenerationSpendingKey::derive_from_seed(rng.random());
-            let config = TxInitiationConfig::default()
+            let config = TxCreationConfig::default()
                 .recover_change_on_chain(a_key.into())
                 .with_prover_capability(TxProvingCapability::PrimitiveWitness)
                 .use_job_queue(&dummy_queue);
@@ -2948,7 +2948,7 @@ mod tests {
                 );
 
                 let dummy_queue = TritonVmJobQueue::dummy();
-                let config = TxInitiationConfig::default()
+                let config = TxCreationConfig::default()
                     .recover_change_on_chain(change_key)
                     .with_prover_capability(TxProvingCapability::PrimitiveWitness)
                     .use_job_queue(&dummy_queue);
@@ -3033,7 +3033,7 @@ mod tests {
                 );
 
                 let dummy_queue = TritonVmJobQueue::dummy();
-                let config = TxInitiationConfig::default()
+                let config = TxCreationConfig::default()
                     .recover_change_off_chain(change_key)
                     .with_prover_capability(TxProvingCapability::PrimitiveWitness)
                     .use_job_queue(&dummy_queue);
@@ -3540,7 +3540,7 @@ mod tests {
                 );
 
                 let dummy_queue = TritonVmJobQueue::dummy();
-                let config = TxInitiationConfig::default()
+                let config = TxCreationConfig::default()
                     .recover_change_off_chain(change_key)
                     .with_prover_capability(TxProvingCapability::PrimitiveWitness)
                     .use_job_queue(&dummy_queue);

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -1852,7 +1852,8 @@ mod tests {
                 &config2,
             )
             .await
-            .unwrap();
+            .unwrap()
+            .transaction;
 
         // Make block 2, verify that Alice registers correct balance.
         let block2 = invalid_block_with_transaction(&block1, tx_block2.clone());
@@ -1897,7 +1898,8 @@ mod tests {
                 &config3,
             )
             .await
-            .unwrap();
+            .unwrap()
+            .transaction;
         let block3 = invalid_block_with_transaction(&block2, tx_block3.clone());
         alice
             .lock_guard_mut()
@@ -1959,7 +1961,8 @@ mod tests {
                 &config,
             )
             .await
-            .unwrap();
+            .unwrap()
+            .transaction;
 
         let mut bad_utxo = txo.utxo();
         bad_utxo = bad_utxo.append_to_coin_state(0, random());
@@ -2061,7 +2064,8 @@ mod tests {
                 &config,
             )
             .await
-            .unwrap();
+            .unwrap()
+            .transaction;
         let unrecognized_typescript = Coin {
             type_script_hash: random(),
             state: vec![random(), random()],
@@ -2771,14 +2775,10 @@ mod tests {
                 .global_state_lock
                 .lock_guard()
                 .await
-                .create_transaction(
-                    vec![].into(),
-                    fee,
-                    block2_timestamp,
-                    &config,
-                )
+                .create_transaction(vec![].into(), fee, block2_timestamp, &config)
                 .await
-                .unwrap();
+                .unwrap()
+                .transaction;
             assert!(
                 tx_spending_guesser_fee.is_valid().await,
                 "Tx spending guesser-fee UTXO must be valid."
@@ -2952,13 +2952,9 @@ mod tests {
                     .recover_change_on_chain(change_key)
                     .with_prover_capability(TxProvingCapability::PrimitiveWitness)
                     .use_job_queue(&dummy_queue);
-                gs.create_transaction(
-                    tx_outputs,
-                    NativeCurrencyAmount::zero(),
-                    timestamp,
-                    &config,
-                )
-                .await?
+                gs.create_transaction(tx_outputs, NativeCurrencyAmount::zero(), timestamp, &config)
+                    .await?
+                    .transaction
             };
 
             // add the tx to the mempool.
@@ -3041,13 +3037,9 @@ mod tests {
                     .global_state_lock
                     .lock_guard()
                     .await
-                    .create_transaction(
-                        vec![tx_output].into(),
-                        fee,
-                        timestamp,
-                        &config,
-                    )
+                    .create_transaction(vec![tx_output].into(), fee, timestamp, &config)
                     .await
+                    .map(|tx| tx.into())
             }
 
             let network = Network::Main;
@@ -3548,14 +3540,10 @@ mod tests {
                     .global_state_lock
                     .lock_guard()
                     .await
-                    .create_transaction(
-                        vec![tx_output].into(),
-                        fee,
-                        timestamp,
-                        &config,
-                    )
+                    .create_transaction(vec![tx_output].into(), fee, timestamp, &config)
                     .await
                     .unwrap()
+                    .transaction
             }
 
             // Verify that monitored UTXOs spent in blocks that do not belong

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -1845,7 +1845,7 @@ mod tests {
         let tx_block2 = bob
             .lock_guard_mut()
             .await
-            .create_transaction_with_prover_capability(
+            .create_transaction_with_config(
                 tx_outputs.clone().into(),
                 fee,
                 network.launch_date() + Timestamp::minutes(11),
@@ -1890,7 +1890,7 @@ mod tests {
         let tx_block3 = bob
             .lock_guard_mut()
             .await
-            .create_transaction_with_prover_capability(
+            .create_transaction_with_config(
                 tx_outputs.into(),
                 fee,
                 network.launch_date() + Timestamp::minutes(22),
@@ -1952,7 +1952,7 @@ mod tests {
         let mut tx_block2 = bob
             .lock_guard_mut()
             .await
-            .create_transaction_with_prover_capability(
+            .create_transaction_with_config(
                 vec![txo.clone()].into(),
                 fee,
                 network.launch_date() + Timestamp::minutes(11),
@@ -2054,7 +2054,7 @@ mod tests {
         let mut tx_block2 = bob
             .lock_guard_mut()
             .await
-            .create_transaction_with_prover_capability(
+            .create_transaction_with_config(
                 vec![txo.clone()].into(),
                 fee,
                 network.launch_date() + Timestamp::minutes(11),
@@ -2771,7 +2771,7 @@ mod tests {
                 .global_state_lock
                 .lock_guard()
                 .await
-                .create_transaction_with_prover_capability(
+                .create_transaction_with_config(
                     vec![].into(),
                     fee,
                     block2_timestamp,
@@ -2952,7 +2952,7 @@ mod tests {
                     .recover_change_on_chain(change_key)
                     .with_prover_capability(TxProvingCapability::PrimitiveWitness)
                     .use_job_queue(&dummy_queue);
-                gs.create_transaction_with_prover_capability(
+                gs.create_transaction_with_config(
                     tx_outputs,
                     NativeCurrencyAmount::zero(),
                     timestamp,
@@ -3041,7 +3041,7 @@ mod tests {
                     .global_state_lock
                     .lock_guard()
                     .await
-                    .create_transaction_with_prover_capability(
+                    .create_transaction_with_config(
                         vec![tx_output].into(),
                         fee,
                         timestamp,
@@ -3548,7 +3548,7 @@ mod tests {
                     .global_state_lock
                     .lock_guard()
                     .await
-                    .create_transaction_with_prover_capability(
+                    .create_transaction_with_config(
                         vec![tx_output].into(),
                         fee,
                         timestamp,

--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -1901,7 +1901,7 @@ mod peer_loop_tests {
     use crate::models::peer::peer_block_notifications::PeerBlockNotification;
     use crate::models::peer::transaction_notification::TransactionNotification;
     use crate::models::state::mempool::TransactionOrigin;
-    use crate::models::state::tx_initiation_config::TxInitiationConfig;
+    use crate::models::state::tx_creation_config::TxCreationConfig;
     use crate::models::state::tx_proving_capability::TxProvingCapability;
     use crate::models::state::wallet::WalletSecret;
     use crate::tests::shared::fake_valid_block_for_tests;
@@ -3282,7 +3282,7 @@ mod peer_loop_tests {
         let genesis_block = Block::genesis(network);
         let now = genesis_block.kernel.header.timestamp;
         let dummy_queue = TritonVmJobQueue::dummy();
-        let config = TxInitiationConfig::default()
+        let config = TxCreationConfig::default()
             .recover_change_off_chain(spending_key.into())
             .with_prover_capability(TxProvingCapability::ProofCollection)
             .use_job_queue(&dummy_queue);
@@ -3367,7 +3367,7 @@ mod peer_loop_tests {
         let genesis_block = Block::genesis(network);
         let now = genesis_block.kernel.header.timestamp;
         let dummy_queue = TritonVmJobQueue::dummy();
-        let config = TxInitiationConfig::default()
+        let config = TxCreationConfig::default()
             .recover_change_off_chain(spending_key.into())
             .with_prover_capability(TxProvingCapability::ProofCollection)
             .use_job_queue(&dummy_queue);
@@ -3577,7 +3577,7 @@ mod peer_loop_tests {
                 TransactionProofQuality::SingleProof => TxProvingCapability::SingleProof,
             };
             let dummy_queue = TritonVmJobQueue::dummy();
-            let config = TxInitiationConfig::default()
+            let config = TxCreationConfig::default()
                 .recover_change_off_chain(alice_key.into())
                 .with_prover_capability(prover_capability)
                 .use_job_queue(&dummy_queue);

--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -3289,7 +3289,7 @@ mod peer_loop_tests {
         let transaction_1 = state_lock
             .lock_guard()
             .await
-            .create_transaction_with_config(
+            .create_transaction(
                 Default::default(),
                 NativeCurrencyAmount::coins(0),
                 now,
@@ -3374,7 +3374,7 @@ mod peer_loop_tests {
         let transaction_1 = state_lock
             .lock_guard()
             .await
-            .create_transaction_with_config(
+            .create_transaction(
                 Default::default(),
                 NativeCurrencyAmount::coins(0),
                 now,
@@ -3582,7 +3582,7 @@ mod peer_loop_tests {
                 .with_prover_capability(prover_capability)
                 .use_job_queue(&dummy_queue);
             alice
-                .create_transaction_with_config(
+                .create_transaction(
                     vec![].into(),
                     NativeCurrencyAmount::coins(1),
                     in_seven_months,

--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -3296,7 +3296,8 @@ mod peer_loop_tests {
                 &config,
             )
             .await
-            .unwrap();
+            .unwrap()
+            .transaction;
 
         // Build the resulting transaction notification
         let tx_notification: TransactionNotification = (&transaction_1).try_into().unwrap();
@@ -3381,7 +3382,8 @@ mod peer_loop_tests {
                 &config,
             )
             .await
-            .unwrap();
+            .unwrap()
+            .transaction;
 
         let (hsd_1, _sa_1) = get_dummy_peer_connection_data_genesis(network, 1);
         let mut peer_loop_handler = PeerLoopHandler::new(
@@ -3590,6 +3592,7 @@ mod peer_loop_tests {
                 )
                 .await
                 .unwrap()
+                .transaction
         }
 
         #[traced_test]

--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -3289,7 +3289,7 @@ mod peer_loop_tests {
         let transaction_1 = state_lock
             .lock_guard()
             .await
-            .create_transaction_with_prover_capability(
+            .create_transaction_with_config(
                 Default::default(),
                 NativeCurrencyAmount::coins(0),
                 now,
@@ -3374,7 +3374,7 @@ mod peer_loop_tests {
         let transaction_1 = state_lock
             .lock_guard()
             .await
-            .create_transaction_with_prover_capability(
+            .create_transaction_with_config(
                 Default::default(),
                 NativeCurrencyAmount::coins(0),
                 now,
@@ -3582,7 +3582,7 @@ mod peer_loop_tests {
                 .with_prover_capability(prover_capability)
                 .use_job_queue(&dummy_queue);
             alice
-                .create_transaction_with_prover_capability(
+                .create_transaction_with_config(
                     vec![].into(),
                     NativeCurrencyAmount::coins(1),
                     in_seven_months,

--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -3293,7 +3293,7 @@ mod peer_loop_tests {
                 Default::default(),
                 NativeCurrencyAmount::coins(0),
                 now,
-                &config,
+                config,
             )
             .await
             .unwrap()
@@ -3379,7 +3379,7 @@ mod peer_loop_tests {
                 Default::default(),
                 NativeCurrencyAmount::coins(0),
                 now,
-                &config,
+                config,
             )
             .await
             .unwrap()
@@ -3588,7 +3588,7 @@ mod peer_loop_tests {
                     vec![].into(),
                     NativeCurrencyAmount::coins(1),
                     in_seven_months,
-                    &config,
+                    config,
                 )
                 .await
                 .unwrap()

--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -82,7 +82,7 @@ use crate::models::peer::PeerStanding;
 use crate::models::proof_abstractions::timestamp::Timestamp;
 use crate::models::state::mining_status::MiningStatus;
 use crate::models::state::transaction_kernel_id::TransactionKernelId;
-use crate::models::state::tx_initiation_config::TxInitiationConfig;
+use crate::models::state::tx_creation_config::TxCreationConfig;
 use crate::models::state::tx_proving_capability::TxProvingCapability;
 use crate::models::state::wallet::address::encrypted_utxo_notification::EncryptedUtxoNotification;
 use crate::models::state::wallet::address::KeyType;
@@ -1901,7 +1901,7 @@ impl NeptuneRPCServer {
         // lengthy operation.
         //
         // note: A change output will be added to tx_outputs if needed.
-        let config = TxInitiationConfig::default()
+        let config = TxCreationConfig::default()
             .recover_change(change_key, owned_utxo_notification_medium)
             .with_prover_capability(tx_proving_capability)
             .use_job_queue(self.state.vm_job_queue());

--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -1906,7 +1906,7 @@ impl NeptuneRPCServer {
             .with_prover_capability(tx_proving_capability)
             .use_job_queue(self.state.vm_job_queue());
         let mut transaction = match state
-            .create_transaction_with_config(tx_outputs.clone(), fee, now, &config)
+            .create_transaction(tx_outputs.clone(), fee, now, &config)
             .await
         {
             Ok(tx) => tx,

--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -1906,7 +1906,7 @@ impl NeptuneRPCServer {
             .with_prover_capability(tx_proving_capability)
             .use_job_queue(self.state.vm_job_queue());
         let mut transaction = match state
-            .create_transaction_with_prover_capability(tx_outputs.clone(), fee, now, &config)
+            .create_transaction_with_config(tx_outputs.clone(), fee, now, &config)
             .await
         {
             Ok(tx) => tx,

--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -1907,7 +1907,7 @@ impl NeptuneRPCServer {
             .record_details()
             .use_job_queue(self.state.vm_job_queue());
         let transaction_creation_artifacts = match state
-            .create_transaction(tx_outputs.clone(), fee, now, &config)
+            .create_transaction(tx_outputs.clone(), fee, now, config)
             .await
         {
             Ok(tx) => tx,


### PR DESCRIPTION
Prior to this PR, the transaction creation tools were rather unwieldy because
 - there were many constructors, offering various levels of customization
 - in some cases extra data was needed.

This PR refactors this interface. Now you call `create_transaction` with a `TxCreationConfig` object which you prepare prior to the call. The function returns a `TxCreationArtifacts` object which definitely contains the transaction, but possibly also (depending on the config) other data.

This PR also contains a new test which doesn't really test anything but whose main purpose is to present the block size and relative composition of blocks with progressively larger numbers of inputs and outputs. (To make this test work, it was necessary to avoid re-selecting UTXOs for the next transaction, which led to the entire interface refactor.)

I'm looking for feedback on the new interface. What kind of tests make sense?