### PR TITLE
docs: document release candidate testnet policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ built-in peer-discovery process.
 
 ## Documentation
 
+The docs are at [docs.neptune.cash](https://docs.neptune.cash/).
+
 Documentation uses [https://rust-lang.github.io/mdBook/](mdBook). To run a local copy:
 
 - install mdBook: `cargo install mdbook`
@@ -103,6 +105,10 @@ neptune-cli block-height
 
 If you set up `neptune-core` to listen for RPC requests on a different port from the default (9799),
 then the flag `--port <port>` is your friend.
+
+## Release Candidates and Public Testnet
+
+It is policy that each release candidate be made available for public testing on `testnet` prior to official release.  [Details](https://docs.neptune.cash/contributing/git-workflow.html#testnet-policy-pre-release)
 
 ## Setup for Development (Ubuntu)
 

--- a/docs/src/contributing/git-workflow.md
+++ b/docs/src/contributing/git-workflow.md
@@ -11,7 +11,7 @@ It can be visualized like this:
 master     / topic   \
 ----------------------------------------->
     * v0.3.0-rc1    * v0.4.0-rc1
-    * v0.3.0        | v0.4.0
+    * v0.3.0        | v0.4.0-rc2
                     ---------
                             * v0.4.0-rc2
                             * v0.4.0
@@ -20,6 +20,8 @@ master     / topic   \
 ```
 
 _note: "*" represents a tag and "|" represents a branch point._
+
+_not shown: changes from branches v0.4.0-rc2 and v0.4.1 should be merged into master, if applicable._
 
 ### visualization, described
 
@@ -105,9 +107,9 @@ It is project policy that each major and minor release be tested as a
 release-candidate in the public community testnet prior to making an official
 release.
 
-A period of public testnet testing provides the community an opportunity to try out
-candidate builds in their own unique environments and report any issues, and to
-prepare for new features in advance.
+A period of public testnet testing provides the community with an opportunity to
+try out candidate builds in their own unique environments and report any issues,
+and to prepare for new features in advance.
 
 It is also an important period of integration testing "in the wild" for the
 release candidate binary.  Operating on a public testnet, it will necessarily be
@@ -116,21 +118,23 @@ that do not occur with automated testing.
 
 #### Some specifics
 
-1. Each release candidate must be publically announced with a dedicated topic in
+1. The release candidate should be published using the same release process as
+   the eventual release; see [releasing](releasing.md).
+2. Each release candidate must be publicly announced with a dedicated topic in
    [talk.neptune.cash](https://talk.neptune.cash).
-2. The release candidate should target 2 weeks of testing after the announcement
+3. The release candidate should target 2 weeks of testing after the announcement
    on average with a minimum of 1 week.
-3. The company behind neptune-cash will provide at least 1 dedicated machine for
+4. The company behind neptune-cash will provide at least 1 dedicated machine for
    the public testnet for the purpose of running the release-candidate binary
    and composing blocks.  Of course the community is also encouraged to run
    nodes and mine (compose or guess) if possible.
-4. A set of automated tests will be created that utilize the RPC API to perform
+5. A set of automated tests will be created that utilize the RPC API to perform
    automated transactions and test basic functionality of the live running
    nodes. These tests should/must be run at least once against each
    release-candidate binary while connected to the public testnet network.
-5. If the release-candidate introduces breaking consensus changes, then a
-reset/restart of the testnet from the genesis block may be performed.
-6. Patch releases may skip testnet testing if the risk seems low and/or the
+6. If the release-candidate introduces breaking consensus changes, then a
+   reset/restart of the testnet from the genesis block may be performed.
+7. Patch releases may skip testnet testing if the risk seems low and/or the
    urgency is sufficiently high.
 
 
@@ -209,36 +213,8 @@ The normal/typical release flow would be:
 
 The release flow for a major version change is essentially the same except that the major version number is bumped and the minor version returns to 0.
 
+Detailed release instructions are in [releasing.md](releasing.md).
 
-## Release Candidate Protocol  (-rc1, -rc2, etc)
-
- - determine source branch and new version.  (see visualization above.)
- - checkout the source branch and ensure working directory is clean.
- - Set the version in `Cargo.toml` (including the -rcX suffix).
- - Ensure that source branch (eg master) builds against crates that live on
-   [crates.io](https://crates.io). In particular, no dependencies on github
-   repositories or revisions.
- - review `README.md` to ensure the installation instructions are up-to-date.
- - Ensure that all tests pass.
- - Create a commit with the subject line `v0.3.0-rc1` (or whatever the new version number is) and in the body list all the changes.
- - Push present branch to github.
- - Add a tag marking the current commit version:
-   - `git tag v0.3.0-rc1` (or whatever the next version is)
-   - `git push --tags`.
- - build binaries and make a "release" on github
- - start a testnet with the release-candidate executables.
- - announce the release and new testnet on [talk.neptune.cash](https://talk.neptune.cash).
-
-## Release Protocol (major.minor.point)
-  Perform steps as above except:
-   - `git tag v0.3.0` (or whatever the next version is)
-   - `git tag latest-release`
-   - `git push --tags`.
-   - no need to make a testnet.
-   - announce the release on [talk.neptune.cash](https://talk.neptune.cash)
-   - Consider updating social media:
-     - telegram, twitter/x, reddit.com/r/cryptocurrencies,
-       reddit.com/r/neptune-cash, etc.
 
 ## latest-release tag
 

--- a/docs/src/contributing/git-workflow.md
+++ b/docs/src/contributing/git-workflow.md
@@ -7,33 +7,81 @@ We follow a standard [GitHub Flow](https://docs.github.com/en/get-started/using-
 It can be visualized like this:
 
 ```
-            --------
-master     / topic  \
-----*----------------------*--------------->
-    \ release              \ release
-    ------------------>    --------->
-    \ hotfix /
-    --------
+            ---------
+master     / topic   \
+----------------------------------------->
+    * v0.3.0-rc1    * v0.4.0-rc1
+    * v0.3.0        | v0.4.0
+                    ---------
+                            * v0.4.0-rc2
+                            * v0.4.0
+                            | v0.4.1
+                            -----------* v0.4.1
 ```
 
-### master branch (aka trunk)
+_note: "*" represents a tag and "|" represents a branch point._
 
-The `master` branch represents the tip of current development. It is an _integration_ branch, in the sense that developer changes from smaller _topic_ branches get merged and integrated into `master` and github's CI performs testing for every pull-request.
+### visualization, described
 
-The master branch of each crate should always build and should always pass all tests.
+1. The `master` branch represents the tip of current development. It is an
+   _integration_ branch, in the sense that developer changes from smaller
+   _topic_ branches get merged and integrated into `master` and github's CI
+   performs testing for every pull-request.
 
-At present, any team member with repo write access may directly commit to the `master` branch. However, as we get closer to a mainnet launch, `master` should/will become locked so that all changes must go through the pull-request process and be peer reviewed.
+2. **Scenario 1 (v0.3.0 - Clean Release):** A release candidate (`v0.3.0-rc1`)
+   is tagged from the `master` branch. Following testing, no significant issues
+   are found, and the **same commit** is directly tagged as the final release
+   (`v0.3.0`). This represents a smooth and efficient release where the first RC
+   is deemed stable enough for production.
 
-### topic branches
+3. **Scenario 2 (v0.4.0 - Iterative Release Candidate Process):** A release
+   candidate (`v0.4.0-rc1`) is tagged from the `master` branch. During testing,
+   problems are identified. This necessitates further development and the
+   creation of a subsequent release candidate (`v0.4.0-rc2`) on a branch derived
+   from `v0.4.0-rc1`. After the issues are resolved in `v0.4.0-rc2`, the final
+   release (`v0.4.0`) is tagged from that stable point.
 
-Even now, team members are encouraged to create a *topic* branch and pull-request for larger changes or anything that might be considered non-obvious or controversial.
+4. **Patch Release (v0.4.1):** Following the stable release of `v0.4.0`, a bug
+   or security issue is discovered. A patch release (`v0.4.1`) is created based
+   on the `v0.4.0` tag to address this specific problem. This allows for a
+   focused update to the stable release without incorporating new features or
+   major changes that would warrant a minor version bump.  Note that a
+   release-candidate is not employed in this example, as such patches should be
+   small and there may be a high urgency.
+
+5. **Topic Branch (`/ topic \`):** This represents a short-lived branch created
+   from the `master` branch for the development of a specific feature or bug
+   fix. Once the work on the topic is complete and tested, it is eventually
+   merged back into the `master` branch, contributing to future release cycles.
+
+
+### Branch policies:
+
+#### master branch (aka trunk)
+
+The master branch of each crate should always build and should always pass all
+tests.
+
+At present, any team member with repo write access may directly commit to the
+`master` branch. However, now that neptune-core has launched Mainnet this policy
+may soon be revised such that `master` will become locked so that all changes
+must go through the pull-request process and be peer reviewed.
+
+#### topic branches
+
+Team members are encouraged to create a *topic* branch and pull-request for
+larger changes or anything that might be considered non-obvious or
+controversial.
 
 tip: *topic* branches are sometimes called *feature* branches.
 
-A *topic* branch typically branches off of `master` or another *topic* branch.  It is intended for an individual
-feature or bug-fix.  We should strive to keep each *topic* branch focused on a single change/feature and as short-lived as possible.
+A *topic* branch typically branches off of `master` or another *topic* branch.
+It is intended for an individual feature or bug-fix.  We should strive to keep
+each *topic* branch focused on a single change/feature and as short-lived as
+possible.
 
-Third party contributors without repo write access must create a *topic* branch and submit a pull request for each change.  This is accomplished by:
+Third party contributors without repo write access must create a *topic* branch
+and submit a pull request for each change.  This is accomplished by:
 1. fork the repo
 2. checkout and build the desired branch (usually master or a release branch)
 3. create a topic branch
@@ -41,7 +89,7 @@ Third party contributors without repo write access must create a *topic* branch 
 5. push your topic branch to your forked repo
 6. submit the pull request.
 
-#### Topic Branch Naming
+##### Topic Branch Naming
 
 When working on an open github issue, it is recommended to prefix the topic branch with the issue identifier.
 
@@ -51,36 +99,173 @@ If the branch exists in a triton/neptune official repo, (as opposed to a persona
 
 So if working on issue `#232` and adding feature *walk_and_chew_gum* one might name the branch `myuser/232_walk_and_chew_gum_pr`.
 
-### release branch
+### Testnet policy (pre-release)
 
-The `master` branch can contain changes that are not compatible with whatever network is currently live. Beta-testers looking for the branch that will synchronize with the network that is currently live need branch `release`. This branch may cherry-pick commits that are meant for `master` so long as they are backwards-compatible. However, when this task is too cumbersome, branch `release` will become effectively abandoned -- until the next network version is released.
+It is project policy that each major and minor release be tested as a
+release-candidate in the public community testnet prior to making an official
+release.
 
-#### TestNet Release Protocol
+A period of public testnet testing provides the community an opportunity to try out
+candidate builds in their own unique environments and report any issues, and to
+prepare for new features in advance.
 
- - Ensure that master builds against crates that live on [crates.io](https://crates.io). In particular, no dependencies on github repositories or revisions.
- - Update `README.md` in case to make sure the installation instructions are up-to-date.
+It is also an important period of integration testing "in the wild" for the
+release candidate binary.  Operating on a public testnet, it will necessarily be
+exposed to peers running older versions of the software and may shake out issues
+that do not occur with automated testing.
+
+#### Some specifics
+
+1. Each release candidate must be publically announced with a dedicated topic in
+   [talk.neptune.cash](https://talk.neptune.cash).
+2. The release candidate should target 2 weeks of testing after the announcement
+   on average with a minimum of 1 week.
+3. The company behind neptune-cash will provide at least 1 dedicated machine for
+   the public testnet for the purpose of running the release-candidate binary
+   and composing blocks.  Of course the community is also encouraged to run
+   nodes and mine (compose or guess) if possible.
+4. A set of automated tests will be created that utilize the RPC API to perform
+   automated transactions and test basic functionality of the live running
+   nodes. These tests should/must be run at least once against each
+   release-candidate binary while connected to the public testnet network.
+5. If the release-candidate introduces breaking consensus changes, then a
+reset/restart of the testnet from the genesis block may be performed.
+6. Patch releases may skip testnet testing if the risk seems low and/or the
+   urgency is sufficiently high.
+
+
+# neptune-core versioning and releases
+
+## deviation from standard semver practice
+
+neptune-core is presently both a (blockchain) library and a binary. Semantic versioning signals changes to APIs and mainly applies to libraries.  But it does not capture breaking changes that can occur in a blockchain ecosystem or breaking changes with regards to stored state, ie databases.
+
+For blockchains it is of primary importance to maintain consensus and network
+compatibility with other nodes on the network.
+
+For these reasons, we define the version identifier as follows.
+
+## version identifier
+
+neptune-core uses sem-ver compatible identifier of the form:
+```
+<major>.<minor>.<patch>[-<candidate>]
+
+where `candidate` is of the form "rc1", "rc2", etc and starts at 1.
+```
+
+Examples:
+```
+0.4.0-rc1
+0.5.0-rc1
+0.5.0-rc2
+0.5.0-rc3
+1.2.2
+```
+
+Non-Examples: (should not occur)
+```
+0.4.1-rc1       (point release should not be a release-candidate)
+1.2.0-rc0       (release candidates start at 1, not 0)
+```
+
+note: for git tags, a "v" is prefixed, as per git convention.
+
+Our release process treats these as:
+
+**major**: bumped any time there are:
+
+1. significant consensus or p2p layer changes. eg hard or soft-fork or breaking protocol change.
+2. breaking library API changes.
+3. breaking database changes.
+
+resets minor and patch to 0.
+
+**minor**: bumped any time changes from master are included in a release candidate.
+
+resets patch to 0.
+
+**patch**: bumped any time changes from a release branch are included in a release.
+
+resets candidate to "-rc1".
+
+**candidate**: added/bumped when a new public testnet is created for a candidate release.
+
+*Note that the optional suffix is supported by cargo and related tools.*
+
+## typical release
+
+The normal/typical release flow would be:
+
+1. normal changes (not consensus) are introduced in master.
+2. a release candidate is tagged from master, eg `v0.3.0-rc1` and built.
+3. a testnet is created for `v0.3.0-rc1`
+4. if significant problems are found then a new branch `v0.3.0-rc2` is created at `v0.3.0-rc1`, or possibly from master.  commit(s) are added. When ready, the final commit in the branch is tagged with `v0.3.0-rc2`, another testnet created, and so on.
+5. fixes for the release-candidate should also be applied to master, if applicable.
+6. After two weeks, or when team decides, the latest release-candidate tag is also tagged with `v0.3.0`, signifying an actual release.
+7. The release is performed.
+
+*note that by the time the release actually occurs, master may have diverged significantly.*
+
+The release flow for a major version change is essentially the same except that the major version number is bumped and the minor version returns to 0.
+
+
+## Release Candidate Protocol  (-rc1, -rc2, etc)
+
+ - determine source branch and new version.  (see visualization above.)
+ - checkout the source branch and ensure working directory is clean.
+ - Set the version in `Cargo.toml` (including the -rcX suffix).
+ - Ensure that source branch (eg master) builds against crates that live on
+   [crates.io](https://crates.io). In particular, no dependencies on github
+   repositories or revisions.
+ - review `README.md` to ensure the installation instructions are up-to-date.
  - Ensure that all tests pass.
- - Bump the version in `Cargo.toml`
- - Create a commit with the subject line `v0.0.6` (or watever the new version number is) and in the body list all the changes.
- - Push to `master` on github.
- - Add a tag marking the current commit with the version:
-   - `git tag v0.0.6` (or whatever the next version is)
+ - Create a commit with the subject line `v0.3.0-rc1` (or whatever the new version number is) and in the body list all the changes.
+ - Push present branch to github.
+ - Add a tag marking the current commit version:
+   - `git tag v0.3.0-rc1` (or whatever the next version is)
    - `git push --tags`.
- - Set branch `release` to point to `master`:
-   - `git checkout release`
-   - `git reset master`
-   - `git push`
- - Consider making an announcement.
+ - build binaries and make a "release" on github
+ - start a testnet with the release-candidate executables.
+ - announce the release and new testnet on [talk.neptune.cash](https://talk.neptune.cash).
+
+## Release Protocol (major.minor.point)
+  Perform steps as above except:
+   - `git tag v0.3.0` (or whatever the next version is)
+   - `git tag latest-release`
+   - `git push --tags`.
+   - no need to make a testnet.
+   - announce the release on [talk.neptune.cash](https://talk.neptune.cash)
+   - Consider updating social media:
+     - telegram, twitter/x, reddit.com/r/cryptocurrencies,
+       reddit.com/r/neptune-cash, etc.
+
+## latest-release tag
+
+The `master` branch may contain changes that are not compatible with previous
+release. Individuals looking for the latest release can simply checkout the
+`latest-release` tag, which is updated as part of the release process.
+
+_note: End-users are discouraged from building and running the `master` branch
+as it could result in undefined and unsupported states with regards to database
+schemas, etc. It could even result in loss of funds or problems interacting with
+peers due to concensus or p2p layer changes._
+
 
 # Conventional Commits
 
-It is preferred/requested that commit messages use the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) format.
+It is preferred/requested that commit messages use the [conventional
+commit](https://www.conventionalcommits.org/en/v1.0.0/) format.
 
-This aids readability of commit messages and facilitates automated generation of the ChangeLog.
+This aids readability of commit messages and facilitates automated generation of
+the ChangeLog.
 
-For all but the most trivial changes, please provide some additional lines with a basic summary of the changes and also the _reason/rationale_ for the changes.
+For all but the most trivial changes, please provide some additional lines with
+a basic summary of the changes and also the _reason/rationale_ for the changes.
 
-A git template for assisting with creation of conventional commit messages can be found in the [Git Message](git-message.md). This template can be added globally to git with this command:
+A git template for assisting with creation of conventional commit messages can
+be found in the [Git Message](git-message.md). This template can be added
+globally to git with this command:
 
 ```
 git config --global commit.template /path/to/neptune-core/docs/src/contributing/.gitmessage
@@ -92,17 +277,21 @@ It can also be added on a per-repository basis by omitting the `--global` flag.
 
 ### For published crate releases
 
-When publishing a crate, and/or when making a release of `neptune-core`, all dependencies should/must reference a version published to [crates.io](https://crates.io).
+When publishing a crate, and/or when making a release of `neptune-core`, all
+dependencies should/must reference a version published to
+[crates.io](https://crates.io).
 
 In particular, git repo references must not be used.
 
 ### For development between crate releases.
 
-Often parallel development will be occurring in
-multiple triton/neptune crates.  In such cases
-there may be API or functionality changes that necessitate temporarily specifying a git dependency reference instead of a published crates.io version.
+Often parallel development will be occurring in multiple triton/neptune crates.
+In such cases there may be API or functionality changes that necessitate
+temporarily specifying a git dependency reference instead of a published
+crates.io version.
 
-For this, we keep the original dependency line unchanged, and add a crates.io patch at the bottom of Cargo.toml.
+For this, we keep the original dependency line unchanged, and add a crates.io
+patch at the bottom of Cargo.toml.
 
 Example:
 
@@ -121,15 +310,17 @@ Note that:
 2. We place a comment indicating the branch on which the
 revision resides, as of placement date.
 
-A branch name is a moving target.  So if we were to specify a branch, then our build might compile fine today
-and tomorrow it no longer does.
+A branch name is a moving target.  So if we were to specify a branch, then our
+build might compile fine today and tomorrow it no longer does.
 
 The [patch section docs](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section) have more detail.  In particular take note that:
 
 1. Cargo only looks at the patch settings in the Cargo.toml manifest at the root of the workspace.
 2. Patch settings defined in dependencies will be ignored.
 
-This [blog article](https://gatowololo.github.io/blog/cargo-patch/) is also helpful.
+This [blog article](https://gatowololo.github.io/blog/cargo-patch/) is also
+helpful.
 
 
-Finally, all such temporary patches must be removed before publishing a crate or issuing a new release!
+Finally, all such temporary patches must be removed before publishing a crate or
+issuing a new release!

--- a/docs/src/contributing/releasing.md
+++ b/docs/src/contributing/releasing.md
@@ -2,6 +2,23 @@
 
 This section describes the steps to publish a new version of Neptune Core, and to release & distribute its binary artifacts.
 
+## Automation
+
+This is presently a largely manual process.  It is expected/encouraged that one
+or more custom deployment tools will be developed so this becomes a push-button
+process instead, or even fully automated when certain event(s) happen.  Such a
+tool will remove tedium as well as the human error factor, which is important
+for performing the task regularly and consistently.
+
+## Release Candidate vs Release.
+
+Review the distinction [here](git-workflow.md), and make sure you know which is being generating and what the correct version should be.
+
+A release should typically be performed two weeks after the matching
+release-candidate has begun testing in testnet, though circumstances might
+dictate otherwise. Also patch releases (major and minor version unchanged) can
+be an exception.
+
 ## Pre-requisites
 
 The following tools are used to ensure a high quality release.
@@ -53,7 +70,10 @@ An appropriate commit message could be:
 
 ### Bump Version
 
-Bump the version in `Cargo.toml` [as appropriate](https://doc.rust-lang.org/cargo/reference/semver.html).
+Bump the version in `Cargo.toml` [as appropriate](git-workflow.md#version_identifier)
+
+See also: https://doc.rust-lang.org/cargo/reference/semver.html.
+
 
 ### Confirm Version Bump as Semantic
 
@@ -166,15 +186,37 @@ Edit them until you are happy, then push the tag(s) to GitHub.
  - To show tags: `git tag --list`
  - To push a tag: `git push origin [tag_name]`
 
-### Set Branch `release`
+### If a release-candidate:
 
-By convention, branch `release` should always point to the latest stable commit compatible with the latest release.
+#### Deploy release to testnet machine(s).
 
-```sh
-git checkout release
-git reset --hard master
-git push --force-with-lease
+(full instructions: TBD)
+
+Announce the release-candidate in a post at talk.neptune.cash.
+
+Ensure that a composer is running using the release-candidate binary.
+
+### If an actual release:
+
+#### Set tag `latest-release`
+
+The tag `latest-release` should always point to the commit for the *latest
+release*.
+
+*note: never a release-candidate, eg ".rc1".*
+
 ```
+git tag --force latest-release
+git push --force origin latest-release
+```
+
+#### Consider updating social media
+
+  Announce the release in a post at talk.neptune.cash.
+
+  telegram, twitter/x, reddit.com/r/cryptocurrencies,
+  reddit.com/r/neptune-cash, etc.
+
 
 ### Check Release Artifacts & Page
 


### PR DESCRIPTION
updates the mdbook with:

1. a (new) description of the versioning scheme.

2. a modified git branching visualization and (new) description to reflect the process of iterating release candidates.

3. a policy for testing each release candidate in the public testnet.

-----------

note: all changes are proposals.  If anything is unclear or there is not concensus, then we should consider a meeting to discuss/resolve, as that should hopefully be faster than a lot of comments back and forth.

Also, it's quite possible that the mdbook document I started from was already out of date with respect to current processes, so if that's the case, please consider merging in current practice and/or documenting in a comment, so I can.