### PR TITLE
Regulate prover fee notifications

### DIFF
--- a/src/config_models/cli_args.rs
+++ b/src/config_models/cli_args.rs
@@ -161,19 +161,21 @@ pub struct Args {
     /// transactions they work on, by directing it to an output only they can
     /// spend. By default, a public announcement is added to the transaction to
     /// enable the composer or proof-upgrader to recover such UTXOs after
-    /// importing the key onto a new machine. This public announcement is
+    /// restoring the wallet from seed phrase. This public announcement is
     /// encryped by default under a symmetric key.
     ///
     /// Valid options:
-    ///  - `--fee-notification on-chain-symmetric` (default) On-chain backups
-    ///    using symmetric key ciphertexts.
-    ///  - `--fee-notification on-chain-generation` On-chain backups using
-    ///    generation addresses, which means that public key encryption is used
-    ///    instead. Note that public key ciphertexts are significantly larger
-    ///    (and thus take up more blockchain space) than symmetric ciphertexts.
-    ///  - `--fee-notification off-chain` Avoid on-chain backups. Saves
-    ///    blockchain space, but risks loss of funds. Enable only if you know
-    ///    what you are doing.
+    ///
+    ///  - `on-chain-symmetric` (default) On-chain backups using symmetric key
+    ///    ciphertexts.
+    ///
+    ///  - `on-chain-generation` On-chain backups using generation addresses,
+    ///    which means that public key encryption is used instead. Note that
+    ///    public key ciphertexts are significantly larger (and thus take up
+    ///    more blockchain space) than symmetric ciphertexts.
+    ///
+    ///  - `off-chain` Avoid on-chain backups. Saves blockchain space, but risks
+    ///    loss of funds. Enable only if you know what you are doing.
     ///
     /// This flag does not apply to guesser fees because those UTXOs are
     /// generated automatically.

--- a/src/config_models/cli_args.rs
+++ b/src/config_models/cli_args.rs
@@ -153,6 +153,22 @@ pub struct Args {
     #[clap(long, default_value = "0.01", value_parser = NativeCurrencyAmount::coins_from_str)]
     pub(crate) min_gobbling_fee: NativeCurrencyAmount,
 
+    /// Whether to keep the UTXO notifications for composer fees and
+    /// proof-upgrader fees off chain.
+    ///
+    /// Composers and proof-upgraders can gobble a portion of the fee of
+    /// transactions they work on, by directing it to an output only they can
+    /// spend. By default, a public announcement is added to the transaction
+    /// which enables the composer or proof-upgrader to use the blockchain to
+    /// back up UTXO data and recover such UTXOs after importing the key onto a
+    /// new machine. Enable this flag to avoid wasting blockchain space, if you
+    /// know what you're doing and a robust alternative for backups is in place.
+    ///
+    /// This flag does not apply to guesser fees because those UTXOs are
+    /// generated automatically.
+    #[clap(long)]
+    pub(crate) offchain_fee_notifications: bool,
+
     /// Prune the mempool when it exceeds this size in RAM.
     ///
     /// Units: B (bytes), K (kilobytes), M (megabytes), G (gigabytes)

--- a/src/config_models/fee_notification_policy.rs
+++ b/src/config_models/fee_notification_policy.rs
@@ -1,0 +1,111 @@
+use anyhow::bail;
+use regex::Regex;
+
+use crate::models::state::wallet::utxo_notification::UtxoNotificationMedium;
+
+/// How notifications for UTXOs resulting from proving jobs (*i.e.*, composing
+/// or upgrading) are communicated.
+//
+// In the future, this enum might be expanded with an option to supply an
+// address (one that is *not* linked to the client's wallet) for cold composing
+// and/or upgrading.
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]
+pub(crate) enum FeeNotificationPolicy {
+    OffChain,
+    #[default]
+    OnChainSymmetric,
+    OnChainGeneration,
+}
+
+impl FeeNotificationPolicy {
+    pub(crate) fn parse(unparsed_policy: &str) -> Result<Self, anyhow::Error> {
+        let off_chain = Regex::new(r"(?i)^off-?chain$").unwrap();
+        let on_chain_symmetric = Regex::new(r"(?i)^((on-?chain-)|(onchain))?symmetric$").unwrap();
+        let on_chain_generation = Regex::new(r"(?i)^((on-?chain-)|(onchain))?generation$").unwrap();
+
+        if off_chain.is_match(unparsed_policy) {
+            Ok(Self::OffChain)
+        } else if on_chain_symmetric.is_match(unparsed_policy) {
+            Ok(Self::OnChainSymmetric)
+        } else if on_chain_generation.is_match(unparsed_policy) {
+            Ok(Self::OnChainGeneration)
+        } else {
+            bail!("failed to parse fee notification policy with regex")
+        }
+    }
+}
+
+impl From<FeeNotificationPolicy> for UtxoNotificationMedium {
+    fn from(value: FeeNotificationPolicy) -> Self {
+        match value {
+            FeeNotificationPolicy::OffChain => UtxoNotificationMedium::OffChain,
+            FeeNotificationPolicy::OnChainSymmetric => UtxoNotificationMedium::OnChain,
+            FeeNotificationPolicy::OnChainGeneration => UtxoNotificationMedium::OnChain,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::FeeNotificationPolicy;
+
+    #[test]
+    fn test_parse_fee_notification_policy() {
+        let vectors_success = [
+            ("off-chain", FeeNotificationPolicy::OffChain),
+            ("offchain", FeeNotificationPolicy::OffChain),
+            ("OffChain", FeeNotificationPolicy::OffChain),
+            ("oFf-chAiN", FeeNotificationPolicy::OffChain),
+            ("off-chain", FeeNotificationPolicy::OffChain),
+            ("off-chain", FeeNotificationPolicy::OffChain),
+            ("off-chain", FeeNotificationPolicy::OffChain),
+            (
+                "on-chain-symmetric",
+                FeeNotificationPolicy::OnChainSymmetric,
+            ),
+            ("onchain-symmetric", FeeNotificationPolicy::OnChainSymmetric),
+            ("onchainsymmetric", FeeNotificationPolicy::OnChainSymmetric),
+            ("onChainSymmetric", FeeNotificationPolicy::OnChainSymmetric),
+            ("OnChainSymmetric", FeeNotificationPolicy::OnChainSymmetric),
+            (
+                "on-chain-generation",
+                FeeNotificationPolicy::OnChainGeneration,
+            ),
+            (
+                "onchain-generation",
+                FeeNotificationPolicy::OnChainGeneration,
+            ),
+            (
+                "onchaingeneration",
+                FeeNotificationPolicy::OnChainGeneration,
+            ),
+            (
+                "onChainGeneration",
+                FeeNotificationPolicy::OnChainGeneration,
+            ),
+            (
+                "OnChainGeneration",
+                FeeNotificationPolicy::OnChainGeneration,
+            ),
+        ];
+        for (argument, target) in vectors_success {
+            assert_eq!(
+                target,
+                FeeNotificationPolicy::parse(argument).unwrap(),
+                "original string: {argument}"
+            );
+        }
+
+        let vectors_fail = [
+            "on-chainsymmetric",
+            "on-chaingeneration",
+            "on-chain",
+            "onchain",
+            "invalid",
+            "error",
+        ];
+        for argument in vectors_fail {
+            assert!(FeeNotificationPolicy::parse(argument).is_err());
+        }
+    }
+}

--- a/src/config_models/fee_notification_policy.rs
+++ b/src/config_models/fee_notification_policy.rs
@@ -103,6 +103,7 @@ mod test {
             "onchain",
             "invalid",
             "error",
+            "",
         ];
         for argument in vectors_fail {
             assert!(FeeNotificationPolicy::parse(argument).is_err());

--- a/src/config_models/fee_notification_policy.rs
+++ b/src/config_models/fee_notification_policy.rs
@@ -30,7 +30,7 @@ impl FeeNotificationPolicy {
         } else if on_chain_generation.is_match(unparsed_policy) {
             Ok(Self::OnChainGeneration)
         } else {
-            bail!("failed to parse fee notification policy with regex")
+            bail!("failed to parse fee notification policy")
         }
     }
 }
@@ -104,6 +104,8 @@ mod test {
             "invalid",
             "error",
             "",
+            " on-chain-symmetric",
+            "off-chain ",
         ];
         for argument in vectors_fail {
             assert!(FeeNotificationPolicy::parse(argument).is_err());

--- a/src/config_models/mod.rs
+++ b/src/config_models/mod.rs
@@ -1,3 +1,4 @@
 pub mod cli_args;
 pub mod data_directory;
+pub(crate) mod fee_notification_policy;
 pub mod network;

--- a/src/main_loop/proof_upgrader.rs
+++ b/src/main_loop/proof_upgrader.rs
@@ -158,7 +158,7 @@ impl UpgradeJob {
     /// The gobbling fee charged for an upgrade job
     ///
     /// Gobbling fees are charged when a transaction is upgraded from
-    /// proof-collectino to single-proof, or when two single proofs are merged.
+    /// proof-collection to single-proof, or when two single proofs are merged.
     /// The other cases are either not worth it, as you need to create a single-
     /// proof to gobble, or the proof upgrade relates to own funds.
     ///
@@ -509,23 +509,13 @@ impl UpgradeJob {
                 utxo_notification_method,
             );
 
-            let expected_utxos =
-                if matches!(fee_notification_policy, FeeNotificationPolicy::OffChain) {
-                    gobbler
-                        .tx_outputs
-                        .iter()
-                        .map(|x| {
-                            ExpectedUtxo::new(
-                                x.utxo(),
-                                x.sender_randomness(),
-                                receiver_preimage,
-                                UtxoNotifier::FeeGobbler,
-                            )
-                        })
-                        .collect_vec()
-                } else {
-                    vec![]
-                };
+            let expected_utxos = if fee_notification_policy == FeeNotificationPolicy::OffChain {
+                gobbler
+                    .tx_outputs
+                    .expected_utxos(UtxoNotifier::FeeGobbler, receiver_preimage)
+            } else {
+                vec![]
+            };
             let gobbler = PrimitiveWitness::from_transaction_details(&gobbler);
             let gobbler_proof =
                 SingleProof::produce(&gobbler, triton_vm_job_queue, proof_job_options.clone())

--- a/src/main_loop/proof_upgrader.rs
+++ b/src/main_loop/proof_upgrader.rs
@@ -430,7 +430,7 @@ impl UpgradeJob {
         own_wallet_entropy: &WalletEntropy,
         notification_policy: FeeNotificationPolicy,
     ) -> (UtxoNotifyMethod, Digest) {
-        let gobble_receiver_key = match notification_policy {
+        let gobble_beneficiary_key = match notification_policy {
             FeeNotificationPolicy::OffChain => {
                 SpendingKey::from(own_wallet_entropy.nth_symmetric_key(0))
             }
@@ -441,18 +441,20 @@ impl UpgradeJob {
                 SpendingKey::from(own_wallet_entropy.nth_generation_spending_key(0))
             }
         };
-        let receiver_preimage = gobble_receiver_key.privacy_preimage().unwrap();
-        let gobble_receiver_address = gobble_receiver_key
+        let receiver_preimage = gobble_beneficiary_key.privacy_preimage().unwrap();
+        let gobble_beneficiary_address = gobble_beneficiary_key
             .to_address()
             .expect("gobble receiver should have a corresponding address");
 
         let fee_notification_method = match notification_policy {
-            FeeNotificationPolicy::OffChain => UtxoNotifyMethod::OffChain(gobble_receiver_address),
+            FeeNotificationPolicy::OffChain => {
+                UtxoNotifyMethod::OffChain(gobble_beneficiary_address)
+            }
             FeeNotificationPolicy::OnChainSymmetric => {
-                UtxoNotifyMethod::OnChain(gobble_receiver_address)
+                UtxoNotifyMethod::OnChain(gobble_beneficiary_address)
             }
             FeeNotificationPolicy::OnChainGeneration => {
-                UtxoNotifyMethod::OnChain(gobble_receiver_address)
+                UtxoNotifyMethod::OnChain(gobble_beneficiary_address)
             }
         };
 

--- a/src/main_loop/proof_upgrader.rs
+++ b/src/main_loop/proof_upgrader.rs
@@ -155,6 +155,17 @@ impl UpgradeJob {
         }
     }
 
+    /// The gobbling fee charged for an upgrade job
+    ///
+    /// Gobbling fees are charged when a transaction is upgraded from
+    /// proof-collectino to single-proof, or when two single proofs are merged.
+    /// The other cases are either not worth it, as you need to create a single-
+    /// proof to gobble, or the proof upgrade relates to own funds.
+    ///
+    /// In particular, no fees are charged for updating a transaction's mutator
+    /// set data because doing so would require a single proof and a merge step,
+    /// which would delay that transaction's propagation and confirmation by the
+    /// network. This policy could be revised when proving gets faster.
     fn gobbling_fee(&self) -> NativeCurrencyAmount {
         match self {
             UpgradeJob::ProofCollectionToSingleProof { gobbling_fee, .. } => *gobbling_fee,

--- a/src/main_loop/proof_upgrader.rs
+++ b/src/main_loop/proof_upgrader.rs
@@ -441,10 +441,12 @@ impl UpgradeJob {
                 SpendingKey::from(own_wallet_entropy.nth_generation_spending_key(0))
             }
         };
-        let receiver_preimage = gobble_beneficiary_key.privacy_preimage().unwrap();
+        let receiver_preimage = gobble_beneficiary_key
+            .privacy_preimage()
+            .expect("gobble beneficiary key cannot be a raw hash lock");
         let gobble_beneficiary_address = gobble_beneficiary_key
             .to_address()
-            .expect("gobble receiver should have a corresponding address");
+            .expect("gobble beneficiary should have a corresponding address");
 
         let fee_notification_method = match notification_policy {
             FeeNotificationPolicy::OffChain => {

--- a/src/main_loop/proof_upgrader.rs
+++ b/src/main_loop/proof_upgrader.rs
@@ -336,14 +336,14 @@ impl UpgradeJob {
                 // Did we receive a new block while proving? If so, perform an
                 // update also, if this was requested.
 
-                let transaction_is_deprecated = upgraded.kernel.mutator_set_hash
-                    != global_state
+                let transaction_is_up_to_date = upgraded.kernel.mutator_set_hash
+                    == global_state
                         .chain
                         .light_state()
                         .mutator_set_accumulator_after()
                         .hash();
 
-                if !transaction_is_deprecated {
+                if transaction_is_up_to_date {
                     // Happy path
 
                     // Insert tx into mempool before notifying peers, so we're

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -988,14 +988,6 @@ pub(crate) mod mine_loop_tests {
         proving_power: TxProvingCapability,
         job_options: TritonVmProofJobOptions,
     ) -> Result<(Transaction, Vec<ExpectedUtxo>)> {
-        // note: it is Ok to always use the same key here because:
-        //  1. if we find a block, the utxo will go to our wallet
-        //     and notification occurs offchain, so there is no privacy issue.
-        //  2. if we were to derive a new addr for each block then we would
-        //     have large gaps since an address only receives funds when
-        //     we actually win the mining lottery.
-        //  3. also this way we do not have to modify global/wallet state.
-
         // It's important to use the input `latest_block` here instead of
         // reading it from state, since that could, because of a race condition
         // lead to an inconsistent witness higher up in the call graph. This is

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -433,19 +433,21 @@ pub(super) fn prepare_coinbase_transaction_stateless(
         .expect("Amount to composer must be larger than liquid amount to composer.");
 
     let owned = true;
-    let liquid_coinbase_output = TxOutput::offchain_native_currency(
+    let liquid_coinbase_output = TxOutput::native_currency(
         liquid_composer_amount,
         composer_parameters.sender_randomness(),
         composer_parameters.reward_address(),
+        composer_parameters.notification_medium(),
         owned,
     );
 
     // Set the time lock to 3 years (minimum) plus 30 minutes margin, since the
     // timestamp might be bumped by future merges.
-    let timelocked_coinbase_output = TxOutput::offchain_native_currency(
+    let timelocked_coinbase_output = TxOutput::native_currency(
         timelocked_composer_amount,
         composer_parameters.sender_randomness(),
         composer_parameters.reward_address(),
+        composer_parameters.notification_medium(),
         owned,
     )
     .with_time_lock(timestamp + MINING_REWARD_TIME_LOCK_PERIOD + Timestamp::minutes(30));
@@ -1020,6 +1022,7 @@ pub(crate) mod mine_loop_tests {
             receiving_address.into(),
             sender_randomness,
             guesser_block_subsidy_fraction,
+            UtxoNotificationMedium::OffChain,
         );
         let (transaction, composer_outputs) = make_coinbase_transaction_stateless(
             latest_block,

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -10,6 +10,7 @@ use block_header::BlockHeaderField;
 use block_header::MINIMUM_BLOCK_TIME;
 use composer_parameters::ComposerParameters;
 use futures::channel::oneshot;
+use itertools::Itertools;
 use num_traits::CheckedSub;
 use primitive_witness::PrimitiveWitness;
 use rand::rngs::StdRng;
@@ -520,23 +521,17 @@ pub(crate) async fn create_block_transaction_from(
     let mut rng: StdRng =
         SeedableRng::from_seed(global_state_lock.lock_guard().await.shuffle_seed());
 
-    let coinbase_recipient_spending_key = global_state_lock
-        .lock_guard()
-        .await
-        .wallet_state
-        .wallet_entropy
-        .nth_generation_spending_key(0);
     let composer_parameters = global_state_lock
         .lock_guard()
         .await
-        .composer_parameters(coinbase_recipient_spending_key.to_address().into());
+        .composer_parameters(Some(predecessor_block.header().height));
 
     // A coinbase transaction implies mining. So you *must*
     // be able to create a SingleProof.
     let vm_job_queue = global_state_lock.vm_job_queue();
     let (coinbase_transaction, composer_txos) = make_coinbase_transaction_stateless(
         predecessor_block,
-        composer_parameters,
+        composer_parameters.clone(),
         timestamp,
         TxProvingCapability::SingleProof,
         vm_job_queue,
@@ -597,17 +592,22 @@ pub(crate) async fn create_block_transaction_from(
         .expect("Must be able to merge transactions in mining context");
     }
 
-    let own_expected_utxos = composer_txos
-        .iter()
-        .map(|txo| {
-            ExpectedUtxo::new(
-                txo.utxo(),
-                txo.sender_randomness(),
-                coinbase_recipient_spending_key.privacy_preimage(),
-                UtxoNotifier::OwnMinerComposeBlock,
-            )
-        })
-        .collect();
+    let own_expected_utxos =
+        composer_parameters
+            .maybe_receiver_preimage()
+            .map_or(vec![], |receiver_preimage| {
+                composer_txos
+                    .iter()
+                    .map(|txo| {
+                        ExpectedUtxo::new(
+                            txo.utxo(),
+                            txo.sender_randomness(),
+                            receiver_preimage,
+                            UtxoNotifier::OwnMinerComposeBlock,
+                        )
+                    })
+                    .collect_vec()
+            });
 
     Ok((block_transaction, own_expected_utxos))
 }
@@ -984,7 +984,6 @@ pub(crate) mod mine_loop_tests {
     pub(crate) async fn make_coinbase_transaction_from_state(
         latest_block: &Block,
         global_state_lock: &GlobalStateLock,
-        guesser_block_subsidy_fraction: f64,
         timestamp: Timestamp,
         proving_power: TxProvingCapability,
         job_options: TritonVmProofJobOptions,
@@ -1001,32 +1000,16 @@ pub(crate) mod mine_loop_tests {
         // reading it from state, since that could, because of a race condition
         // lead to an inconsistent witness higher up in the call graph. This is
         // done to avoid holding a read-lock throughout this function.
-
-        let coinbase_recipient_spending_key = global_state_lock
-            .lock_guard()
-            .await
-            .wallet_state
-            .wallet_entropy
-            .nth_generation_spending_key(0);
-        let receiving_address = coinbase_recipient_spending_key.to_address();
         let next_block_height: BlockHeight = latest_block.header().height.next();
-        let sender_randomness: Digest = global_state_lock
-            .lock_guard()
-            .await
-            .wallet_state
-            .wallet_entropy
-            .generate_sender_randomness(next_block_height, receiving_address.privacy_digest());
         let vm_job_queue = global_state_lock.vm_job_queue();
 
-        let composer_parameters = ComposerParameters::new(
-            receiving_address.into(),
-            sender_randomness,
-            guesser_block_subsidy_fraction,
-            UtxoNotificationMedium::OffChain,
-        );
+        let composer_parameters = global_state_lock
+            .lock_guard()
+            .await
+            .composer_parameters(Some(next_block_height));
         let (transaction, composer_outputs) = make_coinbase_transaction_stateless(
             latest_block,
-            composer_parameters,
+            composer_parameters.clone(),
             timestamp,
             proving_power,
             vm_job_queue,
@@ -1034,17 +1017,22 @@ pub(crate) mod mine_loop_tests {
         )
         .await?;
 
-        let own_expected_utxos = composer_outputs
-            .iter()
-            .map(|txo| {
-                ExpectedUtxo::new(
-                    txo.utxo(),
-                    txo.sender_randomness(),
-                    coinbase_recipient_spending_key.privacy_preimage(),
-                    UtxoNotifier::OwnMinerComposeBlock,
-                )
-            })
-            .collect();
+        let own_expected_utxos =
+            composer_parameters
+                .maybe_receiver_preimage()
+                .map_or(vec![], |receiver_preimage| {
+                    composer_outputs
+                        .iter()
+                        .map(|txo| {
+                            ExpectedUtxo::new(
+                                txo.utxo(),
+                                txo.sender_randomness(),
+                                receiver_preimage,
+                                UtxoNotifier::OwnMinerComposeBlock,
+                            )
+                        })
+                        .collect()
+                });
 
         Ok((transaction, own_expected_utxos))
     }
@@ -1133,19 +1121,18 @@ pub(crate) mod mine_loop_tests {
     async fn estimate_block_preparation_time_invalid_proof() -> f64 {
         let network = Network::Main;
         let genesis_block = Block::genesis(network);
+        let guesser_fee_fraction = 0.0;
+        let cli_args = cli_args::Args {
+            guesser_fraction: guesser_fee_fraction,
+            ..Default::default()
+        };
 
-        let global_state_lock = mock_genesis_global_state(
-            network,
-            2,
-            WalletEntropy::devnet_wallet(),
-            cli_args::Args::default(),
-        )
-        .await;
+        let global_state_lock =
+            mock_genesis_global_state(network, 2, WalletEntropy::devnet_wallet(), cli_args).await;
         let tick = std::time::SystemTime::now();
         let (transaction, _coinbase_utxo_info) = make_coinbase_transaction_from_state(
             &genesis_block,
             &global_state_lock,
-            0f64,
             network.launch_date(),
             TxProvingCapability::PrimitiveWitness,
             (TritonVmJobPriority::Normal, None).into(),
@@ -1391,13 +1378,12 @@ pub(crate) mod mine_loop_tests {
     #[tokio::test]
     async fn mined_block_has_proof_of_work() {
         let network = Network::Main;
-        let global_state_lock = mock_genesis_global_state(
-            network,
-            2,
-            WalletEntropy::devnet_wallet(),
-            cli_args::Args::default(),
-        )
-        .await;
+        let cli_args = cli_args::Args {
+            guesser_fraction: 0.0,
+            ..Default::default()
+        };
+        let global_state_lock =
+            mock_genesis_global_state(network, 2, WalletEntropy::devnet_wallet(), cli_args).await;
         let tip_block_orig = Block::genesis(network);
         let launch_date = tip_block_orig.header().timestamp;
         let (worker_task_tx, worker_task_rx) = oneshot::channel::<NewBlockFound>();
@@ -1405,7 +1391,6 @@ pub(crate) mod mine_loop_tests {
         let (transaction, _composer_utxo_info) = make_coinbase_transaction_from_state(
             &tip_block_orig,
             &global_state_lock,
-            0f64,
             launch_date,
             TxProvingCapability::PrimitiveWitness,
             (TritonVmJobPriority::Normal, None).into(),
@@ -1458,13 +1443,12 @@ pub(crate) mod mine_loop_tests {
     #[tokio::test]
     async fn block_timestamp_represents_time_guessing_started() -> Result<()> {
         let network = Network::Main;
-        let global_state_lock = mock_genesis_global_state(
-            network,
-            2,
-            WalletEntropy::devnet_wallet(),
-            cli_args::Args::default(),
-        )
-        .await;
+        let cli_args = cli_args::Args {
+            guesser_fraction: 0.0,
+            ..Default::default()
+        };
+        let global_state_lock =
+            mock_genesis_global_state(network, 2, WalletEntropy::devnet_wallet(), cli_args).await;
         let (worker_task_tx, worker_task_rx) = oneshot::channel::<NewBlockFound>();
 
         let tip_block_orig = global_state_lock
@@ -1482,7 +1466,6 @@ pub(crate) mod mine_loop_tests {
         let (transaction, _composer_utxo_info) = make_coinbase_transaction_from_state(
             &tip_block_orig,
             &global_state_lock,
-            0f64,
             ten_seconds_ago,
             TxProvingCapability::PrimitiveWitness,
             (TritonVmJobPriority::Normal, None).into(),
@@ -1779,20 +1762,18 @@ pub(crate) mod mine_loop_tests {
     #[tokio::test]
     async fn coinbase_has_expected_timelocked_outputs() {
         let network = Network::Main;
-        let global_state_lock = mock_genesis_global_state(
-            network,
-            2,
-            WalletEntropy::devnet_wallet(),
-            cli_args::Args::default(),
-        )
-        .await;
+        let cli_args = cli_args::Args {
+            guesser_fraction: 0.0,
+            ..Default::default()
+        };
+        let global_state_lock =
+            mock_genesis_global_state(network, 2, WalletEntropy::devnet_wallet(), cli_args).await;
         let genesis_block = Block::genesis(network);
         let launch_date = genesis_block.header().timestamp;
 
         let (transaction, coinbase_utxo_info) = make_coinbase_transaction_from_state(
             &genesis_block,
             &global_state_lock,
-            0f64,
             launch_date,
             TxProvingCapability::PrimitiveWitness,
             (TritonVmJobPriority::Normal, None).into(),

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -546,7 +546,7 @@ pub(crate) async fn create_block_transaction_from(
     let composer_parameters = global_state_lock
         .lock_guard()
         .await
-        .composer_parameters(Some(predecessor_block.header().height));
+        .composer_parameters(Some(predecessor_block.header().height.next()));
 
     // A coinbase transaction implies mining. So you *must*
     // be able to create a SingleProof.

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -438,7 +438,7 @@ pub(super) fn prepare_coinbase_transaction_stateless(
         liquid_composer_amount,
         composer_parameters.sender_randomness(),
         composer_parameters.reward_address(),
-        composer_parameters.notification_medium(),
+        composer_parameters.notification_policy().into(),
         owned,
     );
 
@@ -448,7 +448,7 @@ pub(super) fn prepare_coinbase_transaction_stateless(
         timelocked_composer_amount,
         composer_parameters.sender_randomness(),
         composer_parameters.reward_address(),
-        composer_parameters.notification_medium(),
+        composer_parameters.notification_policy().into(),
         owned,
     )
     .with_time_lock(timestamp + MINING_REWARD_TIME_LOCK_PERIOD + Timestamp::minutes(30));

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -10,7 +10,6 @@ use block_header::BlockHeaderField;
 use block_header::MINIMUM_BLOCK_TIME;
 use composer_parameters::ComposerParameters;
 use futures::channel::oneshot;
-use itertools::Itertools;
 use num_traits::CheckedSub;
 use primitive_witness::PrimitiveWitness;
 use rand::rngs::StdRng;
@@ -28,6 +27,7 @@ use tokio::time::sleep;
 use tracing::*;
 use twenty_first::math::digest::Digest;
 
+use crate::config_models::fee_notification_policy::FeeNotificationPolicy;
 use crate::job_queue::triton_vm::TritonVmJobPriority;
 use crate::job_queue::JobQueue;
 use crate::models::blockchain::block::block_height::BlockHeight;
@@ -398,13 +398,14 @@ pub(crate) async fn make_coinbase_transaction_stateless(
     Ok((transaction, composer_outputs))
 }
 
-/// Produce two outputs spending a given portion of the coinbase.
+/// Produce two outputs spending a given portion of the coinbase amount which is
+/// usually set to the block subsidy for this block height.
 ///
-/// The coinbase is the block subsidy plus the anticipated transaction fee.
 /// There are two outputs because one is liquid immediately, and the other is
-/// locked for 3 years. The portion is determined by the guesser fee fraction
-/// field of the composer parameters.
-pub(crate) fn coinbase_outputs(
+/// locked for 3 years. The portion of the block subsidy that goes to the
+/// composer is determined by the guesser fee fraction field of the composer
+/// parameters.
+pub(crate) fn composer_outputs(
     coinbase_amount: NativeCurrencyAmount,
     composer_parameters: ComposerParameters,
     timestamp: Timestamp,
@@ -420,9 +421,12 @@ pub(crate) fn coinbase_outputs(
         );
     };
 
+    // Note that this calculation guarantees that at least half of the coinbase
+    // is timelocked, as a rounding error in the last digit subtracts from the
+    // liquid amount. This quality is required by the NativeCurrency type
+    // script.
     let mut liquid_composer_amount = amount_to_composer;
     liquid_composer_amount.div_two();
-
     let timelocked_composer_amount = amount_to_composer
         .checked_sub(&liquid_composer_amount)
         .expect("Amount to composer must be larger than liquid amount to composer.");
@@ -437,7 +441,10 @@ pub(crate) fn coinbase_outputs(
     );
 
     // Set the time lock to 3 years (minimum) plus 30 minutes margin, since the
-    // timestamp might be bumped by future merges.
+    // timestamp might be bumped by future merges. These timestamp bumps affect
+    // only the `timestamp` field of the transaction kernel and not the state
+    // of the `TimeLock` type script. So in the end you might end up with a
+    // transaction whose time-locked portion is not time-locked long enough.
     let timelocked_coinbase_output = TxOutput::native_currency(
         timelocked_composer_amount,
         composer_parameters.sender_randomness(),
@@ -463,16 +470,16 @@ pub(super) fn prepare_coinbase_transaction_stateless(
 
     let coinbase_amount = Block::block_subsidy(next_block_height);
     let [liquid_coinbase_output, timelocked_coinbase_output] =
-        coinbase_outputs(coinbase_amount, composer_parameters, timestamp)?;
+        composer_outputs(coinbase_amount, composer_parameters, timestamp)?;
     let total_composer_fee = liquid_coinbase_output.utxo().get_native_currency_amount()
         + timelocked_coinbase_output
             .utxo()
             .get_native_currency_amount();
-    let total_guesser_fee = coinbase_amount.checked_sub(&total_composer_fee).unwrap();
+    let guesser_fee = coinbase_amount.checked_sub(&total_composer_fee).unwrap();
 
     info!(
         "Coinbase amount is set to {coinbase_amount} and is divided between \
-        composer fee ({total_composer_fee}) and guesser fee ({total_guesser_fee})."
+        composer fee ({total_composer_fee}) and guesser fee ({guesser_fee})."
     );
 
     let composer_outputs: TxOutputList = vec![
@@ -484,7 +491,7 @@ pub(super) fn prepare_coinbase_transaction_stateless(
         vec![],
         composer_outputs.clone(),
         coinbase_amount,
-        total_guesser_fee,
+        guesser_fee,
         timestamp,
         mutator_set_accumulator,
     )
@@ -546,7 +553,7 @@ pub(crate) async fn create_block_transaction_from(
     let composer_parameters = global_state_lock
         .lock_guard()
         .await
-        .composer_parameters(Some(predecessor_block.header().height.next()));
+        .composer_parameters(predecessor_block.header().height.next());
 
     // A coinbase transaction implies mining. So you *must*
     // be able to create a SingleProof.
@@ -614,22 +621,23 @@ pub(crate) async fn create_block_transaction_from(
         .expect("Must be able to merge transactions in mining context");
     }
 
-    let own_expected_utxos =
-        composer_parameters
-            .maybe_receiver_preimage()
-            .map_or(vec![], |receiver_preimage| {
-                composer_txos
-                    .iter()
-                    .map(|txo| {
-                        ExpectedUtxo::new(
-                            txo.utxo(),
-                            txo.sender_randomness(),
-                            receiver_preimage,
-                            UtxoNotifier::OwnMinerComposeBlock,
-                        )
-                    })
-                    .collect_vec()
-            });
+    // If composer UTXO notifications are sent onchain, the wallet does not need
+    // to expect them. If they are handled offchain, the wallet must be
+    // notified, but only if the receiver preimage is known (otherwise which
+    // wallet to notify?).
+    let mut own_expected_utxos = vec![];
+    if composer_parameters.notification_policy() == FeeNotificationPolicy::OffChain {
+        if let Some(receiver_preimage) = composer_parameters.maybe_receiver_preimage() {
+            own_expected_utxos.extend(composer_txos.into_iter().map(|txo| {
+                ExpectedUtxo::new(
+                    txo.utxo(),
+                    txo.sender_randomness(),
+                    receiver_preimage,
+                    UtxoNotifier::OwnMinerComposeBlock,
+                )
+            }));
+        }
+    }
 
     Ok((block_transaction, own_expected_utxos))
 }
@@ -1020,7 +1028,7 @@ pub(crate) mod mine_loop_tests {
         let composer_parameters = global_state_lock
             .lock_guard()
             .await
-            .composer_parameters(Some(next_block_height));
+            .composer_parameters(next_block_height);
         let (transaction, composer_outputs) = make_coinbase_transaction_stateless(
             latest_block,
             composer_parameters.clone(),
@@ -1226,7 +1234,7 @@ pub(crate) mod mine_loop_tests {
 
             cli.guesser_fraction = guesser_fee_fraction;
             alice.set_cli(cli.clone()).await;
-            let (transaction_empty_mempool, _coinbase_utxo_info) = {
+            let (transaction_empty_mempool, coinbase_utxo_info) = {
                 create_block_transaction(
                     &genesis_block,
                     &alice,
@@ -1236,6 +1244,11 @@ pub(crate) mod mine_loop_tests {
                 .await
                 .unwrap()
             };
+            assert!(
+                coinbase_utxo_info.is_empty(),
+                "Default composer UTXO notification policy is onchain. \
+             So no expected UTXOs should be returned here."
+            );
 
             let cb_txkmh = transaction_empty_mempool.kernel.mast_hash();
             let cb_tx_claim = SingleProof::claim(cb_txkmh);

--- a/src/mine_loop/composer_parameters.rs
+++ b/src/mine_loop/composer_parameters.rs
@@ -1,12 +1,14 @@
 use tasm_lib::prelude::Digest;
 
 use crate::models::state::wallet::address::ReceivingAddress;
+use crate::models::state::wallet::utxo_notification::UtxoNotificationMedium;
 
 #[derive(Debug, Clone)]
 pub(crate) struct ComposerParameters {
     reward_address: ReceivingAddress,
     sender_randomness: Digest,
     guesser_fee_fraction: f64,
+    notification_medium: UtxoNotificationMedium,
 }
 
 impl ComposerParameters {
@@ -14,6 +16,7 @@ impl ComposerParameters {
         reward_address: ReceivingAddress,
         sender_randomness: Digest,
         guesser_fee_fraction: f64,
+        notification_medium: UtxoNotificationMedium,
     ) -> Self {
         let is_fraction = (0_f64..=1.0).contains(&guesser_fee_fraction);
         assert!(
@@ -24,6 +27,7 @@ impl ComposerParameters {
             reward_address,
             sender_randomness,
             guesser_fee_fraction,
+            notification_medium,
         }
     }
 
@@ -37,5 +41,9 @@ impl ComposerParameters {
 
     pub(crate) fn guesser_fee_fraction(&self) -> f64 {
         self.guesser_fee_fraction
+    }
+
+    pub(crate) fn notification_medium(&self) -> UtxoNotificationMedium {
+        self.notification_medium
     }
 }

--- a/src/mine_loop/composer_parameters.rs
+++ b/src/mine_loop/composer_parameters.rs
@@ -20,7 +20,7 @@ impl Eq for ComposerParameters {}
 impl ComposerParameters {
     /// # Panics
     ///
-    ///  - If `guesser_fee_fraction` is not a fraction contained in [0;1].
+    ///  - If `guesser_fee_fraction` is not a fraction contained in \[0;1\].
     pub(crate) fn new(
         reward_address: ReceivingAddress,
         sender_randomness: Digest,

--- a/src/mine_loop/composer_parameters.rs
+++ b/src/mine_loop/composer_parameters.rs
@@ -3,7 +3,7 @@ use tasm_lib::prelude::Digest;
 use crate::config_models::fee_notification_policy::FeeNotificationPolicy;
 use crate::models::state::wallet::address::ReceivingAddress;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) struct ComposerParameters {
     reward_address: ReceivingAddress,
     sender_randomness: Digest,
@@ -11,6 +11,8 @@ pub(crate) struct ComposerParameters {
     guesser_fee_fraction: f64,
     notification_policy: FeeNotificationPolicy,
 }
+
+impl Eq for ComposerParameters {}
 
 impl ComposerParameters {
     pub(crate) fn new(
@@ -42,6 +44,11 @@ impl ComposerParameters {
         self.sender_randomness
     }
 
+    /// Get the receiver preimage, if it is stored; and `None` otherwise.
+    ///
+    /// Note that the receiver preimage is not known in a *cold composing*
+    /// scenario, where the composer fee UTXOs are sent to a foreign
+    /// [`ReceivingAddress`].
     pub(crate) fn maybe_receiver_preimage(&self) -> Option<Digest> {
         self.maybe_receiver_preimage
     }

--- a/src/mine_loop/composer_parameters.rs
+++ b/src/mine_loop/composer_parameters.rs
@@ -15,8 +15,6 @@ pub(crate) struct ComposerParameters {
     notification_policy: FeeNotificationPolicy,
 }
 
-impl Eq for ComposerParameters {}
-
 impl ComposerParameters {
     /// # Panics
     ///
@@ -26,7 +24,7 @@ impl ComposerParameters {
         sender_randomness: Digest,
         maybe_receiver_preimage: Option<Digest>,
         guesser_fee_fraction: f64,
-        notification_medium: FeeNotificationPolicy,
+        notification_policy: FeeNotificationPolicy,
     ) -> Self {
         let is_fraction = (0_f64..=1.0).contains(&guesser_fee_fraction);
         assert!(
@@ -38,7 +36,7 @@ impl ComposerParameters {
             sender_randomness,
             maybe_receiver_preimage,
             guesser_fee_fraction,
-            notification_policy: notification_medium,
+            notification_policy,
         }
     }
 

--- a/src/mine_loop/composer_parameters.rs
+++ b/src/mine_loop/composer_parameters.rs
@@ -18,6 +18,9 @@ pub(crate) struct ComposerParameters {
 impl Eq for ComposerParameters {}
 
 impl ComposerParameters {
+    /// # Panics
+    ///
+    ///  - If `guesser_fee_fraction` is not a fraction contained in [0;1].
     pub(crate) fn new(
         reward_address: ReceivingAddress,
         sender_randomness: Digest,

--- a/src/mine_loop/composer_parameters.rs
+++ b/src/mine_loop/composer_parameters.rs
@@ -7,6 +7,7 @@ use crate::models::state::wallet::utxo_notification::UtxoNotificationMedium;
 pub(crate) struct ComposerParameters {
     reward_address: ReceivingAddress,
     sender_randomness: Digest,
+    maybe_receiver_preimage: Option<Digest>,
     guesser_fee_fraction: f64,
     notification_medium: UtxoNotificationMedium,
 }
@@ -15,6 +16,7 @@ impl ComposerParameters {
     pub(crate) fn new(
         reward_address: ReceivingAddress,
         sender_randomness: Digest,
+        maybe_receiver_preimage: Option<Digest>,
         guesser_fee_fraction: f64,
         notification_medium: UtxoNotificationMedium,
     ) -> Self {
@@ -26,6 +28,7 @@ impl ComposerParameters {
         Self {
             reward_address,
             sender_randomness,
+            maybe_receiver_preimage,
             guesser_fee_fraction,
             notification_medium,
         }
@@ -37,6 +40,10 @@ impl ComposerParameters {
 
     pub(crate) fn sender_randomness(&self) -> Digest {
         self.sender_randomness
+    }
+
+    pub(crate) fn maybe_receiver_preimage(&self) -> Option<Digest> {
+        self.maybe_receiver_preimage
     }
 
     pub(crate) fn guesser_fee_fraction(&self) -> f64 {

--- a/src/mine_loop/composer_parameters.rs
+++ b/src/mine_loop/composer_parameters.rs
@@ -1,7 +1,7 @@
 use tasm_lib::prelude::Digest;
 
+use crate::config_models::fee_notification_policy::FeeNotificationPolicy;
 use crate::models::state::wallet::address::ReceivingAddress;
-use crate::models::state::wallet::utxo_notification::UtxoNotificationMedium;
 
 #[derive(Debug, Clone)]
 pub(crate) struct ComposerParameters {
@@ -9,7 +9,7 @@ pub(crate) struct ComposerParameters {
     sender_randomness: Digest,
     maybe_receiver_preimage: Option<Digest>,
     guesser_fee_fraction: f64,
-    notification_medium: UtxoNotificationMedium,
+    notification_policy: FeeNotificationPolicy,
 }
 
 impl ComposerParameters {
@@ -18,7 +18,7 @@ impl ComposerParameters {
         sender_randomness: Digest,
         maybe_receiver_preimage: Option<Digest>,
         guesser_fee_fraction: f64,
-        notification_medium: UtxoNotificationMedium,
+        notification_medium: FeeNotificationPolicy,
     ) -> Self {
         let is_fraction = (0_f64..=1.0).contains(&guesser_fee_fraction);
         assert!(
@@ -30,7 +30,7 @@ impl ComposerParameters {
             sender_randomness,
             maybe_receiver_preimage,
             guesser_fee_fraction,
-            notification_medium,
+            notification_policy: notification_medium,
         }
     }
 
@@ -50,7 +50,7 @@ impl ComposerParameters {
         self.guesser_fee_fraction
     }
 
-    pub(crate) fn notification_medium(&self) -> UtxoNotificationMedium {
-        self.notification_medium
+    pub(crate) fn notification_policy(&self) -> FeeNotificationPolicy {
+        self.notification_policy
     }
 }

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -1069,6 +1069,7 @@ pub(crate) mod block_tests {
     use super::super::transaction::transaction_kernel::TransactionKernelModifier;
     use super::*;
     use crate::config_models::cli_args;
+    use crate::config_models::fee_notification_policy::FeeNotificationPolicy;
     use crate::config_models::network::Network;
     use crate::database::storage::storage_schema::SimpleRustyStorage;
     use crate::database::NeptuneLevelDb;
@@ -1161,8 +1162,13 @@ pub(crate) mod block_tests {
         let mut guesser_fraction = 0f64;
         let step = 0.05;
         while guesser_fraction + step <= 1f64 {
-            let composer_parameters =
-                ComposerParameters::new(a_key.to_address().into(), rng.random(), guesser_fraction);
+            let composer_parameters = ComposerParameters::new(
+                a_key.to_address().into(),
+                rng.random(),
+                None,
+                guesser_fraction,
+                FeeNotificationPolicy::OffChain,
+            );
             let (composer_txos, transaction_details) =
                 prepare_coinbase_transaction_stateless(&genesis, composer_parameters, now).unwrap();
             let coinbase_kernel =

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -1433,7 +1433,10 @@ pub(crate) mod block_tests {
                 network,
                 3,
                 alice_wallet.clone(),
-                cli_args::Args::default(),
+                cli_args::Args {
+                    guesser_fraction: 0.5,
+                    ..Default::default()
+                },
             )
             .await;
             alice.set_new_tip(block1.clone()).await.unwrap();
@@ -1454,7 +1457,6 @@ pub(crate) mod block_tests {
             let (coinbase_for_block2, _) = make_coinbase_transaction_from_state(
                 &block1,
                 &alice,
-                0.5f64,
                 plus_eight_months,
                 TxProvingCapability::SingleProof,
                 (TritonVmJobPriority::Normal, None).into(),
@@ -1523,7 +1525,6 @@ pub(crate) mod block_tests {
                 let (coinbase_for_block3, _) = make_coinbase_transaction_from_state(
                     &block2_without_valid_pow,
                     &alice,
-                    0.5f64,
                     plus_nine_months,
                     TxProvingCapability::SingleProof,
                     (TritonVmJobPriority::Normal, None).into(),

--- a/src/models/blockchain/transaction/mod.rs
+++ b/src/models/blockchain/transaction/mod.rs
@@ -92,6 +92,19 @@ impl TransactionProof {
         }
     }
 
+    #[cfg(test)]
+    pub(crate) fn into_proof_collection(self) -> ProofCollection {
+        match self {
+            TransactionProof::Witness(_primitive_witness) => {
+                panic!("Expected ProofCollection, got Witness")
+            }
+            TransactionProof::SingleProof(_proof) => {
+                panic!("Expected ProofCollection, got SingleProof")
+            }
+            TransactionProof::ProofCollection(proof_collection) => proof_collection,
+        }
+    }
+
     pub(crate) fn proof_quality(&self) -> Result<TransactionProofQuality> {
         match self {
             TransactionProof::Witness(_) => bail!("Primitive witness does not have a proof"),

--- a/src/models/blockchain/transaction/mod.rs
+++ b/src/models/blockchain/transaction/mod.rs
@@ -152,6 +152,12 @@ impl Transaction {
         proof_job_options: TritonVmProofJobOptions,
         new_timestamp: Option<Timestamp>,
     ) -> anyhow::Result<Transaction> {
+        if old_transaction_kernel.mutator_set_hash != previous_mutator_set_accumulator.hash() {
+            bail!(
+                "Old transaction kernel's mutator set hash does not agree \
+                with supplied mutator set accumulator."
+            )
+        }
         // apply mutator set update to get new mutator set accumulator
         let addition_records = mutator_set_update.additions.clone();
         let mut calculated_new_mutator_set = previous_mutator_set_accumulator.clone();

--- a/src/models/blockchain/transaction/mod.rs
+++ b/src/models/blockchain/transaction/mod.rs
@@ -74,12 +74,6 @@ pub enum TransactionProof {
 }
 
 impl TransactionProof {
-    /// A proof that will always be invalid
-    #[cfg(test)]
-    pub(crate) fn invalid() -> Self {
-        Self::SingleProof(Proof(vec![]))
-    }
-
     pub(crate) fn into_single_proof(self) -> Proof {
         match self {
             TransactionProof::SingleProof(proof) => proof,
@@ -336,7 +330,7 @@ impl Transaction {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use tasm_lib::prelude::Digest;
     use tests::primitive_witness::SaltedUtxos;
 
@@ -344,6 +338,21 @@ mod tests {
     use crate::models::blockchain::type_scripts::native_currency_amount::NativeCurrencyAmount;
     use crate::util_types::mutator_set::addition_record::AdditionRecord;
     use crate::util_types::mutator_set::removal_record::RemovalRecord;
+
+    impl TransactionProof {
+        /// A proof that will always be invalid
+        pub(crate) fn invalid() -> Self {
+            Self::SingleProof(Proof(vec![]))
+        }
+
+        /// A proof that will always be invalid, with a specified size measured in
+        /// number of [`BFieldElement`](twenty_first::math::b_field_element::BFieldElement)s.
+        pub(crate) fn invalid_single_proof_of_size(size: usize) -> Self {
+            use tasm_lib::twenty_first::bfe;
+
+            Self::SingleProof(Proof(vec![bfe!(0); size]))
+        }
+    }
 
     impl Transaction {
         /// Create a new transaction with primitive witness for a new mutator set.

--- a/src/models/state/archival_state.rs
+++ b/src/models/state/archival_state.rs
@@ -1825,7 +1825,7 @@ mod archival_state_tests {
             .unwrap();
         println!("Generated transaction for Alice and Bob.");
 
-        let (cbtx, composer_expected_utxos) = make_coinbase_transaction_from_state(
+        let (cbtx, _composer_expected_utxos) = make_coinbase_transaction_from_state(
             &premine_rec
                 .global_state_lock
                 .lock_guard()
@@ -1874,7 +1874,7 @@ mod archival_state_tests {
             block_1.kernel.body.transaction_kernel.outputs.len()
         );
 
-        // Expect coinbase and change UTXO
+        // Expect change UTXO, as it uses offchain notifications.
         {
             let mut premine_rec = premine_rec.lock_guard_mut().await;
             let expected_utxos = premine_rec
@@ -1884,12 +1884,6 @@ mod archival_state_tests {
             premine_rec
                 .wallet_state
                 .add_expected_utxos(expected_utxos)
-                .await;
-
-            assert_eq!(2, composer_expected_utxos.len());
-            premine_rec
-                .wallet_state
-                .add_expected_utxos(composer_expected_utxos)
                 .await;
         }
 

--- a/src/models/state/archival_state.rs
+++ b/src/models/state/archival_state.rs
@@ -1717,7 +1717,10 @@ mod archival_state_tests {
             network,
             3,
             premine_rec_ws.wallet_entropy,
-            cli_args::Args::default(),
+            cli_args::Args {
+                guesser_fraction: 0.0,
+                ..Default::default()
+            },
         )
         .await;
         assert_eq!(
@@ -1819,7 +1822,6 @@ mod archival_state_tests {
             .unwrap();
         println!("Generated transaction for Alice and Bob.");
 
-        let guesser_fraction = 0f64;
         let (cbtx, composer_expected_utxos) = make_coinbase_transaction_from_state(
             &premine_rec
                 .global_state_lock
@@ -1829,7 +1831,6 @@ mod archival_state_tests {
                 .light_state()
                 .clone(),
             &premine_rec,
-            guesser_fraction,
             in_seven_months,
             TxProvingCapability::SingleProof,
             TritonVmJobPriority::Normal.into(),
@@ -2082,7 +2083,6 @@ mod archival_state_tests {
                 .light_state()
                 .clone(),
             &premine_rec,
-            guesser_fraction,
             in_seven_months,
             TxProvingCapability::SingleProof,
             TritonVmJobPriority::Normal.into(),

--- a/src/models/state/archival_state.rs
+++ b/src/models/state/archival_state.rs
@@ -1271,8 +1271,9 @@ mod archival_state_tests {
         // Verify that a restored archival mutator set is populated with the right `sync_label`
         let network = Network::Alpha;
         let mut archival_state = make_test_archival_state(network).await;
+        let cli_args = cli_args::Args::default();
         let genesis_wallet_state =
-            mock_genesis_wallet_state(WalletEntropy::devnet_wallet(), network).await;
+            mock_genesis_wallet_state(WalletEntropy::devnet_wallet(), network, &cli_args).await;
         let (mock_block_1, _) = make_mock_block(
             &archival_state.genesis_block,
             None,
@@ -1309,7 +1310,9 @@ mod archival_state_tests {
 
         let network = Network::Alpha;
         let mut rng = StdRng::seed_from_u64(107221549301u64);
-        let alice_wallet = mock_genesis_wallet_state(WalletEntropy::devnet_wallet(), network).await;
+        let cli_args = cli_args::Args::default();
+        let alice_wallet =
+            mock_genesis_wallet_state(WalletEntropy::devnet_wallet(), network, &cli_args).await;
         let alice_wallet = alice_wallet.wallet_entropy;
         let mut alice =
             mock_genesis_global_state(network, 0, alice_wallet, cli_args::Args::default()).await;
@@ -1710,8 +1713,9 @@ mod archival_state_tests {
     async fn allow_multiple_inputs_and_outputs_in_block() {
         // Test various parts of the state update when a block contains multiple inputs and outputs
         let network = Network::Main;
+        let cli_args = cli_args::Args::default();
         let premine_rec_ws =
-            mock_genesis_wallet_state(WalletEntropy::devnet_wallet(), network).await;
+            mock_genesis_wallet_state(WalletEntropy::devnet_wallet(), network, &cli_args).await;
         let premine_rec_spending_key = premine_rec_ws.wallet_entropy.nth_generation_spending_key(0);
         let mut premine_rec = mock_genesis_global_state(
             network,

--- a/src/models/state/archival_state.rs
+++ b/src/models/state/archival_state.rs
@@ -1310,12 +1310,11 @@ mod archival_state_tests {
 
         let network = Network::Alpha;
         let mut rng = StdRng::seed_from_u64(107221549301u64);
-        let cli_args = cli_args::Args::default();
+        let cli_args = cli_args::Args::default_with_network(network);
         let alice_wallet =
             mock_genesis_wallet_state(WalletEntropy::devnet_wallet(), network, &cli_args).await;
         let alice_wallet = alice_wallet.wallet_entropy;
-        let mut alice =
-            mock_genesis_global_state(network, 0, alice_wallet, cli_args::Args::default()).await;
+        let mut alice = mock_genesis_global_state(network, 0, alice_wallet, cli_args).await;
         let alice_key = alice
             .lock_guard()
             .await
@@ -1437,8 +1436,8 @@ mod archival_state_tests {
         let alice_wallet = WalletEntropy::devnet_wallet();
         let alice_key = alice_wallet.nth_generation_spending_key_for_tests(0);
         let alice_address = alice_key.to_address();
-        let mut alice =
-            mock_genesis_global_state(network, 42, alice_wallet, cli_args::Args::default()).await;
+        let cli_args = cli_args::Args::default_with_network(network);
+        let mut alice = mock_genesis_global_state(network, 42, alice_wallet, cli_args).await;
         let genesis_block = Block::genesis(network);
 
         let num_premine_utxos = Block::premine_utxos(network).len();
@@ -1536,8 +1535,8 @@ mod archival_state_tests {
         let genesis_block = Block::genesis(network);
         let alice_key = alice_wallet.nth_generation_spending_key_for_tests(0);
         let alice_address = alice_key.to_address();
-        let mut alice =
-            mock_genesis_global_state(network, 42, alice_wallet, cli_args::Args::default()).await;
+        let cli_args = cli_args::Args::default_with_network(network);
+        let mut alice = mock_genesis_global_state(network, 42, alice_wallet, cli_args).await;
 
         let mut expected_num_utxos = Block::premine_utxos(network).len();
         let mut previous_block = genesis_block.clone();

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -1251,17 +1251,32 @@ mod tests {
         let network = Network::Main;
         let bob_wallet_secret = WalletEntropy::devnet_wallet();
         let bob_spending_key = bob_wallet_secret.nth_generation_spending_key_for_tests(0);
-        let mut bob =
-            mock_genesis_global_state(network, 2, bob_wallet_secret, cli_args::Args::default())
-                .await;
+        let mut bob = mock_genesis_global_state(
+            network,
+            2,
+            bob_wallet_secret,
+            cli_args::Args {
+                guesser_fraction: 0.0,
+                ..Default::default()
+            },
+        )
+        .await;
 
         let bob_address = bob_spending_key.to_address();
 
         let alice_wallet = WalletEntropy::new_pseudorandom(rng.random());
         let alice_key = alice_wallet.nth_generation_spending_key_for_tests(0);
         let alice_address = alice_key.to_address();
-        let mut alice =
-            mock_genesis_global_state(network, 2, alice_wallet, cli_args::Args::default()).await;
+        let mut alice = mock_genesis_global_state(
+            network,
+            2,
+            alice_wallet,
+            cli_args::Args {
+                guesser_fraction: 0.0,
+                ..Default::default()
+            },
+        )
+        .await;
 
         // Ensure that both wallets have a non-zero balance by letting Alice
         // mine a block.
@@ -1367,7 +1382,6 @@ mod tests {
         }
 
         // Create next block which includes Bob's, but not Alice's, transaction.
-        let guesser_fraction = 0f64;
         let (coinbase_transaction, _expected_utxo) = make_coinbase_transaction_from_state(
             &bob.global_state_lock
                 .lock_guard()
@@ -1376,7 +1390,6 @@ mod tests {
                 .light_state()
                 .clone(),
             &bob,
-            guesser_fraction,
             in_eight_months,
             TxProvingCapability::SingleProof,
             TritonVmJobPriority::Normal.into(),
@@ -1456,7 +1469,6 @@ mod tests {
                 .light_state()
                 .clone(),
             &alice,
-            guesser_fraction,
             block_5_timestamp,
             TxProvingCapability::SingleProof,
             TritonVmJobPriority::Normal.into(),

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -364,9 +364,19 @@ impl Mempool {
                 TransactionProof::ProofCollection(_) => conflicts
                     .iter()
                     .any(|x| matches!(&x.1.proof, TransactionProof::Witness(_))),
-                TransactionProof::SingleProof(_) => conflicts
-                    .iter()
-                    .any(|x| !matches!(&x.1.proof, TransactionProof::SingleProof(_))),
+                TransactionProof::SingleProof(_) => {
+                    // A SingleProof-backed transaction kicks out conflicts if
+                    // a) any conflicts are not SingleProof, or
+                    // b) the conflict (as there can be only one) has the same
+                    //    txk-id, which indicates mutator set update. In this
+                    //    case, we just assume that the new transaction has a
+                    //    newer mutator set, because you cannot update back in
+                    //    time.
+                    conflicts.iter().any(|(conflicting_txkid, conflicting_tx)| {
+                        !matches!(&conflicting_tx.proof, TransactionProof::SingleProof(_))
+                            || *conflicting_txkid == new_tx.kernel.txid()
+                    })
+                }
             }
         }
 
@@ -374,38 +384,26 @@ impl Mempool {
 
         // If transaction to be inserted conflicts with transactions already in
         // the mempool, we replace them -- but only if the new transaction has a
-        // higher fee-density than the ones already in mempool. For this check
-        // we disqualify existing transactions that are identical except for the
-        // mutator set hash, because this difference indicates it was updated.
-        // This policy should have
-        // the effect that merged transactions always replace those transactions
+        // higher fee-density than the ones already in mempool, or if it has
+        // a higher proof-quality, meaning that it's in a state more likely to
+        // be picked up by a composer.
+        // Consequently, merged transactions always replace those transactions
         // that were merged since the merged transaction is *very* likely to
         // have a higher fee density that the lowest one of the ones that were
-        // merged. If the new transaction has a higher proof quality than the
-        // conflict, we also replace the old transactions.
+        // merged.
         let conflicts = self.transaction_conflicts_with(&new_tx);
-        let is_likely_mutator_set_update = conflicts.iter().all(|(_txkid, old_tx)| {
-            old_tx
-                .kernel
-                .inputs
-                .iter()
-                .map(|rr| rr.absolute_indices)
-                .collect_vec()
-                == new_tx
-                    .kernel
-                    .inputs
-                    .iter()
-                    .map(|rr| rr.absolute_indices)
-                    .collect_vec()
-                && old_tx.kernel.outputs == new_tx.kernel.outputs
-        });
+
+        // do not insert an existing transaction again
+        if conflicts.contains(&(new_tx.kernel.txid(), &new_tx)) {
+            return vec![];
+        }
+
         let new_tx_has_higher_proof_quality = new_tx_has_higher_proof_quality(&new_tx, &conflicts);
         let min_fee_of_conflicts = conflicts.iter().map(|x| x.1.fee_density()).min();
         let conflicts = conflicts.into_iter().map(|x| x.0).collect_vec();
         if let Some(min_fee_of_conflicting_tx) = min_fee_of_conflicts {
             let better_fee_density = min_fee_of_conflicting_tx < new_tx.fee_density();
-            if new_tx_has_higher_proof_quality || better_fee_density || is_likely_mutator_set_update
-            {
+            if new_tx_has_higher_proof_quality || better_fee_density {
                 for conflicting_txid in conflicts {
                     if let Some(e) = self.remove(conflicting_txid) {
                         events.push(e);

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -2157,7 +2157,7 @@ mod tests {
             assert_eq!(original_tx.kernel.txid(), updated_tx.kernel.txid());
             let txid = original_tx.kernel.txid();
 
-            let mut mempool = setup_mock_mempool(0, Network::Main, tx_origin);
+            let mut mempool = Mempool::new(ByteSize::gb(1), None, Digest::default());
 
             // First insert original transaction, then updated which should
             // always replace the original transaction, regardless of its size.

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -374,18 +374,38 @@ impl Mempool {
 
         // If transaction to be inserted conflicts with transactions already in
         // the mempool, we replace them -- but only if the new transaction has a
-        // higher fee-density than the ones already in mempool. This should have
+        // higher fee-density than the ones already in mempool. For this check
+        // we disqualify existing transactions that are identical except for the
+        // mutator set hash, because this difference indicates it was updated.
+        // This policy should have
         // the effect that merged transactions always replace those transactions
         // that were merged since the merged transaction is *very* likely to
         // have a higher fee density that the lowest one of the ones that were
         // merged. If the new transaction has a higher proof quality than the
         // conflict, we also replace the old transactions.
         let conflicts = self.transaction_conflicts_with(&new_tx);
+        let is_likely_mutator_set_update = conflicts.iter().all(|(_txkid, old_tx)| {
+            old_tx
+                .kernel
+                .inputs
+                .iter()
+                .map(|rr| rr.absolute_indices)
+                .collect_vec()
+                == new_tx
+                    .kernel
+                    .inputs
+                    .iter()
+                    .map(|rr| rr.absolute_indices)
+                    .collect_vec()
+                && old_tx.kernel.outputs == new_tx.kernel.outputs
+        });
         let new_tx_has_higher_proof_quality = new_tx_has_higher_proof_quality(&new_tx, &conflicts);
         let min_fee_of_conflicts = conflicts.iter().map(|x| x.1.fee_density()).min();
         let conflicts = conflicts.into_iter().map(|x| x.0).collect_vec();
         if let Some(min_fee_of_conflicting_tx) = min_fee_of_conflicts {
-            if new_tx_has_higher_proof_quality || min_fee_of_conflicting_tx < new_tx.fee_density() {
+            let better_fee_density = min_fee_of_conflicting_tx < new_tx.fee_density();
+            if new_tx_has_higher_proof_quality || better_fee_density || is_likely_mutator_set_update
+            {
                 for conflicting_txid in conflicts {
                     if let Some(e) = self.remove(conflicting_txid) {
                         events.push(e);

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -413,18 +413,12 @@ impl GlobalState {
             .wallet_entropy
             .generate_sender_randomness(next_block_height, reward_address.privacy_digest());
 
-        let utxo_notification_method = if self.cli().offchain_fee_notifications {
-            UtxoNotificationMedium::OffChain
-        } else {
-            UtxoNotificationMedium::OnChain
-        };
-
         ComposerParameters::new(
             reward_address,
             sender_randomness_for_composer,
             Some(receiver_preimage),
             self.cli.guesser_fraction,
-            utxo_notification_method,
+            self.cli().fee_notification,
         )
     }
 

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -400,17 +400,9 @@ impl GlobalState {
     /// block from the state.
     ///
     /// The relevant CLI parameters are read from the CLI arguments living on
-    /// [`GlobalState`]. If `None` is passed for `maybe_next_block_height` then
-    /// the current block height is read from state. However, in some cases
-    /// (e.g., resolving race conditions) it is necessary to override that state
-    /// read, and in such cases the supplied `Some` block height is used
-    /// instead.
-    pub(crate) fn composer_parameters(
-        &self,
-        maybe_next_block_height: Option<BlockHeight>,
-    ) -> ComposerParameters {
-        let next_block_height = maybe_next_block_height
-            .unwrap_or_else(|| self.chain.light_state().header().height.next());
+    /// [`GlobalState`]. The next block height is passed as an argument since
+    /// the callers need to declare this, to resolve race conditions.
+    pub(crate) fn composer_parameters(&self, next_block_height: BlockHeight) -> ComposerParameters {
         self.wallet_state.composer_parameters(
             next_block_height,
             self.cli.guesser_fraction,

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -396,29 +396,25 @@ impl GlobalState {
         )
     }
 
+    /// Automatically assemble the composer parameters for composing the next
+    /// block from the state.
+    ///
+    /// The relevant CLI parameters are read from the CLI arguments living on
+    /// [`GlobalState`]. If `None` is passed for `maybe_next_block_height` then
+    /// the current block height is read from state. However, in some cases
+    /// (e.g., resolving race conditions) it is necessary to override that state
+    /// read, and in such cases the supplied `Some` block height is used
+    /// instead.
     pub(crate) fn composer_parameters(
         &self,
         maybe_next_block_height: Option<BlockHeight>,
     ) -> ComposerParameters {
-        let reward_address = self.wallet_state.wallet_entropy.prover_fee_address();
-        let receiver_preimage = self
-            .wallet_state
-            .wallet_entropy
-            .prover_fee_key()
-            .privacy_preimage();
         let next_block_height = maybe_next_block_height
             .unwrap_or_else(|| self.chain.light_state().header().height.next());
-        let sender_randomness_for_composer = self
-            .wallet_state
-            .wallet_entropy
-            .generate_sender_randomness(next_block_height, reward_address.privacy_digest());
-
-        ComposerParameters::new(
-            reward_address,
-            sender_randomness_for_composer,
-            Some(receiver_preimage),
+        self.wallet_state.composer_parameters(
+            next_block_height,
             self.cli.guesser_fraction,
-            self.cli().fee_notification,
+            self.cli.fee_notification,
         )
     }
 

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -2149,7 +2149,7 @@ mod global_state_tests {
             network,
             2,
             WalletEntropy::devnet_wallet(),
-            cli_args::Args::default(),
+            cli_args::Args::default_with_network(network),
         )
         .await;
         let mut alice = alice_state_lock.lock_guard_mut().await;
@@ -3422,14 +3422,16 @@ mod global_state_tests {
             let (block_3a, composer_expected_utxos_3a) =
                 make_mock_block(&block_2a, None, spending_key, rng.random()).await;
 
+            let cli_args = cli_args::Args {
+                number_of_mps_per_utxo: 30,
+                network,
+                ..Default::default()
+            };
+
             for claim_composer_fees in [false, true] {
-                let mut global_state_lock = mock_genesis_global_state(
-                    network,
-                    2,
-                    wallet_secret.clone(),
-                    cli_args::Args::default(),
-                )
-                .await;
+                let mut global_state_lock =
+                    mock_genesis_global_state(network, 2, wallet_secret.clone(), cli_args.clone())
+                        .await;
                 let mut global_state = global_state_lock.lock_guard_mut().await;
 
                 if claim_composer_fees {

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -343,6 +343,8 @@ impl GlobalState {
             .await
     }
 
+    /// Return the block height in which the latest UTXO was either spent or
+    /// received. `None` if this wallet never received a UTXO.
     pub async fn get_latest_balance_height(&self) -> Option<BlockHeight> {
         let (height, time_secs) =
             time_fn_call_async(self.get_latest_balance_height_internal()).await;
@@ -402,7 +404,12 @@ impl GlobalState {
     /// The relevant CLI parameters are read from the CLI arguments living on
     /// [`GlobalState`]. The next block height is passed as an argument since
     /// the callers need to declare this, to resolve race conditions.
+    ///
+    /// # Panics
+    ///
+    ///  - If `next_block_height` is genesis.
     pub(crate) fn composer_parameters(&self, next_block_height: BlockHeight) -> ComposerParameters {
+        assert!(!next_block_height.is_genesis());
         self.wallet_state.composer_parameters(
             next_block_height,
             self.cli.guesser_fraction,

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -343,8 +343,8 @@ impl GlobalState {
             .await
     }
 
-    /// Return the block height in which the latest UTXO was either spent or
-    /// received. `None` if this wallet never received a UTXO.
+    /// The block height in which the latest UTXO was either spent or received.
+    /// `None` if this wallet never received a UTXO.
     pub async fn get_latest_balance_height(&self) -> Option<BlockHeight> {
         let (height, time_secs) =
             time_fn_call_async(self.get_latest_balance_height_internal()).await;
@@ -401,9 +401,9 @@ impl GlobalState {
     /// Automatically assemble the composer parameters for composing the next
     /// block from the state.
     ///
-    /// The relevant CLI parameters are read from the CLI arguments living on
-    /// [`GlobalState`]. The next block height is passed as an argument since
-    /// the callers need to declare this, to resolve race conditions.
+    /// The next block height is passed as an argument as opposed to being read
+    /// from state since the caller needs to declare it to resolve race
+    /// conditions.
     ///
     /// # Panics
     ///

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -406,10 +406,17 @@ impl GlobalState {
             .wallet_entropy
             .generate_sender_randomness(next_block_height, reward_address.privacy_digest());
 
+        let utxo_notification_method = if self.cli().offchain_fee_notifications {
+            UtxoNotificationMedium::OffChain
+        } else {
+            UtxoNotificationMedium::OnChain
+        };
+
         ComposerParameters::new(
             reward_address,
             sender_randomness_for_composer,
             self.cli.guesser_fraction,
+            utxo_notification_method,
         )
     }
 

--- a/src/models/state/wallet/mod.rs
+++ b/src/models/state/wallet/mod.rs
@@ -499,9 +499,16 @@ mod wallet_tests {
         let network = Network::Main;
         let mut rng: StdRng = StdRng::seed_from_u64(456416);
         let alice_wallet_secret = WalletEntropy::new_pseudorandom(rng.random());
-        let mut alice =
-            mock_genesis_global_state(network, 2, alice_wallet_secret, cli_args::Args::default())
-                .await;
+        let mut alice = mock_genesis_global_state(
+            network,
+            2,
+            alice_wallet_secret,
+            cli_args::Args {
+                guesser_fraction: 0.0,
+                ..Default::default()
+            },
+        )
+        .await;
         let alice_key = alice
             .lock_guard()
             .await
@@ -797,7 +804,6 @@ mod wallet_tests {
             .await
             .unwrap();
 
-        let guesser_fraction = 0f64;
         let (coinbase_tx, expected_composer_utxos) = make_coinbase_transaction_from_state(
             &alice
                 .global_state_lock
@@ -807,7 +813,6 @@ mod wallet_tests {
                 .light_state()
                 .clone(),
             &alice,
-            guesser_fraction,
             block_2_b.header().timestamp + MINIMUM_BLOCK_TIME,
             TxProvingCapability::SingleProof,
             TritonVmJobPriority::Normal.into(),
@@ -968,13 +973,15 @@ mod wallet_tests {
             network,
             42,
             WalletEntropy::devnet_wallet(),
-            cli_args::Args::default(),
+            cli_args::Args {
+                guesser_fraction: 0.0,
+                ..Default::default()
+            },
         )
         .await;
 
         let mut rng = StdRng::seed_from_u64(87255549301u64);
 
-        let guesser_fraction = 0f64;
         let (cbtx, _cb_expected) = make_coinbase_transaction_from_state(
             &bob.global_state_lock
                 .lock_guard()
@@ -983,7 +990,6 @@ mod wallet_tests {
                 .light_state()
                 .clone(),
             &bob,
-            guesser_fraction,
             in_seven_months,
             TxProvingCapability::SingleProof,
             TritonVmJobPriority::Normal.into(),

--- a/src/models/state/wallet/mod.rs
+++ b/src/models/state/wallet/mod.rs
@@ -77,8 +77,9 @@ mod wallet_tests {
 
         let mut rng = rand::rng();
         for network in Network::iter() {
+            let cli_args = cli_args::Args::default();
             let mut alice =
-                mock_genesis_wallet_state(WalletEntropy::devnet_wallet(), network).await;
+                mock_genesis_wallet_state(WalletEntropy::devnet_wallet(), network, &cli_args).await;
             let alice_wallet = get_monitored_utxos(&alice).await;
             assert_eq!(
                 1,
@@ -93,7 +94,7 @@ mod wallet_tests {
             );
 
             let bob_wallet = WalletEntropy::new_pseudorandom(rng.random());
-            let bob_wallet = mock_genesis_wallet_state(bob_wallet, network).await;
+            let bob_wallet = mock_genesis_wallet_state(bob_wallet, network, &cli_args).await;
             let bob_mutxos = get_monitored_utxos(&bob_wallet).await;
             assert!(
                 bob_mutxos.is_empty(),
@@ -143,8 +144,10 @@ mod wallet_tests {
     async fn wallet_state_correctly_updates_monitored_and_expected_utxos() {
         let mut rng = rand::rng();
         let network = Network::RegTest;
+        let cli_args = cli_args::Args::default();
         let alice_wallet = WalletEntropy::new_random();
-        let mut alice_wallet = mock_genesis_wallet_state(alice_wallet.clone(), network).await;
+        let mut alice_wallet =
+            mock_genesis_wallet_state(alice_wallet.clone(), network, &cli_args).await;
         let bob_wallet = WalletEntropy::new_random();
         let bob_key = bob_wallet.nth_generation_spending_key_for_tests(0);
 
@@ -497,6 +500,7 @@ mod wallet_tests {
         // and the blockchain forks.
 
         let network = Network::Main;
+        let cli_args = cli_args::Args::default();
         let mut rng: StdRng = StdRng::seed_from_u64(456416);
         let alice_wallet_secret = WalletEntropy::new_pseudorandom(rng.random());
         let mut alice = mock_genesis_global_state(
@@ -517,9 +521,10 @@ mod wallet_tests {
             .nth_generation_spending_key_for_tests(0);
         let alice_address = alice_key.to_address();
         let genesis_block = Block::genesis(network);
-        let bob_wallet = mock_genesis_wallet_state(WalletEntropy::devnet_wallet(), network)
-            .await
-            .wallet_entropy;
+        let bob_wallet =
+            mock_genesis_wallet_state(WalletEntropy::devnet_wallet(), network, &cli_args)
+                .await
+                .wallet_entropy;
         let mut bob_global_lock =
             mock_genesis_global_state(network, 2, bob_wallet.clone(), cli_args::Args::default())
                 .await;

--- a/src/models/state/wallet/scan_mode_configuration.rs
+++ b/src/models/state/wallet/scan_mode_configuration.rs
@@ -13,12 +13,15 @@ use crate::models::blockchain::block::Block;
 /// wallet secret seed but with future derivation indices. If an incoming
 /// message is observed, the derivation index counter is updated accordingly.
 /// The number of future indices to scan for is a tunable parameter.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) struct ScanModeConfiguration {
     num_future_keys: usize,
     first_block_height: BlockHeight,
     last_block_height: Option<BlockHeight>,
+    maybe_guesser_fraction: Option<f64>,
 }
+
+impl Eq for ScanModeConfiguration {}
 
 impl Default for ScanModeConfiguration {
     fn default() -> Self {
@@ -26,6 +29,7 @@ impl Default for ScanModeConfiguration {
             num_future_keys: 25,
             first_block_height: BlockHeight::genesis(),
             last_block_height: None,
+            maybe_guesser_fraction: None,
         }
     }
 }
@@ -61,6 +65,11 @@ impl ScanModeConfiguration {
         self
     }
 
+    /// Setter for the guesser fraction
+    pub(crate) fn set_guesser_fraction(&mut self, fraction: f64) {
+        self.maybe_guesser_fraction = Some(fraction);
+    }
+
     /// Determine whether to scan a block given its height.
     ///
     /// Marked `pub(crate)` for testing. Not part of the API. Use
@@ -80,5 +89,9 @@ impl ScanModeConfiguration {
     /// How many future keys to scan for.
     pub(crate) fn num_future_keys(&self) -> usize {
         self.num_future_keys
+    }
+
+    pub(crate) fn maybe_guesser_fraction(&self) -> Option<f64> {
+        self.maybe_guesser_fraction
     }
 }

--- a/src/models/state/wallet/scan_mode_configuration.rs
+++ b/src/models/state/wallet/scan_mode_configuration.rs
@@ -13,7 +13,7 @@ use crate::models::blockchain::block::Block;
 /// wallet secret seed but with future derivation indices. If an incoming
 /// message is observed, the derivation index counter is updated accordingly.
 /// The number of future indices to scan for is a tunable parameter.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) struct ScanModeConfiguration {
     num_future_keys: usize,
     first_block_height: BlockHeight,
@@ -30,8 +30,6 @@ pub(crate) struct ScanModeConfiguration {
     /// lost otherwise.
     maybe_guesser_fraction: Option<f64>,
 }
-
-impl Eq for ScanModeConfiguration {}
 
 impl Default for ScanModeConfiguration {
     fn default() -> Self {
@@ -75,7 +73,7 @@ impl ScanModeConfiguration {
         self
     }
 
-    /// Setter for the guesser fraction
+    /// Set the guesser fraction to `Some` value.
     pub(crate) fn set_guesser_fraction(&mut self, fraction: f64) {
         self.maybe_guesser_fraction = Some(fraction);
     }

--- a/src/models/state/wallet/scan_mode_configuration.rs
+++ b/src/models/state/wallet/scan_mode_configuration.rs
@@ -18,6 +18,16 @@ pub(crate) struct ScanModeConfiguration {
     num_future_keys: usize,
     first_block_height: BlockHeight,
     last_block_height: Option<BlockHeight>,
+
+    /// Relates to the attempted recovery of composer rewards, assuming the user
+    ///  - remembers what they set the guesser fraction to, and
+    ///  - lost incoming_randomness.dat, and
+    ///  - migrated the wallet (or corrupted the wallet database), and
+    ///  - did not use on-chain notifications for the composer (or used the
+    ///    default settings before on-chain notifications were set as default).
+    ///
+    /// Under those conditions, this field will identify composer UTXOs that are
+    /// lost otherwise.
     maybe_guesser_fraction: Option<f64>,
 }
 

--- a/src/models/state/wallet/secret_key_material.rs
+++ b/src/models/state/wallet/secret_key_material.rs
@@ -17,6 +17,7 @@ use zeroize::Zeroize;
 
 /// Holds the secret seed of a wallet.
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(any(test, feature = "arbitrary-impls"), derive(arbitrary::Arbitrary))]
 pub struct SecretKeyMaterial(pub(crate) XFieldElement);
 
 impl Zeroize for SecretKeyMaterial {

--- a/src/models/state/wallet/transaction_output.rs
+++ b/src/models/state/wallet/transaction_output.rs
@@ -125,14 +125,13 @@ impl TxOutput {
         receiving_address: ReceivingAddress,
         owned: bool,
     ) -> Self {
-        let utxo = Utxo::new_native_currency(receiving_address.lock_script(), amount);
-        Self {
-            utxo,
+        Self::native_currency(
+            amount,
             sender_randomness,
-            receiver_digest: receiving_address.privacy_digest(),
-            notification_method: UtxoNotifyMethod::OnChain(receiving_address),
+            receiving_address,
+            UtxoNotificationMedium::OnChain,
             owned,
-        }
+        )
     }
 
     /// Instantiate a [TxOutput] for native currency intended for off-chain UTXO
@@ -143,12 +142,31 @@ impl TxOutput {
         receiving_address: ReceivingAddress,
         owned: bool,
     ) -> Self {
+        Self::native_currency(
+            amount,
+            sender_randomness,
+            receiving_address,
+            UtxoNotificationMedium::OffChain,
+            owned,
+        )
+    }
+
+    /// Instantiate a [TxOutput] for native currency.
+    pub(crate) fn native_currency(
+        amount: NativeCurrencyAmount,
+        sender_randomness: Digest,
+        receiving_address: ReceivingAddress,
+        notification_medium: UtxoNotificationMedium,
+        owned: bool,
+    ) -> Self {
+        let receiver_digest = receiving_address.privacy_digest();
         let utxo = Utxo::new_native_currency(receiving_address.lock_script(), amount);
+        let notify_method = UtxoNotifyMethod::new(notification_medium, receiving_address);
         Self {
             utxo,
             sender_randomness,
-            receiver_digest: receiving_address.privacy_digest(),
-            notification_method: UtxoNotifyMethod::OffChain(receiving_address),
+            receiver_digest,
+            notification_method: notify_method,
             owned,
         }
     }

--- a/src/models/state/wallet/utxo_notification.rs
+++ b/src/models/state/wallet/utxo_notification.rs
@@ -1,5 +1,3 @@
-#[cfg(test)]
-use arbitrary::Arbitrary;
 use serde::Deserialize;
 use serde::Serialize;
 use tasm_lib::prelude::Digest;
@@ -21,7 +19,7 @@ pub enum UtxoNotificationMedium {
 /// enumerates how utxos and spending information is communicated, including how
 /// to encrypt this information.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[cfg_attr(test, derive(Arbitrary))]
+#[cfg_attr(test, derive(arbitrary::Arbitrary))]
 pub(crate) enum UtxoNotifyMethod {
     /// the utxo notification should be transferred to recipient encrypted on the blockchain
     OnChain(ReceivingAddress),
@@ -31,6 +29,15 @@ pub(crate) enum UtxoNotifyMethod {
 
     /// No UTXO notification is intended
     None,
+}
+
+impl UtxoNotifyMethod {
+    pub(crate) fn new(medium: UtxoNotificationMedium, address: ReceivingAddress) -> Self {
+        match medium {
+            UtxoNotificationMedium::OnChain => Self::OnChain(address),
+            UtxoNotificationMedium::OffChain => Self::OffChain(address),
+        }
+    }
 }
 
 /// The payload of a UTXO notification, containing all information necessary

--- a/src/models/state/wallet/wallet_configuration.rs
+++ b/src/models/state/wallet/wallet_configuration.rs
@@ -13,7 +13,7 @@ use crate::config_models::network::Network;
 /// These configurations are often downstream from CLI arguments. However,
 /// exceptions to this rule exist. For instance: scan mode can be activated by
 /// importing a wallet, even without CLI arguments.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) struct WalletConfiguration {
     /// Whether we are in scan mode and, if so, how many future keys to scan
     /// with and the range of block heights where the scanning step is done.

--- a/src/models/state/wallet/wallet_configuration.rs
+++ b/src/models/state/wallet/wallet_configuration.rs
@@ -74,6 +74,12 @@ impl WalletConfiguration {
             }
         };
 
+        if cli_args.compose {
+            if let Some(scan_mode_configuration) = self.scan_mode.as_mut() {
+                scan_mode_configuration.set_guesser_fraction(cli_args.guesser_fraction);
+            };
+        }
+
         self.network = cli_args.network;
 
         self

--- a/src/models/state/wallet/wallet_entropy.rs
+++ b/src/models/state/wallet/wallet_entropy.rs
@@ -18,6 +18,9 @@ use crate::models::state::wallet::address::symmetric_key;
 use crate::models::state::wallet::secret_key_material::SecretKeyMaterial;
 use crate::prelude::twenty_first;
 
+use super::address::ReceivingAddress;
+use super::address::SpendingKey;
+
 /// The wallet's one source of randomness, from which all keys are derived.
 ///
 /// This struct wraps around [`SecretKeyMaterial`], which contains the secret
@@ -60,6 +63,20 @@ impl WalletEntropy {
     /// Returns the spending key for guessing on top of the given block.
     pub(crate) fn guesser_spending_key(&self, prev_block_digest: Digest) -> HashLockKey {
         HashLockKey::from_preimage(self.guesser_preimage(prev_block_digest))
+    }
+
+    /// Returns the spending key for prover rewards, *i.e.*, composer fee or
+    /// proof-upgrader (gobbling) fee.
+    fn prover_fee_key(&self) -> generation_address::GenerationSpendingKey {
+        self.nth_generation_spending_key(0u64)
+    }
+
+    /// Returns the receiving address for prover rewards, *i.e.*, composer fee
+    /// or proof-upgrader (gobbling) fee.
+    pub(crate) fn prover_fee_address(&self) -> ReceivingAddress {
+        SpendingKey::from(self.prover_fee_key())
+            .to_address()
+            .unwrap()
     }
 
     /// derives a generation spending key at `index`

--- a/src/models/state/wallet/wallet_entropy.rs
+++ b/src/models/state/wallet/wallet_entropy.rs
@@ -72,7 +72,7 @@ impl WalletEntropy {
     /// Returns the receiving address for prover rewards, *i.e.*, composer fee
     /// or proof-upgrader (gobbling) fee.
     pub(crate) fn prover_fee_address(&self) -> ReceivingAddress {
-        self.nth_generation_spending_key(0).to_address().into()
+        self.prover_fee_key().to_address().into()
     }
 
     /// derives a generation spending key at `index`

--- a/src/models/state/wallet/wallet_entropy.rs
+++ b/src/models/state/wallet/wallet_entropy.rs
@@ -10,6 +10,7 @@ use twenty_first::math::digest::Digest;
 use twenty_first::math::x_field_element::XFieldElement;
 use zeroize::ZeroizeOnDrop;
 
+use super::address::ReceivingAddress;
 use crate::models::blockchain::block::block_height::BlockHeight;
 use crate::models::state::wallet::address::generation_address;
 use crate::models::state::wallet::address::hash_lock_key;
@@ -17,8 +18,6 @@ use crate::models::state::wallet::address::hash_lock_key::HashLockKey;
 use crate::models::state::wallet::address::symmetric_key;
 use crate::models::state::wallet::secret_key_material::SecretKeyMaterial;
 use crate::prelude::twenty_first;
-
-use super::address::ReceivingAddress;
 
 /// The wallet's one source of randomness, from which all keys are derived.
 ///

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -2962,8 +2962,12 @@ pub(crate) mod tests {
             // below test function.
             tx_spending_guesser_fee.proof = TransactionProof::invalid();
 
-            let composer_parameters =
-                ComposerParameters::new(a_key.to_address().into(), rng.random(), 0.5f64);
+            let composer_parameters = ComposerParameters::new(
+                a_key.to_address().into(),
+                rng.random(),
+                0.5f64,
+                UtxoNotificationMedium::OffChain,
+            );
             let (block2_tx, _) = fake_create_block_transaction_for_tests(
                 &block1,
                 composer_parameters,

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -738,7 +738,7 @@ impl WalletState {
     /// Scan the given transaction for announced UTXOs as recognized by owned
     /// `SpendingKey`s, and then verify those announced UTXOs are actually
     /// present.
-    fn scan_for_utxos_announced_to_known_keys<'a>(
+    pub(crate) fn scan_for_utxos_announced_to_known_keys<'a>(
         &'a self,
         tx_kernel: &'a TransactionKernel,
     ) -> impl Iterator<Item = IncomingUtxo> + 'a {

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -4780,16 +4780,17 @@ pub(crate) mod tests {
 
             // upgrade transaction again
             // this time mutator set data
+            let genesis_mutator_set = genesis_block.mutator_set_accumulator_after();
             let single_proof_transaction = rando
                 .lock_guard()
                 .await
                 .mempool
-                .get_transactions_for_block(10_000_000, None, true)[0]
+                .get_transactions_for_block(10_000_000, None, true, genesis_mutator_set.hash())[0]
                 .clone();
             let upgrade_job_two = UpgradeJob::UpdateMutatorSetData(UpdateMutatorSetDataJob::new(
                 single_proof_transaction.kernel,
                 single_proof_transaction.proof.into_single_proof(),
-                genesis_block.mutator_set_accumulator_after(),
+                genesis_mutator_set,
                 block_one.mutator_set_update(),
             ));
             let (channel_to_nowhere_two, nowhere_two) =
@@ -4806,11 +4807,12 @@ pub(crate) mod tests {
             drop(nowhere_two); // drop must occur after message is sent
 
             // get upgraded transaction
+            let block_one_mutator_set = block_one.mutator_set_accumulator_after();
             let transactions_for_block = rando
                 .lock_guard()
                 .await
                 .mempool
-                .get_transactions_for_block(10_000_000, None, true);
+                .get_transactions_for_block(10_000_000, None, true, block_one_mutator_set.hash());
             assert_eq!(1, transactions_for_block.len());
             let upgraded_transaction = transactions_for_block[0].clone();
             let new_num_public_announcements =

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -1410,8 +1410,9 @@ impl WalletState {
             preprocess_own_mutxos(monitored_utxos, new_block).await;
 
         debug!(
-            "handling {} monitored UTXOs",
-            valid_membership_proofs_and_own_utxo_count.len()
+            "doing maintenance on {}/{} monitored UTXOs",
+            valid_membership_proofs_and_own_utxo_count.len(),
+            all_existing_mutxos.len()
         );
 
         // Loop over all output UTXOs, applying all addition records. In each iteration,
@@ -1913,13 +1914,9 @@ pub(crate) mod tests {
     #[traced_test]
     async fn find_monitored_utxo_test() {
         let network = Network::Testnet;
-        let alice_global_lock = mock_genesis_global_state(
-            network,
-            0,
-            WalletEntropy::devnet_wallet(),
-            cli_args::Args::default(),
-        )
-        .await;
+        let cli_args = cli_args::Args::default_with_network(network);
+        let alice_global_lock =
+            mock_genesis_global_state(network, 0, WalletEntropy::devnet_wallet(), cli_args).await;
 
         let premine_utxo = {
             let wallet = &alice_global_lock.lock_guard().await.wallet_state;
@@ -2779,7 +2776,7 @@ pub(crate) mod tests {
         let wallet = WalletEntropy::devnet_wallet();
         let genesis_block = Block::genesis(network);
 
-        let cli_args = cli_args::Args::default();
+        let cli_args = cli_args::Args::default_with_network(network);
         let wallet_state = mock_genesis_wallet_state(wallet, network, &cli_args).await;
 
         // are we synchronized to the genesis block?

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -4732,7 +4732,7 @@ pub(crate) mod tests {
                 genesis_block.mutator_set_accumulator_after(),
                 new_block.mutator_set_update(),
             ));
-            let (channel_to_nowhere, _) =
+            let (channel_to_nowhere, nowhere) =
                 broadcast::channel::<MainToPeerTask>(PEER_CHANNEL_CAPACITY);
             upgrade_job
                 .handle_upgrade(
@@ -4743,6 +4743,7 @@ pub(crate) mod tests {
                     channel_to_nowhere,
                 )
                 .await;
+            drop(nowhere);
             let transactions_for_block = rando_global_state_lock
                 .lock_guard()
                 .await

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -2967,6 +2967,7 @@ pub(crate) mod tests {
             let composer_parameters = ComposerParameters::new(
                 a_key.to_address().into(),
                 rng.random(),
+                Some(a_key.privacy_preimage()),
                 0.5f64,
                 UtxoNotificationMedium::OffChain,
             );
@@ -4264,11 +4265,14 @@ pub(crate) mod tests {
             assert_eq!(filtered_utxos, caught_utxos);
         }
 
+        #[test]
+        fn scan_mode_recovers_offchain_composer_utxos() {}
     }
 
     pub(crate) mod fee_notifications {
 
         use crate::mine_loop::make_coinbase_transaction_stateless;
+        use crate::models::blockchain::block::block_height::BlockHeight;
         use crate::models::proof_abstractions::tasm::program::TritonVmProofJobOptions;
 
         use super::*;
@@ -4287,7 +4291,6 @@ pub(crate) mod tests {
             let mut wallet_state =
                 WalletState::new_from_wallet_entropy(&data_dir, wallet_secret.clone(), &cli_args)
                     .await;
-            let fee_address = wallet_state.wallet_entropy.prover_fee_address();
             let global_state_lock =
                 mock_genesis_global_state(network, 2, wallet_secret.clone(), cli_args).await;
 
@@ -4301,7 +4304,7 @@ pub(crate) mod tests {
             let composer_parameters = global_state_lock
                 .lock_guard()
                 .await
-                .composer_parameters(fee_address); // on-chain notifications by default
+                .composer_parameters(Some(BlockHeight::genesis())); // on-chain notifications by default
             let (transaction, composer_utxos) = make_coinbase_transaction_stateless(
                 &previous_block,
                 composer_parameters.clone(),

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -173,7 +173,7 @@ impl WalletState {
     ///
     ///  # Panics
     ///
-    ///  - If the `guesser_fraction` is not a fraction contained in [0;1].
+    ///  - If the `guesser_fraction` is not a fraction contained in \[0;1\].
     pub(crate) fn composer_parameters(
         &self,
         next_block_height: BlockHeight,

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -2717,6 +2717,7 @@ pub(crate) mod tests {
         use rand::rng;
 
         use super::*;
+        use crate::config_models::fee_notification_policy::FeeNotificationPolicy;
         use crate::mine_loop::composer_parameters;
         use crate::mine_loop::guess_nonce;
         use crate::mine_loop::GuessingConfiguration;
@@ -2969,7 +2970,7 @@ pub(crate) mod tests {
                 rng.random(),
                 Some(a_key.privacy_preimage()),
                 0.5f64,
-                UtxoNotificationMedium::OffChain,
+                FeeNotificationPolicy::OffChain,
             );
             let (block2_tx, _) = fake_create_block_transaction_for_tests(
                 &block1,

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -4729,7 +4729,7 @@ pub(crate) mod tests {
             let upgrade_job = UpgradeJob::UpdateMutatorSetData(UpdateMutatorSetDataJob::new(
                 transaction.kernel,
                 transaction.proof.into_single_proof(),
-                new_block.mutator_set_accumulator_after(),
+                genesis_block.mutator_set_accumulator_after(),
                 new_block.mutator_set_update(),
             ));
             let (channel_to_nowhere, _) =

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -4473,7 +4473,8 @@ pub(crate) mod tests {
         use crate::models::blockchain::block::block_height::BlockHeight;
         use crate::models::proof_abstractions::tasm::program::TritonVmProofJobOptions;
         use crate::models::state::mempool::TransactionOrigin;
-        use crate::{MainToPeerTask, PEER_CHANNEL_CAPACITY};
+        use crate::MainToPeerTask;
+        use crate::PEER_CHANNEL_CAPACITY;
 
         use super::*;
 
@@ -4628,13 +4629,19 @@ pub(crate) mod tests {
             upgrade_fee_notification_policy: FeeNotificationPolicy,
         ) {
             // derandomize because we will need proofs
-            let seed: [u8; 32] = random();
+            let seed = [
+                155, 213, 11, 57, 97, 48, 59, 23, 111, 107, 153, 29, 219, 126, 204, 48, 17, 5, 105,
+                31, 185, 57, 156, 90, 7, 121, 39, 201, 232, 33, 159, 189,
+            ];
             dbg!(seed);
             let mut rng = StdRng::from_seed(seed);
 
             // set up premine recipient
             let network = Network::Main;
-            let cli_args = cli_args::Args::default();
+            let cli_args = cli_args::Args {
+                tx_proving_capability: Some(TxProvingCapability::SingleProof),
+                ..Default::default()
+            };
             let wallet_secret = WalletEntropy::devnet_wallet();
             let mut global_state_lock =
                 mock_genesis_global_state(network, 2, wallet_secret.clone(), cli_args).await;
@@ -4707,6 +4714,7 @@ pub(crate) mod tests {
             let rando_wallet_secret = WalletEntropy::new_pseudorandom(rng.random());
             let rando_cli_args = cli_args::Args {
                 fee_notification: upgrade_fee_notification_policy,
+                tx_proving_capability: Some(TxProvingCapability::SingleProof),
                 ..Default::default()
             };
             let mut rando_global_state_lock =

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -723,6 +723,7 @@ pub(crate) async fn make_mock_block_guesser_preimage_and_guesser_fraction(
     let composer_parameters = ComposerParameters::new(
         composer_key.to_address().into(),
         coinbase_sender_randomness,
+        Some(composer_key.privacy_preimage()),
         guesser_fraction,
         UtxoNotificationMedium::OffChain,
     );
@@ -1021,6 +1022,7 @@ async fn fake_block_successor(
     let composer_parameters = ComposerParameters::new(
         GenerationReceivingAddress::derive_from_seed(rng.random()).into(),
         rng.random(),
+        None,
         0.5f64,
         UtxoNotificationMedium::OffChain,
     );

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -105,6 +105,7 @@ use crate::models::state::wallet::address::generation_address::GenerationReceivi
 use crate::models::state::wallet::expected_utxo::ExpectedUtxo;
 use crate::models::state::wallet::expected_utxo::UtxoNotifier;
 use crate::models::state::wallet::transaction_output::TxOutputList;
+use crate::models::state::wallet::utxo_notification::UtxoNotificationMedium;
 use crate::models::state::wallet::wallet_entropy::WalletEntropy;
 use crate::models::state::wallet::wallet_state::WalletState;
 use crate::models::state::GlobalStateLock;
@@ -723,6 +724,7 @@ pub(crate) async fn make_mock_block_guesser_preimage_and_guesser_fraction(
         composer_key.to_address().into(),
         coinbase_sender_randomness,
         guesser_fraction,
+        UtxoNotificationMedium::OffChain,
     );
 
     let (tx, composer_txos) = make_coinbase_transaction_stateless(
@@ -1020,6 +1022,7 @@ async fn fake_block_successor(
         GenerationReceivingAddress::derive_from_seed(rng.random()).into(),
         rng.random(),
         0.5f64,
+        UtxoNotificationMedium::OffChain,
     );
     let (block_tx, _) = fake_create_block_transaction_for_tests(
         predecessor,

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -243,7 +243,7 @@ pub(crate) async fn mock_genesis_global_state(
         genesis_block.hash(),
     );
 
-    let wallet_state = mock_genesis_wallet_state(wallet, network).await;
+    let wallet_state = mock_genesis_wallet_state(wallet, network, &cli).await;
 
     GlobalStateLock::new(
         wallet_state,
@@ -781,24 +781,20 @@ pub(crate) async fn make_mock_block(
 /// Return a dummy-wallet used for testing. The returned wallet is populated with
 /// whatever UTXOs are present in the genesis block.
 pub async fn mock_genesis_wallet_state(
-    wallet_secret: WalletEntropy,
+    wallet_entropy: WalletEntropy,
     network: Network,
+    cli_args: &cli_args::Args,
 ) -> WalletState {
     let data_dir = unit_test_data_directory(network).unwrap();
-    mock_genesis_wallet_state_with_data_dir(wallet_secret, network, &data_dir).await
+    mock_genesis_wallet_state_with_data_dir(wallet_entropy, &data_dir, cli_args).await
 }
 
 pub async fn mock_genesis_wallet_state_with_data_dir(
     wallet_entropy: WalletEntropy,
-    network: Network,
     data_dir: &DataDirectory,
+    cli_args: &cli_args::Args,
 ) -> WalletState {
-    let cli_args: cli_args::Args = cli_args::Args {
-        number_of_mps_per_utxo: 30,
-        network,
-        ..Default::default()
-    };
-    WalletState::new_from_wallet_entropy(data_dir, wallet_entropy, &cli_args).await
+    WalletState::new_from_wallet_entropy(data_dir, wallet_entropy, cli_args).await
 }
 
 /// Return an archival state populated with the genesis block

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -47,6 +47,7 @@ use twenty_first::util_types::mmr::mmr_trait::Mmr;
 
 use crate::config_models::cli_args;
 use crate::config_models::data_directory::DataDirectory;
+use crate::config_models::fee_notification_policy::FeeNotificationPolicy;
 use crate::config_models::network::Network;
 use crate::database::storage::storage_vec::traits::StorageVecBase;
 use crate::database::NeptuneLevelDb;
@@ -105,7 +106,6 @@ use crate::models::state::wallet::address::generation_address::GenerationReceivi
 use crate::models::state::wallet::expected_utxo::ExpectedUtxo;
 use crate::models::state::wallet::expected_utxo::UtxoNotifier;
 use crate::models::state::wallet::transaction_output::TxOutputList;
-use crate::models::state::wallet::utxo_notification::UtxoNotificationMedium;
 use crate::models::state::wallet::wallet_entropy::WalletEntropy;
 use crate::models::state::wallet::wallet_state::WalletState;
 use crate::models::state::GlobalStateLock;
@@ -725,7 +725,7 @@ pub(crate) async fn make_mock_block_guesser_preimage_and_guesser_fraction(
         coinbase_sender_randomness,
         Some(composer_key.privacy_preimage()),
         guesser_fraction,
-        UtxoNotificationMedium::OffChain,
+        FeeNotificationPolicy::OffChain,
     );
 
     let (tx, composer_txos) = make_coinbase_transaction_stateless(
@@ -1024,7 +1024,7 @@ async fn fake_block_successor(
         rng.random(),
         None,
         0.5f64,
-        UtxoNotificationMedium::OffChain,
+        FeeNotificationPolicy::OffChain,
     );
     let (block_tx, _) = fake_create_block_transaction_for_tests(
         predecessor,


### PR DESCRIPTION
This PR:
 - Introduces a CLI flag that regulates the notification policy for prover fees (meaning upgrader fees and composition fees, guesser fees are explicitly excluded). The notification policy can be
   - `OnChainSymmetric` (default)
   - `OffChain` (for users who know what they are doing)
   - `OnChainGeneration` (anticipates cold composing/upgrading, where the client mines to an address but does not know the spending key).
 - Streamlines the CLI arguments, and how it is passed down to global state and wallet state.
 - Implements and tests the fee notification policy.
 - Automatically derives and tracks the symmetric (in addition to generation, which was already being done) key with derivation index 0. The default fee notification policy is to use this symmetric key.
 - Adds a step in scan mode when scan mode is active, unrelated to fee notification policy, which tries to reproduce the composer UTXOs and claims them if successful.
 - Modifies the insertion policy into the mempool: new but conflicting transactions with lower fee density are *not* rejected if the inputs and outputs are identical, as this likely indicates that the transaction was updated to a new mutator set.

Fixes #441.
Closes #443.