### PR TITLE
ci: Use tarpaulin to generate coverage reports

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,25 +16,24 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install tarpaulin
+        uses: taiki-e/install-action@v2
         with:
-          components: llvm-tools-preview
+          tool: cargo-tarpaulin
 
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
-
-      - name: Install nextest
-        uses: taiki-e/install-action@nextest
-
-      # For some reason, coverage data for the documentation tests is ~30GiB.
-      # Github's CI runners have ~15GiB of disk space. To have any coverage data
-      # at all, documentation tests are skipped.
-      - name: Collect coverage data (skip doctests & benchmarks)
+      - name: Generate code coverage
         run: >
-          cargo llvm-cov nextest
-          --lib --bins --tests --examples
-          --lcov --output-path lcov.info
+          cargo +nightly tarpaulin
+          --verbose
+          --all-targets
+          --all-features
+          --workspace
+          --engine llvm
+          --timeout 600
+          --out Lcov
           --
           --skip mine_20_blocks_in_40_seconds
           --skip hash_rate_independent_of_tx_size


### PR DESCRIPTION
I'm not sure how much to trust the new data. For example, the file `archival_mutator_set.rs` is now down to <2% test coverage. Prominent functions like [`prove`](https://coveralls.io/builds/73414155/source?filename=src%2Futil_types%2Fmutator_set%2Farchival_mutator_set.rs#L42) are supposedly uncovered. However, I count 11 call sites from within tests. Maybe the tarpaulin doesn't pick up on code executed by the job queue?