### PR TITLE
Initial general-purpose RPC boilerplate/base

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,25 +278,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.3.4",
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
  "serde",
- "sync_wrapper",
- "tower",
+ "sync_wrapper 0.1.2",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d6fd624c75e18b3b4c6b9caf42b1afe24437daaee904069137d8bab077be8b8"
+dependencies = [
+ "axum-core 0.5.0",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -308,12 +342,32 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "mime",
  "rustversion",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1362f362fd16024ae199c1970ce98f9661bf5ef94b9808fee734bc3698b733"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1123,6 +1177,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1291,7 +1354,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
  "indexmap 2.7.1",
  "slab",
  "tokio",
@@ -1390,13 +1453,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.2.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.2.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1429,8 +1526,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -1443,15 +1540,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.32",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "hyper 1.6.0",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1735,6 +1867,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1832,6 +1970,7 @@ dependencies = [
  "assert2",
  "async-stream",
  "async-trait",
+ "axum 0.8.1",
  "bech32",
  "bincode",
  "blake3",
@@ -1886,6 +2025,7 @@ dependencies = [
  "tokio-serde",
  "tokio-test",
  "tokio-util",
+ "tower 0.5.2",
  "tracing",
  "tracing-subscriber",
  "tracing-test",
@@ -2761,6 +2901,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2970,6 +3132,12 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "sysinfo"
@@ -3346,20 +3514,20 @@ checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.6.20",
  "base64",
  "bytes",
  "h2",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
  "prost",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3380,6 +3548,22 @@ dependencies = [
  "slab",
  "tokio",
  "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper 1.0.2",
+ "tokio",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,8 @@ sysinfo = "0.31.4"
 thread-priority = "1.2.0"
 rayon = "1.10"
 humantime = "2.1.0"
+axum = "0.8.1"
+tower = "0.5.2"
 
 [dev-dependencies]
 

--- a/src/config_models/cli_args.rs
+++ b/src/config_models/cli_args.rs
@@ -272,6 +272,10 @@ pub struct Args {
     // to meaningfully suppress rapid reconnection attempts.
     #[clap(long, default_value = "1800", value_parser = duration_from_seconds_str)]
     pub reconnect_cooldown: Duration,
+
+    /// Enables the JSON/HTTP RPC API and listens on specified address and port.
+    #[clap(long)]
+    pub listen_rpc: Option<SocketAddr>,
 }
 
 impl Default for Args {

--- a/src/rpc/Extending RPC.md
+++ b/src/rpc/Extending RPC.md
@@ -1,0 +1,11 @@
+# Add a new method to RPC
+
+## calls.rs
+
+1. Declare a new response type -- remember big numbers that cannot be safely represented by JavaScript etc. must be a String.
+2. Implement a function that returns axum-jsonified version of response type.
+
+## server.rs
+
+1. Register new function to router on ``build_router`` function.
+2. Implement a call test over router and check for validity over body.

--- a/src/rpc/calls.rs
+++ b/src/rpc/calls.rs
@@ -1,0 +1,115 @@
+use crate::{
+    models::{
+        blockchain::block::difficulty_control::{Difficulty, ProofOfWork},
+        state::GlobalStateLock,
+    },
+    VERSION,
+};
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
+use serde::Serialize;
+use tasm_lib::prelude::Digest;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeInfo {
+    version: String,
+    peer_count: usize,
+    syncing: bool,
+    mempool_size: usize,
+    archival: bool,
+}
+
+pub async fn node_info(State(state): State<GlobalStateLock>) -> Json<NodeInfo> {
+    let state = state.lock_guard().await;
+
+    let peer_count = state.net.peer_map.len();
+    let syncing = state.net.sync_anchor.is_some();
+    let mempool_size = state.mempool.len();
+    let archival = state.chain.is_archival_node();
+
+    Json(NodeInfo {
+        version: VERSION.to_string(),
+        peer_count,
+        syncing,
+        mempool_size,
+        archival,
+    })
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NetworkInfo {
+    network: String,
+    tip_hash: String,
+    height: u64,
+    difficulty: Difficulty,
+}
+
+pub async fn network_info(State(state): State<GlobalStateLock>) -> Json<NetworkInfo> {
+    let cli = state.cli();
+    let state = state.lock_guard().await;
+    let tip = state.chain.light_state();
+
+    Json(NetworkInfo {
+        network: cli.network.to_string(),
+        tip_hash: tip.hash().to_hex(),
+        height: tip.header().height.into(),
+        difficulty: tip.header().difficulty,
+    })
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BlockInfo {
+    hash: String,
+    previous_hash: String,
+    height: u64,
+    timestamp: u64,
+    difficulty: Difficulty,
+    cumulative_work: ProofOfWork,
+    coinbase_reward: String,
+    canonical: bool,
+}
+
+pub async fn block_info(
+    Path(hash): Path<String>,
+    State(state): State<GlobalStateLock>,
+) -> Result<Json<BlockInfo>, StatusCode> {
+    let state = state.lock_guard().await;
+    let archival_state = state.chain.archival_state();
+
+    let digest = if let Ok(digest) = Digest::try_from_hex(&hash) {
+        digest
+    } else {
+        let block_height: u64 = hash.parse().map_err(|_| StatusCode::BAD_REQUEST)?;
+        let digests = archival_state
+            .block_height_to_block_digests(block_height.into())
+            .await;
+        digests.first().cloned().ok_or(StatusCode::NOT_FOUND)?
+    };
+
+    let block = archival_state
+        .get_block(digest)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .ok_or(StatusCode::NOT_FOUND)?;
+    let header = block.header();
+    let is_canonical = archival_state
+        .block_belongs_to_canonical_chain(digest)
+        .await;
+
+    Ok(Json(BlockInfo {
+        hash: block.hash().to_hex(),
+        previous_hash: header.prev_block_digest.to_hex(),
+        height: header.height.into(),
+        timestamp: header.timestamp.0.value(),
+        difficulty: header.difficulty,
+        cumulative_work: header.cumulative_proof_of_work,
+        coinbase_reward: block.coinbase_amount().to_nau().to_string(),
+        canonical: is_canonical,
+    }))
+}

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -1,0 +1,2 @@
+mod calls;
+pub mod server;

--- a/src/rpc/server.rs
+++ b/src/rpc/server.rs
@@ -1,0 +1,98 @@
+use crate::models::state::GlobalStateLock;
+use crate::rpc::calls;
+use axum::{routing::get, Router};
+
+pub(crate) struct Server {
+    pub(crate) state: GlobalStateLock,
+}
+
+impl Server {
+    pub fn new(state: GlobalStateLock) -> Self {
+        Self { state }
+    }
+
+    pub async fn serve(
+        &self,
+        listener: tokio::net::TcpListener,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let app = self.build_router();
+        axum::serve(listener, app).await?;
+
+        Ok(())
+    }
+
+    fn build_router(&self) -> Router {
+        Router::new()
+            .route("/node", get(calls::node_info))
+            .route("/network", get(calls::network_info))
+            .route("/block/{hash}", get(calls::block_info))
+            .with_state(self.state.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    use crate::config_models::cli_args;
+    use crate::config_models::network::Network;
+    use crate::models::state::wallet::WalletSecret;
+    use crate::tests::shared::mock_genesis_global_state;
+
+    use super::Server;
+
+    async fn create_test_server() -> Server {
+        let wallet_secret = WalletSecret::new_random();
+        let args = cli_args::Args::default();
+        let state = mock_genesis_global_state(Network::RegTest, 2, wallet_secret, args).await;
+
+        Server::new(state)
+    }
+
+    #[tokio::test]
+    async fn test_server_startup() {
+        let server = create_test_server().await;
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server_handle = tokio::spawn(async move {
+            server
+                .serve(listener)
+                .await
+                .expect("Server should not panic")
+        });
+
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await; // Give some time for the server to start.
+
+        let is_accessible = tokio::net::TcpStream::connect(addr).await.is_ok();
+        assert!(is_accessible, "Server should be accepting connections");
+
+        server_handle.abort();
+
+        let result = server_handle.await;
+        assert!(
+            matches!(&result, Err(e) if e.is_cancelled()),
+            "Server task should be cancelled, but got: {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn test_server_routes() {
+        let server = create_test_server().await;
+        let app = server.build_router();
+
+        let response = app
+            .oneshot(Request::builder().uri("/node").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "Node info route should return 200"
+        );
+    }
+}


### PR DESCRIPTION
It's base of a general-purpose RPC over HTTP/JSON: users are supposed to handle their safety by proxies like nginx etc.
For now it is read-only but in future it should allow submitting txs and PoW(external guessers).
To be extended based on requirements...