### PR TITLE
test(mempool): Ensure MS-updated transaction always replaces progenitor

### DIFF
--- a/src/models/blockchain/transaction/mod.rs
+++ b/src/models/blockchain/transaction/mod.rs
@@ -347,7 +347,6 @@ pub(crate) mod tests {
 
         /// A proof that will always be invalid, with a specified size measured in
         /// number of [`BFieldElement`](twenty_first::math::b_field_element::BFieldElement)s.
-        #[cfg(test)]
         pub(crate) fn invalid_single_proof_of_size(size: usize) -> Self {
             use tasm_lib::twenty_first::bfe;
 

--- a/src/models/blockchain/transaction/mod.rs
+++ b/src/models/blockchain/transaction/mod.rs
@@ -74,12 +74,6 @@ pub enum TransactionProof {
 }
 
 impl TransactionProof {
-    /// A proof that will always be invalid
-    #[cfg(test)]
-    pub(crate) fn invalid() -> Self {
-        Self::SingleProof(Proof(vec![]))
-    }
-
     pub(crate) fn into_single_proof(self) -> Proof {
         match self {
             TransactionProof::SingleProof(proof) => proof,
@@ -336,7 +330,7 @@ impl Transaction {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use tasm_lib::prelude::Digest;
     use tests::primitive_witness::SaltedUtxos;
 
@@ -344,6 +338,23 @@ mod tests {
     use crate::models::blockchain::type_scripts::native_currency_amount::NativeCurrencyAmount;
     use crate::util_types::mutator_set::addition_record::AdditionRecord;
     use crate::util_types::mutator_set::removal_record::RemovalRecord;
+
+    impl TransactionProof {
+        /// A proof that will always be invalid
+        #[cfg(test)]
+        pub(crate) fn invalid() -> Self {
+            Self::SingleProof(Proof(vec![]))
+        }
+
+        /// A proof that will always be invalid, with a specified size measured in
+        /// number of [`BFieldElement`](twenty_first::math::b_field_element::BFieldElement)s.
+        #[cfg(test)]
+        pub(crate) fn invalid_single_proof_of_size(size: usize) -> Self {
+            use tasm_lib::twenty_first::bfe;
+
+            Self::SingleProof(Proof(vec![bfe!(0); size]))
+        }
+    }
 
     impl Transaction {
         /// Create a new transaction with primitive witness for a new mutator set.

--- a/src/models/blockchain/transaction/mod.rs
+++ b/src/models/blockchain/transaction/mod.rs
@@ -341,7 +341,6 @@ pub(crate) mod tests {
 
     impl TransactionProof {
         /// A proof that will always be invalid
-        #[cfg(test)]
         pub(crate) fn invalid() -> Self {
             Self::SingleProof(Proof(vec![]))
         }

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -90,6 +90,7 @@ pub enum MempoolEvent {
 /// Used to mark origin of transaction. To determine if transaction was
 /// initiated locally or not.
 #[derive(Debug, GetSize, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "arbitrary-impls"), derive(arbitrary::Arbitrary))]
 pub(crate) enum TransactionOrigin {
     Foreign,
     Own,
@@ -1811,9 +1812,14 @@ mod tests {
     }
 
     mod proof_quality_tests {
-        use super::*;
+        use proptest::prop_assert_eq;
+        use proptest::prop_assert_ne;
+        use test_strategy::proptest;
 
-        /// Return a valid transaction with a specified proof type.
+        use super::*;
+        use crate::models::blockchain::block::mutator_set_update::MutatorSetUpdate;
+
+        /// Return a valid, deterministic transaction with a specified proof type.
         async fn tx_with_proof_type(
             proof_type: TxProvingCapability,
             network: Network,
@@ -1936,6 +1942,63 @@ mod tests {
                 tx_in_mempool.proof,
                 TransactionProof::ProofCollection(_)
             ));
+        }
+
+        #[proptest(cases = 15, async = "tokio")]
+        async fn ms_updated_transaction_always_replaces_progenitor(
+            #[strategy(0usize..20)] _num_inputs_own: usize,
+            #[strategy(0usize..20)] _num_outputs_own: usize,
+            #[strategy(0usize..20)] _num_public_announcements_own: usize,
+            #[strategy(0usize..20)] _num_inputs_mined: usize,
+            #[strategy(0usize..20)] _num_outputs_mined: usize,
+            #[strategy(0usize..20)] _num_public_announcements_mined: usize,
+            #[strategy(0usize..200_000)] size_old_proof: usize,
+            #[strategy(0usize..200_000)] size_new_proof: usize,
+            #[strategy(arb())] tx_origin: TransactionOrigin,
+            #[strategy(PrimitiveWitness::arbitrary_tuple_with_matching_mutator_sets(
+            [(#_num_inputs_own, #_num_outputs_own, #_num_public_announcements_own),
+            (#_num_inputs_mined, #_num_outputs_mined, #_num_public_announcements_mined),],
+    ))]
+            pws: [PrimitiveWitness; 2],
+        ) {
+            // Transactions in the mempool do not need to be valid, so we just
+            // pretend that the primitive-witness backed transactions have a
+            // SingleProof.
+            let into_single_proof_transaction = |pw: PrimitiveWitness, size_of_proof: usize| {
+                let mock_proof = TransactionProof::invalid_single_proof_of_size(size_of_proof);
+                Transaction {
+                    kernel: pw.kernel,
+                    proof: mock_proof,
+                }
+            };
+            let [mempool_tx, mined_tx] = pws;
+
+            let ms_update = MutatorSetUpdate::new(
+                mined_tx.kernel.inputs.clone(),
+                mined_tx.kernel.outputs.clone(),
+            );
+            let updated_tx =
+                PrimitiveWitness::update_with_new_ms_data(mempool_tx.clone(), ms_update);
+
+            let original_tx = into_single_proof_transaction(mempool_tx, size_old_proof);
+            let updated_tx = into_single_proof_transaction(updated_tx, size_new_proof);
+
+            assert_eq!(original_tx.kernel.txid(), updated_tx.kernel.txid());
+            let txid = original_tx.kernel.txid();
+
+            let mut mempool = setup_mock_mempool(0, Network::Main, tx_origin);
+
+            // First insert original transaction, then updated which should
+            // always replace the original transaction, regardless of its size.
+            mempool.insert(original_tx.clone(), tx_origin);
+            let in_mempool_start = mempool.get(txid).map(|tx| tx.to_owned()).unwrap();
+            prop_assert_eq!(&original_tx, &in_mempool_start);
+            prop_assert_ne!(&updated_tx, &in_mempool_start);
+
+            mempool.insert(updated_tx.clone(), tx_origin);
+            let in_mempool_end = mempool.get(txid).map(|tx| tx.to_owned()).unwrap();
+            prop_assert_eq!(&updated_tx, &in_mempool_end);
+            prop_assert_ne!(&original_tx, &in_mempool_end);
         }
     }
 }


### PR DESCRIPTION
Anytime a SingleProof-backed transaction has its mutator set data updated, it must be such that the updated transaction *always* replaces the existing transaction. This commit adds a test to that effect, as this was not previously always the case.