### PR TITLE
feat: mining-state-machine, display inactive reasons

### DIFF
--- a/scripts/linux/run-multiple-instances-from-genesis.sh
+++ b/scripts/linux/run-multiple-instances-from-genesis.sh
@@ -32,10 +32,10 @@ rm -rf $LOCAL_STATE_DIR
 # to build at the same time.
 cargo $NIGHTLY build $FEATURES
 
-RUST_BACKTRACE=1 XDG_DATA_HOME=$LOCAL_STATE_DIR/0/ nice -n 1 --  cargo $NIGHTLY run $FEATURES -- --network regtest --peer-port 29790 --rpc-port 19790 --compose --guess $EXTRA_ARGS 2>&1 | tee /tmp/integration_test_from_genesis-0.log | sed 's/(.*)/\0 \[I0\]/g'  &
+RUST_BACKTRACE=1 XDG_DATA_HOME=$LOCAL_STATE_DIR/0/ nice -n 1 --  cargo $NIGHTLY run $FEATURES -- --network regtest --peer-port 29790 --rpc-port 19790 --compose $EXTRA_ARGS 2>&1 | tee /tmp/integration_test_from_genesis-0.log | sed 's/(.*)/\0 \[I0\]/g'  &
 pid[0]=$!
 sleep 5s;
-RUST_BACKTRACE=1 XDG_DATA_HOME=$LOCAL_STATE_DIR/1/ nice -n 1 --  cargo $NIGHTLY run $FEATURES -- --network regtest --peer-port 29791 --rpc-port 19791 --peers 127.0.0.1:29790 $EXTRA_ARGS 2>&1 | tee /tmp/integration_test_from_genesis-1.log | sed 's/(.*)/\0 \[I1\]/g'  &
+RUST_BACKTRACE=1 XDG_DATA_HOME=$LOCAL_STATE_DIR/1/ nice -n 1 --  cargo $NIGHTLY run $FEATURES -- --network regtest --peer-port 29791 --rpc-port 19791 --guess --peers 127.0.0.1:29790 $EXTRA_ARGS 2>&1 | tee /tmp/integration_test_from_genesis-1.log | sed 's/(.*)/\0 \[I1\]/g'  &
 pid[1]=$!
 sleep 5s;
 RUST_BACKTRACE=1 XDG_DATA_HOME=$LOCAL_STATE_DIR/2/ nice -n 1 --  cargo $NIGHTLY run $FEATURES  -- --network regtest --peer-port 29792 --rpc-port 19792 --peers 127.0.0.1:29791 --sync-mode-threshold 1000 $EXTRA_ARGS 2>&1 | tee /tmp/integration_test_from_genesis-2.log | sed 's/(.*)/\0 \[I2\]/g'  &

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -162,6 +162,14 @@ pub struct Block {
     digest: OnceLock<Digest>,
 }
 
