### PR TITLE
refactor(`TritonVmJobQueue`): Use singleton pattern

### DIFF
--- a/src/job_queue/queue.rs
+++ b/src/job_queue/queue.rs
@@ -1,6 +1,7 @@
 use std::collections::VecDeque;
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::sync::OnceLock;
 
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
@@ -16,6 +17,7 @@ use super::traits::JobCompletion;
 use super::traits::JobResult;
 use super::traits::JobResultReceiver;
 use super::traits::JobResultSender;
+use super::triton_vm::TritonVmJobPriority;
 
 /// A job-handle enables cancelling a job and awaiting results
 #[derive(Debug)]
@@ -77,6 +79,10 @@ struct AddJobMsg<P> {
 }
 
 /// implements a job queue that sends result of each job to a listener.
+///
+/// The generic argument provides type safety and clarity in case we implement
+/// job queues for other job types. For each job type, there should only ever be
+/// one instance.
 pub struct JobQueue<P> {
     tx: mpsc::UnboundedSender<JobQueueMsg<P>>,
     tracker: TaskTracker,
@@ -122,7 +128,7 @@ impl<P> Drop for JobQueue<P> {
 
 impl<P: Ord + Send + Sync + 'static> JobQueue<P> {
     /// creates job queue and starts it processing.  returns immediately.
-    pub fn start() -> Self {
+    fn start() -> Self {
         struct CurrentJob {
             job_num: usize,
             cancel_tx: JobCancelSender,
@@ -272,6 +278,18 @@ impl<P: Ord + Send + Sync + 'static> JobQueue<P> {
             cancel_tx,
         })
     }
+}
+
+/// A job queue for Triton VM Jobs.
+pub type TritonVmJobQueue = JobQueue<TritonVmJobPriority>;
+
+/// Global singleton accessor for the Triton VM Job Queue
+//
+// Ideally we implement a generic function `instance` on JobQueue but it seems
+// as though generic type arguments do not play ball with static pointers.
+pub fn global_triton_vm_job_queue() -> &'static TritonVmJobQueue {
+    static REGISTRY: OnceLock<TritonVmJobQueue> = OnceLock::new();
+    REGISTRY.get_or_init(TritonVmJobQueue::start)
 }
 
 #[cfg(test)]

--- a/src/job_queue/triton_vm/mod.rs
+++ b/src/job_queue/triton_vm/mod.rs
@@ -1,4 +1,5 @@
-mod triton_vm_job_queue;
+mod triton_vm_job_priority;
 
-pub use triton_vm_job_queue::TritonVmJobPriority;
-pub use triton_vm_job_queue::TritonVmJobQueue;
+pub use super::queue::global_triton_vm_job_queue;
+pub use super::queue::TritonVmJobQueue;
+pub use triton_vm_job_priority::TritonVmJobPriority;

--- a/src/job_queue/triton_vm/triton_vm_job_priority.rs
+++ b/src/job_queue/triton_vm/triton_vm_job_priority.rs
@@ -1,5 +1,3 @@
-use super::super::JobQueue;
-
 // todo: maybe we want to have more levels or just make it an integer eg u8.
 // or maybe name the levels by type/usage of job/proof.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
@@ -11,6 +9,3 @@ pub enum TritonVmJobPriority {
     High = 4,
     Highest = 5,
 }
-
-/// provides type safety and clarity in case we implement multiple job queues.
-pub type TritonVmJobQueue = JobQueue<TritonVmJobPriority>;

