### PR TITLE
backup wallet DB before migrating

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -563,11 +563,11 @@ impl Drop for ScopeDurationLogger<'_> {
 }
 
 /// recursively copy source dir to destination
-pub fn copy_dir_recursive(source: &PathBuf, destination: &PathBuf) -> std::io::Result<()> {
+pub(crate) fn copy_dir_recursive(source: &PathBuf, destination: &PathBuf) -> std::io::Result<()> {
     if !source.is_dir() {
         return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "Source is not a directory",
+            std::io::ErrorKind::NotADirectory,
+            format!("not a directory: {}", source.display()),
         ));
     }
     std::fs::create_dir_all(destination)?;

--- a/src/models/state/wallet/migrate_db/v0_to_v1.rs
+++ b/src/models/state/wallet/migrate_db/v0_to_v1.rs
@@ -154,7 +154,6 @@ mod test {
     use crate::models::state::wallet::rusty_wallet_database::RustyWalletDatabase;
     use crate::models::state::wallet::utxo_notification::UtxoNotifyMethod;
     use crate::models::state::Timestamp;
-    use crate::tests::shared;
     use crate::tests::shared::unit_test_data_directory;
     use crate::tests::shared_tokio_runtime;
     use crate::DataDirectory;
@@ -219,7 +218,7 @@ mod test {
 
         // connect to v0 Db with v1 RustyWalletDatabase.  This is where the
         // migration occurs.
-        let wallet_db_v1 = RustyWalletDatabase::connect(db_v0).await;
+        let wallet_db_v1 = RustyWalletDatabase::try_connect_and_migrate(db_v0).await?;
 
         // dump the (migrated) v1 database to stdout
         println!("dump of v1 (upgraded) database");
@@ -273,7 +272,7 @@ mod test {
         let wallet_database_path = data_dir.wallet_database_dir_path();
 
         // copy DB in test_data to wallet_database_path
-        shared::copy_dir_recursive(&test_data_wallet_db_dir, &wallet_database_path)?;
+        crate::copy_dir_recursive(&test_data_wallet_db_dir, &wallet_database_path)?;
 
         // open v0 DB file
         tracing::info!("opening existing v0 DB for migration to v1");
@@ -285,7 +284,7 @@ mod test {
 
         // connect to v0 Db with v1 RustyWalletDatabase.  This is where the
         // migration occurs.
-        let wallet_db_v1 = RustyWalletDatabase::connect(db_v0).await;
+        let wallet_db_v1 = RustyWalletDatabase::try_connect_and_migrate(db_v0).await?;
 
         // dump the (migrated) v1 database to stdout
         println!("dump of v1 (upgraded) database");

--- a/src/models/state/wallet/rusty_wallet_database.rs
+++ b/src/models/state/wallet/rusty_wallet_database.rs
@@ -200,9 +200,9 @@ impl StorageWriter for RustyWalletDatabase {
 
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum WalletDbConnectError {
-    #[error("Wallet database schema version is lower than expected.  expected schema version: {}, found: {}", found, expected)]
+    #[error("Wallet database schema version is lower than expected.  expected schema version: {}, found: {}", expected, found)]
     SchemaVersionTooLow { found: u16, expected: u16 },
-    #[error("Wallet database schema version is higher than expected.  It appears to come from a newer release of neptune-core.  expected schema version: {}, found: {}", found, expected)]
+    #[error("Wallet database schema version is higher than expected.  It appears to come from a newer release of neptune-core.  expected schema version: {}, found: {}", expected, found)]
     SchemaVersionTooHigh { found: u16, expected: u16 },
     #[error("wallet db connect failed: {0}")]
     Failed(String),

--- a/src/models/state/wallet/wallet_configuration.rs
+++ b/src/models/state/wallet/wallet_configuration.rs
@@ -124,11 +124,11 @@ impl WalletConfiguration {
         schema_version: u16,
     ) -> Option<PathBuf> {
         let mut path = self.wallet_database_directory_path();
-        path.pop();
+        path.pop().then_some(())?; // returns None if pop() is false
         let max_tries = 1000;
 
         // increment filename until we find an unused path or exhaust tries.
-        (1..max_tries)
+        (1..=max_tries)
             .map(|i| {
                 path.join(format!(
                     "{}.schema-v{}.bak.{}",

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::error::Error;
 use std::fmt::Debug;
+use std::path::Path;
+use std::path::PathBuf;
 
 use anyhow::bail;
 use anyhow::Result;
@@ -19,7 +21,6 @@ use tokio::io::AsyncWriteExt;
 use tokio::io::BufReader;
 use tokio::io::BufWriter;
 use tracing::debug;
-use tracing::error;
 use tracing::info;
 use tracing::trace;
 use tracing::warn;
@@ -48,6 +49,8 @@ use crate::config_models::cli_args::Args;
 use crate::config_models::data_directory::DataDirectory;
 use crate::config_models::fee_notification_policy::FeeNotificationPolicy;
 use crate::database::storage::storage_schema::DbtVec;
+use crate::database::storage::storage_schema::RustyKey;
+use crate::database::storage::storage_schema::RustyValue;
 use crate::database::storage::storage_vec::traits::*;
 use crate::database::storage::storage_vec::Index;
 use crate::database::NeptuneLevelDb;
@@ -65,6 +68,7 @@ use crate::models::state::mempool::MempoolEvent;
 use crate::models::state::transaction_kernel_id::TransactionKernelId;
 use crate::models::state::wallet::address::hash_lock_key::HashLockKey;
 use crate::models::state::wallet::monitored_utxo::MonitoredUtxo;
+use crate::models::state::wallet::rusty_wallet_database::WalletDbConnectError;
 use crate::models::state::wallet::transaction_input::TxInput;
 use crate::models::state::wallet::transaction_output::TxOutput;
 use crate::prelude::twenty_first;
@@ -273,15 +277,13 @@ impl WalletState {
     /// Create a `WalletState` object from related data.
     ///
     /// Convenience method to extract required data prior to calling the
-    /// canonical constructor, [`Self::new`].
-    pub(crate) async fn new_from_context(
+    /// canonical constructor, [Self::try_new()].
+    pub(crate) async fn try_new_from_context(
         data_dir: &DataDirectory,
         wallet_file_context: WalletFileContext,
         cli_args: &Args,
-    ) -> Self {
-        let database_is_new = !tokio::fs::try_exists(&data_dir.wallet_database_dir_path())
-            .await
-            .unwrap();
+    ) -> Result<Self> {
+        let database_is_new = !tokio::fs::try_exists(&data_dir.wallet_database_dir_path()).await?;
         info!(
             "wallet DB directory path is {}. Exists: {}",
             data_dir.wallet_database_dir_path().display(),
@@ -297,36 +299,34 @@ impl WalletState {
             configuration.enable_scan_mode();
         }
 
-        Self::new(configuration, wallet_entropy).await
+        Self::try_new(configuration, wallet_entropy).await
     }
 
     /// Construct a `WalletState` object.
-    ///
-    /// Canonical constructor.
-    pub(crate) async fn new(
+    pub(crate) async fn try_new(
         configuration: WalletConfiguration,
         wallet_entropy: WalletEntropy,
-    ) -> Self {
+    ) -> anyhow::Result<Self> {
         const NUM_PREMINE_KEYS: usize = 10;
 
         let wallet_database_path = configuration.wallet_database_directory_path();
-        DataDirectory::create_dir_if_not_exists(&wallet_database_path)
-            .await
-            .unwrap();
-        let wallet_db = NeptuneLevelDb::new(
-            &wallet_database_path,
-            &crate::database::create_db_if_missing(),
-        )
-        .await;
-        let wallet_db = match wallet_db {
-            Ok(wdb) => wdb,
-            Err(err) => {
-                error!("Could not open wallet database: {err:?}");
-                panic!();
-            }
-        };
+        DataDirectory::create_dir_if_not_exists(&wallet_database_path).await?;
+        let wallet_db = Self::open_wallet_db(&wallet_database_path).await?;
 
-        let rusty_wallet_database = RustyWalletDatabase::connect(wallet_db).await;
+        let rusty_wallet_database = match RustyWalletDatabase::try_connect(wallet_db).await {
+            Err(WalletDbConnectError::SchemaVersionTooLow { found, expected: _ }) => {
+                // DB schema version is too low, so we need to migrate it.
+                // note: wallet_db was moved into try_connect() and is now dropped/closed.
+
+                // safety first! backup wallet DB before migrating schema.
+                Self::backup_database(&configuration, found).await?;
+
+                // attempt to connect and migrate the DB to latest version.
+                let db = Self::open_wallet_db(&wallet_database_path).await?;
+                RustyWalletDatabase::try_connect_and_migrate(db).await
+            }
+            other => other,
+        }?;
 
         let sync_label = rusty_wallet_database.get_sync_label();
 
@@ -434,14 +434,48 @@ impl WalletState {
                     &MutatorSetAccumulator::default(),
                     &Block::genesis(configuration.network()),
                 )
-                .await
-                .expect("Updating wallet state with genesis block must succeed");
+                .await?;
 
             // No db-persisting here, as all of state should preferably be
             // persisted at the same time.
         }
 
-        wallet_state
+        Ok(wallet_state)
+    }
+
+    async fn open_wallet_db(path: &Path) -> anyhow::Result<NeptuneLevelDb<RustyKey, RustyValue>> {
+        NeptuneLevelDb::new(path, &crate::database::create_db_if_missing())
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to open wallet db at '{}': {}", path.display(), e))
+    }
+
+    /// performs backup of DB dir by copying it to a new directory.
+    async fn backup_database(
+        configuration: &WalletConfiguration,
+        schema_version: u16,
+    ) -> anyhow::Result<PathBuf> {
+        let db_dir = configuration.wallet_database_directory_path();
+        let backup_dir = configuration
+            .wallet_database_next_unused_backup_path(schema_version)
+            .ok_or_else(|| anyhow::anyhow!("unable to find an unused backup path"))?;
+
+        // we open DB first to ensure no-one else can use it meanwhile.
+        let _db = Self::open_wallet_db(&db_dir).await?;
+
+        tracing::info!(
+            "backing up wallet database from {} to {}",
+            db_dir.display(),
+            backup_dir.display()
+        );
+
+        // perform the backup.
+        crate::copy_dir_recursive(&db_dir, &backup_dir).map_err(|e| {
+            anyhow::anyhow!("failed copying wallet database to backup directory. {e}")
+        })?;
+
+        tracing::info!("backed up wallet database to {}", backup_dir.display());
+
+        Ok(backup_dir) // _db is dropped/closed
     }
 
     /// Extract `ExpectedUtxo`s from the `TxOutputList` that require off-chain
@@ -1992,7 +2026,7 @@ pub(crate) mod tests {
             cli_args: &Args,
         ) -> Self {
             let configuration = WalletConfiguration::new(data_dir).absorb_options(cli_args);
-            Self::new(configuration, wallet_entropy).await
+            Self::try_new(configuration, wallet_entropy).await.unwrap()
         }
     }
 
@@ -4947,6 +4981,49 @@ pub(crate) mod tests {
                 .get_wallet_status(block_two.hash(), &block_two.mutator_set_accumulator_after())
                 .await;
             assert_eq!(2, wallet_status.synced_unspent.len());
+        }
+    }
+
+    mod wallet_db_backup {
+        use super::*;
+        use crate::tests::shared::unit_test_data_directory;
+
+        #[traced_test]
+        #[apply(shared_tokio_runtime)]
+        async fn backup_wallet_db_and_open() -> Result<()> {
+            // basic setup
+            let cli = cli_args::Args::default();
+            let mut rng = StdRng::from_rng(&mut rng());
+            let wallet_entropy = WalletEntropy::new_pseudorandom(rng.random());
+            let data_dir = unit_test_data_directory(cli.network).unwrap();
+
+            let mut configuration = WalletConfiguration::new(&data_dir).absorb_options(&cli);
+
+            // instantiate WalletState to create a new DB and obtain schema version
+            let schema_version =
+                WalletState::try_new(configuration.clone(), wallet_entropy.clone())
+                    .await?
+                    .wallet_db
+                    .schema_version();
+
+            // perform db backup
+            let backup_dir = WalletState::backup_database(&configuration, schema_version).await?;
+
+            // verify backup dir exists and is different from source db dir.
+            assert!(backup_dir.exists());
+            assert_ne!(backup_dir, configuration.wallet_database_directory_path());
+
+            // load backup database into a new WalletState and obtain schema version
+            configuration.wallet_database_directory = backup_dir;
+            let schema_version_from_backup = WalletState::try_new(configuration, wallet_entropy)
+                .await?
+                .wallet_db
+                .schema_version();
+
+            // verify that schema version from backup DB matches original DB.
+            assert_eq!(schema_version, schema_version_from_backup);
+
+            Ok(())
         }
     }
 }

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -1231,24 +1231,3 @@ pub(crate) async fn wallet_state_has_all_valid_mps(
 
     true
 }
-
-// recursively copy source dir to destination
-pub fn copy_dir_recursive(source: &PathBuf, destination: &PathBuf) -> std::io::Result<()> {
-    if !source.is_dir() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "Source is not a directory",
-        ));
-    }
-    std::fs::create_dir_all(destination)?;
-    for entry in std::fs::read_dir(source)? {
-        let entry = entry?;
-        let dest_path = &destination.join(entry.file_name());
-        if entry.path().is_dir() {
-            copy_dir_recursive(&entry.path(), dest_path)?;
-        } else {
-            std::fs::copy(entry.path(), dest_path)?;
-        }
-    }
-    Ok(())
-}


### PR DESCRIPTION
closes #577

It is important to backup wallet db before migrating in case:
1. anything goes wrong with the migration
2. user needs to downgrade the software for some reason.

This refactors RustyWalletDatabase::connect() into two methods try_connect() and try_connect_and_migrate().  The former returns an error that indicates if the DB needs to be migrated.

WalletState (which has DB path info) calls try_connect() and performs a backup if needed. It then calls try_connect_and_migrate().

`WalletState::backup_database()` simply copies the "wallet" directory to `<wallet_db_name>-schema-v<schema-version>.bak.<count>`. For example the first backup of v0 wallet db would be: wallet-schema-v0.bak.1.  This is in the same parent directory as the original `wallet` db directory.  An alternative could be to create a "migration-backups" sub-directory.   That might be better, I haven't given it any thought until now.

The backup process will never overwrite an existing backup.  Instead it bumps the trailing `count` in the directory name until it finds a non-existent path.  Up to 1000 attempts are made (per schema version) after which the backup would fail and WalletState::try_new() would return an error.   An alternative would be to use a randomly generated identifier but then the order of backups is lost.

Some related minor additional cleanups were made.

A new unit test backup_wallet_db_and_open() performs a DB backup and opens the backup DB to verify it still functions and holds data.