### PR TITLE
privacy(mine_loop): Never add zero-valued composer outputs

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -38,30 +38,31 @@ conventional_commits = true
 filter_unconventional = true
 split_commits = false
 commit_preprocessors = [
-      { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](<REPO>/issues/${2}))" },
+  { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](<REPO>/issues/${2}))" },
 ]
 
 # Use <!-- prio --> hack to sort the categories. See: https://github.com/orhun/git-cliff/issues/9
 commit_parsers = [
-  { message = "^feat",              group = "<!-- 000 --> ✨ Features" },
-  { message = "^fix",               group = "<!-- 010 --> 🐛 Bug Fixes" },
-  { message = "^perf",              group = "<!-- 020 --> 🚀 Performance" },
-  { message = "^doc",               group = "<!-- 030 --> 📚 Documentation" },
-  { message = "^WIP",               skip = true },
-  { message = "^chore\\(deps\\)",   skip = true },
-  { message = "^chore\\(pr\\)",     skip = true },
-  { message = "^chore\\(pull\\)",   skip = true },
-  { body = ".*security",            group = "<!-- 040 --> 🔒️ Security" },
-  { message = "^refactor",          group = "<!-- 050 --> ♻️ Refactor" },
-  { message = "^test",              group = "<!-- 060 --> ✅ Testing" },
-  { message = "^bench",             group = "<!-- 070 --> ⏳ Benchmark" },
-  { message = "^style",             group = "<!-- 080 --> 🎨 Styling" },
-  { message = "^build",             group = "<!-- 090 --> 🏗️ Build" },
-  { message = "^revert",            group = "<!-- 100 --> ⏪️ Revert" },
-  { message = "^chore|ci|misc",     group = "<!-- 110 --> ⚙️ Miscellaneous" },
-  { message = "^fork",              group = "<!-- 120 --> 🔱 Fork" },
-  { message = "^log|trace",         group = "<!-- 130 --> 🪵 Log" }, 
-  { message = "^devops|devx|devex", group = "<!-- 140 --> 🚥 Developer Experience" }, 
+  { message = "^feat", group = "<!-- 000 --> ✨ Features" },
+  { message = "^fix", group = "<!-- 010 --> 🐛 Bug Fixes" },
+  { message = "^perf", group = "<!-- 020 --> 🚀 Performance" },
+  { message = "^doc", group = "<!-- 030 --> 📚 Documentation" },
+  { message = "^WIP", skip = true },
+  { message = "^chore\\(deps\\)", skip = true },
+  { message = "^chore\\(pr\\)", skip = true },
+  { message = "^chore\\(pull\\)", skip = true },
+  { body = ".*security", group = "<!-- 040 --> 🔒️ Security" },
+  { message = "^refactor", group = "<!-- 050 --> ♻️ Refactor" },
+  { message = "^test", group = "<!-- 060 --> ✅ Testing" },
+  { message = "^bench", group = "<!-- 070 --> ⏳ Benchmark" },
+  { message = "^style", group = "<!-- 080 --> 🎨 Styling" },
+  { message = "^build", group = "<!-- 090 --> 🏗️ Build" },
+  { message = "^revert", group = "<!-- 100 --> ⏪️ Revert" },
+  { message = "^chore|ci|misc", group = "<!-- 110 --> ⚙️ Miscellaneous" },
+  { message = "^fork", group = "<!-- 120 --> 🔱 Fork" },
+  { message = "^log|trace", group = "<!-- 130 --> 🪵 Log" },
+  { message = "^devops|devx|devex", group = "<!-- 140 --> 🚥 Developer Experience" },
+  { message = "^privacy", group = "<!-- 150 --> 🕵️ Privacy" },
   { footer = "^changelog: ?ignore", skip = true },
 ]
 

--- a/src/models/blockchain/block/mock_block_generator.rs
+++ b/src/models/blockchain/block/mock_block_generator.rs
@@ -136,7 +136,7 @@ impl MockBlockGenerator {
             composer_parameters,
             timestamp,
             network,
-        )?;
+        );
 
         let coinbase_transaction = Self::mock_transaction_from_details(&transaction_details);
 

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -1199,8 +1199,7 @@ pub(crate) mod tests {
                 FeeNotificationPolicy::OffChain,
             );
             let (composer_txos, transaction_details) =
-                prepare_coinbase_transaction_stateless(&genesis, composer_parameters, now, network)
-                    .unwrap();
+                prepare_coinbase_transaction_stateless(&genesis, composer_parameters, now, network);
             let coinbase_kernel =
                 PrimitiveWitness::from_transaction_details(&transaction_details).kernel;
             let coinbase = Transaction {

--- a/src/models/state/wallet/transaction_output.rs
+++ b/src/models/state/wallet/transaction_output.rs
@@ -698,6 +698,13 @@ mod tests {
         }
     }
 
+    #[test]
+    fn iter_over_empty_tx_output_list_works() {
+        let tx_output_list: TxOutputList = Vec::<TxOutput>::default().into();
+        let mut as_iter = tx_output_list.iter();
+        assert!(as_iter.next().is_none());
+    }
+
     #[apply(shared_tokio_runtime)]
     async fn test_utxoreceiver_auto_not_owned_output() {
         let global_state_lock = mock_genesis_global_state(

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -1294,11 +1294,9 @@ impl WalletState {
                     coinbase_amount,
                     composer_parameters.clone(),
                     new_block.header().timestamp,
-                )
-                .map(|array| array.to_vec())
-                .unwrap_or_default();
+                );
 
-                for composer_output in composer_txos {
+                for composer_output in composer_txos.iter() {
                     // compute what the addition record would have been
                     let incoming_utxo = IncomingUtxo {
                         utxo: composer_output.utxo(),

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -1082,7 +1082,7 @@ pub(crate) async fn fake_create_block_transaction_for_tests(
         composer_parameters,
         timestamp,
         network,
-    )?;
+    );
 
     let coinbase_transaction =
         fake_create_transaction_from_details_for_tests(transaction_details).await;


### PR DESCRIPTION
If a block is empty, i.e. contains no inputs and only the coinbase rewards, *and* the composer chooses to reward the entire block subsidy to the guesser, there is no need for the composer to add any outputs to the coinbase transaction.

Prior to this commit, the composer would in that scenario add two ouputs to the coinbase transaciton. Many such blocks with two zero-valued outputs exist on main net today, so this is not a hypothetical scenario.

Avoiding these zero-valued outputs has two benefits:
 - It leaves more room for other transactions to be merged into the block.
 - It avoids zero-valued leafs in the AOCL whose presence would otherwise reduce the anonymity set as zero valued leafs are less likely to be spent than any other leafs and can, in the case of an empty block, be identified in the AOCL.