### PR TITLE
Pin version of build-breaking transitive dependency

### DIFF
--- a/.github/workflows/no_lock_build.yml
+++ b/.github/workflows/no_lock_build.yml
@@ -1,0 +1,29 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+name: Build without Cargo.lock
+
+jobs:
+  runner-matrix:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Remove Cargo.lock
+        run: rm Cargo.lock
+
+      - name: Build
+        run: cargo build --all --release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -938,6 +938,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+
+[[package]]
 name = "derive-where"
 version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1844,6 +1850,7 @@ dependencies = [
  "clienter",
  "console-subscriber",
  "crossterm 0.27.0",
+ "deranged 0.4.0",
  "directories",
  "divan",
  "field_count",
@@ -3173,7 +3180,7 @@ version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
- "deranged",
+ "deranged 0.3.11",
  "itoa",
  "num-conv",
  "powerfmt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,12 @@ thread-priority = "1.2.0"
 rayon = "1.10"
 humantime = "2.1.0"
 
+# Temporary workaround: exactly specify version of transitive dependency.
+# See also: https://github.com/jhpratt/deranged/issues/18
+#
+# Once the issue is resolved, this unused dependency can be removed.
+deranged = "=0.4.0"
+
 [dev-dependencies]
 
 # note: arbitrary, proptest, proptest-arbitrary-interop are duplicated in [dev-dependencies]


### PR DESCRIPTION
- introduce a workflow to check that `neptune-core` can be built in the absence of a `Cargo.lock`, as is the case when using it as a dependency
- fix the version of a transitive dependency that recently started introducing build failures