+impl std::hash::Hash for Block {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        // we just hash the tip5 Digest, which is already cached.
+        let digest = self.hash();
+        std::hash::Hash::hash(&digest, state)
+    }
+}
+
 impl PartialEq for Block {
     fn eq(&self, other: &Self) -> bool {
         // TBD: is it faster overall to compare hashes or equality

--- a/src/models/peer.rs
+++ b/src/models/peer.rs
@@ -7,6 +7,7 @@ pub mod transfer_transaction;
 
 use std::fmt::Display;
 use std::net::SocketAddr;
+use std::sync::Arc;
 use std::time::SystemTime;
 
 use handshake_data::HandshakeData;
@@ -450,7 +451,7 @@ pub(crate) enum PeerMessage {
 
     BlockProposalRequest(BlockProposalRequest),
 
-    BlockProposal(Box<Block>),
+    BlockProposal(Arc<Block>),
 
     /// Send a full transaction object to a peer.
     Transaction(Box<TransferTransaction>),

--- a/src/models/state/mining_state_machine.rs
+++ b/src/models/state/mining_state_machine.rs
@@ -1,0 +1,1050 @@
+//! This module implements [MiningStateMachine], a finite-state-machine
+//! specific to neptune-core mining.
+//!
+//! The [MiningStateMachine] has been implemented with the following
+//! objectives/reasons:
+//!
+//! 1. Simplify the complex code in the mining loop so it is
+//!    more maintainable.
+//!
+//! 2. Facilitate a lock-free mining loop, which means less
+//!    possibility of delay for miners.
+//!
+//! 3. Cleanly support granular display of mining-status, so user can
+//!    see a message like "waiting for block proposal" rather than
+//!    just "inactive".
+//!
+//! 4. consolidate/unify pause and unpause logic, since pausing
+//!    can occur for different reasons.
+//!
+//! 5. Make the core logic of transitioning between mining states
+//!    testable via unit tests.
+//!
+//!
+//! States and events are defined in [super::mining_status].
+//!
+//! A set of allowed state transitions is defined for each state.
+//! I.e. each state can be followed only by certain allowed states.
+//!
+//! The state-machine basically responds to events and determines
+//! what the next state should be. It then verifies that it is allowed
+//! to transition from the present state to the next state.
+//!
+//! If the state transition is not allowed:
+//!  a) the event is ignored, or
+//!  b) an error is returned.
+//!
+//! The exact behavior depends on the `strict_state_transitions` setting
+//! of [MiningStateMachine].
+
+use itertools::Itertools;
+
+use super::mining_status::MiningEvent;
+use super::mining_status::MiningPausedReason;
+use super::mining_status::MiningState;
+use super::mining_status::MiningStateData;
+
+// Defines the allowed transitions between states.
+//
+// The order of sub-arrays is important.  Each sub-array is indexed by the
+// integer value of the corresponding MiningState variant.  Eg:
+//
+//  MiningState::Init = 0                 --> index 0.
+//  MiningState::AwaitBlockProposal = 1   --> index 1.
+//  MiningState::Composing = 2            --> index 2.
+//
+// Each sub-array contains the set of states that are allowed to occur after the
+// indexed state.
+//
+// The "happy path" represents the expected progression of states during normal
+// mining.  see also: state_machine_tests::worker::HAPPY_PATH_STATE_TRANSITIONS
+#[rustfmt::skip]
+const MINING_STATE_TRANSITIONS: [&[MiningState]; 11] = [
+
+    // ----- start happy path -----
+
+    // MiningState::Init
+    &[
+        MiningState::AwaitBlockProposal,
+        MiningState::NewTipBlock,
+        MiningState::Paused,
+        MiningState::Shutdown,
+    ],
+
+    // MiningState::AwaitBlockProposal
+    &[
+        MiningState::Composing,
+        MiningState::Paused,
+        MiningState::Shutdown,
+        MiningState::NewTipBlock,
+    ],
+
+    // MiningState::Composing
+    &[
+        MiningState::AwaitBlock,
+        MiningState::ComposeError,
+        MiningState::Paused,
+        MiningState::Shutdown,
+        MiningState::NewTipBlock,
+    ],
+
+    // MiningState::AwaitBlock
+    &[
+        MiningState::Guessing,
+        MiningState::Paused,
+        MiningState::Shutdown,
+        MiningState::NewTipBlock,
+    ],
+
+    // MiningState::Guessing
+    &[
+        MiningState::NewTipBlock,
+        MiningState::Paused,
+        MiningState::Shutdown,
+    ],
+
+    // MiningState::NewTipBlock
+    &[
+        MiningState::Init,
+        MiningState::Paused,
+        MiningState::Shutdown,
+    ],
+
+    // ---- end happy path ----
+
+    // MiningState::ComposeError
+    &[
+        MiningState::Shutdown
+    ],
+
+    // MiningState::Paused
+    &[
+        MiningState::UnPaused,
+        MiningState::Shutdown
+    ],
+
+    // MiningState::UnPaused
+    &[
+        MiningState::Init,
+        MiningState::Shutdown
+    ],
+
+    // MiningState::Disabled
+    &[],
+
+
+    // MiningState::Shutdown
+    &[],
+];
+
+/// see module description.
+#[derive(Debug, Clone)]
+pub(crate) struct MiningStateMachine {
+    state_data: MiningStateData, // holds a MiningState.
+
+    paused_while_syncing: bool,
+    paused_by_rpc: bool,
+    paused_need_connection: bool,
+
+    config: MiningStateMachineConfig,
+}
+
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("invalid state transition from {:?} to {:?}", old_state, new_state)]
+pub(crate) struct InvalidStateTransition {
+    pub old_state: MiningState,
+    pub new_state: MiningState,
+}
+
+/// configuration for [MiningStateMachine]
+#[derive(Debug, Clone)]
+pub(crate) struct MiningStateMachineConfig {
+    // should we compose?
+    pub role_compose: bool,
+
+    // should we guess?
+    pub role_guess: bool,
+
+    // true: return error on invalid state transitions.
+    // false: ignore invalid state transitions, return Ok()
+    pub strict_state_transitions: bool,
+}
+
+impl MiningStateMachine {
+    pub fn new(config: MiningStateMachineConfig) -> Self {
+        let myself = Self {
+            config,
+            state_data: MiningStateData::init(),
+            paused_while_syncing: false,
+            paused_by_rpc: false,
+            paused_need_connection: false,
+        };
+        tracing::debug!("new {:?}", myself);
+        myself
+    }
+
+    pub fn config(&self) -> &MiningStateMachineConfig {
+        &self.config
+    }
+
+    pub(crate) fn state_data(&self) -> &MiningStateData {
+        &self.state_data
+    }
+
+    /// handles a single [MiningEvent].
+    pub fn handle_event(&mut self, event: MiningEvent) -> Result<(), InvalidStateTransition> {
+        tracing::debug!(
+            "handle_event: old_state: {}, event: {}",
+            self.state_data.name(),
+            event,
+        );
+
+        match event {
+            MiningEvent::Init => self.advance_with(MiningStateData::init())?,
+
+            MiningEvent::AwaitBlockProposal => {
+                self.advance_with(MiningStateData::await_block_proposal())?
+            }
+
+            MiningEvent::StartComposing => self.advance_with(MiningStateData::composing())?,
+
+            MiningEvent::StartGuessing if self.state_data.state() == MiningState::AwaitBlock => {
+                match &self.state_data {
+                    MiningStateData::AwaitBlock(_, proposed_block) => {
+                        self.advance_with(MiningStateData::guessing(proposed_block.clone()))?
+                    }
+                    _ => unreachable!(),
+                }
+            }
+            // out-of-order event.  we can't call
+            // advance_with(MiningEventData::guessing(proposed_block)) because
+            // we don't have a proposed-block.
+            MiningEvent::StartGuessing => {
+                if self.config.strict_state_transitions {
+                    return Err(InvalidStateTransition {
+                        old_state: self.state_data.state(),
+                        new_state: MiningState::Guessing,
+                    });
+                }
+            }
+
+            MiningEvent::PauseByRpc => self.pause_by_rpc(),
+            MiningEvent::UnPauseByRpc => self.unpause_by_rpc(),
+
+            MiningEvent::PauseBySyncBlocks => self.pause_by_sync_blocks(),
+            MiningEvent::UnPauseBySyncBlocks => self.unpause_by_sync_blocks(),
+
+            MiningEvent::PauseByNeedConnection => self.pause_by_need_connection(),
+            MiningEvent::UnPauseByNeedConnection => self.unpause_by_need_connection(),
+
+            // if new-block-proposal arrives while we are guessing, then we need
+            // to update the existing mining state_data, rather than advance to next
+            // state.  (without this special case, if we just advance, it still
+            // works, but guessing time resets to time of latest block proposal,
+            // instead of when guessing actually started.)
+            MiningEvent::NewBlockProposal(proposal)
+                if self.state_data.state() == MiningState::Guessing =>
+            {
+                self.set_state_data(MiningStateData::Guessing(self.state_data.since(), proposal));
+            }
+            // same as above, but this applies to AwaitBlock
+            MiningEvent::NewBlockProposal(proposal)
+                if self.state_data.state() == MiningState::AwaitBlock =>
+            {
+                self.set_state_data(MiningStateData::AwaitBlock(
+                    self.state_data.since(),
+                    proposal,
+                ));
+            }
+            MiningEvent::NewBlockProposal(proposal) => {
+                // guesser skips Composing state.
+                if self.config.role_guess
+                    && self.state_data.state() == MiningState::AwaitBlockProposal
+                {
+                    self.advance_with(MiningStateData::composing())?;
+                }
+                self.advance_with(MiningStateData::await_block(proposal))?;
+            }
+
+            MiningEvent::NewTipBlock => self.advance_with(MiningStateData::new_tip_block())?,
+
+            MiningEvent::ComposeError => self.advance_with(MiningStateData::compose_error())?,
+
+            MiningEvent::Shutdown => self.advance_with(MiningStateData::shutdown())?,
+        }
+        Ok(())
+    }
+
+    // advances to input state-data if allowed.
+    //
+    // returns error if not allowed and in strict_transitions mode.
+    // silently ignores input if not allowed and not in strict mode.
+    fn advance_with(
+        &mut self,
+        new_state_data: MiningStateData,
+    ) -> Result<(), InvalidStateTransition> {
+        tracing::debug!(
+            "advance_with: old_state: {}, new_state: {}",
+            self.state_data.name(),
+            new_state_data.name()
+        );
+
+        // special handling for pause.
+        if let MiningStateData::Paused(_, ref reasons) = new_state_data {
+            assert!(!reasons.is_empty());
+            for reason in reasons {
+                self.pause(reason)
+            }
+        } else if self.config.strict_state_transitions {
+            self.ensure_allowed(&new_state_data)?;
+            self.set_state_data(new_state_data);
+        } else if self.allowed(&new_state_data) {
+            self.set_state_data(new_state_data);
+        }
+
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn exec_states(
+        &mut self,
+        states: Vec<MiningStateData>,
+    ) -> Result<(), InvalidStateTransition> {
+        for state in states {
+            self.advance_with(state)?
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn exec_events(
+        &mut self,
+        events: Vec<MiningEvent>,
+    ) -> Result<(), InvalidStateTransition> {
+        for event in events {
+            self.handle_event(event)?
+        }
+        Ok(())
+    }
+
+    // sets new StateData and logs a debug msg.
+    fn set_state_data(&mut self, new_state_data: MiningStateData) {
+        self.state_data = new_state_data;
+        tracing::debug!("set new state: {}", self.state_data.name());
+    }
+
+    // merges two Paused state-data together and sets.
+    //   1. keeps timestamp of the original state-data.
+    //   2. appends reasons(s) of new state-data to original state-data reasons.
+    //   3. ensures reasons are unique.
+    //
+    // panics if old or new state-data is not Paused.
+    fn merge_paused_state_data(&mut self, new_state_data: MiningStateData) -> MiningStateData {
+        match (self.state_data.clone(), new_state_data) {
+            (
+                MiningStateData::Paused(old_time, mut old_reasons),
+                MiningStateData::Paused(_, mut new_reasons),
+            ) => {
+                old_reasons.append(&mut new_reasons);
+                // ensure unique
+                MiningStateData::Paused(old_time, old_reasons.into_iter().unique().collect())
+            }
+            (_, MiningStateData::Paused(t, reasons)) => MiningStateData::Paused(t, reasons),
+            _ => panic!("attempted to merge MiningStateData other than Paused"),
+        }
+    }
+
+    fn pause(&mut self, reason: &MiningPausedReason) {
+        match reason {
+            MiningPausedReason::Rpc => self.pause_by_rpc(),
+            MiningPausedReason::SyncBlocks => self.pause_by_sync_blocks(),
+            MiningPausedReason::NeedConnection => self.pause_by_need_connection(),
+        };
+    }
+
+    fn pause_by_need_connection(&mut self) {
+        if !self.paused_need_connection {
+            let reason = MiningPausedReason::NeedConnection;
+            let new_state_data = MiningStateData::paused(reason);
+            if self.allowed(&new_state_data) {
+                let merged = self.merge_paused_state_data(new_state_data);
+                self.set_state_data(merged);
+            }
+            self.paused_need_connection = true;
+        }
+    }
+
+    fn unpause_by_need_connection(&mut self) {
+        if self.paused_need_connection {
+            let _ = self.advance_with(MiningStateData::unpaused());
+            let _ = self.advance_with(MiningStateData::init());
+
+            self.paused_need_connection = false;
+        }
+    }
+
+    fn pause_by_rpc(&mut self) {
+        if !self.paused_by_rpc {
+            let reason = MiningPausedReason::Rpc;
+            let new_state_data = MiningStateData::paused(reason);
+            if self.allowed(&new_state_data) {
+                let merged = self.merge_paused_state_data(new_state_data);
+                self.set_state_data(merged);
+            }
+            self.paused_by_rpc = true;
+        }
+    }
+
+    fn unpause_by_rpc(&mut self) {
+        if self.paused_by_rpc {
+            let _ = self.advance_with(MiningStateData::unpaused());
+            let _ = self.advance_with(MiningStateData::init());
+
+            self.paused_by_rpc = false;
+        }
+    }
+
+    fn pause_by_sync_blocks(&mut self) {
+        if !self.paused_while_syncing {
+            let reason = MiningPausedReason::SyncBlocks;
+            let new_state_data = MiningStateData::paused(reason);
+            if self.allowed(&new_state_data) {
+                let merged = self.merge_paused_state_data(new_state_data);
+                self.set_state_data(merged);
+            }
+            self.paused_while_syncing = true;
+        }
+    }
+
+    fn unpause_by_sync_blocks(&mut self) {
+        if self.paused_while_syncing {
+            let _ = self.advance_with(MiningStateData::unpaused());
+            let _ = self.advance_with(MiningStateData::init());
+
+            self.paused_while_syncing = false;
+        }
+    }
+
+    // check if a given target state-data can be transitioned to or not.
+    //
+    // the general case is to check if the target state is allowed
+    // for the current state in the STATE_TRANSITIONS_TABLE.
+    //
+    // however some special cases are checked first:
+    //   1. Allow Init to be specified when already in Init state.
+    //   2. Allow same StateData (no change).
+    //   3. Only allow Disabled state if mining not enabled.
+    //   4. Only allow Shutdown when we have been paused in more than one way.
+    //      (once pause count returns to 1, normal rules apply)
+    fn allowed(&self, state_data: &MiningStateData) -> bool {
+        let state = state_data.state();
+
+        // we normally don't allow state equality since state-data variant data (eg
+        // timestamps) can differ between 2 MiningStateData with same state.
+        // We make an exception for Init because otherwise it can't be
+        // manually set.
+        if state == self.state_data.state() {
+            state == MiningState::Init
+        } else if *state_data == self.state_data {
+            true
+        } else if !self.mining_enabled() {
+            state == MiningState::Disabled
+        } else if self.paused_count() > 1 {
+            state == MiningState::Shutdown
+        } else {
+            // enforce state-transitions defined in MINING_STATE_TRANSITIONS
+            let s = state_data.state();
+            let allowed_states: &[MiningState] =
+                MINING_STATE_TRANSITIONS[self.state_data.state() as usize];
+            allowed_states.iter().any(|v| *v == s)
+        }
+    }
+
+    fn paused_count(&self) -> u8 {
+        self.paused_by_rpc as u8
+            + self.paused_while_syncing as u8
+            + self.paused_need_connection as u8
+    }
+
+    fn ensure_allowed(
+        &self,
+        new_state_data: &MiningStateData,
+    ) -> Result<(), InvalidStateTransition> {
+        if self.allowed(new_state_data) {
+            Ok(())
+        } else {
+            Err(InvalidStateTransition {
+                old_state: self.state_data.state(),
+                new_state: new_state_data.state(),
+            })
+        }
+    }
+
+    pub fn mining_enabled(&self) -> bool {
+        self.config.role_compose || self.config.role_guess
+    }
+
+    pub fn can_start_guessing(&self) -> bool {
+        self.config.role_guess && self.state_data.state() == MiningState::AwaitBlock
+    }
+
+    pub fn is_guessing(&self) -> bool {
+        self.config.role_guess && self.state_data.state() == MiningState::Guessing
+    }
+
+    pub fn can_start_composing(&self) -> bool {
+        self.config.role_compose && self.state_data.state() == MiningState::AwaitBlockProposal
+    }
+
+    pub fn is_composing(&self) -> bool {
+        self.config().role_compose && self.state_data.state() == MiningState::Composing
+    }
+}
+
+#[cfg(test)]
+mod state_machine_tests {
+
+    use tracing_test::traced_test;
+
+    use super::*;
+
+    const PAUSE_EVENTS: &[MiningEvent] = &[
+        MiningEvent::PauseByNeedConnection,
+        MiningEvent::PauseByRpc,
+        MiningEvent::PauseBySyncBlocks,
+    ];
+    const UNPAUSE_EVENTS: &[MiningEvent] = &[
+        MiningEvent::UnPauseByNeedConnection,
+        MiningEvent::UnPauseByRpc,
+        MiningEvent::UnPauseBySyncBlocks,
+    ];
+
+    // verifies that machine can progress through all states in the mining happy path.
+    // for every combination of machine config
+    #[traced_test]
+    #[test]
+    fn compose_and_guess_happy_path() -> anyhow::Result<()> {
+        for mut machine in worker::machine_matrix() {
+            let result = machine.exec_states(worker::compose_and_guess_happy_path());
+
+            if !machine.mining_enabled() && machine.config().strict_state_transitions {
+                assert!(result.is_err());
+            } else {
+                assert!(result.is_ok());
+            }
+        }
+
+        Ok(())
+    }
+
+    // verifies that pause event can occur during every state in the mining
+    // happy path, for every combination of machine config and pause event
+    #[traced_test]
+    #[test]
+    fn can_pause_all_along_happy_path() -> anyhow::Result<()> {
+        // test that all pause events can occur along happy path.
+        for (machine, pause_event) in worker::machine_event_matrix(PAUSE_EVENTS) {
+            if machine.mining_enabled() {
+                worker::can_pause_all_along_happy_path(machine, pause_event.to_owned())?;
+            }
+        }
+        Ok(())
+    }
+
+    // verifies that every pause event can occur during every reachable state
+    // for every combination of machine config and pause event
+    #[traced_test]
+    #[test]
+    fn can_pause_during_every_state() -> anyhow::Result<()> {
+        // test that all pause events can occur during every state
+        for (machine, pause_event) in worker::machine_event_matrix(PAUSE_EVENTS) {
+            worker::can_pause_during_every_state(machine, pause_event.to_owned())?;
+        }
+        Ok(())
+    }
+
+    // verifies that pause events only cause a mining state change for
+    // certain starting states -- for every possible combination of machine
+    // config and pause event
+    #[traced_test]
+    #[test]
+    fn pause_changes_only_certain_states() -> anyhow::Result<()> {
+        // test that all pause events only change correct states
+        for (machine, pause_event) in worker::machine_event_matrix(PAUSE_EVENTS) {
+            worker::pause_changes_only_certain_states(machine, pause_event.to_owned())?;
+        }
+        Ok(())
+    }
+
+    // verifies that unpause events only cause a mining state change for
+    // certain starting states -- for every combination of machine and
+    // pause/unpause event pair.
+    #[traced_test]
+    #[test]
+    fn unpause_changes_only_certain_states() -> anyhow::Result<()> {
+        // test that all unpause events only change correct states
+        for (machine, pause_event, unpause_event) in
+            worker::machine_matched_events_matrix(&worker::all_pause_and_unpause_events())
+        {
+            worker::unpause_changes_only_certain_states(machine, pause_event, unpause_event)?;
+        }
+        Ok(())
+    }
+
+    // verifies that all pause/unpause events work in any order for any state
+    // for every possible machine config.
+    #[traced_test]
+    #[test]
+    fn mixed_pause_unpause_types() -> anyhow::Result<()> {
+        for machine in worker::machine_matrix() {
+            worker::mixed_pause_unpause_types(machine)?;
+        }
+        Ok(())
+    }
+
+    // executes all events in composer+guesser role happy path and verifies no
+    // errors unless the machine is not mining and in strict_state_transitions
+    // mode.
+    #[traced_test]
+    #[test]
+    fn events_happy_path() -> anyhow::Result<()> {
+        for mut machine in worker::machine_matrix() {
+            tracing::debug!("machine config: {:?}", machine.config());
+            let result = machine.exec_events(worker::events_happy_path());
+
+            if !machine.mining_enabled() && machine.config().strict_state_transitions {
+                assert!(result.is_err());
+            } else {
+                assert!(result.is_ok());
+            }
+        }
+        Ok(())
+    }
+
+    // executes all events in composer role happy path and verifies no errors
+    // unless the machine is not mining and in strict_state_transitions mode.
+    #[traced_test]
+    #[test]
+    fn compose_happy_path() -> anyhow::Result<()> {
+        for mut machine in worker::machine_matrix() {
+            tracing::debug!("machine config: {:?}", machine.config());
+            let result = machine.exec_events(worker::events_happy_path());
+
+            if !machine.mining_enabled() && machine.config().strict_state_transitions {
+                assert!(result.is_err());
+            } else {
+                assert!(result.is_ok());
+            }
+        }
+        Ok(())
+    }
+
+    // executes all events in guesser role happy path and verifies no errors
+    // unless the machine is not mining and in strict_state_transitions mode.
+    #[traced_test]
+    #[test]
+    fn guess_happy_path() -> anyhow::Result<()> {
+        for mut machine in worker::machine_matrix() {
+            tracing::debug!("machine config: {:?}", machine.config());
+            let result = machine.exec_events(worker::events_happy_path());
+
+            if !machine.mining_enabled() && machine.config().strict_state_transitions {
+                assert!(result.is_err());
+            } else {
+                assert!(result.is_ok());
+            }
+        }
+        Ok(())
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn new_block_proposal_replaces_old() -> anyhow::Result<()> {
+        for machine in worker::machine_matrix() {
+            tracing::debug!("machine config: {:?}", machine.config());
+            worker::new_block_proposal_replaces_old(machine).await?;
+        }
+        Ok(())
+    }
+
+    mod worker {
+        use std::sync::Arc;
+
+        use rand::rng;
+        use rand::seq::SliceRandom;
+        use strum::IntoEnumIterator;
+
+        use super::super::super::mining_status::ProposedBlock;
+        use super::*;
+        use crate::config_models::network::Network;
+        use crate::tests::shared::make_mock_block_guesser_preimage_and_guesser_fraction_random;
+        use crate::Block;
+
+        #[rustfmt::skip]
+        const HAPPY_PATH_STATE_TRANSITIONS: &[MiningState] = &[
+            MiningState::Init,
+            MiningState::AwaitBlockProposal,
+            MiningState::Composing,
+            MiningState::AwaitBlock,
+            MiningState::Guessing,
+            MiningState::NewTipBlock,
+        ];
+
+        // returns a list of MiningStateMachine, one for every possible configuration.
+        pub fn machine_matrix() -> Vec<MiningStateMachine> {
+            let iter_bool = [true, false];
+            itertools::iproduct!(iter_bool, iter_bool, iter_bool)
+                .map(|(strict_state_transitions, role_compose, role_guess)| {
+                    vec![MiningStateMachine::new(MiningStateMachineConfig {
+                        strict_state_transitions,
+                        role_compose,
+                        role_guess,
+                    })]
+                })
+                .flatten()
+                .collect()
+        }
+
+        // returns a list (matrix) of every possible machine config
+        // and every event from input list.
+        pub fn machine_event_matrix(
+            iter_event: &[MiningEvent],
+        ) -> Vec<(MiningStateMachine, MiningEvent)> {
+            itertools::iproduct!(machine_matrix(), iter_event)
+                .map(|(machine, event)| vec![(machine, event.clone())])
+                .flatten()
+                .collect()
+        }
+
+        // returns a list (matrix) of every possible machine config
+        // and every (MiningEvent, MiningEvent) from input list.
+        pub fn machine_matched_events_matrix(
+            matched_events: &[(MiningEvent, MiningEvent)],
+        ) -> Vec<(MiningStateMachine, MiningEvent, MiningEvent)> {
+            itertools::iproduct!(machine_matrix(), matched_events)
+                .map(|(machine, events)| vec![(machine, events.0.clone(), events.1.clone())])
+                .flatten()
+                .collect()
+        }
+
+        // returns a list of every pause event with its matching unpause event.
+        pub fn all_pause_and_unpause_events() -> Vec<(MiningEvent, MiningEvent)> {
+            PAUSE_EVENTS
+                .iter()
+                .cloned()
+                .zip(UNPAUSE_EVENTS.iter().cloned())
+                .collect()
+        }
+
+        // returns all MiningStateData in the happy path for compose+guess role.
+        pub(super) fn compose_and_guess_happy_path_states() -> Vec<MiningState> {
+            HAPPY_PATH_STATE_TRANSITIONS
+                .iter()
+                .cycle()
+                .take(HAPPY_PATH_STATE_TRANSITIONS.len() + 1)
+                .copied()
+                .collect_vec()
+        }
+
+        pub fn compose_and_guess_happy_path() -> Vec<MiningStateData> {
+            compose_and_guess_happy_path_states()
+                .into_iter()
+                .map(state_to_state_data)
+                .collect_vec()
+        }
+
+        pub fn state_to_state_data(state: MiningState) -> MiningStateData {
+            match state {
+                MiningState::AwaitBlock => MiningStateData::await_block(fake_proposed_block()),
+                MiningState::Guessing => MiningStateData::guessing(fake_proposed_block()),
+                _ => MiningStateData::try_from(state).unwrap(),
+            }
+        }
+
+        pub(super) async fn new_block_proposal_replaces_old(
+            mut machine: MiningStateMachine,
+        ) -> anyhow::Result<()> {
+            for initial_state in [MiningState::AwaitBlock, MiningState::Guessing] {
+                machine.state_data = match initial_state {
+                    MiningState::AwaitBlock => MiningStateData::await_block(fake_proposed_block()),
+                    MiningState::Guessing => MiningStateData::guessing(fake_proposed_block()),
+                    _ => unreachable!(),
+                };
+                let initial_since = machine.state_data.since();
+
+                // default fraction is 0.5, so 0.75 is different.
+                let guesser_fraction = 0.75;
+
+                // generate a new block, as our proposed block
+                let (new_block, _) = make_mock_block_guesser_preimage_and_guesser_fraction_random(
+                    &fake_proposed_block(),
+                    None,
+                    guesser_fraction,
+                )
+                .await;
+
+                let arc_new_block = Arc::new(new_block);
+
+                machine.handle_event(MiningEvent::NewBlockProposal(arc_new_block.clone()))?;
+
+                // verify we are still in initial state.
+                assert!(machine.state_data.state() == initial_state);
+
+                // verify state timestamp hasn't changed.
+                assert!(machine.state_data.since() == initial_since);
+
+                // verify that the proposed block has been updated in the state data.
+                match machine.state_data {
+                    MiningStateData::Guessing(_, p) => {
+                        assert_eq!(p, arc_new_block);
+                    }
+                    MiningStateData::AwaitBlock(_, p) => {
+                        assert_eq!(p, arc_new_block);
+                    }
+                    _ => unreachable!(),
+                }
+            }
+            Ok(())
+        }
+
+        // verifies that input pause event succeeds without error for every
+        // reachable starting-state, for provided machine.
+        pub(super) fn can_pause_during_every_state(
+            machine_in: MiningStateMachine,
+            pause_event: MiningEvent,
+        ) -> anyhow::Result<()> {
+            // for each state, we make a new state-machine and force it
+            // to the target state, then pause it.
+            for state_data in all_reachable_state_data(&machine_in) {
+                let mut machine = machine_in.clone();
+                tracing::debug!(
+                    "state: {}, machine config: {:?}",
+                    state_data.state(),
+                    machine.config()
+                );
+                machine.state_data = state_data;
+                machine.handle_event(pause_event.clone())?;
+            }
+            Ok(())
+        }
+
+        // verifies that pausing only causes mining state to change for
+        // selected starting states.
+        pub(super) fn pause_changes_only_certain_states(
+            machine_in: MiningStateMachine,
+            pause_event: MiningEvent,
+        ) -> anyhow::Result<()> {
+            // for each state, we make a new machine and force it to the target state, then pause it.
+            for state_data in all_reachable_state_data(&machine_in) {
+                let mut machine = machine_in.clone();
+                tracing::debug!(
+                    "state: {}, machine config: {:?}",
+                    state_data.state(),
+                    machine.config()
+                );
+                machine.state_data = state_data.clone();
+                machine.handle_event(pause_event.clone())?;
+
+                let ss = state_data.state();
+                let ms = machine.state_data.state();
+                let ps = MiningState::Paused;
+
+                // certain states should not switch to Paused state.
+                // (although the machine updates the appropiate pause
+                // flag internally)
+
+                match ss {
+                    MiningState::Init => assert_eq!(ms, ps),
+                    MiningState::AwaitBlockProposal => assert_eq!(ms, ps),
+                    MiningState::Composing => assert_eq!(ms, ps),
+                    MiningState::AwaitBlock => assert_eq!(ms, ps),
+                    MiningState::Guessing => assert_eq!(ms, ps),
+                    MiningState::NewTipBlock => assert_eq!(ms, ps),
+                    MiningState::ComposeError => assert_eq!(ms, ss),
+                    MiningState::Paused => assert_eq!(ms, ps),
+                    MiningState::UnPaused => assert_eq!(ms, ss),
+                    MiningState::Disabled => assert_eq!(ms, ss),
+                    MiningState::Shutdown => assert_eq!(ms, ss),
+                }
+            }
+            Ok(())
+        }
+
+        // verifies that unpausing only causes mining state to change for
+        // selected starting states.
+        pub(super) fn unpause_changes_only_certain_states(
+            machine_in: MiningStateMachine,
+            pause_event: MiningEvent,
+            unpause_event: MiningEvent,
+        ) -> anyhow::Result<()> {
+            // for each state, we make a new state-machine and force it
+            // to the target state, then pause and unpause it.
+            for state_data in all_reachable_state_data(&machine_in) {
+                let mut machine = machine_in.clone();
+                tracing::debug!(
+                    "state: {}, machine config: {:?}",
+                    state_data.state(),
+                    machine.config()
+                );
+                machine.state_data = state_data.clone();
+                machine.handle_event(pause_event.clone())?;
+                machine.handle_event(unpause_event.clone())?;
+
+                let ss = state_data.state();
+                let ms = machine.state_data.state();
+                let is = MiningState::Init;
+
+                // certain states should not switch state after UnPause
+                // (although the machine updates the appropiate pause
+                // flag internally)
+
+                match ss {
+                    MiningState::Init => assert_eq!(ms, is),
+                    MiningState::AwaitBlockProposal => assert_eq!(ms, is),
+                    MiningState::Composing => assert_eq!(ms, is),
+                    MiningState::AwaitBlock => assert_eq!(ms, is),
+                    MiningState::Guessing => assert_eq!(ms, is),
+                    MiningState::NewTipBlock => assert_eq!(ms, is),
+                    MiningState::ComposeError => assert_eq!(ms, ss),
+                    MiningState::Paused => assert_eq!(ms, is),
+                    MiningState::UnPaused => assert_eq!(ms, is),
+                    MiningState::Disabled => assert_eq!(ms, ss),
+                    MiningState::Shutdown => assert_eq!(ms, ss),
+                }
+            }
+            Ok(())
+        }
+
+        // verifies that all pause/unpause events work in any order for any state
+        // for a given state machine (config).
+        //
+        // puts machine into random states and then handles all possible pause and unpause
+        // events in random order.
+        //
+        // verifies that machine's pause flags and count match our own.
+        pub(super) fn mixed_pause_unpause_types(
+            mut machine: MiningStateMachine,
+        ) -> anyhow::Result<()> {
+            // for each state, we force machine to the target state, then pause and unpause it.
+
+            let mut paused_by_rpc = false;
+            let mut paused_while_syncing = false;
+            let mut paused_need_connection = false;
+
+            let mut state_data = all_reachable_state_data(&machine);
+            let mut events = all_pause_and_unpause_events()
+                .into_iter()
+                .flat_map(|(a, b)| [a, b])
+                .collect_vec();
+
+            for _ in 0..50 {
+                state_data.shuffle(&mut rng());
+                events.shuffle(&mut rng());
+
+                // force to this random state_data.  (not allowed by API)
+                machine.state_data = state_data.first().cloned().unwrap();
+
+                for event in events.iter() {
+                    match *event {
+                        MiningEvent::PauseByNeedConnection => paused_need_connection = true,
+                        MiningEvent::UnPauseByNeedConnection => paused_need_connection = false,
+                        MiningEvent::PauseByRpc => paused_by_rpc = true,
+                        MiningEvent::UnPauseByRpc => paused_by_rpc = false,
+                        MiningEvent::PauseBySyncBlocks => paused_while_syncing = true,
+                        MiningEvent::UnPauseBySyncBlocks => paused_while_syncing = false,
+                        _ => {}
+                    }
+                    machine.handle_event(event.clone())?;
+                }
+            }
+
+            // verify that machine pause flags match ours.
+            assert_eq!(paused_by_rpc, machine.paused_by_rpc);
+            assert_eq!(paused_while_syncing, machine.paused_while_syncing);
+            assert_eq!(paused_need_connection, machine.paused_need_connection);
+
+            let paused_count =
+                paused_by_rpc as u8 + paused_while_syncing as u8 + paused_need_connection as u8;
+            assert_eq!(paused_count, machine.paused_count());
+
+            Ok(())
+        }
+
+        // returns all state_data variants that can be reached by the input machine.
+        fn all_reachable_state_data(machine: &MiningStateMachine) -> Vec<MiningStateData> {
+            if machine.mining_enabled() {
+                all_enabled_state_data()
+            } else {
+                vec![MiningStateData::disabled()]
+            }
+        }
+
+        // returns all state_data, including different pause reasons, that can be reached
+        // by a machine with mining enabled. (role_compose or role_guess)
+        fn all_enabled_state_data() -> Vec<MiningStateData> {
+            MiningState::iter()
+                .filter(|s| *s != MiningState::Disabled)
+                .flat_map(|state| match state {
+                    MiningState::Paused => MiningPausedReason::iter()
+                        .map(MiningStateData::paused)
+                        .collect_vec(),
+                    _ => vec![state_to_state_data(state)],
+                })
+                .collect()
+        }
+
+        // attempts to handle input pause event for every state in the happy path.
+        pub(super) fn can_pause_all_along_happy_path(
+            machine_in: MiningStateMachine,
+            pause_event: MiningEvent,
+        ) -> anyhow::Result<()> {
+            // for each state_data in happy path, we make a new state-machine and advance it
+            // to the target state, then pause it.
+            for state_data in compose_and_guess_happy_path() {
+                let mut machine = machine_in.clone();
+                tracing::debug!(
+                    "state: {}, machine config: {:?}",
+                    state_data.state(),
+                    machine.config()
+                );
+                advance_init_to_state(&mut machine, state_data.state())?;
+                machine.handle_event(pause_event.clone())?;
+            }
+            Ok(())
+        }
+
+        // advances along the happy path from current state (which should be init)
+        // to a target state using the ::advance_with() method.
+        fn advance_init_to_state(
+            machine: &mut MiningStateMachine,
+            target: MiningState,
+        ) -> anyhow::Result<()> {
+            for state_data in compose_and_guess_happy_path() {
+                let state = state_data.state();
+                machine.advance_with(state_data)?;
+                if state == target {
+                    break;
+                }
+            }
+            Ok(())
+        }
+
+        pub fn fake_proposed_block() -> ProposedBlock {
+            Arc::new(Block::genesis(Network::Main))
+        }
+
+        // return list of events for composer to advance along happy path
+        // from init all the way back to init.
+        pub(super) fn events_happy_path() -> Vec<MiningEvent> {
+            vec![
+                MiningEvent::Init,
+                MiningEvent::AwaitBlockProposal,
+                MiningEvent::StartComposing,
+                MiningEvent::NewBlockProposal(fake_proposed_block()), // Composing   --> AwaitBlock
+                MiningEvent::StartGuessing,
+                MiningEvent::NewTipBlock,
+                MiningEvent::Init,
+            ]
+        }
+    }
+}

--- a/src/models/state/mining_status.rs
+++ b/src/models/state/mining_status.rs
@@ -1,5 +1,32 @@
-use std::fmt::Display;
-use std::time::Duration;
+//! This module defines states used by the `MiningStateMachine`.
+//!
+//! There are 4 primary inter-related enums:
+//!
+//! 1. MiningState
+//! 2. MiningStateData
+//! 3. MiningStatus
+//! 4. MiningEvent
+//!
+//! 1 to 3 all have (must have) the same variants as they all represent
+//! the same states, but for different usages.
+//!
+//! [MiningState] defines the basic states without any associated data.
+//! The `MiningStateMachine` defines allowed transitions between these
+//! states.
+//!
+//! [MiningStateData] variants include a timestamp and data related to
+//! processing, such as a proposed-block.
+//!
+//! [MiningStatus] is intended for display purposes.  Variants include
+//! short informational summaries that can be serialized over the wire
+//! efficiently.
+//!
+//! [MiningEvent] represents events that the MiningStateMachine can handle
+//! in order to transition between states.  These events may have associated
+//! data.
+
+use std::hash::Hash;
+use std::sync::Arc;
 use std::time::SystemTime;
 
 use serde::Deserialize;
@@ -8,97 +35,517 @@ use serde::Serialize;
 use crate::models::blockchain::block::Block;
 use crate::models::blockchain::type_scripts::native_currency_amount::NativeCurrencyAmount;
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-pub struct GuessingWorkInfo {
-    work_start: SystemTime,
-    num_inputs: usize,
-    num_outputs: usize,
-    total_coinbase: NativeCurrencyAmount,
-    total_guesser_fee: NativeCurrencyAmount,
+pub(super) type ProposedBlock = Arc<Block>;
+
+/// Defines the possible states of the `MiningStateMachine`.
+/// The `MiningStateMachine` defines allowed transitions between these
+/// states.
+///
+/// There is a notion of a "Happy Path" which is an ordered
+/// set of states that progress for each block during mining.
+///
+/// The same ordered set of happy-path states applies to both
+/// composing and guessing roles.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::EnumIter)]
+#[repr(u8)]
+pub(crate) enum MiningState {
+    // ---- happy path ----
+    Init = 0,
+    AwaitBlockProposal = 1,
+    Composing = 2,
+    AwaitBlock = 3,
+    Guessing = 4,
+    NewTipBlock = 5,
+    // ---- end happy path ----
+    ComposeError = 6,
+    Paused = 7,   // Rpc, SyncBlocks, NeedConnection
+    UnPaused = 8, // transitional state.
+    Disabled = 9,
+    Shutdown = 10,
 }
 
-impl GuessingWorkInfo {
-    pub(crate) fn new(work_start: SystemTime, block: &Block) -> Self {
-        Self {
-            work_start,
-            num_inputs: block.body().transaction_kernel.inputs.len(),
-            num_outputs: block.body().transaction_kernel.outputs.len(),
-            total_coinbase: block.body().transaction_kernel.coinbase.unwrap_or_default(),
-            total_guesser_fee: block.body().transaction_kernel.fee,
+/// Associates processing data with each state.
+///
+/// note: variants must match those of [MiningState]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub(crate) enum MiningStateData {
+    Disabled(SystemTime),
+    Init(SystemTime),
+    Paused(SystemTime, Vec<MiningPausedReason>), // Rpc, SyncBlocks, NeedConnection
+    UnPaused(SystemTime),
+    AwaitBlockProposal(SystemTime),
+    AwaitBlock(SystemTime, ProposedBlock),
+    Composing(SystemTime),
+    Guessing(SystemTime, ProposedBlock),
+    NewTipBlock(SystemTime),
+    ComposeError(SystemTime),
+    Shutdown(SystemTime),
+}
+
+/// associates display/summary data with each state.
+///
+/// This type is intended for RPC API usage.  As such it implements
+/// Serialize and Deserialize.
+///
+/// note: variants must match those of [MiningState]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum MiningStatus {
+    Disabled(SystemTime),
+    Init(SystemTime),
+    Paused(SystemTime, Vec<MiningPausedReason>), // Rpc, SyncBlocks, NeedConnection
+    UnPaused(SystemTime),
+    AwaitBlockProposal(SystemTime),
+    AwaitBlock(SystemTime, BlockSummary),
+    Composing(SystemTime),
+    Guessing(SystemTime, BlockSummary),
+    NewTipBlock(SystemTime),
+    ComposeError(SystemTime),
+    Shutdown(SystemTime),
+}
+
+/// defines events that the `MiningStateMachine` can handle.
+#[derive(Clone)]
+pub(crate) enum MiningEvent {
+    /// initialize. reset. restart.
+    /// each time a block is found, we begin with Init.
+    Init,
+
+    /// signals the start of mining.
+    /// Composers should receive a StartComposing event.
+    /// Guessers wait here until a block proposal is found.
+    AwaitBlockProposal,
+
+    /// signals to begin composing.
+    StartComposing,
+
+    /// signals to begin guessing.
+    StartGuessing,
+
+    /// signals mining is paused via RPC
+    PauseByRpc,
+
+    /// signals mining is unpaused via RPC
+    UnPauseByRpc,
+
+    /// signals mining is paused while syncing blocks
+    PauseBySyncBlocks,
+
+    /// signals mining is unpaused after syncing blocks
+    UnPauseBySyncBlocks,
+
+    /// signals mining is paused because we need a connection
+    PauseByNeedConnection,
+
+    /// signals mining is unpaused because we got a connection
+    UnPauseByNeedConnection,
+
+    /// signals we received a new block proposal
+    NewBlockProposal(ProposedBlock),
+
+    /// signals we received a new tip block
+    NewTipBlock,
+
+    /// signals that an error occurred while composing.
+    ComposeError,
+
+    /// signals that mining is shutting down.
+    Shutdown,
+}
+
+/// Indicates reason for being in the Paused state.
+///
+/// note that Paused state can have multiple `MiningPausedReason`
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, strum::EnumIter)]
+pub enum MiningPausedReason {
+    /// paused by rpc. (user)
+    Rpc,
+
+    /// syncing blocks
+    SyncBlocks,
+
+    /// need peer connections
+    NeedConnection,
+}
+
+/// intended for summarizing a proposed block for the Guessing state.
+///
+/// Intended to be sent via RPC API.  So it implements Serialize and
+/// Deserialize.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct BlockSummary {
+    pub num_inputs: usize,
+    pub num_outputs: usize,
+    pub total_coinbase: NativeCurrencyAmount,
+    pub total_guesser_fee: NativeCurrencyAmount,
+}
+
+// This file contains several inter-related enums and it is useful to
+// present them one after another (above).
+//
+// To keep things organized, we place the impl for each one into its
+// own module below.  We could also consider making a file for each.
+
+mod mining_event_impl {
+    use super::*;
+
+    impl MiningEvent {
+        fn name(&self) -> &str {
+            match self {
+                Self::Init => "init",
+                Self::AwaitBlockProposal => "await-block-proposal",
+                Self::StartComposing => "start-composing",
+                Self::StartGuessing => "start-guessing",
+                Self::PauseByRpc => "pause-by-rpc",
+                Self::UnPauseByRpc => "unpause-by-rpc",
+                Self::PauseBySyncBlocks => "pause-by-sync-blocks",
+                Self::UnPauseBySyncBlocks => "unpause-by-sync-blocks",
+                Self::PauseByNeedConnection => "pause-by-need-connection",
+                Self::UnPauseByNeedConnection => "unpause-by-need-connection",
+                Self::NewBlockProposal(_) => "new-block-proposal",
+                Self::NewTipBlock => "new-tip-block",
+                Self::ComposeError => "compose-error",
+                Self::Shutdown => "shutdown",
+            }
+        }
+    }
+
+    // we impl Debug in order to prevent writing out entire block in log(s)
+    impl std::fmt::Debug for MiningEvent {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{}", self.name())
+        }
+    }
+
+    impl std::fmt::Display for MiningEvent {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{}", self.name())
         }
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-pub struct ComposingWorkInfo {
-    // Only this info is available at the beginning of the composition work.
-    // The rest of the information will have to be read from the log.
-    work_start: SystemTime,
-}
+mod mining_state_impl {
+    use super::*;
 
-impl ComposingWorkInfo {
-    pub(crate) fn new(work_start: SystemTime) -> Self {
-        Self { work_start }
+    impl MiningState {
+        pub(super) fn name(&self) -> &str {
+            match *self {
+                Self::Disabled => "disabled",
+                Self::Init => "initializing",
+                Self::Paused => "paused",
+                Self::UnPaused => "unpaused",
+                Self::AwaitBlockProposal => "await block proposal",
+                Self::AwaitBlock => "await block",
+                Self::Composing => "composing",
+                Self::Guessing => "guessing",
+                Self::NewTipBlock => "new tip block",
+                Self::ComposeError => "composer error",
+                Self::Shutdown => "shutdown",
+            }
+        }
+    }
+
+    impl From<&MiningStatus> for MiningState {
+        fn from(s: &MiningStatus) -> MiningState {
+            match *s {
+                MiningStatus::Disabled(_) => MiningState::Disabled,
+                MiningStatus::Init(_) => MiningState::Init,
+                MiningStatus::Paused(..) => MiningState::Paused,
+                MiningStatus::UnPaused(_) => MiningState::UnPaused,
+                MiningStatus::AwaitBlockProposal(_) => MiningState::AwaitBlockProposal,
+                MiningStatus::AwaitBlock(..) => MiningState::AwaitBlock,
+                MiningStatus::Composing(_) => MiningState::Composing,
+                MiningStatus::Guessing(..) => MiningState::Guessing,
+                MiningStatus::NewTipBlock(_) => MiningState::NewTipBlock,
+                MiningStatus::ComposeError(_) => MiningState::ComposeError,
+                MiningStatus::Shutdown(_) => MiningState::Shutdown,
+            }
+        }
+    }
+
+    impl From<&MiningStateData> for MiningState {
+        fn from(s: &MiningStateData) -> Self {
+            match *s {
+                MiningStateData::Disabled(_) => MiningState::Disabled,
+                MiningStateData::Init(_) => MiningState::Init,
+                MiningStateData::Paused(..) => MiningState::Paused,
+                MiningStateData::UnPaused(_) => MiningState::UnPaused,
+                MiningStateData::AwaitBlockProposal(_) => MiningState::AwaitBlockProposal,
+                MiningStateData::AwaitBlock(..) => MiningState::AwaitBlock,
+                MiningStateData::Composing(_) => MiningState::Composing,
+                MiningStateData::Guessing(..) => MiningState::Guessing,
+                MiningStateData::NewTipBlock(_) => MiningState::NewTipBlock,
+                MiningStateData::ComposeError(_) => MiningState::ComposeError,
+                MiningStateData::Shutdown(_) => MiningState::Shutdown,
+            }
+        }
+    }
+
+    impl std::fmt::Display for MiningState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{}", self.name())
+        }
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum MiningStatus {
-    Guessing(GuessingWorkInfo),
-    Composing(ComposingWorkInfo),
-    Inactive,
+mod mining_state_data_impl {
+    use std::hash::Hasher;
+
+    use super::*;
+
+    impl TryFrom<MiningState> for MiningStateData {
+        type Error = anyhow::Error;
+
+        /// note that:
+        ///
+        ///   1. MiningStateData::Guessing is not supported.
+        ///   2. MiningStateData::Paused will use MiningPausedReason::Rpc
+        fn try_from(state: MiningState) -> Result<Self, Self::Error> {
+            Ok(match state {
+                MiningState::Disabled => MiningStateData::disabled(),
+                MiningState::Init => MiningStateData::init(),
+                MiningState::AwaitBlockProposal => MiningStateData::await_block_proposal(),
+                MiningState::AwaitBlock => anyhow::bail!("unsupported usage"),
+                MiningState::Composing => MiningStateData::composing(),
+                MiningState::Guessing => anyhow::bail!("unsupported usage"),
+                MiningState::NewTipBlock => MiningStateData::new_tip_block(),
+                MiningState::ComposeError => MiningStateData::compose_error(),
+                MiningState::Shutdown => MiningStateData::shutdown(),
+                MiningState::Paused => MiningStateData::paused(MiningPausedReason::Rpc),
+                MiningState::UnPaused => MiningStateData::unpaused(),
+            })
+        }
+    }
+
+    impl MiningStateData {
+        pub fn disabled() -> Self {
+            Self::Disabled(SystemTime::now())
+        }
+
+        pub fn init() -> Self {
+            Self::Init(SystemTime::now())
+        }
+
+        pub fn paused(reason: MiningPausedReason) -> Self {
+            Self::Paused(SystemTime::now(), vec![reason])
+        }
+
+        pub fn unpaused() -> Self {
+            Self::UnPaused(SystemTime::now())
+        }
+
+        pub fn await_block_proposal() -> Self {
+            Self::AwaitBlockProposal(SystemTime::now())
+        }
+
+        pub fn await_block(proposed_block: ProposedBlock) -> Self {
+            Self::AwaitBlock(SystemTime::now(), proposed_block)
+        }
+
+        pub fn composing() -> Self {
+            Self::Composing(SystemTime::now())
+        }
+
+        pub fn guessing(proposed_block: ProposedBlock) -> Self {
+            Self::Guessing(SystemTime::now(), proposed_block)
+        }
+
+        pub fn new_tip_block() -> Self {
+            Self::NewTipBlock(SystemTime::now())
+        }
+
+        pub fn compose_error() -> Self {
+            Self::ComposeError(SystemTime::now())
+        }
+
+        pub fn shutdown() -> Self {
+            Self::Shutdown(SystemTime::now())
+        }
+
+        pub fn is_init(&self) -> bool {
+            self.state() == MiningState::Init
+        }
+
+        pub fn is_composing(&self) -> bool {
+            self.state() == MiningState::Composing
+        }
+
+        pub fn is_guessing(&self) -> bool {
+            self.state() == MiningState::Guessing
+        }
+
+        pub fn is_shutdown(&self) -> bool {
+            self.state() == MiningState::Shutdown
+        }
+
+        pub fn state(&self) -> MiningState {
+            MiningState::from(self)
+        }
+
+        pub(crate) fn name(&self) -> String {
+            self.state().name().to_owned()
+        }
+
+        pub fn since(&self) -> SystemTime {
+            match *self {
+                Self::Disabled(t) => t,
+                Self::Init(t) => t,
+                Self::Paused(t, _) => t,
+                Self::UnPaused(t) => t,
+                Self::AwaitBlockProposal(t) => t,
+                Self::AwaitBlock(t, _) => t,
+                Self::Composing(t) => t,
+                Self::Guessing(t, _) => t,
+                Self::NewTipBlock(t) => t,
+                Self::ComposeError(t) => t,
+                Self::Shutdown(t) => t,
+            }
+        }
+
+        // returns hash of this MiningStateData, using [std::hash::DefaultHasher].
+        pub fn std_hash(&self) -> u64 {
+            let mut s = std::hash::DefaultHasher::new();
+            self.hash(&mut s);
+            s.finish()
+        }
+    }
 }
 
-impl Display for MiningStatus {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let elapsed_time_exact = match self {
-            MiningStatus::Guessing(guessing_work_info) => Some(
-                guessing_work_info
-                    .work_start
-                    .elapsed()
-                    .unwrap_or(Duration::ZERO),
-            ),
-            MiningStatus::Composing(composing_work_info) => Some(
-                composing_work_info
-                    .work_start
-                    .elapsed()
-                    .unwrap_or(Duration::ZERO),
-            ),
-            MiningStatus::Inactive => None,
-        };
+mod mining_status_impl {
+    use std::time::Duration;
+
+    use itertools::Itertools;
+
+    use super::*;
+
+    impl MiningStatus {
+        /// returns time when mining entered this status.
+        pub fn since(&self) -> SystemTime {
+            match *self {
+                Self::Disabled(t) => t,
+                Self::Init(t) => t,
+                Self::Paused(t, _) => t,
+                Self::UnPaused(t) => t,
+                Self::AwaitBlockProposal(t) => t,
+                Self::AwaitBlock(t, _) => t,
+                Self::Composing(t) => t,
+                Self::Guessing(t, _) => t,
+                Self::NewTipBlock(t) => t,
+                Self::ComposeError(t) => t,
+                Self::Shutdown(t) => t,
+            }
+        }
+
+        /// returns a list of reasons why mining is paused.
+        /// empty if not paused.
+        pub fn paused_reasons(&self) -> &[MiningPausedReason] {
+            match self {
+                Self::Paused(_, reasons) => reasons,
+                _ => &[],
+            }
+        }
+    }
+
+    impl std::fmt::Display for MiningStatus {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            let input_output_info = match self {
+                Self::Guessing(_, info) => {
+                    format!(" {}/{}", info.num_inputs, info.num_outputs)
+                }
+                _ => String::default(),
+            };
+
+            let work_type_and_duration = match self {
+                Self::Disabled(_) => MiningState::from(self).to_string(),
+                Self::Paused(t, reasons) => {
+                    format!(
+                        "paused for {}  ({})",
+                        human_duration_secs(&t.elapsed()),
+                        reasons.iter().map(|r| r.description()).join(", ")
+                    )
+                }
+                _ => format!(
+                    "{} for {}",
+                    MiningState::from(self),
+                    human_duration_secs(&self.since().elapsed()),
+                ),
+            };
+            let reward = match self {
+                Self::Guessing(_, block_summary) => format!(
+                    "; total guesser reward: {}",
+                    block_summary.total_guesser_fee
+                ),
+                _ => String::default(),
+            };
+
+            write!(f, "{work_type_and_duration}{input_output_info}{reward}",)
+        }
+    }
+
+    impl From<&MiningStateData> for MiningStatus {
+        fn from(ms: &MiningStateData) -> Self {
+            match ms {
+                MiningStateData::Disabled(t) => Self::Disabled(*t),
+                MiningStateData::Init(t) => Self::Init(*t),
+                MiningStateData::Paused(t, r) => Self::Paused(*t, r.clone()),
+                MiningStateData::UnPaused(t) => Self::UnPaused(*t),
+                MiningStateData::AwaitBlockProposal(t) => Self::AwaitBlockProposal(*t),
+                MiningStateData::AwaitBlock(t, p) => Self::AwaitBlock(*t, (&**p).into()),
+                MiningStateData::Composing(t) => Self::Composing(*t),
+                MiningStateData::Guessing(t, b) => Self::Guessing(*t, (&**b).into()),
+                MiningStateData::NewTipBlock(t) => Self::NewTipBlock(*t),
+                MiningStateData::ComposeError(t) => Self::ComposeError(*t),
+                MiningStateData::Shutdown(t) => Self::Shutdown(*t),
+            }
+        }
+    }
+
+    // formats a duration in human readable form, to seconds precision.
+    // eg: 7h 5m 23s
+    fn human_duration_secs(
+        duration_exact: &Result<Duration, std::time::SystemTimeError>,
+    ) -> String {
         // remove sub-second component, so humantime ends with seconds.
-        let elapsed_time =
-            elapsed_time_exact.map(|v| v - Duration::from_nanos(v.subsec_nanos().into()));
-        let input_output_info = match self {
-            MiningStatus::Guessing(info) => {
-                format!(" {}/{}", info.num_inputs, info.num_outputs)
-            }
-            _ => String::default(),
-        };
+        // also set to 0 if any error.
+        let duration_to_secs = duration_exact
+            .as_ref()
+            .map(|v| *v - Duration::from_nanos(v.subsec_nanos().into()))
+            .unwrap_or(Duration::ZERO);
+        humantime::format_duration(duration_to_secs).to_string()
+    }
+}
 
-        let work_type_and_duration = match self {
-            MiningStatus::Guessing(_) => {
-                format!(
-                    "guessing for {}",
-                    humantime::format_duration(elapsed_time.unwrap())
-                )
-            }
-            MiningStatus::Composing(_) => {
-                format!(
-                    "composing for {}",
-                    humantime::format_duration(elapsed_time.unwrap())
-                )
-            }
-            MiningStatus::Inactive => "inactive".to_owned(),
-        };
-        let reward = match self {
-            MiningStatus::Guessing(block_work_info) => format!(
-                "; total guesser reward: {}",
-                block_work_info.total_guesser_fee
-            ),
-            _ => String::default(),
-        };
+mod mining_paused_reason_impl {
+    use super::*;
 
-        write!(f, "{work_type_and_duration}{input_output_info}{reward}",)
+    impl MiningPausedReason {
+        pub fn description(&self) -> &str {
+            match self {
+                Self::Rpc => "user",
+                Self::SyncBlocks => "syncing blocks",
+                Self::NeedConnection => "await connections",
+            }
+        }
+    }
+
+    impl std::fmt::Display for MiningPausedReason {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            let desc = self.description();
+            write!(f, "{}", desc)
+        }
+    }
+}
+
+mod block_summary_impl {
+    use super::*;
+
+    impl From<&Block> for BlockSummary {
+        fn from(b: &Block) -> Self {
+            Self {
+                num_inputs: b.body().transaction_kernel.inputs.len(),
+                num_outputs: b.body().transaction_kernel.outputs.len(),
+                total_coinbase: b.body().transaction_kernel.coinbase.unwrap_or_default(),
+                total_guesser_fee: b.body().transaction_kernel.fee,
+            }
+        }
     }
 }

--- a/src/models/state/wallet/expected_utxo.rs
+++ b/src/models/state/wallet/expected_utxo.rs
@@ -46,7 +46,7 @@ use crate::util_types::mutator_set::commit;
 ///
 /// see [IncomingUtxo](crate::models::state::wallet::incoming_utxo::IncomingUtxo),
 /// [UtxoNotificationPayLoad](crate::models::state::wallet::utxo_notification::UtxoNotificationPayload)
-#[derive(Clone, Debug, Hash, GetSize, Serialize, Deserialize)]
+#[derive(Clone, Debug, Hash, GetSize, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ExpectedUtxo {
     pub utxo: Utxo,
     pub addition_record: AdditionRecord,

--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -3036,7 +3036,7 @@ impl RPC for NeptuneRPCServer {
         if self.state.cli().mine() {
             let _ = self
                 .rpc_server_to_main_tx
-                .send(RPCServerToMain::PauseMiner)
+                .send(RPCServerToMain::MinerPauseByRpc)
                 .await;
         } else {
             info!("Cannot pause miner since it was never started");
@@ -3056,7 +3056,7 @@ impl RPC for NeptuneRPCServer {
         if self.state.cli().mine() {
             let _ = self
                 .rpc_server_to_main_tx
-                .send(RPCServerToMain::RestartMiner)
+                .send(RPCServerToMain::MinerUnPauseByRpc)
                 .await;
         } else {
             info!("Cannot restart miner since it was never started");

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -736,6 +736,27 @@ pub(crate) async fn make_mock_block_guesser_preimage_and_guesser_fraction(
     (block, composer_expected_utxos)
 }
 
+/// Build a fake and invalid block where the caller can specify the
+/// guesser fraction.  The composer-key, seed, and guesser-preimage
+/// are randomly generated.
+///
+/// Returns (block, composer's expected UTXOs).
+pub(crate) async fn make_mock_block_guesser_preimage_and_guesser_fraction_random(
+    previous_block: &Block,
+    block_timestamp: Option<Timestamp>,
+    guesser_fraction: f64,
+) -> (Block, Vec<ExpectedUtxo>) {
+    make_mock_block_guesser_preimage_and_guesser_fraction(
+        previous_block,
+        block_timestamp,
+        generation_address::GenerationSpendingKey::derive_from_seed(rand::random()),
+        rand::random(),
+        guesser_fraction,
+        rand::random(),
+    )
+    .await
+}
+
 /// Build a fake block with a random hash, containing *two* outputs for the
 /// composer.
 ///


### PR DESCRIPTION
draft PR for now.  I will add some screenshots and notes later.

-------------

closes #423

implements a custom finite-state-machine that processes events in the mining loop and handles state-transitions.

benefits/reasons:

1. Simplify the complex code in the mining loop so it is more maintainable.

2. move towards a lock-free mining loop, which means less possibility of delay for miners.

3. Cleanly support granular display of mining-status, so user can see a message like "waiting for block proposal" rather than just "inactive".

4. consolidate/unify pause and unpause logic, since pausing can occur for different reasons.

5. Make the core logic of transitioning between mining states testable via unit tests.