--- a/src/models/blockchain/block/validity/block_primitive_witness.rs
+++ b/src/models/blockchain/block/validity/block_primitive_witness.rs
@@ -131,7 +131,6 @@ pub(crate) mod test {
 
     use super::BlockPrimitiveWitness;
     use crate::job_queue::triton_vm::TritonVmJobPriority;
-    use crate::job_queue::triton_vm::TritonVmJobQueue;
     use crate::models::blockchain::block::block_appendix::BlockAppendix;
     use crate::models::blockchain::block::block_body::BlockBody;
     use crate::models::blockchain::block::block_header::BlockHeader;
@@ -181,7 +180,6 @@ pub(crate) mod test {
                 let single_proof_inputs = rt
                     .block_on(SingleProof::produce(
                         &primwit_inputs,
-                        &TritonVmJobQueue::dummy(),
                         TritonVmJobPriority::default().into(),
                     ))
                     .unwrap();
@@ -193,7 +191,6 @@ pub(crate) mod test {
                 let single_proof_coinbase = rt
                     .block_on(SingleProof::produce(
                         &primwit_coinbase,
-                        &TritonVmJobQueue::dummy(),
                         TritonVmJobPriority::default().into(),
                     ))
                     .unwrap();
@@ -205,7 +202,6 @@ pub(crate) mod test {
                 rt.block_on(tx_inputs.merge_with(
                     tx_coinbase,
                     shuffle_seed,
-                    &TritonVmJobQueue::dummy(),
                     TritonVmJobPriority::default().into(),
                 ))
                 .unwrap()

--- a/src/models/blockchain/block/validity/block_program.rs
+++ b/src/models/blockchain/block/validity/block_program.rs
@@ -340,7 +340,6 @@ pub(crate) mod test {
     use crate::config_models::cli_args;
     use crate::config_models::network::Network;
     use crate::job_queue::triton_vm::TritonVmJobPriority;
-    use crate::job_queue::triton_vm::TritonVmJobQueue;
     use crate::mine_loop::create_block_transaction_from;
     use crate::mine_loop::TxMergeOrigin;
     use crate::models::blockchain::block::validity::block_primitive_witness::test::deterministic_block_primitive_witness;
@@ -480,7 +479,6 @@ pub(crate) mod test {
                 block_tx,
                 timestamp,
                 None,
-                &TritonVmJobQueue::dummy(),
                 TritonVmProofJobOptions::default(),
             )
             .await
@@ -519,7 +517,6 @@ pub(crate) mod test {
                 fee,
                 now,
                 TxProvingCapability::SingleProof,
-                &TritonVmJobQueue::dummy(),
             )
             .await
             .unwrap();
@@ -533,7 +530,6 @@ pub(crate) mod test {
             &genesis_block.mutator_set_accumulator_after(),
             &block1.mutator_set_update(),
             tx.proof.into_single_proof(),
-            &TritonVmJobQueue::dummy(),
             TritonVmJobPriority::default().into(),
             Some(later),
         )

--- a/src/models/blockchain/transaction/lock_script.rs
+++ b/src/models/blockchain/transaction/lock_script.rs
@@ -12,7 +12,6 @@ use twenty_first::math::bfield_codec::BFieldCodec;
 use twenty_first::math::tip5::Digest;
 
 use super::utxo::Utxo;
-use crate::job_queue::triton_vm::TritonVmJobQueue;
 use crate::models::proof_abstractions::tasm::program::prove_consensus_program;
 use crate::models::proof_abstractions::tasm::program::TritonVmProofJobOptions;
 use crate::prelude::twenty_first;
@@ -146,7 +145,6 @@ impl LockScriptAndWitness {
     pub(crate) async fn prove(
         &self,
         public_input: PublicInput,
-        triton_vm_job_queue: &TritonVmJobQueue,
         proof_job_options: TritonVmProofJobOptions,
     ) -> anyhow::Result<Proof> {
         let claim = Claim::new(self.program.hash()).with_input(public_input.individual_tokens);
@@ -154,7 +152,6 @@ impl LockScriptAndWitness {
             self.program.clone(),
             claim,
             self.nondeterminism(),
-            triton_vm_job_queue,
             proof_job_options,
         )
         .await

--- a/src/models/blockchain/transaction/validity/proof_collection.rs
+++ b/src/models/blockchain/transaction/validity/proof_collection.rs
@@ -13,7 +13,6 @@ use tracing::trace;
 use super::collect_type_scripts::CollectTypeScriptsWitness;
 use super::kernel_to_outputs::KernelToOutputsWitness;
 use super::removal_records_integrity::RemovalRecordsIntegrity;
-use crate::job_queue::triton_vm::TritonVmJobQueue;
 use crate::models::blockchain::shared::Hash;
 use crate::models::blockchain::transaction::primitive_witness::PrimitiveWitness;
 use crate::models::blockchain::transaction::transaction_kernel::TransactionKernelField;
@@ -82,7 +81,6 @@ impl ProofCollection {
 
     pub(crate) async fn produce(
         primitive_witness: &PrimitiveWitness,
-        triton_vm_job_queue: &TritonVmJobQueue,
         proof_job_options: TritonVmProofJobOptions,
     ) -> anyhow::Result<Self> {
         let (
@@ -106,7 +104,6 @@ impl ProofCollection {
             .prove(
                 removal_records_integrity_witness.claim(),
                 removal_records_integrity_witness.nondeterminism(),
-                triton_vm_job_queue,
                 proof_job_options.clone(),
             )
             .await?;
@@ -116,7 +113,6 @@ impl ProofCollection {
             .prove(
                 collect_lock_scripts_witness.claim(),
                 collect_lock_scripts_witness.nondeterminism(),
-                triton_vm_job_queue,
                 proof_job_options.clone(),
             )
             .await?;
@@ -126,7 +122,6 @@ impl ProofCollection {
             .prove(
                 kernel_to_outputs_witness.claim(),
                 kernel_to_outputs_witness.nondeterminism(),
-                triton_vm_job_queue,
                 proof_job_options.clone(),
             )
             .await?;
@@ -136,7 +131,6 @@ impl ProofCollection {
             .prove(
                 collect_type_scripts_witness.claim(),
                 collect_type_scripts_witness.nondeterminism(),
-                triton_vm_job_queue,
                 proof_job_options.clone(),
             )
             .await?;
@@ -146,11 +140,7 @@ impl ProofCollection {
         for lock_script_and_witness in &primitive_witness.lock_scripts_and_witnesses {
             lock_scripts_halt.push(
                 lock_script_and_witness
-                    .prove(
-                        txk_mast_hash_as_input.clone(),
-                        triton_vm_job_queue,
-                        proof_job_options.clone(),
-                    )
+                    .prove(txk_mast_hash_as_input.clone(), proof_job_options.clone())
                     .await?,
             );
         }
@@ -168,7 +158,6 @@ impl ProofCollection {
                     txk_mast_hash,
                     salted_inputs_hash,
                     salted_outputs_hash,
-                    triton_vm_job_queue,
                     proof_job_options.clone(),
                 )
                 .await?,

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_collect_lock_scripts_claim.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_collect_lock_scripts_claim.rs
@@ -154,7 +154,6 @@ mod tests {
 
     use super::*;
     use crate::job_queue::triton_vm::TritonVmJobPriority;
-    use crate::job_queue::triton_vm::TritonVmJobQueue;
     use crate::models::blockchain::transaction::primitive_witness::PrimitiveWitness;
 
     #[test]
@@ -201,7 +200,6 @@ mod tests {
             let proof_collection = rt
                 .block_on(ProofCollection::produce(
                     &primitive_witness,
-                    &TritonVmJobQueue::dummy(),
                     TritonVmJobPriority::default().into(),
                 ))
                 .unwrap();

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_collect_type_scripts_claim.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_collect_type_scripts_claim.rs
@@ -184,7 +184,6 @@ mod tests {
 
     use super::*;
     use crate::job_queue::triton_vm::TritonVmJobPriority;
-    use crate::job_queue::triton_vm::TritonVmJobQueue;
     use crate::models::blockchain::transaction::primitive_witness::PrimitiveWitness;
     use crate::models::blockchain::type_scripts::time_lock::neptune_arbitrary::arbitrary_primitive_witness_with_active_timelocks;
     use crate::models::proof_abstractions::timestamp::Timestamp;
@@ -250,7 +249,6 @@ mod tests {
             let proof_collection = rt
                 .block_on(ProofCollection::produce(
                     &primitive_witness,
-                    &TritonVmJobQueue::dummy(),
                     TritonVmJobPriority::default().into(),
                 ))
                 .unwrap();

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_k2o_claim.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_k2o_claim.rs
@@ -138,7 +138,6 @@ mod tests {
 
     use super::*;
     use crate::job_queue::triton_vm::TritonVmJobPriority;
-    use crate::job_queue::triton_vm::TritonVmJobQueue;
     use crate::models::blockchain::transaction::primitive_witness::PrimitiveWitness;
 
     #[test]
@@ -202,7 +201,6 @@ mod tests {
             let proof_collection = rt
                 .block_on(ProofCollection::produce(
                     &primitive_witness,
-                    &TritonVmJobQueue::dummy(),
                     TritonVmJobPriority::default().into(),
                 ))
                 .unwrap();

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_lock_script_claim_template.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_lock_script_claim_template.rs
@@ -88,7 +88,6 @@ mod test {
 
     use super::GenerateLockScriptClaimTemplate;
     use crate::job_queue::triton_vm::TritonVmJobPriority;
-    use crate::job_queue::triton_vm::TritonVmJobQueue;
     use crate::models::blockchain::transaction::primitive_witness::PrimitiveWitness;
     use crate::models::blockchain::transaction::validity::proof_collection::ProofCollection;
     use crate::models::blockchain::transaction::validity::tasm::claims::new_claim::NewClaim;
@@ -135,7 +134,6 @@ mod test {
             let proof_collection = rt
                 .block_on(ProofCollection::produce(
                     &primitive_witness,
-                    &TritonVmJobQueue::dummy(),
                     TritonVmJobPriority::default().into(),
                 ))
                 .unwrap();

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_rri_claim.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_rri_claim.rs
@@ -139,7 +139,6 @@ mod tests {
 
     use super::*;
     use crate::job_queue::triton_vm::TritonVmJobPriority;
-    use crate::job_queue::triton_vm::TritonVmJobQueue;
     use crate::models::blockchain::transaction::primitive_witness::PrimitiveWitness;
 
     #[test]
@@ -203,7 +202,6 @@ mod tests {
             let proof_collection = rt
                 .block_on(ProofCollection::produce(
                     &primitive_witness,
-                    &TritonVmJobQueue::dummy(),
                     TritonVmJobPriority::default().into(),
                 ))
                 .unwrap();

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_type_script_claim_template.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_type_script_claim_template.rs
@@ -115,7 +115,6 @@ mod test {
 
     use super::*;
     use crate::job_queue::triton_vm::TritonVmJobPriority;
-    use crate::job_queue::triton_vm::TritonVmJobQueue;
     use crate::models::blockchain::transaction::primitive_witness::PrimitiveWitness;
     use crate::models::blockchain::transaction::validity::proof_collection::ProofCollection;
 
@@ -166,7 +165,6 @@ mod test {
             let proof_collection = rt
                 .block_on(ProofCollection::produce(
                     &primitive_witness,
-                    &TritonVmJobQueue::dummy(),
                     TritonVmJobPriority::default().into(),
                 ))
                 .unwrap();

--- a/src/models/blockchain/transaction/validity/tasm/single_proof/merge_branch.rs
+++ b/src/models/blockchain/transaction/validity/tasm/single_proof/merge_branch.rs
@@ -910,7 +910,6 @@ pub(crate) mod test {
 
     use super::*;
     use crate::job_queue::triton_vm::TritonVmJobPriority;
-    use crate::job_queue::triton_vm::TritonVmJobQueue;
     use crate::models::blockchain::transaction::PrimitiveWitness;
     use crate::models::proof_abstractions::tasm::builtins as tasm;
     use crate::util_types::mutator_set::removal_record::RemovalRecord;
@@ -1102,20 +1101,14 @@ pub(crate) mod test {
             .unwrap()
             .current();
 
-        let single_proof_1 = SingleProof::produce(
-            &primitive_witness_1,
-            &TritonVmJobQueue::dummy(),
-            TritonVmJobPriority::default().into(),
-        )
-        .await
-        .unwrap();
-        let single_proof_2 = SingleProof::produce(
-            &primitive_witness_2,
-            &TritonVmJobQueue::dummy(),
-            TritonVmJobPriority::default().into(),
-        )
-        .await
-        .unwrap();
+        let single_proof_1 =
+            SingleProof::produce(&primitive_witness_1, TritonVmJobPriority::default().into())
+                .await
+                .unwrap();
+        let single_proof_2 =
+            SingleProof::produce(&primitive_witness_2, TritonVmJobPriority::default().into())
+                .await
+                .unwrap();
 
         MergeWitness::from_transactions(
             primitive_witness_1.kernel,
@@ -1147,20 +1140,12 @@ pub(crate) mod test {
             .unwrap()
             .current();
 
-        let left_proof = SingleProof::produce(
-            &left,
-            &TritonVmJobQueue::dummy(),
-            TritonVmJobPriority::default().into(),
-        )
-        .await
-        .unwrap();
-        let right_proof = SingleProof::produce(
-            &right,
-            &TritonVmJobQueue::dummy(),
-            TritonVmJobPriority::default().into(),
-        )
-        .await
-        .unwrap();
+        let left_proof = SingleProof::produce(&left, TritonVmJobPriority::default().into())
+            .await
+            .unwrap();
+        let right_proof = SingleProof::produce(&right, TritonVmJobPriority::default().into())
+            .await
+            .unwrap();
 
         MergeWitness::from_transactions(
             left.kernel,

--- a/src/models/blockchain/transaction/validity/tasm/single_proof/update_branch.rs
+++ b/src/models/blockchain/transaction/validity/tasm/single_proof/update_branch.rs
@@ -673,7 +673,6 @@ pub(crate) mod test {
 
     use super::*;
     use crate::job_queue::triton_vm::TritonVmJobPriority;
-    use crate::job_queue::triton_vm::TritonVmJobQueue;
     use crate::models::blockchain::block::mutator_set_update::MutatorSetUpdate;
     use crate::models::blockchain::transaction::PrimitiveWitness;
     use crate::models::blockchain::transaction::Transaction;
@@ -917,13 +916,9 @@ pub(crate) mod test {
         MutatorSetUpdate::new(mined.kernel.inputs.clone(), mined.kernel.outputs.clone())
             .apply_to_accumulator(&mut new_mutator_set_accumulator)
             .unwrap();
-        let old_proof = SingleProof::produce(
-            &old_pw,
-            &TritonVmJobQueue::dummy(),
-            TritonVmJobPriority::default().into(),
-        )
-        .await
-        .unwrap();
+        let old_proof = SingleProof::produce(&old_pw, TritonVmJobPriority::default().into())
+            .await
+            .unwrap();
         let num_seconds = (0u64..=10).new_tree(&mut test_runner).unwrap().current();
 
         updated.kernel = TransactionKernelModifier::default()
@@ -983,13 +978,10 @@ pub(crate) mod test {
             &primitive_witness.mutator_set_accumulator.aocl,
             &newly_confirmed_records,
         );
-        let old_proof = SingleProof::produce(
-            &primitive_witness,
-            &TritonVmJobQueue::dummy(),
-            TritonVmJobPriority::default().into(),
-        )
-        .await
-        .unwrap();
+        let old_proof =
+            SingleProof::produce(&primitive_witness, TritonVmJobPriority::default().into())
+                .await
+                .unwrap();
 
         UpdateWitness::from_old_transaction(
             primitive_witness.kernel,

--- a/src/models/blockchain/type_scripts/mod.rs
+++ b/src/models/blockchain/type_scripts/mod.rs
@@ -19,7 +19,6 @@ use tasm_lib::twenty_first::math::bfield_codec::BFieldCodec;
 use super::transaction::primitive_witness::SaltedUtxos;
 use super::transaction::transaction_kernel::TransactionKernel;
 use super::transaction::utxo::Coin;
-use crate::job_queue::triton_vm::TritonVmJobQueue;
 use crate::models::proof_abstractions::mast_hash::MastHash;
 use crate::models::proof_abstractions::tasm::program::prove_consensus_program;
 use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
@@ -104,7 +103,6 @@ impl TypeScriptAndWitness {
         txk_mast_hash: Digest,
         salted_inputs_hash: Digest,
         salted_outputs_hash: Digest,
-        triton_vm_job_queue: &TritonVmJobQueue,
         proof_job_options: TritonVmProofJobOptions,
     ) -> anyhow::Result<Proof> {
         let input = [txk_mast_hash, salted_inputs_hash, salted_outputs_hash]
@@ -116,7 +114,6 @@ impl TypeScriptAndWitness {
             self.program.clone(),
             claim,
             self.nondeterminism(),
-            triton_vm_job_queue,
             proof_job_options,
         )
         .await

--- a/src/models/blockchain/type_scripts/native_currency.rs
+++ b/src/models/blockchain/type_scripts/native_currency.rs
@@ -1051,7 +1051,6 @@ pub mod test {
 
     use super::*;
     use crate::job_queue::triton_vm::TritonVmJobPriority;
-    use crate::job_queue::triton_vm::TritonVmJobQueue;
     use crate::models::blockchain::shared::Hash;
     use crate::models::blockchain::transaction::lock_script::LockScriptAndWitness;
     use crate::models::blockchain::transaction::transaction_kernel::TransactionKernelModifier;
@@ -1496,7 +1495,6 @@ pub mod test {
                 txk_mast_hash,
                 salted_input_utxos_hash,
                 salted_output_utxos_hash,
-                &TritonVmJobQueue::dummy(),
                 TritonVmJobPriority::default().into(),
             )
             .await

--- a/src/models/state/archival_state.rs
+++ b/src/models/state/archival_state.rs
@@ -1148,7 +1148,6 @@ mod archival_state_tests {
     use crate::config_models::network::Network;
     use crate::database::storage::storage_vec::traits::*;
     use crate::job_queue::triton_vm::TritonVmJobPriority;
-    use crate::job_queue::triton_vm::TritonVmJobQueue;
     use crate::mine_loop::mine_loop_tests::make_coinbase_transaction_from_state;
     use crate::models::blockchain::block::block_header::MINIMUM_BLOCK_TIME;
     use crate::models::blockchain::transaction::lock_script::LockScript;
@@ -1357,7 +1356,6 @@ mod archival_state_tests {
                 NativeCurrencyAmount::coins(2),
                 in_seven_months,
                 TxProvingCapability::PrimitiveWitness,
-                &TritonVmJobQueue::dummy(),
             )
             .await
             .unwrap();
@@ -1463,7 +1461,6 @@ mod archival_state_tests {
                 fee,
                 in_seven_months,
                 TxProvingCapability::PrimitiveWitness,
-                &TritonVmJobQueue::dummy(),
             )
             .await
             .unwrap();
@@ -1479,7 +1476,6 @@ mod archival_state_tests {
                 fee,
                 in_seven_months,
                 TxProvingCapability::PrimitiveWitness,
-                &TritonVmJobQueue::dummy(),
             )
             .await
             .unwrap();
@@ -1564,7 +1560,6 @@ mod archival_state_tests {
                     fee,
                     timestamp,
                     TxProvingCapability::PrimitiveWitness,
-                    &TritonVmJobQueue::dummy(),
                 )
                 .await
                 .unwrap();
@@ -1813,7 +1808,6 @@ mod archival_state_tests {
                 fee,
                 in_seven_months,
                 TxProvingCapability::SingleProof,
-                &TritonVmJobQueue::dummy(),
             )
             .await
             .unwrap();
@@ -1841,7 +1835,6 @@ mod archival_state_tests {
             .merge_with(
                 tx_to_alice_and_bob,
                 Default::default(),
-                &TritonVmJobQueue::dummy(),
                 TritonVmJobPriority::default().into(),
             )
             .await
@@ -1853,7 +1846,6 @@ mod archival_state_tests {
             block_tx,
             in_seven_months,
             None,
-            &TritonVmJobQueue::dummy(),
             TritonVmJobPriority::default().into(),
         )
         .await
@@ -2013,7 +2005,6 @@ mod archival_state_tests {
                 NativeCurrencyAmount::coins(1),
                 in_seven_months,
                 TxProvingCapability::SingleProof,
-                &TritonVmJobQueue::dummy(),
             )
             .await
             .unwrap();
@@ -2059,7 +2050,6 @@ mod archival_state_tests {
                 NativeCurrencyAmount::coins(1),
                 in_seven_months,
                 TxProvingCapability::SingleProof,
-                &TritonVmJobQueue::dummy(),
             )
             .await
             .unwrap();
@@ -2093,7 +2083,6 @@ mod archival_state_tests {
             .merge_with(
                 tx_from_alice,
                 Default::default(),
-                &TritonVmJobQueue::dummy(),
                 TritonVmJobPriority::default().into(),
             )
             .await
@@ -2101,7 +2090,6 @@ mod archival_state_tests {
             .merge_with(
                 tx_from_bob,
                 Default::default(),
-                &TritonVmJobQueue::dummy(),
                 TritonVmJobPriority::default().into(),
             )
             .await
@@ -2111,7 +2099,6 @@ mod archival_state_tests {
             block_tx2,
             in_seven_months + MINIMUM_BLOCK_TIME,
             None,
-            &TritonVmJobQueue::dummy(),
             TritonVmJobPriority::default().into(),
         )
         .await

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -838,7 +838,6 @@ mod tests {
     use crate::models::state::wallet::utxo_notification::UtxoNotificationMedium;
     use crate::models::state::wallet::wallet_entropy::WalletEntropy;
     use crate::models::state::GlobalStateLock;
-    use crate::models::state::TritonVmJobQueue;
     use crate::tests::shared::make_mock_block;
     use crate::tests::shared::make_mock_txs_with_primitive_witness_with_timestamp;
     use crate::tests::shared::make_plenty_mock_transaction_with_primitive_witness;
@@ -906,10 +905,7 @@ mod tests {
         let mut updated_txs = vec![];
         for job in update_jobs {
             let updated = job
-                .upgrade(
-                    &TritonVmJobQueue::dummy(),
-                    TritonVmJobPriority::Highest.into(),
-                )
+                .upgrade(TritonVmJobPriority::Highest.into())
                 .await
                 .unwrap();
             updated_txs.push(updated);
@@ -992,7 +988,6 @@ mod tests {
                 high_fee,
                 in_seven_months,
                 TxProvingCapability::ProofCollection,
-                &TritonVmJobQueue::dummy(),
             )
             .await
             .unwrap();
@@ -1146,7 +1141,6 @@ mod tests {
                 NativeCurrencyAmount::coins(1),
                 in_seven_months,
                 TxProvingCapability::SingleProof,
-                &TritonVmJobQueue::dummy(),
             )
             .await
             .unwrap();
@@ -1187,7 +1181,6 @@ mod tests {
                 NativeCurrencyAmount::coins(1),
                 in_seven_months,
                 TxProvingCapability::SingleProof,
-                &TritonVmJobQueue::dummy(),
             )
             .await
             .unwrap();
@@ -1229,7 +1222,6 @@ mod tests {
             .merge_with(
                 coinbase_transaction,
                 Default::default(),
-                &TritonVmJobQueue::dummy(),
                 TritonVmJobPriority::default().into(),
             )
             .await
@@ -1302,7 +1294,6 @@ mod tests {
             .merge_with(
                 tx_by_alice_updated,
                 Default::default(),
-                &TritonVmJobQueue::dummy(),
                 TritonVmJobPriority::default().into(),
             )
             .await
@@ -1344,20 +1335,14 @@ mod tests {
             .unwrap()
             .current();
 
-            let left_single_proof = SingleProof::produce(
-                &left,
-                &TritonVmJobQueue::dummy(),
-                TritonVmJobPriority::default().into(),
-            )
-            .await
-            .unwrap();
-            let right_single_proof = SingleProof::produce(
-                &right,
-                &TritonVmJobQueue::dummy(),
-                TritonVmJobPriority::default().into(),
-            )
-            .await
-            .unwrap();
+            let left_single_proof =
+                SingleProof::produce(&left, TritonVmJobPriority::default().into())
+                    .await
+                    .unwrap();
+            let right_single_proof =
+                SingleProof::produce(&right, TritonVmJobPriority::default().into())
+                    .await
+                    .unwrap();
 
             let left = Transaction {
                 kernel: left.kernel,
@@ -1376,7 +1361,6 @@ mod tests {
                 left.clone(),
                 right.clone(),
                 shuffle_seed,
-                &TritonVmJobQueue::dummy(),
                 TritonVmJobPriority::default().into(),
             )
             .await
@@ -1480,7 +1464,6 @@ mod tests {
                 NativeCurrencyAmount::coins(1),
                 in_seven_years,
                 proving_capability,
-                &TritonVmJobQueue::dummy(),
             )
             .await
             .unwrap();
@@ -1609,7 +1592,6 @@ mod tests {
                         fee,
                         in_seven_months,
                         TxProvingCapability::ProofCollection,
-                        &TritonVmJobQueue::dummy(),
                     )
                     .await
                     .expect("producing proof collection should succeed");
@@ -1810,7 +1792,6 @@ mod tests {
                     fee,
                     in_seven_months,
                     proof_type,
-                    &TritonVmJobQueue::dummy(),
                 )
                 .await
                 .unwrap();

--- a/src/models/state/wallet/mod.rs
+++ b/src/models/state/wallet/mod.rs
@@ -41,7 +41,6 @@ mod wallet_tests {
     use crate::config_models::network::Network;
     use crate::database::storage::storage_vec::traits::*;
     use crate::job_queue::triton_vm::TritonVmJobPriority;
-    use crate::job_queue::triton_vm::TritonVmJobQueue;
     use crate::mine_loop::mine_loop_tests::make_coinbase_transaction_from_state;
     use crate::models::blockchain::block::block_header::MINIMUM_BLOCK_TIME;
     use crate::models::blockchain::block::block_height::BlockHeight;
@@ -555,7 +554,6 @@ mod wallet_tests {
                 NativeCurrencyAmount::coins(2),
                 in_seven_months,
                 TxProvingCapability::SingleProof,
-                &TritonVmJobQueue::dummy(),
             )
             .await
             .unwrap();
@@ -792,7 +790,6 @@ mod wallet_tests {
                 NativeCurrencyAmount::coins(4),
                 block_2_b.header().timestamp + MINIMUM_BLOCK_TIME,
                 TxProvingCapability::SingleProof,
-                &TritonVmJobQueue::dummy(),
             )
             .await
             .unwrap();
@@ -818,7 +815,6 @@ mod wallet_tests {
             .merge_with(
                 tx_from_bob,
                 Default::default(),
-                &TritonVmJobQueue::dummy(),
                 TritonVmJobPriority::default().into(),
             )
             .await
@@ -829,7 +825,6 @@ mod wallet_tests {
             merged_tx,
             timestamp,
             None,
-            &TritonVmJobQueue::dummy(),
             TritonVmJobPriority::default().into(),
         )
         .await
@@ -1006,7 +1001,6 @@ mod wallet_tests {
                 one_money,
                 in_seven_months,
                 TxProvingCapability::SingleProof,
-                &TritonVmJobQueue::dummy(),
             )
             .await
             .unwrap();
@@ -1014,7 +1008,6 @@ mod wallet_tests {
             .merge_with(
                 cbtx,
                 Default::default(),
-                &TritonVmJobQueue::dummy(),
                 TritonVmJobPriority::default().into(),
             )
             .await
@@ -1024,7 +1017,6 @@ mod wallet_tests {
             tx_for_block,
             in_seven_months,
             None,
-            &TritonVmJobQueue::dummy(),
             TritonVmJobPriority::default().into(),
         )
         .await

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -1773,7 +1773,6 @@ pub(crate) mod tests {
     use super::*;
     use crate::config_models::cli_args;
     use crate::config_models::network::Network;
-    use crate::job_queue::triton_vm::TritonVmJobQueue;
     use crate::models::blockchain::transaction::transaction_kernel::TransactionKernelModifier;
     use crate::models::blockchain::transaction::utxo::Coin;
     use crate::models::state::tx_proving_capability::TxProvingCapability;
@@ -2030,7 +2029,6 @@ pub(crate) mod tests {
                 fee,
                 network.launch_date() + Timestamp::minutes(11),
                 TxProvingCapability::PrimitiveWitness,
-                &TritonVmJobQueue::dummy(),
             )
             .await
             .unwrap();
@@ -2074,7 +2072,6 @@ pub(crate) mod tests {
                 fee,
                 network.launch_date() + Timestamp::minutes(22),
                 TxProvingCapability::PrimitiveWitness,
-                &TritonVmJobQueue::dummy(),
             )
             .await
             .unwrap();
@@ -2134,7 +2131,6 @@ pub(crate) mod tests {
                 fee,
                 network.launch_date() + Timestamp::minutes(11),
                 TxProvingCapability::PrimitiveWitness,
-                &TritonVmJobQueue::dummy(),
             )
             .await
             .unwrap();
@@ -2234,7 +2230,6 @@ pub(crate) mod tests {
                 fee,
                 network.launch_date() + Timestamp::minutes(11),
                 TxProvingCapability::PrimitiveWitness,
-                &TritonVmJobQueue::dummy(),
             )
             .await
             .unwrap();
@@ -2949,7 +2944,6 @@ pub(crate) mod tests {
                     fee,
                     block2_timestamp,
                     TxProvingCapability::PrimitiveWitness,
-                    &TritonVmJobQueue::dummy(),
                 )
                 .await
                 .unwrap();
@@ -3036,7 +3030,6 @@ pub(crate) mod tests {
 
         use super::*;
         use crate::config_models::cli_args;
-        use crate::job_queue::triton_vm::TritonVmJobQueue;
         use crate::models::blockchain::block::block_height::BlockHeight;
         use crate::models::blockchain::transaction::Transaction;
         use crate::models::state::tx_proving_capability::TxProvingCapability;
@@ -3130,7 +3123,6 @@ pub(crate) mod tests {
                         NativeCurrencyAmount::zero(),
                         timestamp,
                         TxProvingCapability::PrimitiveWitness,
-                        &TritonVmJobQueue::dummy(),
                     )
                     .await?;
                 tx
@@ -3217,7 +3209,6 @@ pub(crate) mod tests {
                         fee,
                         timestamp,
                         TxProvingCapability::PrimitiveWitness,
-                        &TritonVmJobQueue::dummy(),
                     )
                     .await
                     .map(|x| x.0)
@@ -3718,7 +3709,6 @@ pub(crate) mod tests {
                         fee,
                         timestamp,
                         TxProvingCapability::PrimitiveWitness,
-                        &TritonVmJobQueue::dummy(),
                     )
                     .await
                     .unwrap();
@@ -3922,7 +3912,6 @@ pub(crate) mod tests {
         use rand::rng;
 
         use super::*;
-        use crate::job_queue::JobQueue;
         use crate::models::blockchain::transaction::transaction_kernel::transaction_kernel_tests::pseudorandom_transaction_kernel;
         use crate::models::state::wallet::utxo_notification::UtxoNotificationPayload;
         use crate::tests::shared::unit_test_data_directory;
@@ -3982,7 +3971,6 @@ pub(crate) mod tests {
                     NativeCurrencyAmount::coins(0),
                     now,
                     TxProvingCapability::PrimitiveWitness,
-                    &JobQueue::dummy(),
                 )
                 .await
                 .unwrap();

--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -1915,7 +1915,6 @@ mod peer_loop_tests {
     use super::*;
     use crate::config_models::cli_args;
     use crate::config_models::network::Network;
-    use crate::job_queue::triton_vm::TritonVmJobQueue;
     use crate::models::blockchain::block::block_header::TARGET_BLOCK_INTERVAL;
     use crate::models::blockchain::type_scripts::native_currency_amount::NativeCurrencyAmount;
     use crate::models::peer::peer_block_notifications::PeerBlockNotification;
@@ -3339,7 +3338,6 @@ mod peer_loop_tests {
                 NativeCurrencyAmount::coins(0),
                 now,
                 TxProvingCapability::ProofCollection,
-                &TritonVmJobQueue::dummy(),
             )
             .await
             .unwrap();
@@ -3422,7 +3420,6 @@ mod peer_loop_tests {
                 NativeCurrencyAmount::coins(0),
                 now,
                 TxProvingCapability::ProofCollection,
-                &TritonVmJobQueue::dummy(),
             )
             .await
             .unwrap();
@@ -3628,7 +3625,6 @@ mod peer_loop_tests {
                     NativeCurrencyAmount::coins(1),
                     in_seven_months,
                     prover_capability,
-                    &TritonVmJobQueue::dummy(),
                 )
                 .await
                 .unwrap()

--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -2011,7 +2011,6 @@ impl NeptuneRPCServer {
                 fee,
                 now,
                 tx_proving_capability,
-                self.state.vm_job_queue(),
             )
             .await
         {

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -51,7 +51,6 @@ use crate::config_models::network::Network;
 use crate::database::storage::storage_vec::traits::StorageVecBase;
 use crate::database::NeptuneLevelDb;
 use crate::job_queue::triton_vm::TritonVmJobPriority;
-use crate::job_queue::JobQueue;
 use crate::mine_loop::composer_parameters::ComposerParameters;
 use crate::mine_loop::make_coinbase_transaction_stateless;
 use crate::mine_loop::mine_loop_tests::mine_iteration_for_tests;
@@ -719,7 +718,6 @@ pub(crate) async fn make_mock_block_guesser_preimage_and_guesser_fraction(
         composer_parameters,
         block_timestamp,
         TxProvingCapability::PrimitiveWitness,
-        &JobQueue::dummy(),
         (TritonVmJobPriority::Normal, None).into(),
     )
     .await


### PR DESCRIPTION
The purpose of the job queue is to prevent different jobs from competing for the same compute resources at the same time. As such, having multiple job queues defeats the purpose of having one. In other words, there should only ever be one job queue.

This commit refactors the interface of `JobQueue` and `TritonVmJobQueue` to enforce that only one instance of the latter type is ever constructed. Specifically, the constructor `start` is downgraded in visibility from public to private. To get the Triton VM proof queue object, the caller calls `global_triton_vm_job_queue()`, which is a public function that internally uses a static `OnceLock` to ensure that no more than one instance is ever created.

Also, this commit removes the reference to the triton vm job queue from all function interfaces.

