### PR TITLE
Fix MSMP Resync From Blocks

### DIFF
--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -1754,7 +1754,7 @@ pub(crate) mod tests {
         use super::*;
         use crate::models::state::tx_creation_config::TxCreationConfig;
         use crate::models::state::wallet::address::generation_address::GenerationSpendingKey;
-        use crate::tests::shared::make_mock_block_guesser_preimage_and_guesser_fraction;
+        use crate::tests::shared::make_mock_block_with_puts_and_guesser_preimage_and_guesser_fraction;
 
         #[apply(shared_tokio_runtime)]
         async fn guesser_fee_addition_records_are_consistent() {
@@ -1765,8 +1765,10 @@ pub(crate) mod tests {
             let genesis_block = Block::genesis(Network::Main);
             let a_key = GenerationSpendingKey::derive_from_seed(rng.random());
             let guesser_preimage = rng.random();
-            let (block1, _) = make_mock_block_guesser_preimage_and_guesser_fraction(
+            let (block1, _) = make_mock_block_with_puts_and_guesser_preimage_and_guesser_fraction(
                 &genesis_block,
+                vec![],
+                vec![],
                 None,
                 a_key,
                 rng.random(),

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -1772,8 +1772,7 @@ pub(crate) mod tests {
                 None,
                 a_key,
                 rng.random(),
-                0.4,
-                guesser_preimage,
+                (0.4, guesser_preimage),
             )
             .await;
             let ars = block1.guesser_fee_addition_records();

--- a/src/models/blockchain/block/mutator_set_update.rs
+++ b/src/models/blockchain/block/mutator_set_update.rs
@@ -99,9 +99,12 @@ impl MutatorSetUpdate {
         authenticated_items: &mut [&mut AuthenticatedItem],
     ) -> bool {
         let mut cloned_removals = self.removals.clone();
-        let mut applied_removal_records = cloned_removals.iter_mut().rev().collect::<Vec<_>>();
+        let mut remaining_removal_records = cloned_removals.iter_mut().rev().collect::<Vec<_>>();
         for addition_record in &self.additions {
-            RemovalRecord::batch_update_from_addition(&mut applied_removal_records, ms_accumulator);
+            RemovalRecord::batch_update_from_addition(
+                &mut remaining_removal_records,
+                ms_accumulator,
+            );
 
             RemovalRecord::batch_update_from_addition(removal_records, ms_accumulator);
 
@@ -115,9 +118,9 @@ impl MutatorSetUpdate {
         }
 
         let mut removal_records_are_valid = true;
-        while let Some(applied_removal_record) = applied_removal_records.pop() {
+        while let Some(applied_removal_record) = remaining_removal_records.pop() {
             RemovalRecord::batch_update_from_remove(
-                &mut applied_removal_records,
+                &mut remaining_removal_records,
                 applied_removal_record,
             );
 

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -1100,9 +1100,9 @@ impl GlobalState {
     /// tip. This path may involve some blocks to revert ("backwards"),
     /// certainly involves a latest universal common ancestor ("LUCA"), and
     /// probably involves some blocks to apply ("forwards"). As we walk this
-    /// this path, the mutator set membership proof of the monitored UTXO is
-    /// modified in accordance with the mutator set update induced by the block
-    /// in question, which could be a revert (backwards) or a regular apply
+    /// path, the mutator set membership proof of the monitored UTXO is modified
+    /// in accordance with the mutator set update induced by the block in
+    /// question, which could be a revert (backwards) or a regular apply
     /// (forwards).
     ///
     ///  Locking:
@@ -1259,16 +1259,17 @@ impl GlobalState {
                 }
 
                 // apply removals
-                let mut applied_removals = removals.clone();
-                while let Some(applied_removal_record) = applied_removals.pop() {
+                let mut remaining_removal_records = removals;
+                remaining_removal_records.reverse();
+                while let Some(current_removal_record) = remaining_removal_records.pop() {
                     // keep removal records in sync
                     RemovalRecord::batch_update_from_remove(
-                        &mut applied_removals.iter_mut().collect_vec(),
-                        &applied_removal_record,
+                        &mut remaining_removal_records.iter_mut().collect_vec(),
+                        &current_removal_record,
                     );
 
-                    membership_proof.update_from_remove(&applied_removal_record);
-                    block_msa.remove(&applied_removal_record);
+                    membership_proof.update_from_remove(&current_removal_record);
+                    block_msa.remove(&current_removal_record);
                 }
 
                 // sanity check

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -2564,8 +2564,7 @@ pub(crate) mod tests {
                 None,
                 bob_key,
                 mock_block_seed,
-                guesser_fraction,
-                guesser_preimage_1a,
+                (guesser_fraction, guesser_preimage_1a),
             )
             .await;
 
@@ -2600,8 +2599,7 @@ pub(crate) mod tests {
                 None,
                 bob_key,
                 mock_block_seed,
-                guesser_fraction,
-                guesser_preimage_1b,
+                (guesser_fraction, guesser_preimage_1b),
             )
             .await;
 
@@ -3484,8 +3482,7 @@ pub(crate) mod tests {
                     None,
                     alice_wallet.nth_generation_spending_key(0),
                     rng.random(),
-                    guesser_fraction,
-                    guesser_preimage,
+                    (guesser_fraction, guesser_preimage),
                 )
                 .await;
 
@@ -4120,8 +4117,7 @@ pub(crate) mod tests {
                     None,
                     alice_wallet.nth_generation_spending_key(14),
                     rng.random(),
-                    guesser_fraction,
-                    guesser_preimage,
+                    (guesser_fraction, guesser_preimage),
                 )
                 .await;
 

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -2016,7 +2016,7 @@ pub(crate) mod tests {
     use crate::models::state::GlobalStateLock;
     use crate::tests::shared::invalid_block_with_transaction;
     use crate::tests::shared::make_mock_block;
-    use crate::tests::shared::make_mock_block_guesser_preimage_and_guesser_fraction;
+    use crate::tests::shared::make_mock_block_with_puts_and_guesser_preimage_and_guesser_fraction;
     use crate::tests::shared::mock_genesis_global_state;
     use crate::tests::shared::mock_genesis_wallet_state;
     use crate::tests::shared::wallet_state_has_all_valid_mps;
@@ -2557,8 +2557,10 @@ pub(crate) mod tests {
 
         // `bob` both composes and guesses the PoW solution of this block.
         let (block_1a, expected_utxos_block_1a) =
-            make_mock_block_guesser_preimage_and_guesser_fraction(
+            make_mock_block_with_puts_and_guesser_preimage_and_guesser_fraction(
                 &genesis_block,
+                vec![],
+                vec![],
                 None,
                 bob_key,
                 mock_block_seed,
@@ -2591,8 +2593,10 @@ pub(crate) mod tests {
         // solution. `bob` did *not* find the PoW-solution for this block.
         let guesser_preimage_1b: Digest = rng.random();
         let (block_1b, expected_utxos_block_1b) =
-            make_mock_block_guesser_preimage_and_guesser_fraction(
+            make_mock_block_with_puts_and_guesser_preimage_and_guesser_fraction(
                 &genesis_block,
+                vec![],
+                vec![],
                 None,
                 bob_key,
                 mock_block_seed,
@@ -3473,8 +3477,10 @@ pub(crate) mod tests {
 
             // Alice mines a block
             let (block, composer_expected_utxos) =
-                make_mock_block_guesser_preimage_and_guesser_fraction(
+                make_mock_block_with_puts_and_guesser_preimage_and_guesser_fraction(
                     &genesis,
+                    vec![],
+                    vec![],
                     None,
                     alice_wallet.nth_generation_spending_key(0),
                     rng.random(),
@@ -4107,8 +4113,10 @@ pub(crate) mod tests {
 
             let guesser_fraction = 0.6f64;
             let (block_1a, composer_expected_utxos_1a) =
-                make_mock_block_guesser_preimage_and_guesser_fraction(
+                make_mock_block_with_puts_and_guesser_preimage_and_guesser_fraction(
                     &genesis,
+                    vec![],
+                    vec![],
                     None,
                     alice_wallet.nth_generation_spending_key(14),
                     rng.random(),

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -288,8 +288,7 @@ pub(crate) async fn state_with_premine_and_self_mined_blocks<T: RngCore>(
                 None,
                 own_key,
                 rng.random(),
-                0.5,
-                guesser_preimage,
+                (0.5, guesser_preimage),
             )
             .await;
 
@@ -760,7 +759,6 @@ pub(crate) fn invalid_block_with_transaction(
 /// guesser-preimage and guesser fraction.
 ///
 /// Returns (block, composer's expected UTXOs).
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn make_mock_block_with_puts_and_guesser_preimage_and_guesser_fraction(
     previous_block: &Block,
     inputs: Vec<RemovalRecord>,
@@ -768,9 +766,10 @@ pub(crate) async fn make_mock_block_with_puts_and_guesser_preimage_and_guesser_f
     block_timestamp: Option<Timestamp>,
     composer_key: generation_address::GenerationSpendingKey,
     seed: [u8; 32],
-    guesser_fraction: f64,
-    guesser_preimage: Digest,
+    guesser_parameters: (f64, Digest),
 ) -> (Block, Vec<ExpectedUtxo>) {
+    let (guesser_fraction, guesser_preimage) = guesser_parameters;
+
     let mut rng: StdRng = SeedableRng::from_seed(seed);
 
     // Build coinbase UTXO and associated data
@@ -869,8 +868,7 @@ pub(crate) async fn make_mock_block_with_inputs_and_outputs(
         block_timestamp,
         composer_key,
         seed,
-        0f64,
-        Digest::default(),
+        (0f64, Digest::default()),
     )
     .await
 }


### PR DESCRIPTION
Cf. #568.

Function `resync_membership_proofs_from_stored_blocks` contains a logical error (now fixed) by failing to update the `RemovalRecords` in the course of updating a `MsMembershipProof` with a `MutatorSetUpdate`.

Test `resync_ms_membership_proofs_across_stale_fork` missed the opportunity to catch this logic error. It triggered the above function but only with sequences of blocks devoid of `RemovalRecord`s. Now the sequences of blocks have a nontrivial number of `RemovalRecord`s and `AdditionRecord`s. Without the above above fix in `resync_membership_proofs_from_stored_blocks`, this updated test reliably triggers some logic error related to mutator sets in that function.

Also: refactor mock block generators to facilitate the changes to the test.