### PR TITLE
fork!: Increase block size

### DIFF
--- a/src/models/blockchain/block/block_height.rs
+++ b/src/models/blockchain/block/block_height.rs
@@ -35,6 +35,10 @@ pub const BLOCKS_PER_GENERATION: u64 = 160815;
 impl BlockHeight {
     pub const MAX: u64 = BFieldElement::MAX;
 
+    pub const fn new(value: BFieldElement) -> Self {
+        Self(value)
+    }
+
     pub fn get_generation(&self) -> u64 {
         self.0.value() / BLOCKS_PER_GENERATION
     }

--- a/src/models/blockchain/block/block_validation_error.rs
+++ b/src/models/blockchain/block/block_validation_error.rs
@@ -73,4 +73,13 @@ pub(super) enum BlockValidationError {
     ///   2.h) 0 <= transaction fee (also checked in block program).
     #[error("fee must be non-negative")]
     NegativeFee,
+    ///   2.i) restrict number of inputs.
+    #[error("number of inputs may not be too large")]
+    TooManyInputs,
+    ///   2.j) restrict number of outputs.
+    #[error("number of outputs may not be too large")]
+    TooManyOutputs,
+    ///   2.k) restrict number of public announcements.
+    #[error("number of public announcements may not be too large")]
+    TooManyPublicAnnouncements,
 }


### PR DESCRIPTION
We discovered that the number of inputs allowed into a block had a much lower practical limit than we intended. The problem is that the `inputs` field of the `TransactionKernel` holds up to 45 authentication paths of the sliding-window Bloom filter MMR. If this MMR has a height of 20, which will be reached when the total number of outputs is ~8M, these 45 authentication paths take up 4.500 `BFieldElement`s. The block proof being ~125.000 `BFieldElement`s and the old block size limit 250.000, this only leaves room for 125.000 / 4.500 ~= 28 inputs! And that's assuming that the mutator set accumulator takes up no space, and that there are no outputs.

With this increase, the practical limit on the number of inputs per block rises to ~195, which is still quite low but should be enough for "some" time.