### PR TITLE
increase a test timeout so hopefully windows CI passes.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,13 @@ jobs:
         with:
           components: rustfmt, clippy
 
+      # Necessary for integration tests where p2p nodes connect to each other.
+      # Windows Firewall blocks incoming connections by default, even on localhost.            
+      - name: Allow Incoming TCP Traffic for P2P Ports on Localhost
+        if: runner.os == 'Windows'
+        run: |
+          New-NetFirewallRule -DisplayName "Allow P2P Ports Localhost" -Direction Inbound -Action Allow -Protocol TCP -LocalPort 1024-65000 -LocalAddress 127.0.0.1
+
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
 

--- a/tests/send_and_receive_basic.rs
+++ b/tests/send_and_receive_basic.rs
@@ -131,7 +131,7 @@ pub async fn alice_sends_to_bob(
     proving_capability: TxProvingCapability,
 ) -> anyhow::Result<()> {
     logging::tracing_logger();
-    let timeout_secs = 5;
+    let timeout_secs = 30;
 
     let mut base_args = GenesisNode::default_args();
     base_args.tx_proving_capability = Some(proving_capability);

--- a/tests/send_and_receive_basic.rs
+++ b/tests/send_and_receive_basic.rs
@@ -383,3 +383,40 @@ pub async fn alice_sends_to_random_key() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn simple_localhost_connection_test() {
+    use tokio::net::TcpListener;
+    use tokio::net::TcpStream;
+
+    let listener_result = TcpListener::bind("127.0.0.1:8888").await;
+    if let Err(e) = listener_result {
+        eprintln!("Error binding listener: {:?}", e);
+        panic!("Failed to bind listener");
+    }
+    let listener = listener_result.unwrap();
+
+    tokio::spawn(async move {
+        let accept_result = listener.accept().await;
+        if let Err(e) = accept_result {
+            eprintln!("Error accepting connection: {:?}", e);
+        } else {
+            let (_stream, addr) = accept_result.unwrap();
+            println!("Accepted connection from: {:?}", addr);
+            // You might want to read/write to the stream here in a real test
+        }
+    });
+
+    // Give the listener a little time to start
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let connect_result = TcpStream::connect("127.0.0.1:8888").await;
+    if let Err(e) = connect_result {
+        eprintln!("Error connecting: {:?}", e);
+        panic!("Failed to connect");
+    } else {
+        println!("Successfully connected!");
+        let _stream = connect_result.unwrap();
+        // send/receive data here
+    }
+}


### PR DESCRIPTION
Increasing a test timeout from 5 to 30 secs in the hope it will enable the test to consistently pass CI for windows.

------

will merge if/when all the integration tests in send_and_receive_basic.rs pass on all platforms.