### PR TITLE
feat(mempool): Filter transactions for mutator set match

### DIFF
--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -512,10 +512,8 @@ pub(crate) async fn create_block_transaction_from(
     let block_capacity_for_transactions = SIZE_20MB_IN_BYTES;
 
     let predecessor_block_ms = predecessor_block.mutator_set_accumulator_after();
-    debug!(
-        "Creating block transaction with mutator set hash: {}",
-        predecessor_block_ms.hash()
-    );
+    let mutator_set_hash = predecessor_block_ms.hash();
+    debug!("Creating block transaction with mutator set hash: {mutator_set_hash}",);
 
     let mut rng: StdRng =
         SeedableRng::from_seed(global_state_lock.lock_guard().await.shuffle_seed());
@@ -557,6 +555,7 @@ pub(crate) async fn create_block_transaction_from(
                 block_capacity_for_transactions,
                 Some(MAX_NUM_TXS_TO_MERGE),
                 only_merge_single_proofs,
+                mutator_set_hash,
             ),
     };
 

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -118,6 +118,30 @@ pub(crate) struct MempoolTransaction {
     pub(crate) origin: TransactionOrigin,
 }
 
+/// Unpersisted view of valid transactions that have not been confirmed yet.
+///
+/// Transactions can be inserted into the mempool, and a max size of the
+/// mempool can be declared, either in number of bytes, or in number of
+/// transactions allowed into the mempool.
+///
+/// The mempool uses [`TransactionKernelId`] as its main key, meaning that two
+/// transactions with the same [`TransactionKernelId`] can never be stored in
+/// the mempool. The mempool keeps a sorted view of which transactions are the
+/// most fee-paying as measured by [`FeeDensity`], thus allowing for the least
+/// valuable (from a miner's and proof upgrader's perspective) transactions to
+/// be dropped. However, the mempool always favors transactions of higher
+/// "proof-quality" such that a single-proof backed transaction will always
+/// replace a primitive-witness or proof-collection backed transaction, without
+/// considering fee densities. This is because a) single-proof backed
+/// transactions can always be synced to the latest block (assuming no
+/// reorganization has occurred), and b) because single-proof backed
+/// transactions are more likely to be picked for inclusion in the next block.
+///
+/// The mempool does not attempt to confirm validity or confirmability of its
+/// transactions, that must be handled by the caller. It does, however,
+/// guarantee that no conflicting transactions can be contained in the mempool.
+/// This means that two transactions that spend the same input will never be
+/// allowed into the mempool simultaneously.
 #[derive(Debug, GetSize)]
 pub struct Mempool {
     /// Maximum size this data structure may take up in memory.

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -487,7 +487,18 @@ pub(crate) fn make_mock_txs_with_primitive_witness_with_timestamp(
         .collect_vec()
 }
 
-pub(crate) fn make_plenty_mock_transaction_with_primitive_witness(
+pub(crate) fn make_plenty_mock_transaction_supported_by_invalid_single_proofs(
+    count: usize,
+) -> Vec<Transaction> {
+    let mut pw_backeds = make_plenty_mock_transaction_supported_by_primitive_witness(count);
+    for pw_backed in &mut pw_backeds {
+        pw_backed.proof = TransactionProof::invalid();
+    }
+
+    pw_backeds
+}
+
+pub(crate) fn make_plenty_mock_transaction_supported_by_primitive_witness(
     count: usize,
 ) -> Vec<Transaction> {
     let mut test_runner = TestRunner::deterministic();


### PR DESCRIPTION
When returning a list of transactions for inclusion in a block, only those transactions with a mutator set hash matching the expected value should be returned, as any other transactions cannot directly be merged into a block.