### PR TITLE
style: Report guesser fee of rejected blocks

### DIFF
--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -1459,10 +1459,14 @@ impl PeerLoopHandler {
                         ))
                         .await?
                     }
-                    Err(reject_reason) => info!(
-                        "Got unfavorable block proposal notification from {} peer; rejecting. Reason:\n{reject_reason}",
+                    Err(reject_reason) => {
+                        info!(
+                        "Rejecting notification of block proposal with guesser fee {} from peer \
+                        {}. Reason:\n{reject_reason}",
+                        block_proposal_notification.guesser_fee.display_n_decimals(5),
                         self.peer_address
-                    ),
+                    )
+                    }
                 }
 
                 Ok(KEEP_CONNECTION_ALIVE)


### PR DESCRIPTION
When rejecting a block proposal notification, an info message is logged showing the reason why it was rejected. This commit changes that info message to include the rejected proposal's guesser fee.

This change answers a request made by a composer who would like to know what fees other competing composers are offering, in order to adapt their own price.