### PR TITLE
fix(proof_upgrader): Check for double-spending

### DIFF
--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -39,6 +39,7 @@ use tracing::debug;
 use tracing::info;
 use tracing::warn;
 use transaction_details::TransactionDetails;
+use transaction_kernel_id::TransactionKernelId;
 use twenty_first::math::digest::Digest;
 use tx_proving_capability::TxProvingCapability;
 use wallet::address::ReceivingAddress;
@@ -1700,6 +1701,12 @@ impl GlobalState {
 
     pub(crate) fn max_num_proofs(&self) -> usize {
         self.cli().max_num_proofs
+    }
+
+    /// Remove one transaction from the mempool and notify wallet of changes.
+    pub(crate) async fn mempool_remove(&mut self, transaction_id: TransactionKernelId) {
+        let events = self.mempool.remove(transaction_id);
+        self.wallet_state.handle_mempool_events(events).await;
     }
 
     /// clears all Tx from mempool and notifies wallet of changes.

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -1057,6 +1057,16 @@ async fn fake_block_successor(
     seed: [u8; 32],
     with_valid_pow: bool,
 ) -> Block {
+    fake_block_successor_with_merged_tx(predecessor, timestamp, seed, with_valid_pow, vec![]).await
+}
+
+pub async fn fake_block_successor_with_merged_tx(
+    predecessor: &Block,
+    timestamp: Timestamp,
+    seed: [u8; 32],
+    with_valid_pow: bool,
+    txs: Vec<Transaction>,
+) -> Block {
     let mut rng = StdRng::from_seed(seed);
 
     let composer_parameters = ComposerParameters::new(
@@ -1071,7 +1081,7 @@ async fn fake_block_successor(
         composer_parameters,
         timestamp,
         rng.random(),
-        vec![],
+        txs,
     )
     .await
     .unwrap();


### PR DESCRIPTION
After a proof-upgrade is completed, the associated transaction might no longer be valid because it was mined, or in the case of a merge-proof, one of the inputs to the transaction might have been mined. This commit verifies that the transction is still confirmable before sharing it with peers.