### PR TITLE
refactor: Use mempool to avoid double-spends

### DIFF
--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -800,16 +800,6 @@ impl GlobalState {
             None
         };
 
-        // if selection-tracking is enabled, store the keys
-        #[cfg(test)]
-        let unlocked_utxos: HashSet<wallet::wallet_state::StrongUtxoKey> = config
-            .selection_is_tracked()
-            .then(|| tx_inputs.iter())
-            .into_iter()
-            .flatten()
-            .map(wallet::wallet_state::StrongUtxoKey::from)
-            .collect();
-
         let transaction_details = TransactionDetails::new_without_coinbase(
             tx_inputs,
             tx_outputs.to_owned(),
@@ -835,8 +825,6 @@ impl GlobalState {
             transaction,
             details: maybe_transaction_details,
             change_output: maybe_change_output,
-            #[cfg(test)]
-            selection: unlocked_utxos,
         };
 
         Ok(transaction_creation_artifacts)

--- a/src/models/state/tx_creation_artifacts.rs
+++ b/src/models/state/tx_creation_artifacts.rs
@@ -7,10 +7,6 @@ pub(crate) struct TxCreationArtifacts {
     pub(crate) transaction: Transaction,
     pub(crate) details: Option<TransactionDetails>,
     pub(crate) change_output: Option<TxOutput>,
-
-    #[cfg(test)]
-    pub(crate) selection:
-        std::collections::HashSet<crate::models::state::wallet::wallet_state::StrongUtxoKey>,
 }
 
 impl From<TxCreationArtifacts> for Transaction {

--- a/src/models/state/tx_creation_config.rs
+++ b/src/models/state/tx_creation_config.rs
@@ -62,9 +62,6 @@ pub(crate) struct TxCreationConfig {
     select_utxos: Option<DebuggableUtxoSelector>,
     record_details: bool,
     proof_job_options: TritonVmProofJobOptions,
-
-    #[cfg(test)]
-    track_selection: bool,
 }
 
 impl TxCreationConfig {
@@ -119,29 +116,9 @@ impl TxCreationConfig {
         self
     }
 
-    /// When selecting UTXOs, filter them through the given closure.
-    #[cfg(test)]
-    pub(crate) fn select_utxos<F>(mut self, selector: F) -> Self
-    where
-        F: Fn(&UnlockedUtxo) -> bool + Send + Sync + 'static,
-    {
-        self.select_utxos = Some(DebuggableUtxoSelector(Box::new(selector)));
-        self
-    }
-
     /// Produce a [`TransactionDetails`] object along with the other artifacts.
     pub(crate) fn record_details(mut self) -> Self {
         self.record_details = true;
-        self
-    }
-
-    /// Enable selection-tracking.
-    ///
-    /// When enabled, the a hash set of [`StrongUtxoKey`]s is stored, indicating
-    /// which UTXOs were selected for the transaction.
-    #[cfg(test)]
-    pub(crate) fn track_selection(mut self) -> Self {
-        self.track_selection = true;
         self
     }
 
@@ -160,12 +137,6 @@ impl TxCreationConfig {
     /// Determine whether a [`TransactionDetails`] object should be produced.
     pub(crate) fn details_are_recorded(&self) -> bool {
         self.record_details
-    }
-
-    /// Determine whether to track the selection of input UTXOs.
-    #[cfg(test)]
-    pub(crate) fn selection_is_tracked(&self) -> bool {
-        self.track_selection
     }
 
     /// Get the change key and notification medium, if any.


### PR DESCRIPTION
Drop the field `selection` from `TxCreationArtifacts` as the task of keeping track of unconfirmed spent UTXOs can be handled by the mempool