### PR TITLE
use common tokio Runtime and TritonVmJobQueue for unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1703,6 +1703,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "macro_rules_attr"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac8e59369155fdc751b1f687fec504eef885545d7f131f4a19741612fc31fdc7"
+
+[[package]]
 name = "manyhow"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1859,6 +1865,7 @@ dependencies = [
  "humantime",
  "itertools 0.11.0",
  "leveldb-sys",
+ "macro_rules_attr",
  "memmap2",
  "num-bigint",
  "num-rational",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,7 @@ assert2 = "0.3"
 blake3 = "1.5.4"
 clienter = "0.1.1"
 divan = "0.1.14"
+macro_rules_attr = "0.1.3"
 pin-project-lite = "0.2.14"
 proptest = { version = "1.5" }
 proptest-arbitrary-interop = { version = "0.1" }

--- a/src/connect_to_peers.rs
+++ b/src/connect_to_peers.rs
@@ -582,9 +582,12 @@ mod connect_tests {
     use crate::tests::shared::to_bytes;
     use crate::MAGIC_STRING_REQUEST;
     use crate::MAGIC_STRING_RESPONSE;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
+
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn test_outgoing_connection_succeed() -> Result<()> {
         let network = Network::Alpha;
         let other_handshake = get_dummy_handshake_data_for_genesis(network);
@@ -655,7 +658,7 @@ mod connect_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn test_get_connection_status() -> Result<()> {
         let network = Network::Alpha;
         let (_, _, _, _, mut state_lock, own_handshake) =
@@ -789,7 +792,7 @@ mod connect_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn node_refuses_reconnects_within_disconnect_cooldown_period() -> Result<()> {
         let network = Network::Main;
         let reconnect_cooldown = Duration::from_secs(8);
@@ -863,7 +866,7 @@ mod connect_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn test_incoming_connection_succeed() -> Result<()> {
         // This builds a mock object which expects to have a certain
         // sequence of methods called on it: First it expects to have
@@ -912,7 +915,7 @@ mod connect_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn test_incoming_connection_fail_bad_magic_value() -> Result<()> {
         let network = Network::Alpha;
         let other_handshake = get_dummy_handshake_data_for_genesis(network);
@@ -942,7 +945,7 @@ mod connect_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn test_incoming_connection_fail_bad_network() -> Result<()> {
         let other_handshake = get_dummy_handshake_data_for_genesis(Network::Testnet);
         let own_handshake = get_dummy_handshake_data_for_genesis(Network::Alpha);
@@ -975,7 +978,7 @@ mod connect_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn test_incoming_connection_fail_bad_version() {
         let mut other_handshake = get_dummy_handshake_data_for_genesis(Network::Testnet);
         let (_peer_broadcast_tx, from_main_rx_clone, to_main_tx, _to_main_rx1, state_lock, _hsd) =
@@ -1041,7 +1044,7 @@ mod connect_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn test_incoming_connection_fail_max_peers_exceeded() -> Result<()> {
         // In this scenario a node attempts to make an ingoing connection but the max
         // peer count should prevent a new incoming connection from being accepted.
@@ -1090,7 +1093,7 @@ mod connect_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn allow_capping_number_of_peers_per_ip() {
         let allow_5_connections_from_same_ip = cli_args::Args {
             max_connections_per_ip: Some(5),
@@ -1167,7 +1170,7 @@ mod connect_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn disallow_ingoing_connections_from_banned_peers_test() -> Result<()> {
         // In this scenario a peer has been banned, and is attempting to make an ingoing
         // connection. This should not be possible.

--- a/src/connect_to_peers.rs
+++ b/src/connect_to_peers.rs
@@ -560,6 +560,7 @@ mod connect_tests {
 
     use anyhow::bail;
     use anyhow::Result;
+    use macro_rules_attr::apply;
     use tokio_test::io::Builder;
     use tracing_test::traced_test;
     use twenty_first::math::digest::Digest;
@@ -580,11 +581,9 @@ mod connect_tests {
     use crate::tests::shared::get_dummy_socket_address;
     use crate::tests::shared::get_test_genesis_setup;
     use crate::tests::shared::to_bytes;
+    use crate::tests::shared_tokio_runtime;
     use crate::MAGIC_STRING_REQUEST;
     use crate::MAGIC_STRING_RESPONSE;
-    use macro_rules_attr::apply;
-    use crate::tests::shared_tokio_runtime;
-
 
     #[traced_test]
     #[apply(shared_tokio_runtime)]

--- a/src/database/storage/storage_schema/dbtvec.rs
+++ b/src/database/storage/storage_schema/dbtvec.rs
@@ -167,10 +167,11 @@ mod tests {
     }
 
     pub mod streams {
+        use macro_rules_attr::apply;
+
         use super::super::super::super::storage_vec::traits::tests::streams as stream_tests;
         use super::*;
-    use macro_rules_attr::apply;
-    use crate::tests::shared_tokio_runtime;
+        use crate::tests::shared_tokio_runtime;
 
         #[apply(shared_tokio_runtime)]
         pub async fn stream() {

--- a/src/database/storage/storage_schema/dbtvec.rs
+++ b/src/database/storage/storage_schema/dbtvec.rs
@@ -169,13 +169,15 @@ mod tests {
     pub mod streams {
         use super::super::super::super::storage_vec::traits::tests::streams as stream_tests;
         use super::*;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
 
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         pub async fn stream() {
             stream_tests::stream(mk_test_vec_u64().await).await
         }
 
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         pub async fn stream_many() {
             stream_tests::stream_many(mk_test_vec_u64().await).await
         }

--- a/src/database/storage/storage_schema/mod.rs
+++ b/src/database/storage/storage_schema/mod.rs
@@ -61,6 +61,9 @@ mod tests {
     use super::*;
     use crate::database::NeptuneLevelDb;
     use crate::twenty_first::math::other::random_elements;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
+
 
     #[derive(Default, PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
     struct S(Vec<u8>);
@@ -87,7 +90,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn test_simple_singleton() {
         let singleton_value = S([1u8, 3u8, 3u8, 7u8].to_vec());
 
@@ -150,7 +153,7 @@ mod tests {
         assert_eq!(new_singleton.get(), singleton_value);
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn test_simple_vector() {
         // open new NeptuneLevelDb that will not be dropped on close.
         let db = NeptuneLevelDb::open_new_test_database(false, None, None, None)
@@ -399,7 +402,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn test_dbtcvecs_get_many() {
         const TEST_LIST_LENGTH: u8 = 105;
 
@@ -452,7 +455,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn test_dbtcvecs_set_many_get_many() {
         const TEST_LIST_LENGTH: u8 = 105;
 
@@ -537,7 +540,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn test_dbtcvecs_set_all_get_many() {
         const TEST_LIST_LENGTH: u8 = 105;
 
@@ -605,7 +608,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn storage_schema_vector_pbt() {
         let db = NeptuneLevelDb::open_new_test_database(true, None, None, None)
             .await
@@ -720,7 +723,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn singleton_vector_key_collision() {
         let db = NeptuneLevelDb::open_new_test_database(false, None, None, None)
             .await
@@ -753,7 +756,7 @@ mod tests {
         assert!(new_vector1.is_empty().await);
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn test_two_vectors_and_singleton() {
         let singleton_value = S([3u8, 3u8, 3u8, 1u8].to_vec());
 
@@ -958,7 +961,7 @@ mod tests {
     #[should_panic(
         expected = "Out-of-bounds. Got 2 but length was 2. persisted vector name: test-vector"
     )]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn out_of_bounds_using_get() {
         let db = NeptuneLevelDb::open_new_test_database(true, None, None, None)
             .await
@@ -975,7 +978,7 @@ mod tests {
     #[should_panic(
         expected = "Out-of-bounds. Got index 2 but length was 2. persisted vector name: test-vector"
     )]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn out_of_bounds_using_get_many() {
         let db = NeptuneLevelDb::open_new_test_database(true, None, None, None)
             .await
@@ -992,7 +995,7 @@ mod tests {
     #[should_panic(
         expected = "Out-of-bounds. Got 1 but length was 1. persisted vector name: test-vector"
     )]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn out_of_bounds_using_set_many() {
         let db = NeptuneLevelDb::open_new_test_database(true, None, None, None)
             .await
@@ -1008,7 +1011,7 @@ mod tests {
     }
 
     #[should_panic(expected = "size-mismatch.  input has 2 elements and target has 1 elements")]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn size_mismatch_too_many_using_set_all() {
         let db = NeptuneLevelDb::open_new_test_database(true, None, None, None)
             .await
@@ -1024,7 +1027,7 @@ mod tests {
     }
 
     #[should_panic(expected = "size-mismatch.  input has 1 elements and target has 2 elements")]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn size_mismatch_too_few_using_set_all() {
         let db = NeptuneLevelDb::open_new_test_database(true, None, None, None)
             .await
@@ -1040,7 +1043,7 @@ mod tests {
         vector.set_all([5]).await;
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn test_db_sync_and_send() {
         fn sync_and_send<T: Sync + Send>(_t: T) {}
 

--- a/src/database/storage/storage_schema/mod.rs
+++ b/src/database/storage/storage_schema/mod.rs
@@ -49,6 +49,7 @@ mod tests {
     use std::sync::Arc;
 
     use itertools::Itertools;
+    use macro_rules_attr::apply;
     use rand::random;
     use rand::Rng;
     use rand::RngCore;
@@ -60,10 +61,8 @@ mod tests {
     use super::traits::*;
     use super::*;
     use crate::database::NeptuneLevelDb;
-    use crate::twenty_first::math::other::random_elements;
-    use macro_rules_attr::apply;
     use crate::tests::shared_tokio_runtime;
-
+    use crate::twenty_first::math::other::random_elements;
 
     #[derive(Default, PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
     struct S(Vec<u8>);

--- a/src/database/storage/storage_vec/mod.rs
+++ b/src/database/storage/storage_vec/mod.rs
@@ -30,6 +30,9 @@ mod tests {
 
     use super::traits::*;
     use super::*;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
+
 
     /// Return a persisted vector and a regular in-memory vector with the same elements
     async fn get_persisted_vec_with_length(
@@ -133,13 +136,13 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn test_simple_prop() {
         let ordinary_vec: OrdinaryVec<[u8; 13]> = Default::default();
         simple_prop(ordinary_vec).await;
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn multiple_vectors_in_one_db() {
         let mut delegated_db_vec_a: OrdinaryVec<u128> = Default::default();
         let delegated_db_vec_b: OrdinaryVec<u128> = Default::default();
@@ -153,7 +156,7 @@ mod tests {
         assert_eq!(0, delegated_db_vec_b.len().await);
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn test_set_many() {
         let mut delegated_db_vec_a: OrdinaryVec<u128> = Default::default();
 
@@ -188,7 +191,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn test_set_all() {
         let mut delegated_db_vec_a: OrdinaryVec<u128> = Default::default();
 
@@ -214,7 +217,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn get_many_ordering_of_outputs() {
         let mut delegated_db_vec_a: OrdinaryVec<u128> = Default::default();
 
@@ -249,7 +252,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn delegated_vec_pbt() {
         let (mut persisted_vector, mut normal_vector) =
             get_persisted_vec_with_length(10000, "vec 1").await;
@@ -329,28 +332,28 @@ mod tests {
     }
 
     #[should_panic(expected = "Out-of-bounds. Got index 3 but length was 1.")]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn panic_on_out_of_bounds_get() {
         let (delegated_db_vec, _) = get_persisted_vec_with_length(1, "unit test vec 0").await;
         delegated_db_vec.get(3).await;
     }
 
     #[should_panic(expected = "Out-of-bounds. Got index 3 but length was 1.")]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn panic_on_out_of_bounds_get_many() {
         let (delegated_db_vec, _) = get_persisted_vec_with_length(1, "unit test vec 0").await;
         delegated_db_vec.get_many(&[3]).await;
     }
 
     #[should_panic(expected = "index out of bounds: the len is 1 but the index is 1")]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn panic_on_out_of_bounds_set() {
         let (mut delegated_db_vec, _) = get_persisted_vec_with_length(1, "unit test vec 0").await;
         delegated_db_vec.set(1, 3000).await;
     }
 
     #[should_panic(expected = "index out of bounds: the len is 1 but the index is 1")]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn panic_on_out_of_bounds_set_many() {
         let (mut delegated_db_vec, _) = get_persisted_vec_with_length(1, "unit test vec 0").await;
 
@@ -359,7 +362,7 @@ mod tests {
     }
 
     #[should_panic(expected = "size-mismatch.  input has 2 elements and target has 1 elements.")]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn panic_on_size_mismatch_set_all() {
         let (mut delegated_db_vec, _) = get_persisted_vec_with_length(1, "unit test vec 0").await;
 
@@ -368,7 +371,7 @@ mod tests {
     }
 
     #[should_panic(expected = "Out-of-bounds. Got index 11 but length was 11.")]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn panic_on_out_of_bounds_get_even_though_value_exists_in_persistent_memory() {
         let (mut delegated_db_vec, _) = get_persisted_vec_with_length(12, "unit test vec 0").await;
         delegated_db_vec.pop().await;
@@ -376,7 +379,7 @@ mod tests {
     }
 
     #[should_panic(expected = "index out of bounds: the len is 11 but the index is 11")]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn panic_on_out_of_bounds_set_even_though_value_exists_in_persistent_memory() {
         let (mut delegated_db_vec, _) = get_persisted_vec_with_length(12, "unit test vec 0").await;
         delegated_db_vec.pop().await;

--- a/src/database/storage/storage_vec/mod.rs
+++ b/src/database/storage/storage_vec/mod.rs
@@ -25,14 +25,13 @@ mod tests {
     use std::collections::HashMap;
 
     use itertools::Itertools;
+    use macro_rules_attr::apply;
     use rand::Rng;
     use rand::RngCore;
 
     use super::traits::*;
     use super::*;
-    use macro_rules_attr::apply;
     use crate::tests::shared_tokio_runtime;
-
 
     /// Return a persisted vector and a regular in-memory vector with the same elements
     async fn get_persisted_vec_with_length(

--- a/src/database/storage/storage_vec/ordinary_vec.rs
+++ b/src/database/storage/storage_vec/ordinary_vec.rs
@@ -133,15 +133,18 @@ mod tests {
 
     pub mod streams {
         use trait_tests::streams as stream_tests;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
+
 
         use super::*;
 
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         pub async fn stream() {
             stream_tests::stream(mk_test_vec_u64()).await
         }
 
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         pub async fn stream_many() {
             stream_tests::stream_many(mk_test_vec_u64()).await
         }

--- a/src/database/storage/storage_vec/ordinary_vec.rs
+++ b/src/database/storage/storage_vec/ordinary_vec.rs
@@ -132,12 +132,11 @@ mod tests {
     }
 
     pub mod streams {
+        use macro_rules_attr::apply;
         use trait_tests::streams as stream_tests;
-    use macro_rules_attr::apply;
-    use crate::tests::shared_tokio_runtime;
-
 
         use super::*;
+        use crate::tests::shared_tokio_runtime;
 
         #[apply(shared_tokio_runtime)]
         pub async fn stream() {

--- a/src/job_queue/errors.rs
+++ b/src/job_queue/errors.rs
@@ -15,7 +15,7 @@ pub enum JobHandleError {
     #[error("channel send error cancelling job")]
     CancelJobError(#[from] tokio::sync::watch::error::SendError<()>),
 
-    #[error("channel recv error waiting for job results")]
+    #[error("channel recv error waiting for job results: {0}")]
     JobResultError(#[from] tokio::sync::oneshot::error::RecvError),
 }
 
@@ -73,7 +73,18 @@ impl From<JobHandleError> for JobHandleErrorSync {
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
-pub enum JobQueueError {
+#[non_exhaustive]
+pub enum AddJobError {
     #[error("channel send error adding job.  error: {0}")]
-    AddJobError(String),
+    SendError(#[from] tokio::sync::mpsc::error::SendError<()>),
+}
+
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum StopQueueError {
+    #[error("channel send error adding job.  error: {0}")]
+    SendError(#[from] tokio::sync::watch::error::SendError<()>),
+
+    #[error("join error while waiting for job-queue to stop.  error: {0}")]
+    JoinError(#[from] tokio::task::JoinError),
 }

--- a/src/job_queue/triton_vm/triton_vm_job_queue.rs
+++ b/src/job_queue/triton_vm/triton_vm_job_queue.rs
@@ -46,13 +46,6 @@ impl TritonVmJobQueue {
             .get_or_init(|| Arc::new(Self(JobQueue::<TritonVmJobPriority>::start())))
             .clone()
     }
-
-    /// Wrapper for Self::get_instance()
-    /// here for backwards compat with existing tests
-    #[cfg(test)]
-    pub fn dummy() -> Arc<Self> {
-        Self::get_instance()
-    }
 }
 
 /// returns a clonable reference to the single (per process) VM job queue.

--- a/src/locks/tokio/atomic_mutex.rs
+++ b/src/locks/tokio/atomic_mutex.rs
@@ -555,12 +555,11 @@ impl<T> Atomic<T> for AtomicMutex<T> {
 #[cfg(test)]
 mod tests {
     use futures::future::FutureExt;
-    use tracing_test::traced_test;
     use macro_rules_attr::apply;
-    use crate::tests::shared_tokio_runtime;
-
+    use tracing_test::traced_test;
 
     use super::*;
+    use crate::tests::shared_tokio_runtime;
 
     /// Verify (compile-time) that AtomicMutex:.lock() and :.lock_mut() accept
     /// mutable values. (FnMut)

--- a/src/locks/tokio/atomic_mutex.rs
+++ b/src/locks/tokio/atomic_mutex.rs
@@ -556,12 +556,15 @@ impl<T> Atomic<T> for AtomicMutex<T> {
 mod tests {
     use futures::future::FutureExt;
     use tracing_test::traced_test;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
+
 
     use super::*;
 
     /// Verify (compile-time) that AtomicMutex:.lock() and :.lock_mut() accept
     /// mutable values. (FnMut)
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn mutable_assignment() {
         let name = "Jim".to_string();
         let mut atomic_name = AtomicMutex::from(name);
@@ -572,7 +575,7 @@ mod tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn try_acquire_no_log() {
         let unit = ();
         let atomic_unit = AtomicMutex::<()>::from(unit);
@@ -589,7 +592,7 @@ mod tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn try_acquire_with_log() {
         pub fn log_lock_event(lock_event: LockEvent) {
             let (event, info, acquisition) = match lock_event {
@@ -631,7 +634,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn lock_async() {
         struct Car {
             year: u16,

--- a/src/locks/tokio/atomic_rw.rs
+++ b/src/locks/tokio/atomic_rw.rs
@@ -599,12 +599,15 @@ impl<T> Atomic<T> for AtomicRw<T> {
 #[cfg(test)]
 mod tests {
     use futures::future::FutureExt;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
+
 
     use super::*;
 
     /// Verify (compile-time) that AtomicRw::lock() and ::lock_mut() accept
     /// mutable values. (FnMut)
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn mutable_assignment() {
         let name = "Jim".to_string();
         let mut atomic_name = AtomicRw::from(name);
@@ -614,7 +617,7 @@ mod tests {
         atomic_name.lock_mut(|n| new_name = (*n).to_string()).await;
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn lock_async() {
         struct Car {
             year: u16,

--- a/src/locks/tokio/atomic_rw.rs
+++ b/src/locks/tokio/atomic_rw.rs
@@ -600,10 +600,9 @@ impl<T> Atomic<T> for AtomicRw<T> {
 mod tests {
     use futures::future::FutureExt;
     use macro_rules_attr::apply;
-    use crate::tests::shared_tokio_runtime;
-
 
     use super::*;
+    use crate::tests::shared_tokio_runtime;
 
     /// Verify (compile-time) that AtomicRw::lock() and ::lock_mut() accept
     /// mutable values. (FnMut)

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -90,11 +90,11 @@ macro_rules! log_scope_duration {
     };
 }
 
+
 // These allow the macros to be used as
 // use crate::macros::xxxxx;
 //
 // see: https://stackoverflow.com/a/67140319/10087197
-
 pub(crate) use fn_name;
 pub(crate) use fn_name_bare;
 pub(crate) use log_scope_duration;
@@ -103,7 +103,7 @@ pub(crate) use state_lock_call_async;
 pub(crate) use state_lock_call_mut_async;
 
 #[cfg(test)]
-mod test {
+pub mod test {
 
     use super::*;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -90,7 +90,6 @@ macro_rules! log_scope_duration {
     };
 }
 
-
 // These allow the macros to be used as
 // use crate::macros::xxxxx;
 //

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -1862,6 +1862,8 @@ impl MainLoopHandler {
 mod test {
     use std::str::FromStr;
     use std::time::UNIX_EPOCH;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
 
     use tracing_test::traced_test;
 
@@ -1947,7 +1949,7 @@ mod test {
         }
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn handle_self_guessed_block_new_tip() {
         // A new tip is registered by main_loop. Verify correct state update.
         let TestSetup {
@@ -2040,7 +2042,7 @@ mod test {
             );
         }
 
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         #[traced_test]
         async fn sync_mode_abandoned_on_global_timeout() {
             let num_outgoing_connections = 0;
@@ -2176,7 +2178,7 @@ mod test {
                 .transaction
         }
 
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         #[traced_test]
         async fn upgrade_proof_collection_to_single_proof_foreign_tx() {
             let num_outgoing_connections = 0;
@@ -2310,7 +2312,7 @@ mod test {
     mod peer_discovery {
         use super::*;
 
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         #[traced_test]
         async fn prune_peers_too_many_connections() {
             let num_init_peers_outgoing = 10;
@@ -2339,7 +2341,7 @@ mod test {
             }
         }
 
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         #[traced_test]
         async fn prune_peers_not_too_many_connections() {
             let num_init_peers_outgoing = 10;
@@ -2364,7 +2366,7 @@ mod test {
             assert!(main_to_peer_rx.is_empty());
         }
 
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         #[traced_test]
         async fn skip_peer_discovery_if_peer_limit_is_exceeded() {
             let num_init_peers_outgoing = 2;
@@ -2391,7 +2393,7 @@ mod test {
             assert!(logs_contain("Skipping peer discovery."));
         }
 
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         #[traced_test]
         async fn performs_peer_discovery_on_few_connections() {
             let num_init_peers_outgoing = 2;
@@ -2451,7 +2453,7 @@ mod test {
         use crate::tests::shared::get_dummy_peer_connection_data_genesis;
         use crate::tests::shared::to_bytes;
 
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         #[traced_test]
         async fn disconnect_from_oldest_peer_upon_connection_request() {
             // Set up a node in bootstrapper mode and connected to a given

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -1862,9 +1862,8 @@ impl MainLoopHandler {
 mod test {
     use std::str::FromStr;
     use std::time::UNIX_EPOCH;
-    use macro_rules_attr::apply;
-    use crate::tests::shared_tokio_runtime;
 
+    use macro_rules_attr::apply;
     use tracing_test::traced_test;
 
     use super::*;
@@ -1873,6 +1872,7 @@ mod test {
     use crate::tests::shared::get_dummy_peer_incoming;
     use crate::tests::shared::get_test_genesis_setup;
     use crate::tests::shared::invalid_empty_block;
+    use crate::tests::shared_tokio_runtime;
     use crate::MINER_CHANNEL_CAPACITY;
 
     impl MainLoopHandler {

--- a/src/main_loop/proof_upgrader.rs
+++ b/src/main_loop/proof_upgrader.rs
@@ -837,6 +837,8 @@ mod test {
     use tokio::sync::broadcast;
     use tokio::sync::broadcast::error::TryRecvError;
     use tracing_test::traced_test;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
 
     use super::*;
     use crate::config_models::cli_args;
@@ -888,7 +890,7 @@ mod test {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn dont_upgrade_foreign_proof_collection_if_fee_too_low() {
         let network = Network::Main;
 
@@ -954,7 +956,7 @@ mod test {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn happy_path() {
         let network = Network::Main;
 
@@ -1033,7 +1035,7 @@ mod test {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn race_condition_with_one_new_block() {
         let network = Network::Main;
 
@@ -1129,7 +1131,7 @@ mod test {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn dont_share_partly_mined_merge_upgrade() {
         let network = Network::Main;
 

--- a/src/main_loop/proof_upgrader.rs
+++ b/src/main_loop/proof_upgrader.rs
@@ -874,7 +874,7 @@ mod test {
         let mut gsm = state.lock_guard_mut().await;
         let change_key = gsm.wallet_state.next_unused_symmetric_key().await;
         drop(gsm);
-        let dummy = TritonVmJobQueue::dummy();
+        let dummy = TritonVmJobQueue::get_instance();
         let timestamp = Network::Main.launch_date() + Timestamp::months(7);
         let config = TxCreationConfig::default()
             .recover_change_off_chain(change_key.into())
@@ -990,7 +990,7 @@ mod test {
                 UpgradeJob::from_primitive_witness(network, proving_capability, pw.to_owned());
             pw_to_tx_upgrade_job
                 .handle_upgrade(
-                    TritonVmJobQueue::dummy(),
+                    TritonVmJobQueue::get_instance(),
                     TransactionOrigin::Own,
                     true,
                     alice.clone(),
@@ -1077,7 +1077,7 @@ mod test {
 
             upgrade_job
                 .handle_upgrade(
-                    TritonVmJobQueue::dummy(),
+                    TritonVmJobQueue::get_instance(),
                     TransactionOrigin::Own,
                     true,
                     alice.clone(),
@@ -1198,7 +1198,7 @@ mod test {
             broadcast::channel::<MainToPeerTask>(PEER_CHANNEL_CAPACITY);
         merge_upgrade_job
             .handle_upgrade(
-                TritonVmJobQueue::dummy(),
+                TritonVmJobQueue::get_instance(),
                 TransactionOrigin::Own,
                 true,
                 alice.clone(),

--- a/src/main_loop/proof_upgrader.rs
+++ b/src/main_loop/proof_upgrader.rs
@@ -834,11 +834,10 @@ pub(super) fn get_upgrade_task_from_mempool(
 
 #[cfg(test)]
 mod test {
+    use macro_rules_attr::apply;
     use tokio::sync::broadcast;
     use tokio::sync::broadcast::error::TryRecvError;
     use tracing_test::traced_test;
-    use macro_rules_attr::apply;
-    use crate::tests::shared_tokio_runtime;
 
     use super::*;
     use crate::config_models::cli_args;
@@ -852,6 +851,7 @@ mod test {
     use crate::tests::shared::invalid_empty_block_with_timestamp;
     use crate::tests::shared::mock_genesis_global_state;
     use crate::tests::shared::state_with_premine_and_self_mined_blocks;
+    use crate::tests::shared_tokio_runtime;
     use crate::PEER_CHANNEL_CAPACITY;
 
     /// Returns a transaction initiated by the global state provided as

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -998,14 +998,12 @@ pub(crate) async fn mine(
 pub(crate) mod mine_loop_tests {
     use std::hint::black_box;
 
-    use macro_rules_attr::apply;
-    use crate::tests::shared_tokio_runtime;
-
     use block_appendix::BlockAppendix;
     use block_body::BlockBody;
     use block_header::block_header_tests::random_block_header;
     use difficulty_control::Difficulty;
     use itertools::Itertools;
+    use macro_rules_attr::apply;
     use num_bigint::BigUint;
     use num_traits::One;
     use num_traits::Pow;
@@ -1033,6 +1031,7 @@ pub(crate) mod mine_loop_tests {
     use crate::tests::shared::make_mock_transaction_with_mutator_set_hash;
     use crate::tests::shared::mock_genesis_global_state;
     use crate::tests::shared::random_transaction_kernel;
+    use crate::tests::shared_tokio_runtime;
     use crate::util_types::test_shared::mutator_set::pseudorandom_addition_record;
     use crate::util_types::test_shared::mutator_set::random_mmra;
     use crate::util_types::test_shared::mutator_set::random_mutator_set_accumulator;

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -1292,7 +1292,7 @@ pub(crate) mod mine_loop_tests {
                 transaction_empty_mempool,
                 now,
                 None,
-                TritonVmJobQueue::dummy(),
+                TritonVmJobQueue::get_instance(),
                 TritonVmJobPriority::High.into(),
             )
             .await
@@ -1336,7 +1336,7 @@ pub(crate) mod mine_loop_tests {
                 transaction_non_empty_mempool,
                 now,
                 None,
-                TritonVmJobQueue::dummy(),
+                TritonVmJobQueue::get_instance(),
                 TritonVmJobPriority::default().into(),
             )
             .await

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -998,6 +998,9 @@ pub(crate) async fn mine(
 pub(crate) mod mine_loop_tests {
     use std::hint::black_box;
 
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
+
     use block_appendix::BlockAppendix;
     use block_body::BlockBody;
     use block_header::block_header_tests::random_block_header;
@@ -1179,8 +1182,7 @@ pub(crate) mod mine_loop_tests {
         tock
     }
 
-    #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn block_proposal_for_height_one_is_valid_for_various_guesser_fee_fractions() {
         // Verify that a block template made with transaction from the mempool is a valid block
         let network = Network::Main;
@@ -1351,7 +1353,7 @@ pub(crate) mod mine_loop_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn block_proposal_for_height_two_is_valid() {
         // Verify that block proposals of both height 1 and 2 are valid.
         let network = Network::Main;
@@ -1417,7 +1419,7 @@ pub(crate) mod mine_loop_tests {
     /// This test is present and fails in commit
     /// b093631fd0d479e6c2cc252b08f18d920a1ec2e5 which is prior to the fix.
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn mined_block_has_proof_of_work() {
         let network = Network::Main;
         let cli_args = cli_args::Args {
@@ -1483,7 +1485,7 @@ pub(crate) mod mine_loop_tests {
     /// note: this test fails in 318b7a20baf11a7a99f249660f1f70484c586012
     ///       and should always pass in later commits.
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn block_timestamp_represents_time_guessing_started() -> Result<()> {
         let network = Network::Main;
         let cli_args = cli_args::Args {
@@ -1776,14 +1778,14 @@ pub(crate) mod mine_loop_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn mine_20_blocks_in_40_seconds() -> Result<()> {
         mine_m_blocks_in_n_seconds::<20, 40>().await.unwrap();
         Ok(())
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn hash_rate_independent_of_tx_size() {
         // It's crucial that the hash rate is independent of the size of the
         // block, since miners are otherwise heavily incentivized to mine small
@@ -1803,7 +1805,7 @@ pub(crate) mod mine_loop_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn coinbase_transaction_has_one_timelocked_and_one_liquid_output() {
         for notification_policy in [
             FeeNotificationPolicy::OffChain,

--- a/src/models/blockchain/block/block_height.rs
+++ b/src/models/blockchain/block/block_height.rs
@@ -140,6 +140,7 @@ impl Display for BlockHeight {
 
 #[cfg(test)]
 mod test {
+    use macro_rules_attr::apply;
     use num_traits::CheckedAdd;
     use num_traits::CheckedSub;
     use tracing_test::traced_test;
@@ -150,7 +151,6 @@ mod test {
     use crate::models::blockchain::block::TARGET_BLOCK_INTERVAL;
     use crate::models::blockchain::type_scripts::native_currency_amount::NativeCurrencyAmount;
     use crate::models::proof_abstractions::timestamp::Timestamp;
-    use macro_rules_attr::apply;
     use crate::tests::shared_tokio_runtime;
 
     #[traced_test]

--- a/src/models/blockchain/block/block_height.rs
+++ b/src/models/blockchain/block/block_height.rs
@@ -150,9 +150,11 @@ mod test {
     use crate::models::blockchain::block::TARGET_BLOCK_INTERVAL;
     use crate::models::blockchain::type_scripts::native_currency_amount::NativeCurrencyAmount;
     use crate::models::proof_abstractions::timestamp::Timestamp;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn genesis_test() {
         assert!(BlockHeight::genesis().is_genesis());
         assert!(!BlockHeight::genesis().next().is_genesis());

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -1115,6 +1115,8 @@ pub(crate) mod block_tests {
     use crate::tests::shared::make_mock_transaction;
     use crate::tests::shared::mock_genesis_global_state;
     use crate::util_types::archival_mmr::ArchivalMmr;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
 
     pub(crate) const PREMINE_MAX_SIZE: NativeCurrencyAmount = NativeCurrencyAmount::coins(831488);
 
@@ -1176,7 +1178,7 @@ pub(crate) mod block_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn total_block_subsidy_is_128_coins_regardless_of_guesser_fraction() {
         let network = Network::Main;
         let a_wallet_secret = WalletEntropy::new_random();
@@ -1260,7 +1262,7 @@ pub(crate) mod block_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn test_difficulty_control_matches() {
         let network = Network::Main;
 
@@ -1323,7 +1325,7 @@ pub(crate) mod block_tests {
         assert_eq!(bfe_max_elem, some_threshold_actual.values()[3]);
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn block_with_wrong_mmra_is_invalid() {
         let network = Network::Main;
         let genesis_block = Block::genesis(network);
@@ -1355,7 +1357,7 @@ pub(crate) mod block_tests {
         }
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn can_prove_block_ancestry() {
         let mut rng = rand::rng();
         let network = Network::RegTest;
@@ -1445,7 +1447,7 @@ pub(crate) mod block_tests {
         use crate::tests::shared::fake_valid_successor_for_tests;
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn blocks_with_0_to_10_inputs_and_successors_are_valid() {
             // Scenario: Build different blocks of height 2, with varying number
             // of inputs. Verify all are valid. The build a block of height 3
@@ -1614,7 +1616,7 @@ pub(crate) mod block_tests {
         }
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn block_with_far_future_timestamp_is_invalid() {
             let network = Network::Main;
             let genesis_block = Block::genesis(network);
@@ -1753,7 +1755,7 @@ pub(crate) mod block_tests {
         use crate::models::state::wallet::address::generation_address::GenerationSpendingKey;
         use crate::tests::shared::make_mock_block_guesser_preimage_and_guesser_fraction;
 
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn guesser_fee_addition_records_are_consistent() {
             // Ensure that multiple ways of deriving guesser-fee addition
             // records are consistent.
@@ -1813,7 +1815,7 @@ pub(crate) mod block_tests {
         }
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn guesser_fees_are_added_to_mutator_set() {
             // Mine two blocks on top of the genesis block. Verify that the guesser
             // fee for the 1st block was added to the mutator set. The genesis
@@ -1917,7 +1919,7 @@ pub(crate) mod block_tests {
     /// spend the same UTXOs over and over. To avoid doing this, you insert the
     /// transaction into the mempool thus making the wallet aware of this
     /// transaction and avoiding a double-spend of a UTXO.
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn avoid_reselecting_same_input_utxos() {
         let mut rng = StdRng::seed_from_u64(893423984854);
         let network = Network::Main;

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -1531,7 +1531,7 @@ pub(crate) mod block_tests {
                     .merge_with(
                         (*tx2).clone(),
                         rng.random(),
-                        TritonVmJobQueue::dummy(),
+                        TritonVmJobQueue::get_instance(),
                         TritonVmProofJobOptions::default(),
                     )
                     .await
@@ -1541,7 +1541,7 @@ pub(crate) mod block_tests {
                     block2_tx,
                     plus_eight_months,
                     None,
-                    TritonVmJobQueue::dummy(),
+                    TritonVmJobQueue::get_instance(),
                     TritonVmProofJobOptions::default(),
                 )
                 .await
@@ -1586,7 +1586,7 @@ pub(crate) mod block_tests {
                     .merge_with(
                         (*tx3).clone(),
                         rng.random(),
-                        TritonVmJobQueue::dummy(),
+                        TritonVmJobQueue::get_instance(),
                         TritonVmProofJobOptions::default(),
                     )
                     .await
@@ -1600,7 +1600,7 @@ pub(crate) mod block_tests {
                     block3_tx,
                     plus_nine_months,
                     None,
-                    TritonVmJobQueue::dummy(),
+                    TritonVmJobQueue::get_instance(),
                     TritonVmProofJobOptions::default(),
                 )
                 .await
@@ -1927,7 +1927,7 @@ pub(crate) mod block_tests {
         let mut alice =
             mock_genesis_global_state(network, 0, devnet_wallet, cli_args::Args::default()).await;
 
-        let job_queue = TritonVmJobQueue::dummy();
+        let job_queue = TritonVmJobQueue::get_instance();
 
         let genesis_block = Block::genesis(network);
 

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -1080,6 +1080,7 @@ impl Block {
 
 #[cfg(test)]
 pub(crate) mod block_tests {
+    use macro_rules_attr::apply;
     use rand::random;
     use rand::rngs::StdRng;
     use rand::Rng;
@@ -1114,9 +1115,8 @@ pub(crate) mod block_tests {
     use crate::tests::shared::make_mock_block;
     use crate::tests::shared::make_mock_transaction;
     use crate::tests::shared::mock_genesis_global_state;
-    use crate::util_types::archival_mmr::ArchivalMmr;
-    use macro_rules_attr::apply;
     use crate::tests::shared_tokio_runtime;
+    use crate::util_types::archival_mmr::ArchivalMmr;
 
     pub(crate) const PREMINE_MAX_SIZE: NativeCurrencyAmount = NativeCurrencyAmount::coins(831488);
 

--- a/src/models/blockchain/block/validity/block_primitive_witness.rs
+++ b/src/models/blockchain/block/validity/block_primitive_witness.rs
@@ -181,7 +181,7 @@ pub(crate) mod test {
                 let single_proof_inputs = rt
                     .block_on(SingleProof::produce(
                         &primwit_inputs,
-                        TritonVmJobQueue::dummy(),
+                        TritonVmJobQueue::get_instance(),
                         TritonVmJobPriority::default().into(),
                     ))
                     .unwrap();
@@ -193,7 +193,7 @@ pub(crate) mod test {
                 let single_proof_coinbase = rt
                     .block_on(SingleProof::produce(
                         &primwit_coinbase,
-                        TritonVmJobQueue::dummy(),
+                        TritonVmJobQueue::get_instance(),
                         TritonVmJobPriority::default().into(),
                     ))
                     .unwrap();
@@ -205,7 +205,7 @@ pub(crate) mod test {
                 rt.block_on(tx_inputs.merge_with(
                     tx_coinbase,
                     shuffle_seed,
-                    TritonVmJobQueue::dummy(),
+                    TritonVmJobQueue::get_instance(),
                     TritonVmJobPriority::default().into(),
                 ))
                 .unwrap()

--- a/src/models/blockchain/block/validity/block_primitive_witness.rs
+++ b/src/models/blockchain/block/validity/block_primitive_witness.rs
@@ -175,7 +175,7 @@ pub(crate) mod test {
             arb::<[u8; 32]>(),
         )
             .prop_map(move |((primwit_inputs, primwit_coinbase), shuffle_seed)| {
-                let rt = tokio::runtime::Runtime::new().unwrap();
+                let rt = crate::tests::tokio_runtime();
                 let _guard = rt.enter();
 
                 let single_proof_inputs = rt

--- a/src/models/blockchain/block/validity/block_program.rs
+++ b/src/models/blockchain/block/validity/block_program.rs
@@ -360,6 +360,8 @@ pub(crate) mod test {
     use crate::models::state::wallet::wallet_entropy::WalletEntropy;
     use crate::tests::shared::mock_genesis_global_state;
     use crate::GlobalStateLock;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
 
     impl ConsensusProgramSpecification for BlockProgram {
         fn source(&self) {
@@ -459,7 +461,7 @@ pub(crate) mod test {
     //       disallowed.
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn disallow_double_spends_across_blocks() {
         async fn mine_tx(
             state: &GlobalStateLock,

--- a/src/models/blockchain/block/validity/block_program.rs
+++ b/src/models/blockchain/block/validity/block_program.rs
@@ -484,7 +484,7 @@ pub(crate) mod test {
                 block_tx,
                 timestamp,
                 None,
-                TritonVmJobQueue::dummy(),
+                TritonVmJobQueue::get_instance(),
                 TritonVmProofJobOptions::default(),
             )
             .await
@@ -534,7 +534,7 @@ pub(crate) mod test {
             &genesis_block.mutator_set_accumulator_after(),
             &block1.mutator_set_update(),
             tx.proof.into_single_proof(),
-            TritonVmJobQueue::dummy(),
+            TritonVmJobQueue::get_instance(),
             TritonVmJobPriority::default().into(),
             Some(later),
         )

--- a/src/models/blockchain/block/validity/block_program.rs
+++ b/src/models/blockchain/block/validity/block_program.rs
@@ -328,6 +328,7 @@ impl ConsensusProgram for BlockProgram {
 #[cfg(test)]
 pub(crate) mod test {
     use itertools::Itertools;
+    use macro_rules_attr::apply;
     use rand::rngs::StdRng;
     use rand::Rng;
     use rand::SeedableRng;
@@ -359,9 +360,8 @@ pub(crate) mod test {
     use crate::models::state::wallet::transaction_output::TxOutput;
     use crate::models::state::wallet::wallet_entropy::WalletEntropy;
     use crate::tests::shared::mock_genesis_global_state;
-    use crate::GlobalStateLock;
-    use macro_rules_attr::apply;
     use crate::tests::shared_tokio_runtime;
+    use crate::GlobalStateLock;
 
     impl ConsensusProgramSpecification for BlockProgram {
         fn source(&self) {

--- a/src/models/blockchain/transaction/mod.rs
+++ b/src/models/blockchain/transaction/mod.rs
@@ -356,6 +356,7 @@ pub(crate) mod tests {
 #[cfg(test)]
 mod transaction_tests {
     use lock_script::LockScript;
+    use macro_rules_attr::apply;
     use proptest::prelude::Strategy;
     use proptest::test_runner::TestRunner;
     use rand::random;
@@ -370,9 +371,8 @@ mod transaction_tests {
     use crate::models::proof_abstractions::timestamp::Timestamp;
     use crate::tests::shared::make_mock_transaction;
     use crate::tests::shared::mock_block_from_transaction_and_msa;
-    use crate::util_types::mutator_set::commit;
-    use macro_rules_attr::apply;
     use crate::tests::shared_tokio_runtime;
+    use crate::util_types::mutator_set::commit;
 
     #[traced_test]
     #[test]

--- a/src/models/blockchain/transaction/mod.rs
+++ b/src/models/blockchain/transaction/mod.rs
@@ -398,7 +398,7 @@ mod transaction_tests {
             let network = Network::Main;
             let as_single_proof = SingleProof::produce(
                 &to_be_updated,
-                TritonVmJobQueue::dummy(),
+                TritonVmJobQueue::get_instance(),
                 TritonVmJobPriority::default().into(),
             )
             .await
@@ -416,7 +416,7 @@ mod transaction_tests {
                 &to_be_updated.mutator_set_accumulator,
                 &mutator_set_update,
                 original_tx.proof.into_single_proof(),
-                TritonVmJobQueue::dummy(),
+                TritonVmJobQueue::get_instance(),
                 TritonVmJobPriority::default().into(),
                 None,
             )

--- a/src/models/blockchain/transaction/mod.rs
+++ b/src/models/blockchain/transaction/mod.rs
@@ -371,6 +371,8 @@ mod transaction_tests {
     use crate::tests::shared::make_mock_transaction;
     use crate::tests::shared::mock_block_from_transaction_and_msa;
     use crate::util_types::mutator_set::commit;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
 
     #[traced_test]
     #[test]
@@ -390,7 +392,7 @@ mod transaction_tests {
     // `traced_test` macro inserts return type that clippy doesn't like.
     // Macro is at fault.
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn update_single_proof_works() {
         async fn prop(to_be_updated: PrimitiveWitness, mined: PrimitiveWitness) {
             let network = Network::Main;
@@ -447,7 +449,7 @@ mod transaction_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn primitive_witness_update_properties() {
         fn update_with_block(
             to_be_updated: PrimitiveWitness,
@@ -584,7 +586,7 @@ mod transaction_tests {
     // }
 
     // #[traced_test]
-    // #[tokio::test]
+    // #[apply(shared_tokio_runtime)]
     // async fn transaction_is_valid_after_block_update_simple_test() -> Result<()> {
     //     // We need the global state to construct a transaction. This global state
     //     // has a wallet which receives a premine-UTXO.
@@ -645,7 +647,7 @@ mod transaction_tests {
     // }
 
     // #[traced_test]
-    // #[tokio::test]
+    // #[apply(shared_tokio_runtime)]
     // async fn transaction_is_valid_after_block_update_multiple_ios_test() -> Result<()> {
     //     // We need the global state to construct a transaction. This global state
     //     // has a wallet which receives a premine-UTXO.

--- a/src/models/blockchain/transaction/primitive_witness.rs
+++ b/src/models/blockchain/transaction/primitive_witness.rs
@@ -1104,6 +1104,8 @@ mod test {
     use proptest_arbitrary_interop::arb;
     use test_strategy::proptest;
     use tracing_test::traced_test;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
 
     use super::*;
     use crate::config_models::network::Network;
@@ -1748,7 +1750,7 @@ mod test {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn arb_is_valid_unit_test_small() {
         let network = Network::Main;
         for num_inputs in 0..=2 {

--- a/src/models/blockchain/transaction/primitive_witness.rs
+++ b/src/models/blockchain/transaction/primitive_witness.rs
@@ -1092,6 +1092,7 @@ pub mod neptune_arbitrary {
 mod test {
     use itertools::izip;
     use itertools::Itertools;
+    use macro_rules_attr::apply;
     use num_traits::CheckedAdd;
     use num_traits::CheckedSub;
     use num_traits::Zero;
@@ -1104,8 +1105,6 @@ mod test {
     use proptest_arbitrary_interop::arb;
     use test_strategy::proptest;
     use tracing_test::traced_test;
-    use macro_rules_attr::apply;
-    use crate::tests::shared_tokio_runtime;
 
     use super::*;
     use crate::config_models::network::Network;
@@ -1120,6 +1119,7 @@ mod test {
     use crate::models::proof_abstractions::tasm::program::ConsensusProgram;
     use crate::models::proof_abstractions::timestamp::Timestamp;
     use crate::models::state::wallet::address::hash_lock_key::HashLockKey;
+    use crate::tests::shared_tokio_runtime;
     use crate::util_types::mutator_set::commit;
     use crate::util_types::mutator_set::msa_and_records::MsaAndRecords;
     use crate::util_types::mutator_set::removal_record::RemovalRecord;

--- a/src/models/blockchain/transaction/validity/single_proof.rs
+++ b/src/models/blockchain/transaction/validity/single_proof.rs
@@ -729,6 +729,8 @@ mod test {
     use crate::models::proof_abstractions::tasm::program::test::ConsensusProgramSpecification;
     use crate::models::proof_abstractions::tasm::program::ConsensusError;
     use crate::models::proof_abstractions::timestamp::Timestamp;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
 
     impl ConsensusProgramSpecification for SingleProof {
         fn source(&self) {
@@ -815,7 +817,7 @@ mod test {
         }
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn invalid_discriminant_crashes_execution() {
         let pub_input = PublicInput::new(bfe_vec![0, 0, 0, 0, 0]);
         for illegal_discriminant_value in bfe_array![-1, 3, 4, 1u64 << 40] {
@@ -849,7 +851,7 @@ mod test {
 
         use super::*;
 
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn disallow_set_merge_bit_in_pc_path() {
             let mut test_runner = TestRunner::deterministic();
             let good_primitive_witness =
@@ -899,7 +901,7 @@ mod test {
                 .unwrap();
         }
 
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn can_verify_via_valid_proof_collection() {
             let network = Network::Main;
             let mut test_runner = TestRunner::deterministic();
@@ -934,7 +936,7 @@ mod test {
         }
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn can_verify_via_valid_proof_collection_if_timelocked_expired() {
             let network = Network::Main;
             let mut test_runner = TestRunner::deterministic();
@@ -972,7 +974,7 @@ mod test {
 
         use super::*;
 
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn can_verify_transaction_merger_without_coinbase() {
             let merge_witness = deterministic_merge_witness((2, 2, 2), (2, 2, 2)).await;
             let merge_witness = SingleProofWitness::Merger(merge_witness);
@@ -985,7 +987,7 @@ mod test {
             assert_eq!(rust_result.unwrap(), tasm_result.unwrap());
         }
 
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn can_verify_transaction_merger_with_coinbase() {
             let merge_witness = deterministic_merge_witness_with_coinbase(3, 3, 3).await;
             let merge_witness = SingleProofWitness::Merger(merge_witness);
@@ -1026,36 +1028,36 @@ mod test {
             assert_eq!(rust_result.unwrap(), tasm_result.unwrap());
         }
 
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn only_additions_small() {
             positive_prop(
                 deterministic_update_witness_only_additions_to_mutator_set(2, 2, 2).await,
             );
         }
 
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn only_additions_medium() {
             positive_prop(
                 deterministic_update_witness_only_additions_to_mutator_set(4, 4, 4).await,
             );
         }
 
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn addition_and_removals_tiny() {
             positive_prop(deterministic_update_witness_additions_and_removals(1, 1, 1).await);
         }
 
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn addition_and_removals_small() {
             positive_prop(deterministic_update_witness_additions_and_removals(2, 2, 2).await);
         }
 
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn addition_and_removals_midi() {
             positive_prop(deterministic_update_witness_additions_and_removals(3, 3, 3).await);
         }
 
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn addition_and_removals_medium() {
             positive_prop(deterministic_update_witness_additions_and_removals(4, 4, 4).await);
         }
@@ -1205,7 +1207,7 @@ mod test {
             test_result.unwrap();
         }
 
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn update_witness_negative_tests() {
             // It takes a long time to generate the witness, so we reuse it across
             // multiple tests
@@ -1220,7 +1222,7 @@ mod test {
             bad_absolute_index_set_length_too_long(&good_witness);
         }
 
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn disallow_update_of_tx_with_zero_inputs() {
             let only_new_additions_0_outputs =
                 deterministic_update_witness_only_additions_to_mutator_set(0, 0, 0).await;

--- a/src/models/blockchain/transaction/validity/single_proof.rs
+++ b/src/models/blockchain/transaction/validity/single_proof.rs
@@ -862,7 +862,7 @@ mod test {
 
             let good_proof_collection = ProofCollection::produce(
                 &good_primitive_witness,
-                TritonVmJobQueue::dummy(),
+                TritonVmJobQueue::get_instance(),
                 TritonVmJobPriority::default().into(),
             )
             .await
@@ -881,7 +881,7 @@ mod test {
 
             let bad_proof_collection = ProofCollection::produce(
                 &bad_primitive_witness,
-                TritonVmJobQueue::dummy(),
+                TritonVmJobQueue::get_instance(),
                 TritonVmJobPriority::default().into(),
             )
             .await
@@ -913,7 +913,7 @@ mod test {
 
             let proof_collection = ProofCollection::produce(
                 &primitive_witness,
-                TritonVmJobQueue::dummy(),
+                TritonVmJobQueue::get_instance(),
                 TritonVmJobPriority::default().into(),
             )
             .await
@@ -953,7 +953,7 @@ mod test {
 
             let proof_collection = ProofCollection::produce(
                 &primitive_witness,
-                TritonVmJobQueue::dummy(),
+                TritonVmJobQueue::get_instance(),
                 TritonVmJobPriority::default().into(),
             )
             .await

--- a/src/models/blockchain/transaction/validity/single_proof.rs
+++ b/src/models/blockchain/transaction/validity/single_proof.rs
@@ -710,6 +710,7 @@ impl ConsensusProgram for SingleProof {
 #[cfg(test)]
 mod test {
     use assert2::let_assert;
+    use macro_rules_attr::apply;
     use proptest::prelude::Strategy;
     use proptest::strategy::ValueTree;
     use proptest::test_runner::TestRunner;
@@ -729,7 +730,6 @@ mod test {
     use crate::models::proof_abstractions::tasm::program::test::ConsensusProgramSpecification;
     use crate::models::proof_abstractions::tasm::program::ConsensusError;
     use crate::models::proof_abstractions::timestamp::Timestamp;
-    use macro_rules_attr::apply;
     use crate::tests::shared_tokio_runtime;
 
     impl ConsensusProgramSpecification for SingleProof {

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_collect_lock_scripts_claim.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_collect_lock_scripts_claim.rs
@@ -201,7 +201,7 @@ mod tests {
             let proof_collection = rt
                 .block_on(ProofCollection::produce(
                     &primitive_witness,
-                    TritonVmJobQueue::dummy(),
+                    TritonVmJobQueue::get_instance(),
                     TritonVmJobPriority::default().into(),
                 ))
                 .unwrap();

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_collect_lock_scripts_claim.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_collect_lock_scripts_claim.rs
@@ -196,7 +196,7 @@ mod tests {
                     .new_tree(&mut test_runner)
                     .unwrap()
                     .current();
-            let rt = tokio::runtime::Runtime::new().unwrap();
+            let rt = crate::tests::tokio_runtime();
             let _guard = rt.enter();
             let proof_collection = rt
                 .block_on(ProofCollection::produce(

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_collect_type_scripts_claim.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_collect_type_scripts_claim.rs
@@ -245,7 +245,7 @@ mod tests {
                 .unwrap()
                 .current()
             };
-            let rt = tokio::runtime::Runtime::new().unwrap();
+            let rt = crate::tests::tokio_runtime();
             let _guard = rt.enter();
             let proof_collection = rt
                 .block_on(ProofCollection::produce(

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_collect_type_scripts_claim.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_collect_type_scripts_claim.rs
@@ -250,7 +250,7 @@ mod tests {
             let proof_collection = rt
                 .block_on(ProofCollection::produce(
                     &primitive_witness,
-                    TritonVmJobQueue::dummy(),
+                    TritonVmJobQueue::get_instance(),
                     TritonVmJobPriority::default().into(),
                 ))
                 .unwrap();

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_k2o_claim.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_k2o_claim.rs
@@ -197,7 +197,7 @@ mod tests {
                 .new_tree(&mut test_runner)
                 .unwrap()
                 .current();
-            let rt = tokio::runtime::Runtime::new().unwrap();
+            let rt = crate::tests::tokio_runtime();
             let _guard = rt.enter();
             let proof_collection = rt
                 .block_on(ProofCollection::produce(

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_k2o_claim.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_k2o_claim.rs
@@ -202,7 +202,7 @@ mod tests {
             let proof_collection = rt
                 .block_on(ProofCollection::produce(
                     &primitive_witness,
-                    TritonVmJobQueue::dummy(),
+                    TritonVmJobQueue::get_instance(),
                     TritonVmJobPriority::default().into(),
                 ))
                 .unwrap();

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_lock_script_claim_template.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_lock_script_claim_template.rs
@@ -135,7 +135,7 @@ mod test {
             let proof_collection = rt
                 .block_on(ProofCollection::produce(
                     &primitive_witness,
-                    TritonVmJobQueue::dummy(),
+                    TritonVmJobQueue::get_instance(),
                     TritonVmJobPriority::default().into(),
                 ))
                 .unwrap();

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_lock_script_claim_template.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_lock_script_claim_template.rs
@@ -130,7 +130,7 @@ mod test {
                 .new_tree(&mut test_runner)
                 .unwrap()
                 .current();
-            let rt = tokio::runtime::Runtime::new().unwrap();
+            let rt = crate::tests::tokio_runtime();
             let _guard = rt.enter();
             let proof_collection = rt
                 .block_on(ProofCollection::produce(

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_rri_claim.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_rri_claim.rs
@@ -203,7 +203,7 @@ mod tests {
             let proof_collection = rt
                 .block_on(ProofCollection::produce(
                     &primitive_witness,
-                    TritonVmJobQueue::dummy(),
+                    TritonVmJobQueue::get_instance(),
                     TritonVmJobPriority::default().into(),
                 ))
                 .unwrap();

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_rri_claim.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_rri_claim.rs
@@ -198,7 +198,7 @@ mod tests {
                 .new_tree(&mut test_runner)
                 .unwrap()
                 .current();
-            let rt = tokio::runtime::Runtime::new().unwrap();
+            let rt = crate::tests::tokio_runtime();
             let _guard = rt.enter();
             let proof_collection = rt
                 .block_on(ProofCollection::produce(

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_type_script_claim_template.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_type_script_claim_template.rs
@@ -166,7 +166,7 @@ mod test {
             let proof_collection = rt
                 .block_on(ProofCollection::produce(
                     &primitive_witness,
-                    TritonVmJobQueue::dummy(),
+                    TritonVmJobQueue::get_instance(),
                     TritonVmJobPriority::default().into(),
                 ))
                 .unwrap();

--- a/src/models/blockchain/transaction/validity/tasm/claims/generate_type_script_claim_template.rs
+++ b/src/models/blockchain/transaction/validity/tasm/claims/generate_type_script_claim_template.rs
@@ -161,7 +161,7 @@ mod test {
                 .new_tree(&mut test_runner)
                 .unwrap()
                 .current();
-            let rt = tokio::runtime::Runtime::new().unwrap();
+            let rt = crate::tests::tokio_runtime();
             let _guard = rt.enter();
             let proof_collection = rt
                 .block_on(ProofCollection::produce(

--- a/src/models/blockchain/transaction/validity/tasm/single_proof/merge_branch.rs
+++ b/src/models/blockchain/transaction/validity/tasm/single_proof/merge_branch.rs
@@ -1104,14 +1104,14 @@ pub(crate) mod test {
 
         let single_proof_1 = SingleProof::produce(
             &primitive_witness_1,
-            TritonVmJobQueue::dummy(),
+            TritonVmJobQueue::get_instance(),
             TritonVmJobPriority::default().into(),
         )
         .await
         .unwrap();
         let single_proof_2 = SingleProof::produce(
             &primitive_witness_2,
-            TritonVmJobQueue::dummy(),
+            TritonVmJobQueue::get_instance(),
             TritonVmJobPriority::default().into(),
         )
         .await
@@ -1149,14 +1149,14 @@ pub(crate) mod test {
 
         let left_proof = SingleProof::produce(
             &left,
-            TritonVmJobQueue::dummy(),
+            TritonVmJobQueue::get_instance(),
             TritonVmJobPriority::default().into(),
         )
         .await
         .unwrap();
         let right_proof = SingleProof::produce(
             &right,
-            TritonVmJobQueue::dummy(),
+            TritonVmJobQueue::get_instance(),
             TritonVmJobPriority::default().into(),
         )
         .await

--- a/src/models/blockchain/transaction/validity/tasm/single_proof/update_branch.rs
+++ b/src/models/blockchain/transaction/validity/tasm/single_proof/update_branch.rs
@@ -671,6 +671,7 @@ impl BasicSnippet for UpdateBranch {
 
 #[cfg(test)]
 pub(crate) mod test {
+    use macro_rules_attr::apply;
     use proptest::collection::vec;
     use proptest::strategy::Strategy;
     use proptest::strategy::ValueTree;
@@ -678,8 +679,6 @@ pub(crate) mod test {
     use proptest_arbitrary_interop::arb;
     use strum::EnumCount;
     use tasm_lib::triton_vm::prelude::*;
-    use macro_rules_attr::apply;
-    use crate::tests::shared_tokio_runtime;
 
     use super::*;
     use crate::job_queue::triton_vm::TritonVmJobPriority;
@@ -690,6 +689,7 @@ pub(crate) mod test {
     use crate::models::blockchain::transaction::TransactionKernelModifier;
     use crate::models::proof_abstractions::tasm::builtins as tasm;
     use crate::models::proof_abstractions::timestamp::Timestamp;
+    use crate::tests::shared_tokio_runtime;
     use crate::util_types::mutator_set::addition_record::AdditionRecord;
 
     // The main tests are actually in [`../../single_proof.rs`].

--- a/src/models/blockchain/transaction/validity/tasm/single_proof/update_branch.rs
+++ b/src/models/blockchain/transaction/validity/tasm/single_proof/update_branch.rs
@@ -929,7 +929,7 @@ pub(crate) mod test {
             .unwrap();
         let old_proof = SingleProof::produce(
             &old_pw,
-            TritonVmJobQueue::dummy(),
+            TritonVmJobQueue::get_instance(),
             TritonVmJobPriority::default().into(),
         )
         .await
@@ -995,7 +995,7 @@ pub(crate) mod test {
         );
         let old_proof = SingleProof::produce(
             &primitive_witness,
-            TritonVmJobQueue::dummy(),
+            TritonVmJobQueue::get_instance(),
             TritonVmJobPriority::default().into(),
         )
         .await

--- a/src/models/blockchain/transaction/validity/tasm/single_proof/update_branch.rs
+++ b/src/models/blockchain/transaction/validity/tasm/single_proof/update_branch.rs
@@ -678,6 +678,8 @@ pub(crate) mod test {
     use proptest_arbitrary_interop::arb;
     use strum::EnumCount;
     use tasm_lib::triton_vm::prelude::*;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
 
     use super::*;
     use crate::job_queue::triton_vm::TritonVmJobPriority;
@@ -1011,7 +1013,7 @@ pub(crate) mod test {
 
     /// A test of the simple test generator, that it leaves the expected fields
     /// untouched, or at most permuted.
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn txid_is_constant_under_tx_updates_only_additions() {
         let update_witness =
             deterministic_update_witness_only_additions_to_mutator_set(4, 4, 4).await;
@@ -1024,7 +1026,7 @@ pub(crate) mod test {
 
     /// A test of the simple test generator, that it leaves the expected fields
     /// untouched, or at most permuted.
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn txid_is_constant_under_tx_updates_additions_and_removals() {
         let update_witness = deterministic_update_witness_additions_and_removals(4, 4, 4).await;
         assert_eq!(

--- a/src/models/blockchain/type_scripts/native_currency.rs
+++ b/src/models/blockchain/type_scripts/native_currency.rs
@@ -1048,6 +1048,8 @@ pub mod test {
     use proptest_arbitrary_interop::arb;
     use tasm_lib::triton_vm::proof::Claim;
     use test_strategy::proptest;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
 
     use super::*;
     use crate::config_models::network::Network;
@@ -1466,7 +1468,7 @@ pub mod test {
             .unwrap();
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn native_currency_failing_proof() {
         let network = Network::Main;
         let mut test_runner = TestRunner::deterministic();

--- a/src/models/blockchain/type_scripts/native_currency.rs
+++ b/src/models/blockchain/type_scripts/native_currency.rs
@@ -1500,7 +1500,7 @@ pub mod test {
                 txk_mast_hash,
                 salted_input_utxos_hash,
                 salted_output_utxos_hash,
-                TritonVmJobQueue::dummy(),
+                TritonVmJobQueue::get_instance(),
                 TritonVmJobPriority::default().into(),
             )
             .await

--- a/src/models/blockchain/type_scripts/native_currency.rs
+++ b/src/models/blockchain/type_scripts/native_currency.rs
@@ -1039,6 +1039,7 @@ impl SecretWitness for NativeCurrencyWitness {
 pub mod test {
     use std::panic;
 
+    use macro_rules_attr::apply;
     use num_traits::CheckedAdd;
     use num_traits::Zero;
     use proptest::collection::vec;
@@ -1048,8 +1049,6 @@ pub mod test {
     use proptest_arbitrary_interop::arb;
     use tasm_lib::triton_vm::proof::Claim;
     use test_strategy::proptest;
-    use macro_rules_attr::apply;
-    use crate::tests::shared_tokio_runtime;
 
     use super::*;
     use crate::config_models::network::Network;
@@ -1067,6 +1066,7 @@ pub mod test {
     use crate::models::proof_abstractions::tasm::program::ConsensusError;
     use crate::models::proof_abstractions::timestamp::Timestamp;
     use crate::models::proof_abstractions::verifier::verify;
+    use crate::tests::shared_tokio_runtime;
 
     impl ConsensusProgramSpecification for NativeCurrency {
         fn source(&self) {

--- a/src/models/blockchain/type_scripts/time_lock.rs
+++ b/src/models/blockchain/type_scripts/time_lock.rs
@@ -1009,7 +1009,6 @@ mod test {
     use proptest_arbitrary_interop::arb;
     use tasm_lib::twenty_first::math::tip5::Tip5;
     use test_strategy::proptest;
-    use tokio::runtime::Runtime;
 
     use super::neptune_arbitrary::arbitrary_primitive_witness_with_active_timelocks;
     use super::neptune_arbitrary::arbitrary_primitive_witness_with_expired_timelocks;
@@ -1256,10 +1255,8 @@ mod test {
     ) {
         // Negative test: Primitive witness spending inputs that are timelocked
         // must fail to validate.
-        prop_assert!(Runtime::new()
-            .unwrap()
-            .block_on(primitive_witness.validate())
-            .is_err());
+        let rt = crate::tests::tokio_runtime();
+        prop_assert!(rt.block_on(primitive_witness.validate()).is_err());
     }
 
     #[proptest(cases = 10)]

--- a/src/models/peer.rs
+++ b/src/models/peer.rs
@@ -914,6 +914,8 @@ mod tests {
     use crate::models::blockchain::block::block_header::HeaderToBlockHashWitness;
     use crate::models::blockchain::block::Block;
     use crate::tests::shared::fake_valid_sequence_of_blocks_for_tests;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
 
     impl PeerStanding {
         pub fn init(
@@ -931,7 +933,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn sync_challenge_response_pow_witnesses_must_be_a_chain() {
         let network = Network::Main;
         let genesis = Block::genesis(network);

--- a/src/models/peer.rs
+++ b/src/models/peer.rs
@@ -908,13 +908,13 @@ impl SyncChallengeResponse {
 
 #[cfg(test)]
 mod tests {
+    use macro_rules_attr::apply;
     use rand::random;
 
     use super::*;
     use crate::models::blockchain::block::block_header::HeaderToBlockHashWitness;
     use crate::models::blockchain::block::Block;
     use crate::tests::shared::fake_valid_sequence_of_blocks_for_tests;
-    use macro_rules_attr::apply;
     use crate::tests::shared_tokio_runtime;
 
     impl PeerStanding {

--- a/src/models/peer/transfer_block.rs
+++ b/src/models/peer/transfer_block.rs
@@ -73,6 +73,7 @@ impl TryFrom<&Block> for TransferBlock {
 
 #[cfg(test)]
 mod test {
+    use macro_rules_attr::apply;
     use rand::rngs::StdRng;
     use rand::Rng;
     use rand::SeedableRng;
@@ -83,7 +84,6 @@ mod test {
     use crate::models::proof_abstractions::timestamp::Timestamp;
     use crate::tests::shared::fake_valid_sequence_of_blocks_for_tests;
     use crate::tests::shared::invalid_empty_block;
-    use macro_rules_attr::apply;
     use crate::tests::shared_tokio_runtime;
 
     #[test]

--- a/src/models/peer/transfer_block.rs
+++ b/src/models/peer/transfer_block.rs
@@ -83,6 +83,8 @@ mod test {
     use crate::models::proof_abstractions::timestamp::Timestamp;
     use crate::tests::shared::fake_valid_sequence_of_blocks_for_tests;
     use crate::tests::shared::invalid_empty_block;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
 
     #[test]
     fn cannot_transfer_blocks_that_are_not_single_proof_supported() {
@@ -102,7 +104,7 @@ mod test {
 
     // test: verify digest is the same after conversion from
     //       TransferBlock and back.
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     #[traced_test]
     async fn from_transfer_block() {
         let network = Network::Main;

--- a/src/models/proof_abstractions/tasm/program.rs
+++ b/src/models/proof_abstractions/tasm/program.rs
@@ -193,10 +193,9 @@ pub mod test {
     use std::path::PathBuf;
     use std::time::Duration;
     use std::time::SystemTime;
-    use macro_rules_attr::apply;
-    use crate::tests::shared_tokio_runtime;
 
     use itertools::Itertools;
+    use macro_rules_attr::apply;
     use rand::seq::SliceRandom;
     use tasm_lib::triton_vm;
     use tracing::debug;
@@ -207,6 +206,7 @@ pub mod test {
     use crate::models::blockchain::transaction::transaction_proof::TransactionProofType;
     use crate::models::proof_abstractions::tasm::environment;
     use crate::models::state::tx_proving_capability::TxProvingCapability;
+    use crate::tests::shared_tokio_runtime;
     use crate::triton_vm::stark::Stark;
 
     const TEST_DATA_DIR: &str = "test_data";

--- a/src/models/proof_abstractions/tasm/program.rs
+++ b/src/models/proof_abstractions/tasm/program.rs
@@ -193,6 +193,8 @@ pub mod test {
     use std::path::PathBuf;
     use std::time::Duration;
     use std::time::SystemTime;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
 
     use itertools::Itertools;
     use rand::seq::SliceRandom;
@@ -598,7 +600,7 @@ pub mod test {
         None
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn test_query_proof() {
         // Ensure file exists on machine, in case this machine syncs automatically with proof server
         let program = triton_program!(halt);

--- a/src/models/proof_abstractions/tasm/program.rs
+++ b/src/models/proof_abstractions/tasm/program.rs
@@ -609,7 +609,7 @@ pub mod test {
             program,
             claim.clone(),
             NonDeterminism::default(),
-            TritonVmJobQueue::dummy(),
+            TritonVmJobQueue::get_instance(),
             TritonVmProofJobOptions::default(),
         )
         .await

--- a/src/models/proof_abstractions/verifier.rs
+++ b/src/models/proof_abstractions/verifier.rs
@@ -84,13 +84,13 @@ pub(crate) async fn cache_true_claim(claim: Claim) {
 #[cfg(test)]
 pub(crate) mod test {
     use itertools::Itertools;
+    use macro_rules_attr::apply;
     use rand::Rng;
     use tasm_lib::prelude::Tip5;
     use triton_vm::prelude::BFieldCodec;
-    use macro_rules_attr::apply;
-    use crate::tests::shared_tokio_runtime;
 
     use super::*;
+    use crate::tests::shared_tokio_runtime;
 
     pub(crate) fn bogus_proof(claim: &Claim) -> Proof {
         Proof::from(Tip5::hash_varlen(&claim.encode()).values().to_vec())

--- a/src/models/proof_abstractions/verifier.rs
+++ b/src/models/proof_abstractions/verifier.rs
@@ -87,6 +87,8 @@ pub(crate) mod test {
     use rand::Rng;
     use tasm_lib::prelude::Tip5;
     use triton_vm::prelude::BFieldCodec;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
 
     use super::*;
 
@@ -94,7 +96,7 @@ pub(crate) mod test {
         Proof::from(Tip5::hash_varlen(&claim.encode()).values().to_vec())
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn test_claims_cache() {
         let network = Network::Main;
 

--- a/src/models/state/archival_state.rs
+++ b/src/models/state/archival_state.rs
@@ -1844,7 +1844,7 @@ mod archival_state_tests {
             .merge_with(
                 tx_to_alice_and_bob.into(),
                 Default::default(),
-                TritonVmJobQueue::dummy(),
+                TritonVmJobQueue::get_instance(),
                 TritonVmJobPriority::default().into(),
             )
             .await
@@ -1856,7 +1856,7 @@ mod archival_state_tests {
             block_tx,
             in_seven_months,
             None,
-            TritonVmJobQueue::dummy(),
+            TritonVmJobQueue::get_instance(),
             TritonVmJobPriority::default().into(),
         )
         .await
@@ -2097,7 +2097,7 @@ mod archival_state_tests {
             .merge_with(
                 tx_from_alice.into(),
                 Default::default(),
-                TritonVmJobQueue::dummy(),
+                TritonVmJobQueue::get_instance(),
                 TritonVmJobPriority::default().into(),
             )
             .await
@@ -2105,7 +2105,7 @@ mod archival_state_tests {
             .merge_with(
                 tx_from_bob.into(),
                 Default::default(),
-                TritonVmJobQueue::dummy(),
+                TritonVmJobQueue::get_instance(),
                 TritonVmJobPriority::default().into(),
             )
             .await
@@ -2115,7 +2115,7 @@ mod archival_state_tests {
             block_tx2,
             in_seven_months + MINIMUM_BLOCK_TIME,
             None,
-            TritonVmJobQueue::dummy(),
+            TritonVmJobQueue::get_instance(),
             TritonVmJobPriority::default().into(),
         )
         .await

--- a/src/models/state/archival_state.rs
+++ b/src/models/state/archival_state.rs
@@ -1134,6 +1134,7 @@ impl ArchivalState {
 mod archival_state_tests {
 
     use itertools::Itertools;
+    use macro_rules_attr::apply;
     use rand::random;
     use rand::rngs::StdRng;
     use rand::Rng;
@@ -1170,9 +1171,8 @@ mod archival_state_tests {
     use crate::tests::shared::mock_genesis_global_state;
     use crate::tests::shared::mock_genesis_wallet_state;
     use crate::tests::shared::unit_test_databases;
-    use crate::util_types::test_shared::mutator_set::random_removal_record;
-    use macro_rules_attr::apply;
     use crate::tests::shared_tokio_runtime;
+    use crate::util_types::test_shared::mutator_set::random_removal_record;
 
     async fn make_test_archival_state(network: Network) -> ArchivalState {
         let (block_index_db, _peer_db_lock, data_dir) = unit_test_databases(network).await.unwrap();

--- a/src/models/state/archival_state.rs
+++ b/src/models/state/archival_state.rs
@@ -1171,6 +1171,8 @@ mod archival_state_tests {
     use crate::tests::shared::mock_genesis_wallet_state;
     use crate::tests::shared::unit_test_databases;
     use crate::util_types::test_shared::mutator_set::random_removal_record;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
 
     async fn make_test_archival_state(network: Network) -> ArchivalState {
         let (block_index_db, _peer_db_lock, data_dir) = unit_test_databases(network).await.unwrap();
@@ -1187,7 +1189,7 @@ mod archival_state_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn initialize_archival_state_test() -> Result<()> {
         // Ensure that the archival state can be initialized without overflowing the stack
         let seed: [u8; 32] = rand::rng().random();
@@ -1214,7 +1216,7 @@ mod archival_state_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn archival_state_init_test() -> Result<()> {
         // Verify that archival mutator set is populated with outputs from genesis block
         let network = Network::RegTest;
@@ -1265,7 +1267,7 @@ mod archival_state_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn archival_state_restore_test() -> Result<()> {
         let mut rng = rand::rng();
         // Verify that a restored archival mutator set is populated with the right `sync_label`
@@ -1303,7 +1305,7 @@ mod archival_state_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn update_mutator_set_db_write_test() {
         // Verify that `update_mutator_set` writes the active window back to disk.
         // Creates blocks and transaction with invalid proofs.
@@ -1389,7 +1391,7 @@ mod archival_state_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn update_mutator_set_rollback_ms_block_sync_test() -> Result<()> {
         let mut rng = rand::rng();
         let network = Network::Alpha;
@@ -1431,7 +1433,7 @@ mod archival_state_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn update_mutator_set_rollback_ms_block_sync_multiple_inputs_outputs_in_block_test() {
         // Make a rollback of one block that contains multiple inputs and outputs.
         // This test is intended to verify that rollbacks work for non-trivial
@@ -1524,7 +1526,7 @@ mod archival_state_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn update_mutator_set_rollback_many_blocks_multiple_inputs_outputs_test() {
         // Make a rollback of multiple blocks that contains multiple inputs and outputs.
         // This test is intended to verify that rollbacks work for non-trivial
@@ -1706,7 +1708,7 @@ mod archival_state_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn allow_multiple_inputs_and_outputs_in_block() {
         // Test various parts of the state update when a block contains multiple inputs and outputs
         let network = Network::Main;
@@ -2223,7 +2225,7 @@ mod archival_state_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn get_tip_block_test() -> Result<()> {
         for network in [
             Network::Alpha,
@@ -2312,7 +2314,7 @@ mod archival_state_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn get_block_test() -> Result<()> {
         let mut rng = rand::rng();
         let network = Network::Alpha;
@@ -2385,7 +2387,7 @@ mod archival_state_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn ms_update_to_tip_genesis() {
         let network = Network::Main;
         let mut archival_state = make_test_archival_state(network).await;
@@ -2427,7 +2429,7 @@ mod archival_state_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn ms_update_to_tip_five_blocks() {
         let network = Network::Main;
         let wallet = WalletEntropy::new_random();
@@ -2472,7 +2474,7 @@ mod archival_state_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn find_canonical_block_with_aocl_index_five_blocks() {
         let network = Network::Main;
         let wallet = WalletEntropy::new_random();
@@ -2534,7 +2536,7 @@ mod archival_state_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn find_canonical_block_with_aocl_index_genesis() {
         for network in Network::iter() {
             let archival_state = make_test_archival_state(network).await;
@@ -2566,7 +2568,7 @@ mod archival_state_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn find_canonical_block_with_output_genesis_block_test() {
         let network = Network::Main;
         let archival_state = make_test_archival_state(network).await;
@@ -2588,7 +2590,7 @@ mod archival_state_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn find_canonical_block_with_input_genesis_block_test() {
         let network = Network::Main;
         let archival_state = make_test_archival_state(network).await;
@@ -2601,7 +2603,7 @@ mod archival_state_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn ms_update_to_tip_fork_depth_1() {
         let mut rng = rand::rng();
         let network = Network::Main;
@@ -2645,7 +2647,7 @@ mod archival_state_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn ms_update_to_tip_fork_depth_2() {
         let mut rng = rand::rng();
         let network = Network::Main;
@@ -2733,7 +2735,7 @@ mod archival_state_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn find_path_simple_test() -> Result<()> {
         let mut rng = rand::rng();
         let network = Network::Alpha;
@@ -2817,7 +2819,7 @@ mod archival_state_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn fork_path_finding_test() -> Result<()> {
         let mut rng = rand::rng();
         // Test behavior of fork-resolution functions such as `find_path` and checking if block
@@ -3217,7 +3219,7 @@ mod archival_state_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn block_belongs_to_canonical_chain_doesnt_crash_on_unknown_block() {
         let archival_state = make_test_archival_state(Network::Main).await;
         assert!(
@@ -3229,7 +3231,7 @@ mod archival_state_tests {
 
     #[should_panic]
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn digest_of_ancestors_panic_test() {
         let archival_state = make_test_archival_state(Network::Alpha).await;
 
@@ -3240,7 +3242,7 @@ mod archival_state_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn digest_of_ancestors_test() {
         let mut rng = rand::rng();
         let mut archival_state = make_test_archival_state(Network::Alpha).await;
@@ -3339,7 +3341,7 @@ mod archival_state_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn write_block_db_test() -> Result<()> {
         let mut rng = rand::rng();
         let mut archival_state = make_test_archival_state(Network::Alpha).await;
@@ -3567,7 +3569,7 @@ mod archival_state_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn can_initialize_mutator_set_database() {
         let args: cli_args::Args = cli_args::Args::default();
         let data_dir = DataDirectory::get(args.data_dir.clone(), args.network).unwrap();
@@ -3582,7 +3584,7 @@ mod archival_state_tests {
         use crate::tests::shared::fake_valid_sequence_of_blocks_for_tests;
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn stored_block_hash_witness_agrees_with_block_hash() {
             let network = Network::Main;
             let mut rng = rand::rng();

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -892,8 +892,10 @@ mod tests {
     use crate::tests::shared::make_plenty_mock_transaction_supported_by_invalid_single_proofs;
     use crate::tests::shared::make_plenty_mock_transaction_supported_by_primitive_witness;
     use crate::tests::shared::mock_genesis_global_state;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     pub async fn insert_then_get_then_remove_then_get() {
         let network = Network::Main;
         let genesis_block = Block::genesis(network);
@@ -985,7 +987,7 @@ mod tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn get_densest_transactions_no_tx_cap() {
         // Verify that transactions are returned ordered by fee density, with highest fee density first
         let num_txs = 10;
@@ -1008,7 +1010,7 @@ mod tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn get_densest_transactions_with_tx_cap() {
         // Verify that transactions are returned ordered by fee density, with highest fee density first
         let num_txs = 12;
@@ -1034,7 +1036,7 @@ mod tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn most_dense_proof_collection_test() {
         let network = Network::Main;
         let sync_block = Block::genesis(network);
@@ -1089,7 +1091,7 @@ mod tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn get_sorted_iter() {
         // Verify that the function `get_sorted_iter` returns transactions sorted by fee density
         let network = Network::Main;
@@ -1108,7 +1110,7 @@ mod tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn max_num_transactions_is_respected() {
         let network = Network::Main;
         let sync_block = Block::genesis(network);
@@ -1227,7 +1229,7 @@ mod tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn prune_stale_transactions() {
         let network = Network::Alpha;
         let genesis_block = Block::genesis(network);
@@ -1257,7 +1259,7 @@ mod tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn remove_transactions_with_block_test() {
         // Check that the mempool removes transactions that were incorporated or
         // made unconfirmable by the new block.
@@ -1529,7 +1531,7 @@ mod tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn merged_tx_kicks_out_merge_inputs() {
         /// Returns three transactions: Two transactions that are input to the
         /// transaction-merge function, and the resulting merged transaction.
@@ -1629,7 +1631,7 @@ mod tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn reorganization_does_not_crash_mempool() {
         // Verify that reorganizations do not crash the client, and other
         // qualities.
@@ -1770,7 +1772,7 @@ mod tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn conflicting_txs_preserve_highest_fee() {
         // Create a global state object, controlled by a preminer who receives a premine-UTXO.
         let network = Network::Main;
@@ -1873,7 +1875,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn single_proof_flag_is_respected() {
         let network = Network::Main;
         let genesis_block = Block::genesis(network);
@@ -1889,7 +1891,7 @@ mod tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn max_len_none() {
         let network = Network::Main;
         let genesis_block = Block::genesis(network);
@@ -1908,7 +1910,7 @@ mod tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn max_len_is_respected() {
         let network = Network::Main;
         let genesis_block = Block::genesis(network);
@@ -1942,7 +1944,7 @@ mod tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn get_mempool_size() {
         // Verify that the `get_size` method on mempool returns sane results
         let network = Network::Main;
@@ -2024,7 +2026,7 @@ mod tests {
         }
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn single_proof_always_replaces_primitive_witness() {
             let network = Network::Main;
             let pw_high_fee = tx_with_proof_type(
@@ -2055,7 +2057,7 @@ mod tests {
         }
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn single_proof_always_replaces_proof_collection() {
             let network = Network::Main;
             let pc_high_fee = tx_with_proof_type(
@@ -2086,7 +2088,7 @@ mod tests {
         }
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn proof_collection_always_replaces_proof_primitive_witness() {
             let network = Network::Main;
             let pc_high_fee = tx_with_proof_type(

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -852,6 +852,7 @@ impl Mempool {
 #[cfg(test)]
 mod tests {
     use itertools::Itertools;
+    use macro_rules_attr::apply;
     use num_bigint::BigInt;
     use num_traits::One;
     use num_traits::Zero;
@@ -892,7 +893,6 @@ mod tests {
     use crate::tests::shared::make_plenty_mock_transaction_supported_by_invalid_single_proofs;
     use crate::tests::shared::make_plenty_mock_transaction_supported_by_primitive_witness;
     use crate::tests::shared::mock_genesis_global_state;
-    use macro_rules_attr::apply;
     use crate::tests::shared_tokio_runtime;
 
     #[apply(shared_tokio_runtime)]

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -967,7 +967,7 @@ mod tests {
         for job in update_jobs {
             let updated = job
                 .upgrade(
-                    TritonVmJobQueue::dummy(),
+                    TritonVmJobQueue::get_instance(),
                     TritonVmJobPriority::Highest.into(),
                 )
                 .await
@@ -1425,7 +1425,7 @@ mod tests {
             .merge_with(
                 coinbase_transaction,
                 Default::default(),
-                TritonVmJobQueue::dummy(),
+                TritonVmJobQueue::get_instance(),
                 TritonVmJobPriority::default().into(),
             )
             .await
@@ -1503,7 +1503,7 @@ mod tests {
             .merge_with(
                 tx_by_alice_updated,
                 Default::default(),
-                TritonVmJobQueue::dummy(),
+                TritonVmJobQueue::get_instance(),
                 TritonVmJobPriority::default().into(),
             )
             .await
@@ -1547,14 +1547,14 @@ mod tests {
 
             let left_single_proof = SingleProof::produce(
                 &left,
-                TritonVmJobQueue::dummy(),
+                TritonVmJobQueue::get_instance(),
                 TritonVmJobPriority::default().into(),
             )
             .await
             .unwrap();
             let right_single_proof = SingleProof::produce(
                 &right,
-                TritonVmJobQueue::dummy(),
+                TritonVmJobQueue::get_instance(),
                 TritonVmJobPriority::default().into(),
             )
             .await
@@ -1577,7 +1577,7 @@ mod tests {
                 left.clone(),
                 right.clone(),
                 shuffle_seed,
-                TritonVmJobQueue::dummy(),
+                TritonVmJobQueue::get_instance(),
                 TritonVmJobPriority::default().into(),
             )
             .await

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -2690,7 +2690,7 @@ mod global_state_tests {
             .merge_with(
                 coinbase_transaction,
                 Default::default(),
-                TritonVmJobQueue::dummy(),
+                TritonVmJobQueue::get_instance(),
                 TritonVmJobPriority::default().into(),
             )
             .await
@@ -2704,7 +2704,7 @@ mod global_state_tests {
             block_transaction,
             in_seven_months,
             None,
-            TritonVmJobQueue::dummy(),
+            TritonVmJobQueue::get_instance(),
             TritonVmJobPriority::default().into(),
         )
         .await
@@ -2927,7 +2927,7 @@ mod global_state_tests {
             .merge_with(
                 tx_from_alice.into(),
                 Default::default(),
-                TritonVmJobQueue::dummy(),
+                TritonVmJobQueue::get_instance(),
                 TritonVmJobPriority::default().into(),
             )
             .await
@@ -2935,7 +2935,7 @@ mod global_state_tests {
             .merge_with(
                 tx_from_bob.into(),
                 Default::default(),
-                TritonVmJobQueue::dummy(),
+                TritonVmJobQueue::get_instance(),
                 TritonVmJobPriority::default().into(),
             )
             .await
@@ -2950,7 +2950,7 @@ mod global_state_tests {
             block_transaction2,
             in_eight_months,
             None,
-            TritonVmJobQueue::dummy(),
+            TritonVmJobQueue::get_instance(),
             TritonVmJobPriority::default().into(),
         )
         .await
@@ -3880,7 +3880,7 @@ mod global_state_tests {
                     block_1_tx,
                     seven_months_post_launch,
                     None,
-                    TritonVmJobQueue::dummy(),
+                    TritonVmJobQueue::get_instance(),
                     TritonVmJobPriority::default().into(),
                 )
                 .await

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -1693,6 +1693,7 @@ impl GlobalState {
 #[cfg(test)]
 mod global_state_tests {
     use itertools::Itertools;
+    use macro_rules_attr::apply;
     use num_traits::Zero;
     use rand::random;
     use rand::rngs::StdRng;
@@ -1722,7 +1723,6 @@ mod global_state_tests {
     use crate::tests::shared::mock_genesis_global_state;
     use crate::tests::shared::state_with_premine_and_self_mined_blocks;
     use crate::tests::shared::wallet_state_has_all_valid_mps;
-    use macro_rules_attr::apply;
     use crate::tests::shared_tokio_runtime;
 
     mod handshake {

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -1722,11 +1722,13 @@ mod global_state_tests {
     use crate::tests::shared::mock_genesis_global_state;
     use crate::tests::shared::state_with_premine_and_self_mined_blocks;
     use crate::tests::shared::wallet_state_has_all_valid_mps;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
 
     mod handshake {
         use super::*;
 
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn generating_own_handshake_doesnt_crash() {
             mock_genesis_global_state(
                 Network::Main,
@@ -1741,7 +1743,7 @@ mod global_state_tests {
         }
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn handshakes_listen_port_is_some_when_max_peers_is_default() {
             let network = Network::Main;
             let bob = mock_genesis_global_state(
@@ -1761,7 +1763,7 @@ mod global_state_tests {
         }
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn handshakes_listen_port_is_none_when_max_peers_is_zero() {
             let network = Network::Main;
             let mut bob = mock_genesis_global_state(
@@ -1786,7 +1788,7 @@ mod global_state_tests {
         }
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn set_new_tip_clears_block_proposal_related_data() {
         let network = Network::Main;
         let mut bob = mock_genesis_global_state(
@@ -1816,7 +1818,7 @@ mod global_state_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn premine_recipient_cannot_spend_premine_before_and_can_after_release_date() {
         let network = Network::Main;
         let mut rng = StdRng::seed_from_u64(u64::from_str_radix("3014221", 6).unwrap());
@@ -1942,7 +1944,7 @@ mod global_state_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn restore_monitored_utxos_from_recovery_data_duplicated_entries() {
         // Verify that duplicated entries in `incoming_randomness.dat` are
         // handled correctly.
@@ -2039,7 +2041,7 @@ mod global_state_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn restore_monitored_utxos_from_recovery_data_test() {
         let network = Network::Main;
         let mut rng = rand::rng();
@@ -2198,7 +2200,7 @@ mod global_state_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn resync_ms_membership_proofs_simple_test() -> Result<()> {
         let mut rng = rand::rng();
         let network = Network::RegTest;
@@ -2255,7 +2257,7 @@ mod global_state_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn resync_ms_membership_proofs_fork_test() -> Result<()> {
         let network = Network::Main;
         let mut rng = rand::rng();
@@ -2348,7 +2350,7 @@ mod global_state_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn resync_ms_membership_proofs_across_stale_fork() {
         /// Create 3 branches and return them in an array.
         ///
@@ -2548,7 +2550,7 @@ mod global_state_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn flaky_mutator_set_test() {
         // Test various parts of the state update when a block contains multiple inputs and outputs
         // Scenario: Three parties: Alice, Bob, and Premine Receiver, mine blocks and pass coins
@@ -2960,7 +2962,7 @@ mod global_state_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn mock_global_state_is_valid() {
         // Verify that the states, not just the blocks, are valid.
 
@@ -3004,7 +3006,7 @@ mod global_state_tests {
         );
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn favor_incoming_block_proposal_test() {
         async fn block1_proposal(global_state_lock: &GlobalStateLock) -> Block {
             let genesis_block = Block::genesis(global_state_lock.cli().network);
@@ -3237,7 +3239,7 @@ mod global_state_tests {
         }
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn can_handle_deep_reorganization() {
             // Mine 60 blocks, then switch to a new chain branching off from
             // genesis block. Verify that state is integral after each block.
@@ -3307,7 +3309,7 @@ mod global_state_tests {
         }
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn can_store_block_without_marking_it_as_tip_1_block() {
             // Verify that [GlobalState::store_block_not_tip] stores block
             // correctly, and that [GlobalState::set_new_tip] can be used to
@@ -3366,7 +3368,7 @@ mod global_state_tests {
         }
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn can_jump_to_new_tip_over_blocks_that_were_never_tips() {
             let network = Network::Main;
             let wallet_secret = WalletEntropy::new_random();
@@ -3429,7 +3431,7 @@ mod global_state_tests {
         }
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn reorganization_with_blocks_that_were_never_tips_n_blocks_deep() {
             // Verify that [GlobalState::store_block_not_tip] stores block
             // correctly, and that [GlobalState::set_new_tip] can be used to
@@ -3476,7 +3478,7 @@ mod global_state_tests {
         }
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn set_new_tip_can_roll_back() {
             // Verify that [GlobalState::set_new_tip] works for rolling back the
             // blockchain to a previous block.
@@ -3587,7 +3589,7 @@ mod global_state_tests {
         }
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn setting_same_tip_twice_is_allowed() {
             let mut rng = rand::rng();
             let network = Network::Main;
@@ -3659,7 +3661,7 @@ mod global_state_tests {
         ///
         /// test described in [change_exists()]
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn onchain_symmetric_change_exists() {
             change_exists(UtxoNotificationMedium::OnChain, KeyType::Symmetric).await
         }
@@ -3669,7 +3671,7 @@ mod global_state_tests {
         ///
         /// test described in [change_exists()]
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn onchain_generation_change_exists() {
             change_exists(UtxoNotificationMedium::OnChain, KeyType::Generation).await
         }
@@ -3679,7 +3681,7 @@ mod global_state_tests {
         ///
         /// test described in [change_exists()]
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn offchain_symmetric_change_exists() {
             change_exists(UtxoNotificationMedium::OffChain, KeyType::Symmetric).await
         }
@@ -3689,7 +3691,7 @@ mod global_state_tests {
         ///
         /// test described in [change_exists()]
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn offchain_generation_change_exists() {
             change_exists(UtxoNotificationMedium::OffChain, KeyType::Generation).await
         }

--- a/src/models/state/wallet/migrate_db/v0_to_v1.rs
+++ b/src/models/state/wallet/migrate_db/v0_to_v1.rs
@@ -156,13 +156,15 @@ mod test {
     use crate::tests::shared;
     use crate::tests::shared::unit_test_data_directory;
     use crate::DataDirectory;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
 
     /// tests migrating a simulated v0 wallet db to v1.
     ///
     /// This test uses mock types from v0 wallet to create a v0
     /// database and then migrates it.
     #[tracing_test::traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn migrate() -> anyhow::Result<()> {
         // basics
         let network = Network::Main;
@@ -259,7 +261,7 @@ mod test {
         ignore = "Test disabled on Windows due to LevelDB cross-platform issues"
     )]
     #[tracing_test::traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn migrate_real_v0_db() -> anyhow::Result<()> {
         // basics
         let network = Network::Testnet;

--- a/src/models/state/wallet/migrate_db/v0_to_v1.rs
+++ b/src/models/state/wallet/migrate_db/v0_to_v1.rs
@@ -139,6 +139,7 @@ mod migration {
 
 #[cfg(test)]
 mod test {
+    use macro_rules_attr::apply;
     use tasm_lib::prelude::Digest;
 
     use super::*;
@@ -155,9 +156,8 @@ mod test {
     use crate::models::state::Timestamp;
     use crate::tests::shared;
     use crate::tests::shared::unit_test_data_directory;
-    use crate::DataDirectory;
-    use macro_rules_attr::apply;
     use crate::tests::shared_tokio_runtime;
+    use crate::DataDirectory;
 
     /// tests migrating a simulated v0 wallet db to v1.
     ///

--- a/src/models/state/wallet/mod.rs
+++ b/src/models/state/wallet/mod.rs
@@ -69,13 +69,15 @@ mod wallet_tests {
     use crate::tests::shared::make_mock_transaction_with_mutator_set_hash;
     use crate::tests::shared::mock_genesis_global_state;
     use crate::tests::shared::mock_genesis_wallet_state;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
 
     async fn get_monitored_utxos(wallet_state: &WalletState) -> Vec<MonitoredUtxo> {
         // note: we could just return a DbtVec here and avoid cloning...
         wallet_state.wallet_db.monitored_utxos().get_all().await
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn wallet_state_constructor_with_genesis_block_test() {
         // This test is designed to verify that the genesis block is applied
         // to the wallet state at initialization. For all networks.
@@ -145,7 +147,7 @@ mod wallet_tests {
         }
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn wallet_state_correctly_updates_monitored_and_expected_utxos() {
         let mut rng = rand::rng();
         let network = Network::RegTest;
@@ -261,7 +263,7 @@ mod wallet_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn allocate_sufficient_input_funds_test() {
         // Scenario:
         // Alice is not coinbase recipient. She mines many blocks. It is tested
@@ -499,7 +501,7 @@ mod wallet_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn wallet_state_maintenence_multiple_inputs_outputs_enough_mps_test() {
         // Bob is premine receiver, Alice is not. They send coins back and forth
         // and the blockchain forks. The fork is shallower than the number of
@@ -994,7 +996,7 @@ mod wallet_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn allow_consumption_of_genesis_output_test() {
         let network = Network::Main;
         let genesis_block = Block::genesis(network);
@@ -1074,7 +1076,7 @@ mod wallet_tests {
         assert_eq!(4, block_1.body().transaction_kernel.outputs.len());
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn basic_wallet_secret_functionality_test() {
         let random_wallet_secret = WalletEntropy::new_random();
         let spending_key = random_wallet_secret.nth_generation_spending_key_for_tests(0);
@@ -1239,7 +1241,7 @@ mod wallet_tests {
         }
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn verify_premine_receipt_works_with_test_addresses() {
             let network = Network::Main;
             let cli = cli_args::Args::default();

--- a/src/models/state/wallet/mod.rs
+++ b/src/models/state/wallet/mod.rs
@@ -24,6 +24,7 @@ pub mod wallet_status;
 mod wallet_tests {
     use expected_utxo::ExpectedUtxo;
     use itertools::Itertools;
+    use macro_rules_attr::apply;
     use num_traits::CheckedSub;
     use num_traits::Zero;
     use rand::random;
@@ -69,7 +70,6 @@ mod wallet_tests {
     use crate::tests::shared::make_mock_transaction_with_mutator_set_hash;
     use crate::tests::shared::mock_genesis_global_state;
     use crate::tests::shared::mock_genesis_wallet_state;
-    use macro_rules_attr::apply;
     use crate::tests::shared_tokio_runtime;
 
     async fn get_monitored_utxos(wallet_state: &WalletState) -> Vec<MonitoredUtxo> {

--- a/src/models/state/wallet/mod.rs
+++ b/src/models/state/wallet/mod.rs
@@ -855,7 +855,7 @@ mod wallet_tests {
             .merge_with(
                 tx_from_bob,
                 Default::default(),
-                TritonVmJobQueue::dummy(),
+                TritonVmJobQueue::get_instance(),
                 TritonVmJobPriority::default().into(),
             )
             .await
@@ -866,7 +866,7 @@ mod wallet_tests {
             merged_tx,
             timestamp,
             None,
-            TritonVmJobQueue::dummy(),
+            TritonVmJobQueue::get_instance(),
             TritonVmJobPriority::default().into(),
         )
         .await
@@ -1048,7 +1048,7 @@ mod wallet_tests {
             .merge_with(
                 cbtx,
                 Default::default(),
-                TritonVmJobQueue::dummy(),
+                TritonVmJobQueue::get_instance(),
                 TritonVmJobPriority::default().into(),
             )
             .await
@@ -1058,7 +1058,7 @@ mod wallet_tests {
             tx_for_block,
             in_seven_months,
             None,
-            TritonVmJobQueue::dummy(),
+            TritonVmJobQueue::get_instance(),
             TritonVmJobPriority::default().into(),
         )
         .await

--- a/src/models/state/wallet/transaction_output.rs
+++ b/src/models/state/wallet/transaction_output.rs
@@ -659,6 +659,7 @@ impl TxOutputList {
 
 #[cfg(test)]
 mod tests {
+    use macro_rules_attr::apply;
     use rand::Rng;
 
     use super::*;
@@ -670,7 +671,6 @@ mod tests {
     use crate::models::state::wallet::address::KeyType;
     use crate::models::state::wallet::wallet_entropy::WalletEntropy;
     use crate::tests::shared::mock_genesis_global_state;
-    use macro_rules_attr::apply;
     use crate::tests::shared_tokio_runtime;
 
     impl TxOutput {

--- a/src/models/state/wallet/transaction_output.rs
+++ b/src/models/state/wallet/transaction_output.rs
@@ -670,6 +670,8 @@ mod tests {
     use crate::models::state::wallet::address::KeyType;
     use crate::models::state::wallet::wallet_entropy::WalletEntropy;
     use crate::tests::shared::mock_genesis_global_state;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
 
     impl TxOutput {
         pub(crate) fn with_coin(self, coin: Coin) -> Self {
@@ -695,7 +697,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn test_utxoreceiver_auto_not_owned_output() {
         let global_state_lock = mock_genesis_global_state(
             Network::RegTest,
@@ -744,7 +746,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn test_utxoreceiver_auto_owned_output() {
         let mut global_state_lock = mock_genesis_global_state(
             Network::RegTest,
@@ -819,7 +821,7 @@ mod tests {
         }
     }
     /*
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn test_tx_output_upgrade_serialization() {
             #[serde(Serialize)]
             struct TxOutputV1 {

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -1975,6 +1975,8 @@ pub(crate) mod tests {
     use crate::tests::shared::mock_genesis_global_state;
     use crate::tests::shared::mock_genesis_wallet_state;
     use crate::tests::shared::wallet_state_has_all_valid_mps;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
 
     impl WalletState {
         /// Delete all guesser-preimage keys from database and cache.
@@ -1994,7 +1996,7 @@ pub(crate) mod tests {
         }
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     #[traced_test]
     async fn find_monitored_utxo_test() {
         let network = Network::Testnet;
@@ -2040,7 +2042,7 @@ pub(crate) mod tests {
             .is_none());
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     #[traced_test]
     async fn does_not_make_tx_with_timelocked_utxos() {
         // Ensure that timelocked UTXOs are not used when selecting input-UTXOs
@@ -2176,7 +2178,7 @@ pub(crate) mod tests {
         (block1, bob_global_lock, bob_key)
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     #[traced_test]
     async fn test_update_wallet_state_repeated_addition_records() {
         let network = Network::Main;
@@ -2286,7 +2288,7 @@ pub(crate) mod tests {
         }
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     #[traced_test]
     async fn test_invalid_type_script_states() {
         let network = Network::Main;
@@ -2386,7 +2388,7 @@ pub(crate) mod tests {
         );
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     #[traced_test]
     async fn test_unrecognized_type_script() {
         let network = Network::Main;
@@ -2488,7 +2490,7 @@ pub(crate) mod tests {
         );
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     #[traced_test]
     async fn never_store_same_utxo_twice_different_blocks() {
         let mut rng = rand::rng();
@@ -2594,7 +2596,7 @@ pub(crate) mod tests {
         }
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     #[traced_test]
     async fn never_store_same_utxo_twice_same_block() {
         let mut rng = rand::rng();
@@ -2669,7 +2671,7 @@ pub(crate) mod tests {
         assert!(wallet_state_has_all_valid_mps(&bob.wallet_state, &block1).await);
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     #[traced_test]
     async fn wallet_state_prune_abandoned_mutxos() {
         // Get genesis block. Verify wallet is empty
@@ -2860,7 +2862,7 @@ pub(crate) mod tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn mock_wallet_state_is_synchronized_to_genesis_block() {
         let network = Network::RegTest;
         let wallet = WalletEntropy::devnet_wallet();
@@ -2917,7 +2919,7 @@ pub(crate) mod tests {
         use crate::tests::shared::fake_valid_block_proposal_successor_for_test;
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn registers_guesser_fee_utxos_correctly() {
             let network = Network::Main;
             let genesis_block = Block::genesis(network);
@@ -3190,7 +3192,7 @@ pub(crate) mod tests {
             }
         }
 
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn guesser_fee_scanner_finds_guesser_fee_iff_present() {
             let network = Network::Main;
             let mut rng = rng();
@@ -3250,7 +3252,7 @@ pub(crate) mod tests {
         ///  5. empties the mempool (removing our unconfirmed tx)
         ///  6. verifies that unconfirmed balance is `coinbase amt`
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn confirmed_and_unconfirmed_balance() -> Result<()> {
             let network = Network::Main;
             let mut rng = StdRng::seed_from_u64(664505904);
@@ -3379,7 +3381,7 @@ pub(crate) mod tests {
         }
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn do_not_attempt_to_spend_utxos_already_spent_in_mempool_txs() {
             async fn outgoing_transaction(
                 alice_global_lock: &mut GlobalStateLock,
@@ -3527,7 +3529,7 @@ pub(crate) mod tests {
 
         /// tests that all known keys are unique, for all key types.
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn known_keys_are_unique() {
             for key_type in KeyType::all_types() {
                 worker::known_keys_are_unique(key_type).await
@@ -3536,7 +3538,7 @@ pub(crate) mod tests {
 
         /// tests that spending key counter persists across restart for all key types.
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn derivation_counter_persists_across_restart() -> Result<()> {
             for key_type in KeyType::all_types() {
                 worker::derivation_counter_persists_across_restart(key_type).await?
@@ -3666,7 +3668,7 @@ pub(crate) mod tests {
         use crate::util_types::mutator_set::commit;
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn insert_and_scan() {
             let cli_args = cli_args::Args::default();
             let mut wallet =
@@ -3723,7 +3725,7 @@ pub(crate) mod tests {
         }
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn prune_stale() {
             let cli_args = cli_args::Args::default();
             let mut wallet =
@@ -3788,7 +3790,7 @@ pub(crate) mod tests {
         ///
         /// https://github.com/Neptune-Crypto/neptune-core/issues/172
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn persisted_exists_after_wallet_restored() {
             worker::restore_wallet(true).await
         }
@@ -3797,7 +3799,7 @@ pub(crate) mod tests {
         /// ExpectedUtxo is added, then the ExpectedUtxo will not exist after
         /// wallet is dropped from RAM and re-created from disk.
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn unpersisted_gone_after_wallet_restored() {
             worker::restore_wallet(false).await
         }
@@ -3888,7 +3890,7 @@ pub(crate) mod tests {
         use crate::tests::shared::invalid_empty_block;
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn mutxos_spent_in_orphaned_blocks_are_still_spendable() {
             /// Crate an outgoing transaction. Panics on insufficient balance.
             async fn outgoing_transaction(
@@ -4037,7 +4039,7 @@ pub(crate) mod tests {
                 .is_zero());
         }
 
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn abandoned_utxo_is_unsynced() {
             // 1. create a genesis state for Alice
             // 2. create block_1a where Alice gets a guesser-fee UTXO, set as tip
@@ -4133,7 +4135,7 @@ pub(crate) mod tests {
         ///    catch the UTXO.
         ///  - In the last case, her derivation counter is updated accordingly.
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn test_recovery_on_imported_wallet() {
             let network = Network::Main;
             let alice_secret = WalletEntropy::new_random();
@@ -4245,7 +4247,7 @@ pub(crate) mod tests {
             }
         }
 
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn get_future_keys_do_not_modify_counters() {
             let network = Network::Main;
             let mut rng = StdRng::from_rng(&mut rng());
@@ -4308,7 +4310,7 @@ pub(crate) mod tests {
         ///     b) the relative index is smaller than num_future_keys.
         ///
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn scan_for_utxos_announced_to_future_keys_behaves() {
             let network = Network::Main;
             let seed: [u8; 32] = random();
@@ -4453,7 +4455,7 @@ pub(crate) mod tests {
         }
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn scan_mode_recovers_unexpected_offchain_composer_utxos() {
             // Set up Rando with scan mode active
             let network = Network::Main;
@@ -4565,19 +4567,19 @@ pub(crate) mod tests {
         use crate::PEER_CHANNEL_CAPACITY;
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn wallet_recovers_unexpected_onchain_symmetric_composer_utxos() {
             wallet_recovers_composer_utxos(FeeNotificationPolicy::OnChainSymmetric).await
         }
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn wallet_recovers_unexpected_onchain_generation_composer_utxos() {
             wallet_recovers_composer_utxos(FeeNotificationPolicy::OnChainGeneration).await
         }
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn wallet_recovers_expected_offchain_composer_utxos() {
             wallet_recovers_composer_utxos(FeeNotificationPolicy::OffChain).await
         }
@@ -4673,7 +4675,7 @@ pub(crate) mod tests {
         }
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn wallet_recovers_expected_offchain_upgrader_fee_utxos() {
             wallet_recovers_upgrader_fee_utxos_given_notification_policy(
                 FeeNotificationPolicy::OffChain,
@@ -4681,7 +4683,7 @@ pub(crate) mod tests {
             .await;
         }
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn wallet_recovers_unexpected_onchain_symmetric_upgrader_fee_utxos() {
             wallet_recovers_upgrader_fee_utxos_given_notification_policy(
                 FeeNotificationPolicy::OnChainSymmetric,
@@ -4689,7 +4691,7 @@ pub(crate) mod tests {
             .await;
         }
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn wallet_recovers_unexpected_onchain_generation_upgrader_fee_utxos() {
             wallet_recovers_upgrader_fee_utxos_given_notification_policy(
                 FeeNotificationPolicy::OnChainGeneration,

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -4488,7 +4488,7 @@ pub(crate) mod tests {
                 &previous_block,
                 composer_parameters.clone(),
                 now,
-                TritonVmJobQueue::dummy(),
+                TritonVmJobQueue::get_instance(),
                 rando.cli().proof_job_options_primitive_witness(),
             )
             .await
@@ -4619,7 +4619,7 @@ pub(crate) mod tests {
                 &genesis_block,
                 composer_parameters.clone(),
                 now,
-                TritonVmJobQueue::dummy(),
+                TritonVmJobQueue::get_instance(),
                 global_state_lock
                     .cli()
                     .proof_job_options_primitive_witness(),
@@ -4761,7 +4761,7 @@ pub(crate) mod tests {
                 .next_unused_symmetric_key()
                 .await;
             let now = network.launch_date() + Timestamp::months(7);
-            let dummy_queue = TritonVmJobQueue::dummy();
+            let dummy_queue = TritonVmJobQueue::get_instance();
 
             let config = TxCreationConfig::default()
                 .recover_change_on_chain(change_key.into())

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -1950,6 +1950,7 @@ pub(crate) mod tests {
     use std::sync::Arc;
 
     use generation_address::GenerationSpendingKey;
+    use macro_rules_attr::apply;
     use rand::prelude::*;
     use rand::random;
     use rand::rng;
@@ -1975,7 +1976,6 @@ pub(crate) mod tests {
     use crate::tests::shared::mock_genesis_global_state;
     use crate::tests::shared::mock_genesis_wallet_state;
     use crate::tests::shared::wallet_state_has_all_valid_mps;
-    use macro_rules_attr::apply;
     use crate::tests::shared_tokio_runtime;
 
     impl WalletState {

--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -1934,6 +1934,7 @@ impl PeerLoopHandler {
 
 #[cfg(test)]
 mod peer_loop_tests {
+    use macro_rules_attr::apply;
     use rand::rngs::StdRng;
     use rand::Rng;
     use rand::SeedableRng;
@@ -1960,9 +1961,7 @@ mod peer_loop_tests {
     use crate::tests::shared::invalid_empty_single_proof_transaction;
     use crate::tests::shared::Action;
     use crate::tests::shared::Mock;
-    use macro_rules_attr::apply;
     use crate::tests::shared_tokio_runtime;
-
 
     #[traced_test]
     #[apply(shared_tokio_runtime)]

--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -1960,9 +1960,12 @@ mod peer_loop_tests {
     use crate::tests::shared::invalid_empty_single_proof_transaction;
     use crate::tests::shared::Action;
     use crate::tests::shared::Mock;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
+
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn test_peer_loop_bye() -> Result<()> {
         let mock = Mock::new(vec![Action::Read(PeerMessage::Bye)]);
 
@@ -1987,7 +1990,7 @@ mod peer_loop_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn test_peer_loop_peer_list() {
         let (peer_broadcast_tx, _from_main_rx_clone, to_main_tx, _to_main_rx1, state_lock, _hsd) =
             get_test_genesis_setup(Network::Alpha, 2, cli_args::Args::default())
@@ -2041,7 +2044,7 @@ mod peer_loop_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn different_genesis_test() -> Result<()> {
         // In this scenario a peer provides another genesis block than what has been
         // hardcoded. This should lead to the closing of the connection to this peer
@@ -2123,7 +2126,7 @@ mod peer_loop_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn node_does_not_record_disconnection_time_when_peer_initiates_disconnect() -> Result<()>
     {
         let args = cli_args::Args::default();
@@ -2158,7 +2161,7 @@ mod peer_loop_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn block_without_valid_pow_test() -> Result<()> {
         // In this scenario, a block without a valid PoW is received. This block should be rejected
         // by the peer loop and a notification should never reach the main loop.
@@ -2249,7 +2252,7 @@ mod peer_loop_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn test_peer_loop_block_with_block_in_db() -> Result<()> {
         // The scenario tested here is that a client receives a block that is already
         // known and stored. The expected behavior is to ignore the block and not send
@@ -2310,7 +2313,7 @@ mod peer_loop_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn block_request_batch_simple() {
         // Scenario: Six blocks (including genesis) are known. Peer requests
         // from all possible starting points, and client responds with the
@@ -2385,7 +2388,7 @@ mod peer_loop_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn block_request_batch_in_order_test() -> Result<()> {
         // Scenario: A fork began at block 2, node knows two blocks of height 2 and two of height 3.
         // A peer requests a batch of blocks starting from block 1. Ensure that the correct blocks
@@ -2501,7 +2504,7 @@ mod peer_loop_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn block_request_batch_out_of_order_test() -> Result<()> {
         // Scenario: A fork began at block 2, node knows two blocks of height 2 and two of height 3.
         // A peer requests a batch of blocks starting from block 1, but the peer supplies their
@@ -2593,7 +2596,7 @@ mod peer_loop_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn request_unknown_height_doesnt_crash() {
         // Scenario: Only genesis block is known. Peer requests block of height
         // 2.
@@ -2637,7 +2640,7 @@ mod peer_loop_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn find_canonical_chain_when_multiple_blocks_at_same_height_test() -> Result<()> {
         // Scenario: A fork began at block 2, node knows two blocks of height 2 and two of height 3.
         // A peer requests a block at height 2. Verify that the correct block at height 2 is
@@ -2701,7 +2704,7 @@ mod peer_loop_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn receival_of_block_notification_height_1() {
         // Scenario: client only knows genesis block. Then receives block
         // notification of height 1. Must request block 1.
@@ -2738,7 +2741,7 @@ mod peer_loop_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn receive_block_request_by_height_block_7() {
         // Scenario: client only knows blocks up to height 7. Then receives block-
         // request-by-height for height 7. Must respond with block 7.
@@ -2789,7 +2792,7 @@ mod peer_loop_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn test_peer_loop_receival_of_first_block() -> Result<()> {
         // Scenario: client only knows genesis block. Then receives block 1.
 
@@ -2839,7 +2842,7 @@ mod peer_loop_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn test_peer_loop_receival_of_second_block_no_blocks_in_db() -> Result<()> {
         // In this scenario, the client only knows the genesis block (block 0) and then
         // receives block 2, meaning that block 1 will have to be requested.
@@ -2911,7 +2914,7 @@ mod peer_loop_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn prevent_ram_exhaustion_test() -> Result<()> {
         // In this scenario the peer sends more blocks than the client allows to store in the
         // fork-reconciliation field. This should result in abandonment of the fork-reconciliation
@@ -2995,7 +2998,7 @@ mod peer_loop_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn test_peer_loop_receival_of_fourth_block_one_block_in_db() {
         // In this scenario, the client know the genesis block (block 0) and block 1, it
         // then receives block 4, meaning that block 3 and 2 will have to be requested.
@@ -3069,7 +3072,7 @@ mod peer_loop_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn test_peer_loop_receival_of_third_block_no_blocks_in_db() -> Result<()> {
         // In this scenario, the client only knows the genesis block (block 0) and then
         // receives block 3, meaning that block 2 and 1 will have to be requested.
@@ -3143,7 +3146,7 @@ mod peer_loop_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn test_block_reconciliation_interrupted_by_block_notification() -> Result<()> {
         // In this scenario, the client know the genesis block (block 0) and block 1, it
         // then receives block 4, meaning that block 3, 2, and 1 will have to be requested.
@@ -3248,7 +3251,7 @@ mod peer_loop_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn test_block_reconciliation_interrupted_by_peer_list_request() -> Result<()> {
         // In this scenario, the client knows the genesis block (block 0) and block 1, it
         // then receives block 4, meaning that block 3, 2, and 1 will have to be requested.
@@ -3354,7 +3357,7 @@ mod peer_loop_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn receive_transaction_request() {
         let network = Network::Main;
         let dummy_tx = invalid_empty_single_proof_transaction();
@@ -3407,7 +3410,7 @@ mod peer_loop_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn empty_mempool_request_tx_test() {
         // In this scenario the client receives a transaction notification from
         // a peer of a transaction it doesn't know; the client must then request it.
@@ -3487,7 +3490,7 @@ mod peer_loop_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn populated_mempool_request_tx_test() -> Result<()> {
         // In this scenario the peer is informed of a transaction that it already knows
 
@@ -3618,7 +3621,7 @@ mod peer_loop_tests {
         }
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn accept_block_proposal_height_one() {
             // Node knows genesis block, receives a block proposal for block 1
             // and must accept this. Verify that main loop is informed of block
@@ -3659,7 +3662,7 @@ mod peer_loop_tests {
         }
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn accept_block_proposal_notification_height_one() {
             // Node knows genesis block, receives a block proposal notification
             // for block 1 and must accept this by requesting the block
@@ -3741,7 +3744,7 @@ mod peer_loop_tests {
         }
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn client_favors_higher_proof_quality() {
             // In this scenario the peer is informed of a transaction that it
             // already knows, and it's tested that it checks the proof quality
@@ -3847,7 +3850,7 @@ mod peer_loop_tests {
         use crate::tests::shared::fake_valid_sequence_of_blocks_for_tests_dyn;
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn bad_sync_challenge_height_greater_than_tip() {
             // Criterium: Challenge height may not exceed that of tip in the
             // request.
@@ -3918,7 +3921,7 @@ mod peer_loop_tests {
         }
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn bad_sync_challenge_genesis_block_doesnt_crash_client() {
             // Criterium: Challenge may not point to genesis block, or block 1, as
             // tip.
@@ -3979,7 +3982,7 @@ mod peer_loop_tests {
         }
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn sync_challenge_happy_path() -> Result<()> {
             // Bob notifies Alice of a block whose parameters satisfy the sync mode
             // criterion. Alice issues a challenge. Bob responds. Alice enters into

--- a/src/rpc_auth.rs
+++ b/src/rpc_auth.rs
@@ -280,11 +280,11 @@ pub mod error {
 
 #[cfg(test)]
 mod test {
+    use macro_rules_attr::apply;
+
     use super::*;
     use crate::tests::shared::unit_test_data_directory;
-    use macro_rules_attr::apply;
     use crate::tests::shared_tokio_runtime;
-
 
     mod token {
         use super::*;

--- a/src/rpc_auth.rs
+++ b/src/rpc_auth.rs
@@ -282,6 +282,9 @@ pub mod error {
 mod test {
     use super::*;
     use crate::tests::shared::unit_test_data_directory;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
+
 
     mod token {
         use super::*;
@@ -294,7 +297,7 @@ mod test {
             /// tests:
             ///  1. Token::auth() succeeds for valid token
             ///  2. Token::auth() returns AuthError::InvalidCookie for invalid token
-            #[tokio::test]
+            #[apply(shared_tokio_runtime)]
             pub async fn auth() -> anyhow::Result<()> {
                 let data_dir = unit_test_data_directory(Network::Main)?;
 
@@ -325,7 +328,7 @@ mod test {
         ///
         /// tests:
         ///  1. Verify that HashSet contains 50 items.
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         pub async fn try_new_unique() -> anyhow::Result<()> {
             const NUM_COOKIES: usize = 50;
 
@@ -352,7 +355,7 @@ mod test {
         /// tests:
         ///  1. Cookie::auth() succeeds for valid cookie
         ///  2. Cookie::auth() returns AuthError::InvalidCookie for invalid cookie
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         pub async fn auth() -> anyhow::Result<()> {
             let data_dir = unit_test_data_directory(Network::Alpha)?;
 
@@ -398,7 +401,7 @@ mod test {
         //
         // if any error occurs, the test will panic.
         #[cfg(not(target_os = "windows"))]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         pub async fn concurrency() -> anyhow::Result<()> {
             async fn add_cookie(data_dir: &DataDirectory, cookie: &Cookie) {
                 let path = data_dir.root_dir_path().join("tmp").join(cookie.as_hex());

--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -3622,6 +3622,9 @@ mod rpc_server_tests {
     use rand::SeedableRng;
     use strum::IntoEnumIterator;
     use tracing_test::traced_test;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
+
 
     use super::*;
     use crate::config_models::cli_args;
@@ -3673,7 +3676,7 @@ mod rpc_server_tests {
             .into()
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn network_response_is_consistent() -> Result<()> {
         // Verify that a wallet not receiving a premine is empty at startup
         for network in Network::iter() {
@@ -3693,7 +3696,7 @@ mod rpc_server_tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn verify_that_all_requests_leave_server_running() -> Result<()> {
         // Got through *all* request types and verify that server does not crash.
         // We don't care about the actual response data in this test, just that the
@@ -3846,7 +3849,7 @@ mod rpc_server_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn balance_is_zero_at_init() -> Result<()> {
         // Verify that a wallet not receiving a premine is empty at startup
         let rpc_server = test_rpc_server(
@@ -3867,7 +3870,7 @@ mod rpc_server_tests {
 
     #[expect(clippy::shadow_unrelated)]
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn clear_ip_standing_test() -> Result<()> {
         let mut rpc_server = test_rpc_server(
             Network::Alpha,
@@ -4025,7 +4028,7 @@ mod rpc_server_tests {
 
     #[expect(clippy::shadow_unrelated)]
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn clear_all_standings_test() -> Result<()> {
         // Create initial conditions
         let mut rpc_server = test_rpc_server(
@@ -4155,7 +4158,7 @@ mod rpc_server_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn utxo_digest_test() {
         let rpc_server = test_rpc_server(
             Network::Alpha,
@@ -4194,7 +4197,7 @@ mod rpc_server_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn block_info_test() {
         let network = Network::RegTest;
         let rpc_server = test_rpc_server(
@@ -4306,7 +4309,7 @@ mod rpc_server_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn public_announcements_in_block_test() {
         let network = Network::Main;
         let mut rpc_server = test_rpc_server(
@@ -4374,7 +4377,7 @@ mod rpc_server_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn block_digest_test() {
         let network = Network::RegTest;
         let rpc_server = test_rpc_server(
@@ -4456,7 +4459,7 @@ mod rpc_server_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn getting_temperature_doesnt_crash_test() {
         // On your local machine, this should return a temperature but in CI,
         // the RPC call returns `None`, so we only verify that the call doesn't
@@ -4476,7 +4479,7 @@ mod rpc_server_tests {
     }
 
     #[traced_test]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn cannot_initiate_transaction_if_notx_flag_is_set() {
         let network = Network::Main;
         let ctx = context::current();
@@ -4540,7 +4543,7 @@ mod rpc_server_tests {
             assert_eq!(block1.hash(), resulting_block_hash);
         }
 
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn provide_solution_when_no_proposal_known() {
             let network = Network::Main;
             let bob = test_rpc_server(
@@ -4569,7 +4572,7 @@ mod rpc_server_tests {
             );
         }
 
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn cached_exported_proposals_are_stored_correctly() {
             let network = Network::Main;
             let bob = WalletEntropy::new_random();
@@ -4628,7 +4631,7 @@ mod rpc_server_tests {
             );
         }
 
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn exported_pow_puzzle_is_consistent_with_block_hash() {
             let network = Network::Main;
             let bob = WalletEntropy::new_random();
@@ -4763,31 +4766,31 @@ mod rpc_server_tests {
         use super::*;
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn claim_utxo_owned_before_confirmed() -> Result<()> {
             worker::claim_utxo_owned(false, false).await
         }
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn claim_utxo_owned_after_confirmed() -> Result<()> {
             worker::claim_utxo_owned(true, false).await
         }
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn claim_utxo_owned_after_confirmed_and_after_spent() -> Result<()> {
             worker::claim_utxo_owned(true, true).await
         }
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn claim_utxo_unowned_before_confirmed() -> Result<()> {
             worker::claim_utxo_unowned(false).await
         }
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn claim_utxo_unowned_after_confirmed() -> Result<()> {
             worker::claim_utxo_unowned(true).await
         }
@@ -5173,7 +5176,7 @@ mod rpc_server_tests {
         use crate::tests::shared::mine_block_to_wallet_invalid_block_proof;
 
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn send_to_many_n_outputs() {
             let mut rng = StdRng::seed_from_u64(1815);
             let network = Network::Main;
@@ -5237,7 +5240,7 @@ mod rpc_server_tests {
         /// sends a tx with two outputs: one self, one external, for each key type
         /// that accepts incoming UTXOs.
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn send_to_many_test() -> Result<()> {
             for recipient_key_type in KeyType::all_types() {
                 worker::send_to_many(recipient_key_type).await?;
@@ -5248,7 +5251,7 @@ mod rpc_server_tests {
         /// checks that the sending rate limit kicks in after 2 tx are sent.
         /// note: rate-limit only applies below block 25000
         #[traced_test]
-        #[tokio::test]
+        #[apply(shared_tokio_runtime)]
         async fn send_rate_limit() -> Result<()> {
             let mut rng = StdRng::seed_from_u64(1815);
             let network = Network::Main;

--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -3615,6 +3615,7 @@ pub mod error {
 #[cfg(test)]
 mod rpc_server_tests {
     use anyhow::Result;
+    use macro_rules_attr::apply;
     use num_traits::One;
     use num_traits::Zero;
     use rand::rngs::StdRng;
@@ -3622,9 +3623,6 @@ mod rpc_server_tests {
     use rand::SeedableRng;
     use strum::IntoEnumIterator;
     use tracing_test::traced_test;
-    use macro_rules_attr::apply;
-    use crate::tests::shared_tokio_runtime;
-
 
     use super::*;
     use crate::config_models::cli_args;
@@ -3641,6 +3639,7 @@ mod rpc_server_tests {
     use crate::tests::shared::make_mock_block;
     use crate::tests::shared::mock_genesis_global_state;
     use crate::tests::shared::unit_test_data_directory;
+    use crate::tests::shared_tokio_runtime;
     use crate::Block;
 
     async fn test_rpc_server(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -31,4 +31,3 @@ macro_rules! shared_tokio_runtime {
 }
 
 pub(crate) use shared_tokio_runtime;
-

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,1 +1,34 @@
 pub mod shared;
+
+use std::sync::OnceLock;
+
+use tokio::runtime::Runtime;
+
+pub fn tokio_runtime() -> &'static Runtime {
+    static RUNTIME: OnceLock<Runtime> = OnceLock::new();
+    RUNTIME.get_or_init(|| Runtime::new().unwrap())
+}
+
+macro_rules! shared_tokio_runtime {
+    (
+        $(#[$fn_meta:meta])*
+        $vis:vis async fn $fn_name:ident() $(-> $ret:ty)? {
+            $($tt:tt)*
+        }
+    ) => {
+        $(#[$fn_meta])*
+        #[test]
+        fn $fn_name() $(-> $ret)? { // Propagate the return type to the #[test] fn
+            let runtime = $crate::tests::tokio_runtime();
+            runtime.block_on(async {
+                async fn __inner() $(-> $ret)? {
+                    $($tt)*
+                }
+                __inner().await // Return the awaited result
+            })
+        }
+    };
+}
+
+pub(crate) use shared_tokio_runtime;
+

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -787,7 +787,7 @@ pub(crate) async fn make_mock_block_guesser_preimage_and_guesser_fraction(
         previous_block,
         composer_parameters,
         block_timestamp,
-        TritonVmJobQueue::dummy(),
+        TritonVmJobQueue::get_instance(),
         cli.proof_job_options_primitive_witness(),
     )
     .await

--- a/src/util_types/archival_mmr.rs
+++ b/src/util_types/archival_mmr.rs
@@ -369,6 +369,8 @@ pub(crate) mod mmr_test {
     use crate::database::storage::storage_vec::OrdinaryVec;
     use crate::database::NeptuneLevelDb;
     use crate::Hash;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
 
     type Storage = OrdinaryVec<Digest>;
 
@@ -400,7 +402,7 @@ pub(crate) mod mmr_test {
         }
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn prune_to_num_leafs_unit_test() {
         let mut archival_mmr: ArchivalMmr<Storage> =
             mock::get_ammr_from_digests(vec![Digest::default(); 7]).await;
@@ -409,7 +411,7 @@ pub(crate) mod mmr_test {
         assert_eq!(2, archival_mmr.num_leafs().await as u64);
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn prune_to_num_leafs_empty() {
         for init_size in 0..3 {
             let mut archival_mmr: ArchivalMmr<Storage> =
@@ -435,7 +437,7 @@ pub(crate) mod mmr_test {
         prop_assert_eq!(final_num_leafs, archival_mmr.num_leafs().await as u64);
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn empty_mmr_behavior_test() {
         let mut archival_mmr: ArchivalMmr<Storage> = mock::get_empty_ammr().await;
         let mut accumulator_mmr: MmrAccumulator = MmrAccumulator::new_from_leafs(vec![]);
@@ -509,7 +511,7 @@ pub(crate) mod mmr_test {
         );
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn verify_against_correct_peak_test() {
         // This test addresses a bug that was discovered late in the development process
         // where it was possible to fake a verification proof by providing a valid leaf
@@ -545,7 +547,7 @@ pub(crate) mod mmr_test {
         ));
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn mutate_leaf_archival_test() {
         type H = Tip5;
 
@@ -645,12 +647,12 @@ pub(crate) mod mmr_test {
             .any(|peak| *peak == accumulator_mmr_small.bag_peaks()));
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn bag_peaks_tip5_test() {
         bag_peaks_gen().await;
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn compare_batch_and_individual_leaf_mutation() {
         use rand::prelude::IndexedRandom;
 
@@ -690,7 +692,7 @@ pub(crate) mod mmr_test {
         }
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn accumulator_mmr_mutate_leaf_test() {
         // Verify that updating leafs in archival and in accumulator MMR results in the same peaks
         // and verify that updating all leafs in an MMR results in the expected MMR
@@ -738,7 +740,7 @@ pub(crate) mod mmr_test {
         ));
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn mmr_prove_verify_leaf_mutation_test() {
         for size in 1u64..150 {
             let new_leaf: Digest = random();
@@ -791,7 +793,7 @@ pub(crate) mod mmr_test {
         }
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn mmr_append_test() {
         // Verify that building an MMR iteratively or in *one* function call results in the same MMR
         for size in 1..260 {
@@ -848,7 +850,7 @@ pub(crate) mod mmr_test {
         }
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn one_input_mmr_test() {
         type H = Tip5;
 
@@ -933,7 +935,7 @@ pub(crate) mod mmr_test {
         );
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn two_input_mmr_test() {
         let num_leaves: u64 = 3;
         let input_digests: Vec<Digest> = random_elements(num_leaves as usize);
@@ -982,7 +984,7 @@ pub(crate) mod mmr_test {
         }
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn variable_size_tip5_mmr_test() {
         type H = Tip5;
 
@@ -1043,7 +1045,7 @@ pub(crate) mod mmr_test {
         }
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn remove_last_leaf_test() {
         let input_digests: Vec<Digest> = random_elements(12);
         let mut mmr: ArchivalMmr<Storage> =
@@ -1081,7 +1083,7 @@ pub(crate) mod mmr_test {
         assert!(mmr.get_latest_leaf().await.is_none());
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn remove_last_leaf_pbt() {
         let small_size: usize = 100;
         let big_size: usize = 350;
@@ -1103,7 +1105,7 @@ pub(crate) mod mmr_test {
         assert_eq!(mmr_big.count_nodes().await, mmr_small.count_nodes().await);
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn variable_size_tip5_mmr_test2() {
         let node_counts: Vec<u64> = vec![
             1, 3, 4, 7, 8, 10, 11, 15, 16, 18, 19, 22, 23, 25, 26, 31, 32, 34, 35, 38, 39, 41, 42,
@@ -1198,7 +1200,7 @@ pub(crate) mod mmr_test {
     }
 
     #[cfg(debug_assertions)] // this tests get_leaf_async() use of debug_assert!()
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     #[should_panic(expected = "Leaf index out-of-bounds. Got leaf index 17 but num_leafs was 17")]
     async fn get_panics_when_out_of_bounds() {
         let digests = vec![Digest::default(); 17];
@@ -1206,7 +1208,7 @@ pub(crate) mod mmr_test {
         ammr.get_leaf_async(17).await;
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn leveldb_persist_storage_schema_test() {
         let db = NeptuneLevelDb::open_new_test_database(true, None, None, None)
             .await

--- a/src/util_types/archival_mmr.rs
+++ b/src/util_types/archival_mmr.rs
@@ -353,6 +353,7 @@ pub(crate) mod mmr_test {
     use std::cmp;
 
     use itertools::*;
+    use macro_rules_attr::apply;
     use proptest::collection::vec;
     use proptest::prelude::*;
     use proptest_arbitrary_interop::arb;
@@ -368,9 +369,8 @@ pub(crate) mod mmr_test {
     use crate::database::storage::storage_schema::SimpleRustyStorage;
     use crate::database::storage::storage_vec::OrdinaryVec;
     use crate::database::NeptuneLevelDb;
-    use crate::Hash;
-    use macro_rules_attr::apply;
     use crate::tests::shared_tokio_runtime;
+    use crate::Hash;
 
     type Storage = OrdinaryVec<Digest>;
 

--- a/src/util_types/mutator_set.rs
+++ b/src/util_types/mutator_set.rs
@@ -86,6 +86,7 @@ pub fn commit(item: Digest, sender_randomness: Digest, receiver_digest: Digest) 
 
 #[cfg(test)]
 mod test {
+    use macro_rules_attr::apply;
     use rand::Rng;
     use tasm_lib::twenty_first::util_types::mmr::mmr_trait::Mmr;
     use test::ms_membership_proof::MsMembershipProof;
@@ -93,10 +94,9 @@ mod test {
 
     use super::*;
     use crate::tests::shared::mock_item_and_randomnesses;
+    use crate::tests::shared_tokio_runtime;
     use crate::util_types::mutator_set::mutator_set_accumulator::MutatorSetAccumulator;
     use crate::util_types::test_shared::mutator_set::*;
-    use macro_rules_attr::apply;
-    use crate::tests::shared_tokio_runtime;
 
     #[test]
     fn get_batch_index_test() {

--- a/src/util_types/mutator_set.rs
+++ b/src/util_types/mutator_set.rs
@@ -95,6 +95,8 @@ mod test {
     use crate::tests::shared::mock_item_and_randomnesses;
     use crate::util_types::mutator_set::mutator_set_accumulator::MutatorSetAccumulator;
     use crate::util_types::test_shared::mutator_set::*;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
 
     #[test]
     fn get_batch_index_test() {
@@ -129,7 +131,7 @@ mod test {
         );
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn mutator_set_hash_test() {
         let empty_set = MutatorSetAccumulator::default();
         let empty_hash = empty_set.hash();
@@ -220,7 +222,7 @@ mod test {
         }
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn init_test() {
         let accumulator = MutatorSetAccumulator::default();
         let mut rms = empty_rusty_mutator_set().await;

--- a/src/util_types/mutator_set/archival_mutator_set.rs
+++ b/src/util_types/mutator_set/archival_mutator_set.rs
@@ -470,8 +470,10 @@ mod archival_mutator_set_tests {
     use crate::util_types::mutator_set::shared::NUM_TRIALS;
     use crate::util_types::test_shared::mutator_set::empty_rusty_mutator_set;
     use crate::util_types::test_shared::mutator_set::mock_item_and_randomnesses;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn archival_set_commitment_test() {
         let mut rms = empty_rusty_mutator_set().await;
         let archival_mutator_set = rms.ams_mut();
@@ -527,7 +529,7 @@ mod archival_mutator_set_tests {
         }
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn archival_mutator_set_revert_add_test() {
         let mut rms = empty_rusty_mutator_set().await;
         let archival_mutator_set = rms.ams_mut();
@@ -583,7 +585,7 @@ mod archival_mutator_set_tests {
         }
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn bloom_filter_is_reversible() {
         // With the `3086841408u32` seed a collision is generated at i = 1 and i = 38, on index 510714
         let seed_integer = 3086841408u32;
@@ -811,7 +813,7 @@ mod archival_mutator_set_tests {
     }
 
     #[should_panic(expected = "Decremented integer is already zero.")]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn revert_remove_from_active_bloom_filter_panic() {
         let mut rms = empty_rusty_mutator_set().await;
         let archival_mutator_set = rms.ams_mut();
@@ -827,7 +829,7 @@ mod archival_mutator_set_tests {
     }
 
     #[should_panic(expected = "Attempted to remove index that was not present in chunk.")]
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn revert_remove_invalid_panic() {
         let mut rms = empty_rusty_mutator_set().await;
         let archival_mutator_set = rms.ams_mut();
@@ -852,7 +854,7 @@ mod archival_mutator_set_tests {
             .await;
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn archival_mutator_set_revert_remove_test() {
         let mut rms = empty_rusty_mutator_set().await;
         let archival_mutator_set = rms.ams_mut();
@@ -909,7 +911,7 @@ mod archival_mutator_set_tests {
         }
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn archival_set_batch_remove_simple_test() {
         let mut rms = empty_rusty_mutator_set().await;
         let archival_mutator_set = rms.ams_mut();
@@ -957,7 +959,7 @@ mod archival_mutator_set_tests {
         }
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn archival_set_batch_remove_dynamic_test() {
         let mut rms = empty_rusty_mutator_set().await;
         let archival_mutator_set = rms.ams_mut();

--- a/src/util_types/mutator_set/archival_mutator_set.rs
+++ b/src/util_types/mutator_set/archival_mutator_set.rs
@@ -459,19 +459,19 @@ where
 #[cfg(test)]
 mod archival_mutator_set_tests {
     use itertools::Itertools;
+    use macro_rules_attr::apply;
     use rand::rngs::StdRng;
     use rand::Rng;
     use rand::SeedableRng;
 
     use super::*;
+    use crate::tests::shared_tokio_runtime;
     use crate::util_types::mutator_set::commit;
     use crate::util_types::mutator_set::removal_record::AbsoluteIndexSet;
     use crate::util_types::mutator_set::shared::BATCH_SIZE;
     use crate::util_types::mutator_set::shared::NUM_TRIALS;
     use crate::util_types::test_shared::mutator_set::empty_rusty_mutator_set;
     use crate::util_types::test_shared::mutator_set::mock_item_and_randomnesses;
-    use macro_rules_attr::apply;
-    use crate::tests::shared_tokio_runtime;
 
     #[apply(shared_tokio_runtime)]
     async fn archival_set_commitment_test() {

--- a/src/util_types/mutator_set/chunk_dictionary.rs
+++ b/src/util_types/mutator_set/chunk_dictionary.rs
@@ -209,16 +209,16 @@ pub fn pseudorandom_chunk_dictionary(seed: [u8; 32]) -> ChunkDictionary {
 #[cfg(test)]
 mod chunk_dict_tests {
 
+    use macro_rules_attr::apply;
     use twenty_first::math::other::random_elements;
     use twenty_first::math::tip5::Digest;
     use twenty_first::util_types::mmr::mmr_membership_proof::MmrMembershipProof;
 
     use super::*;
+    use crate::tests::shared_tokio_runtime;
     use crate::util_types::archival_mmr::mmr_test::mock;
     use crate::util_types::mutator_set::shared::CHUNK_SIZE;
     use crate::util_types::test_shared::mutator_set::random_chunk_dictionary;
-    use macro_rules_attr::apply;
-    use crate::tests::shared_tokio_runtime;
 
     #[apply(shared_tokio_runtime)]
     async fn hash_test() {

--- a/src/util_types/mutator_set/chunk_dictionary.rs
+++ b/src/util_types/mutator_set/chunk_dictionary.rs
@@ -217,8 +217,10 @@ mod chunk_dict_tests {
     use crate::util_types::archival_mmr::mmr_test::mock;
     use crate::util_types::mutator_set::shared::CHUNK_SIZE;
     use crate::util_types::test_shared::mutator_set::random_chunk_dictionary;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn hash_test() {
         let chunkdict0 = ChunkDictionary::default();
         let chunkdict00 = ChunkDictionary::default();
@@ -280,7 +282,7 @@ mod chunk_dict_tests {
         assert_ne!(Hash::hash(&chunkdict3), Hash::hash(&chunkdict3_switched));
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn serialization_test() {
         // TODO: You could argue that this test doesn't belong here, as it tests the behavior of
         // an imported library. I included it here, though, because the setup seems a bit clumsy

--- a/src/util_types/mutator_set/ms_membership_proof.rs
+++ b/src/util_types/mutator_set/ms_membership_proof.rs
@@ -594,6 +594,7 @@ pub fn pseudorandom_mmr_membership_proof_with_index(seed: [u8; 32]) -> (MmrMembe
 mod ms_proof_tests {
     use itertools::Either;
     use itertools::Itertools;
+    use macro_rules_attr::apply;
     use rand::random;
     use rand::rngs::StdRng;
     use rand::Rng;
@@ -603,14 +604,13 @@ mod ms_proof_tests {
     use twenty_first::util_types::mmr::mmr_membership_proof::MmrMembershipProof;
 
     use super::*;
+    use crate::tests::shared_tokio_runtime;
     use crate::util_types::mutator_set::active_window::ActiveWindow;
     use crate::util_types::mutator_set::chunk::Chunk;
     use crate::util_types::mutator_set::commit;
     use crate::util_types::test_shared::mutator_set::empty_rusty_mutator_set;
     use crate::util_types::test_shared::mutator_set::mock_item_and_randomnesses;
     use crate::util_types::test_shared::mutator_set::random_mutator_set_membership_proof;
-    use macro_rules_attr::apply;
-    use crate::tests::shared_tokio_runtime;
 
     #[test]
     fn mp_equality_test() {

--- a/src/util_types/mutator_set/ms_membership_proof.rs
+++ b/src/util_types/mutator_set/ms_membership_proof.rs
@@ -609,6 +609,8 @@ mod ms_proof_tests {
     use crate::util_types::test_shared::mutator_set::empty_rusty_mutator_set;
     use crate::util_types::test_shared::mutator_set::mock_item_and_randomnesses;
     use crate::util_types::test_shared::mutator_set::random_mutator_set_membership_proof;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
 
     #[test]
     fn mp_equality_test() {
@@ -696,7 +698,7 @@ mod ms_proof_tests {
         }
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn revert_update_from_remove_test() {
         let n = 100;
         let mut rng = rand::rng();
@@ -833,7 +835,7 @@ mod ms_proof_tests {
         );
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn revert_update_single_remove_test() {
         let mut rms = empty_rusty_mutator_set().await;
         let ams = rms.ams_mut();
@@ -912,7 +914,7 @@ mod ms_proof_tests {
         }
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn revert_update_single_addition_test() {
         for j in 2..30 {
             let mut rms = empty_rusty_mutator_set().await;
@@ -960,7 +962,7 @@ mod ms_proof_tests {
         }
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn revert_update_from_addition_batches_test() {
         let mut msa: MutatorSetAccumulator = MutatorSetAccumulator::default();
 
@@ -1036,7 +1038,7 @@ mod ms_proof_tests {
         }
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn revert_update_from_addition_test() {
         let mut rng = rand::rng();
         let n = rng.next_u32() as usize % 100 + 1;
@@ -1130,7 +1132,7 @@ mod ms_proof_tests {
         }
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn revert_updates_mixed_test() {
         let mut rng_seeder = rand::rng();
         // let seed_integer = rng.next_u32();

--- a/src/util_types/mutator_set/mutator_set_accumulator.rs
+++ b/src/util_types/mutator_set/mutator_set_accumulator.rs
@@ -504,19 +504,19 @@ impl MutatorSetAccumulator {
 mod ms_accumulator_tests {
     use itertools::izip;
     use itertools::Itertools;
+    use macro_rules_attr::apply;
     use proptest::prop_assert_eq;
     use rand::Rng;
     use test_strategy::proptest;
 
     use super::*;
+    use crate::tests::shared_tokio_runtime;
     use crate::util_types::mutator_set::commit;
     use crate::util_types::mutator_set::shared::BATCH_SIZE;
     use crate::util_types::mutator_set::shared::CHUNK_SIZE;
     use crate::util_types::mutator_set::shared::NUM_TRIALS;
     use crate::util_types::mutator_set::shared::WINDOW_SIZE;
     use crate::util_types::test_shared::mutator_set::*;
-    use macro_rules_attr::apply;
-    use crate::tests::shared_tokio_runtime;
 
     #[test]
     fn active_window_chunk_interval_unit_test() {

--- a/src/util_types/mutator_set/mutator_set_accumulator.rs
+++ b/src/util_types/mutator_set/mutator_set_accumulator.rs
@@ -515,6 +515,8 @@ mod ms_accumulator_tests {
     use crate::util_types::mutator_set::shared::NUM_TRIALS;
     use crate::util_types::mutator_set::shared::WINDOW_SIZE;
     use crate::util_types::test_shared::mutator_set::*;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
 
     #[test]
     fn active_window_chunk_interval_unit_test() {
@@ -556,7 +558,7 @@ mod ms_accumulator_tests {
         }
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn mutator_set_batch_remove_accumulator_test() {
         // Test the batch-remove function for mutator set accumulator
         let mut accumulator: MutatorSetAccumulator = MutatorSetAccumulator::default();
@@ -618,7 +620,7 @@ mod ms_accumulator_tests {
         }
     }
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn mutator_set_accumulator_pbt() {
         // This tests verifies that items can be added and removed from the mutator set
         // without assuming anything about the order of the adding and removal. It also

--- a/src/util_types/mutator_set/rusty_archival_mutator_set.rs
+++ b/src/util_types/mutator_set/rusty_archival_mutator_set.rs
@@ -108,16 +108,16 @@ impl StorageWriter for RustyArchivalMutatorSet {
 #[cfg(test)]
 mod tests {
     use itertools::Itertools;
+    use macro_rules_attr::apply;
     use rand::random;
     use rand::RngCore;
 
     use super::*;
+    use crate::tests::shared_tokio_runtime;
     use crate::util_types::mutator_set::commit;
     use crate::util_types::mutator_set::ms_membership_proof::MsMembershipProof;
     use crate::util_types::mutator_set::shared::BATCH_SIZE;
     use crate::util_types::test_shared::mutator_set::*;
-    use macro_rules_attr::apply;
-    use crate::tests::shared_tokio_runtime;
 
     #[apply(shared_tokio_runtime)]
     async fn persist_test() {

--- a/src/util_types/mutator_set/rusty_archival_mutator_set.rs
+++ b/src/util_types/mutator_set/rusty_archival_mutator_set.rs
@@ -116,8 +116,10 @@ mod tests {
     use crate::util_types::mutator_set::ms_membership_proof::MsMembershipProof;
     use crate::util_types::mutator_set::shared::BATCH_SIZE;
     use crate::util_types::test_shared::mutator_set::*;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn persist_test() {
         let num_additions = 150 + 2 * BATCH_SIZE as usize;
         let num_removals = 50usize;

--- a/src/util_types/test_shared/mutator_set.rs
+++ b/src/util_types/test_shared/mutator_set.rs
@@ -415,8 +415,9 @@ fn merkle_verify_tester_helper(root: Digest, index: u64, path: &[Digest], leaf: 
 
 #[cfg(test)]
 mod shared_tests_test {
-    use super::*;
     use macro_rules_attr::apply;
+
+    use super::*;
     use crate::tests::shared_tokio_runtime;
 
     #[apply(shared_tokio_runtime)]

--- a/src/util_types/test_shared/mutator_set.rs
+++ b/src/util_types/test_shared/mutator_set.rs
@@ -416,8 +416,10 @@ fn merkle_verify_tester_helper(root: Digest, index: u64, path: &[Digest], leaf: 
 #[cfg(test)]
 mod shared_tests_test {
     use super::*;
+    use macro_rules_attr::apply;
+    use crate::tests::shared_tokio_runtime;
 
-    #[tokio::test]
+    #[apply(shared_tokio_runtime)]
     async fn can_call() {
         let rcd = random_chunk_dictionary();
         assert!(!rcd.is_empty());


### PR DESCRIPTION
I plan to merge this right away to avoid merge conflict hell, but making it a PR in case anyone wishes to review post-hoc.

----------
Selected `cargo test -- --nocapture` log output, demonstrating shared job-queue usage in tests.

```
$ grep "begin job" /tmp/test10.out | head -n 200 | tail -n 1
2025-04-26T18:19:05.498349Z  INFO neptune_cash::job_queue::queue:   *** JobQueue: begin job #113 - bae809233ab5b9ed78369281 - 45 queued job(s) ***

$ grep "begin job" /tmp/test10.out | head -n 600 | tail -n 1
2025-04-26T18:19:49.754200Z  INFO neptune_cash::job_queue::queue:   *** JobQueue: begin job #513 - c26fba5ad85ab5751def2e97 - 47 queued job(s) ***

$ grep "begin job" /tmp/test10.out | head -n 1000 | tail -n 1
2025-04-26T18:20:56.447659Z  INFO neptune_cash::job_queue::queue:   *** JobQueue: begin job #913 - 1982551c7ae04b67d3d16952 - 21 queued job(s) ***

$ grep "begin job" /tmp/test10.out | head -n 1400 | tail -n 1
2025-04-26T18:22:07.064543Z  INFO neptune_cash::job_queue::queue:   *** JobQueue: begin job #1313 - c29014f9d8a50c8ec5db1ee8 - 2 queued job(s) ***

$ grep "begin job" /tmp/test10.out | tail -n 1
2025-04-26T18:23:26.718204Z  INFO neptune_cash::job_queue::queue:   *** JobQueue: begin job #1571 - 41dc5fc021681f06a4f268d4 - 0 queued job(s) ***
```

jobs now have a random job_id that is assigned when added and can be helpful for tracking in the logs.

```
$ grep "c26fba5ad85ab5751def2e97" /tmp/test10.out
2025-04-26T18:19:41.262403Z  INFO neptune_cash::job_queue::queue: JobQueue: job added - c26fba5ad85ab5751def2e97  49 queued job(s).  job running: #465 - 29ae04dca4c2bdefe12b2d1c
2025-04-26T18:19:49.754200Z  INFO neptune_cash::job_queue::queue:   *** JobQueue: begin job #513 - c26fba5ad85ab5751def2e97 - 47 queued job(s) ***
2025-04-26T18:19:49.786660Z  INFO neptune_cash::job_queue::queue:   *** JobQueue: ended job #513 - c26fba5ad85ab5751def2e97 - Completion: Finished - 0.03245471 secs ***
```

_note the 8 second difference between "job added" and "begin job".  Previously these could not be correlated_

-------------

closes #551

purpose: share a common tokio runtime for unit tests so that they can
likewise share a common TritonVmJobQueue.

This enables running tests in parallel even when generating proofs.

Changes:
1. adds test fn tokio_runtime() that returns a singleton Runtime
   reference.
2. add macro shared_tokio_runtime!() which enables modifying an existing
   async fn to use the shared runtime, instead of #[tokio::test]
3. add dev dependency on macro_rules_attr, to apply the macro
4. apply to async test fn with #[apply(shared_tokio_runtime)]
5. tests now acquire singleton TritonVmJobQueue instead of a new one.

Squashed:
* first test compiles with shared_tokio_test attribute
* 1. all async tests now share tokio runtime.
  2. tests now share single TritonVmJobQueue instance
* use shared tokio runtime for test fn that call block_on() manually
 
-------------

the above is the primary commit.   But in the course of this I also implemented some improvements to the job-queue, in this commit.

refactor: simplify job-queue and log unique job-id

These changes were motivated by a need to follow/debug job-queue
behavior in the logs when shared by all async unit tests.

Primary changes:
1. Each job is now assigned a randomly generated 12-byte job-id that is
   logged when adding a job and when it begins and completes
   processing.
2. Simplifies queue implementation by removing the "add_job" spawned
   task.  There is now just a single "process_job" task, and jobs are
   added to the queue, via mutex, in the caller's task.
3. The process_job task listens for a Stop message and will stop
   right away, after signaling running job to cancel, if any.
4. Adds an async stop() method that also drops the queue. It performs
   cleanup better than a simple drop().
5. improve error handling.

Squashed:

* refactor job-queue so there is only one spawned task
* separate add-job and stop into separate channels
* add job_id to jobs, log
* job-queue cleanups
* wait for current job to complete when stopping queue


