### PR TITLE
feat: improve job_queue ergonomics

### DIFF
--- a/src/api/tx_initiation/error.rs
+++ b/src/api/tx_initiation/error.rs
@@ -7,7 +7,6 @@ use crate::api::export::NativeCurrencyAmount;
 use crate::api::export::WitnessValidationError;
 use crate::job_queue::errors::AddJobError;
 use crate::job_queue::errors::JobHandleError;
-use crate::job_queue::errors::JobHandleErrorSync;
 use crate::models::blockchain::transaction::transaction_proof::TransactionProofType;
 use crate::models::proof_abstractions::tasm::prover_job::ProverJobError;
 use crate::models::state::tx_proving_capability::TxProvingCapability;
@@ -87,7 +86,7 @@ pub enum CreateProofError {
     ProverJobError(#[from] ProverJobError),
 
     #[error(transparent)]
-    JobHandleError(#[from] JobHandleErrorSync),
+    JobHandleError(#[from] JobHandleError),
 
     #[error("Could not forward job cancellation msg to proving job. {0}")]
     JobCancelSendError(#[from] tokio::sync::watch::error::SendError<()>),
@@ -133,12 +132,6 @@ pub enum SendError {
         tip_digest: Digest,
         max: usize,
     },
-}
-
-impl From<JobHandleError> for CreateProofError {
-    fn from(e: JobHandleError) -> Self {
-        e.into_sync().into()
-    }
 }
 
 // convert anyhow::Error to a CreateTxError::Failed.

--- a/src/job_queue/errors.rs
+++ b/src/job_queue/errors.rs
@@ -1,73 +1,195 @@
+use std::sync::Arc;
+use std::sync::Mutex;
+
 /// a job-handle error.
-///
-/// This error is not `Sync` due to the `JobPanicked` variant
-/// which holds panic information as returned from tokio::spawn().
-///
-/// If a Sync type is needed, use the `into_sync()` method.
 #[derive(Debug, thiserror::Error)]
 pub enum JobHandleError {
     #[error("the job was cancelled")]
     JobCancelled,
 
+    // note: the Arc<Mutex<_>> is used to make the inner Box `Sync`.
+    // The mutex is never acquired and can thus never be poisoned.
     #[error("the job panicked during processing")]
-    JobPanicked(Box<dyn std::any::Any + Send + 'static>),
+    JobPanicked(Arc<Mutex<Box<dyn std::any::Any + Send + 'static>>>),
 
     #[error("channel send error cancelling job")]
     CancelJobError(#[from] tokio::sync::watch::error::SendError<()>),
 
     #[error("channel recv error waiting for job results: {0}")]
     JobResultError(#[from] tokio::sync::oneshot::error::RecvError),
+
+    #[error("downcast failed converting '{from}' to '{to}'")]
+    JobResultWrapperError {
+        from: &'static str,
+        to: &'static str,
+    },
 }
 
-impl JobHandleError {
-    /// convert into a type that implements `Sync`
-    ///
-    /// note that the JobPanicked variant becomes a `String`.
-    pub fn into_sync(self) -> JobHandleErrorSync {
-        self.into()
+impl From<Box<dyn std::any::Any + Send + 'static>> for JobHandleError {
+    fn from(panic_info: Box<dyn std::any::Any + Send + 'static>) -> Self {
+        Self::JobPanicked(Arc::new(Mutex::new(panic_info)))
     }
 }
 
-#[derive(Debug, thiserror::Error)]
-pub enum JobHandleErrorSync {
-    #[error("the job was cancelled")]
-    JobCancelled,
+impl JobHandleError {
+    /// Returns true if the error was caused by the task panicking.
+    ///
+    /// ```
+    /// use neptune_cash::job_queue::JobQueue;
+    /// use neptune_cash::job_queue::traits::*;
+    ///
+    /// struct PanicJob;
+    ///
+    /// #[async_trait::async_trait]
+    /// impl Job for PanicJob {
+    ///     fn is_async(&self) -> bool {
+    ///         true
+    ///     }
+    ///     async fn run_async(&self) -> Box<dyn JobResult> {
+    ///        panic!("{}", "boom");
+    ///     }
+    /// }
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> anyhow::Result<()> {
+    ///     let job_queue = JobQueue::start();
+    ///     let job_handle = job_queue.add_job(PanicJob, 1)?;
+    ///
+    ///     let err = job_handle.await?.unwrap_err();
+    ///     assert!(err.is_panic());
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn is_panic(&self) -> bool {
+        matches!(self, Self::JobPanicked(_))
+    }
 
-    #[error("the job panicked: {0}")]
-    JobPanicked(String),
+    /// into_panic() panics if the Error does not represent the underlying task terminating with a panic. Use is_panic to check the error reason or try_into_panic for a variant that does not panic.
+    ///
+    /// ```should_panic(expected = "boom")
+    /// use neptune_cash::job_queue::JobQueue;
+    /// use neptune_cash::job_queue::traits::*;
+    ///
+    /// struct PanicJob;
+    ///
+    /// #[async_trait::async_trait]
+    /// impl Job for PanicJob {
+    ///     fn is_async(&self) -> bool {
+    ///         true
+    ///     }
+    ///     async fn run_async(&self) -> Box<dyn JobResult> {
+    ///        panic!("{}", "boom");
+    ///     }
+    /// }
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> anyhow::Result<()> {
+    ///     let job_queue = JobQueue::start();
+    ///     let job_handle = job_queue.add_job(PanicJob, 1)?;
+    ///
+    ///     let err = job_handle.await?.unwrap_err();
+    ///
+    ///     // Resume the panic on the main task
+    ///     std::panic::resume_unwind(err.into_panic());
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn into_panic(self) -> Box<dyn std::any::Any + Send + 'static> {
+        self.try_into_panic()
+            .expect("should be JobPanicked variant")
+    }
 
-    #[error("channel send error cancelling job")]
-    CancelJobError(#[from] tokio::sync::watch::error::SendError<()>),
-
-    #[error("channel recv error waiting for job results")]
-    JobResultError(#[from] tokio::sync::oneshot::error::RecvError),
-}
-
-impl From<JobHandleError> for JobHandleErrorSync {
-    fn from(e: JobHandleError) -> Self {
-        match e {
-            JobHandleError::JobPanicked(panic_info) => {
-                // we have to convert panic payload to a string because panics can
-                // contain any type, and they are Send but not Sync.
-                let panic_message =
-                    panic_info
-                        .downcast_ref::<String>()
-                        .cloned()
-                        .unwrap_or_else(|| {
-                            if let Some(s) = panic_info.downcast_ref::<&'static str>() {
-                                (*s).to_string()
-                            } else {
-                                format!(
-                                    "Panic occurred with an unsupported payload type: {}",
-                                    std::any::type_name_of_val(&*panic_info)
-                                )
-                            }
-                        });
-                Self::JobPanicked(panic_message)
+    /// Consumes the `JobHandleError`, returning the object with which the task panicked if the task terminated due to a panic. Otherwise, self is returned.
+    ///
+    /// ```should_panic(expected = "boom")
+    /// use neptune_cash::job_queue::JobQueue;
+    /// use neptune_cash::job_queue::traits::*;
+    ///
+    /// struct PanicJob;
+    ///
+    /// #[async_trait::async_trait]
+    /// impl Job for PanicJob {
+    ///     fn is_async(&self) -> bool {
+    ///         true
+    ///     }
+    ///     async fn run_async(&self) -> Box<dyn JobResult> {
+    ///        panic!("{}", "boom");
+    ///     }
+    /// }
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> anyhow::Result<()> {
+    ///     let job_queue = JobQueue::start();
+    ///     let job_handle = job_queue.add_job(PanicJob, 1)?;
+    ///
+    ///     let err = job_handle.await?.unwrap_err();
+    ///
+    ///     // Resume the panic on the main task
+    ///     let panic = err.try_into_panic()?;
+    ///     std::panic::resume_unwind(panic);
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn try_into_panic(self) -> Result<Box<dyn std::any::Any + Send + 'static>, Self> {
+        match self {
+            // Consume self here
+            Self::JobPanicked(arc_mutex) => {
+                // 1. The 1st unwrap() cannot fail because the Arc is never cloned.
+                //    Thus Arc::into_inner() is guaranteed to return Some().
+                // 2. The 2nd unwrap() cannot fail because the Mutex is guaranteed unpoisoned
+                //    because lock() is never called on it.
+                Ok(Arc::into_inner(arc_mutex).unwrap().into_inner().unwrap())
             }
-            JobHandleError::JobCancelled => Self::JobCancelled,
-            JobHandleError::CancelJobError(e) => Self::CancelJobError(e),
-            JobHandleError::JobResultError(e) => Self::JobResultError(e),
+            other => Err(other), // For other variants, just return them
+        }
+    }
+
+    /// returns panic message, if available
+    ///
+    /// returns None if Error variant is not `JobPanicked` or panic info cannot
+    /// be downcast to a string representation
+    ///
+    /// ```
+    /// use neptune_cash::job_queue::JobQueue;
+    /// use neptune_cash::job_queue::traits::*;
+    ///
+    /// struct PanicJob;
+    ///
+    /// #[async_trait::async_trait]
+    /// impl Job for PanicJob {
+    ///     fn is_async(&self) -> bool {
+    ///         true
+    ///     }
+    ///     async fn run_async(&self) -> Box<dyn JobResult> {
+    ///        panic!("{}", "boom");
+    ///     }
+    /// }
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> anyhow::Result<()> {
+    ///     let job_queue = JobQueue::start();
+    ///     let job_handle = job_queue.add_job(PanicJob, 1)?;
+    ///
+    ///     let err = job_handle.await?.unwrap_err();
+    ///     assert_eq!( Some("boom".to_string()), err.panic_message());
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn panic_message(&self) -> Option<String> {
+        match self {
+            JobHandleError::JobPanicked(payload) => {
+                let guard = payload.lock().unwrap();
+                if let Some(s) = guard.downcast_ref::<&'static str>() {
+                    Some((*s).to_string())
+                } else {
+                    guard.downcast_ref::<String>().cloned()
+                }
+            }
+            _ => None,
         }
     }
 }
@@ -87,4 +209,31 @@ pub enum StopQueueError {
 
     #[error("join error while waiting for job-queue to stop.  error: {0}")]
     JoinError(#[from] tokio::task::JoinError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn job_handle_error_into_panic() {
+        let join_err = tokio::spawn(async { panic!("boom") }).await.unwrap_err();
+        let err: JobHandleError = join_err.into_panic().into();
+        // just execute, to ensure it does not panic.
+        let _ = err.into_panic();
+    }
+
+    #[tokio::test]
+    async fn job_handle_error_try_into_panic() {
+        let join_err = tokio::spawn(async { panic!("boom") }).await.unwrap_err();
+        let err: JobHandleError = join_err.into_panic().into();
+        assert!(err.try_into_panic().is_ok());
+    }
+
+    #[tokio::test]
+    async fn job_handle_error_panic_message() {
+        let join_err = tokio::spawn(async { panic!("boom") }).await.unwrap_err();
+        let err: JobHandleError = join_err.into_panic().into();
+        assert_eq!(Some("boom"), err.panic_message().as_deref());
+    }
 }

--- a/src/job_queue/job_completion.rs
+++ b/src/job_queue/job_completion.rs
@@ -1,8 +1,12 @@
+use std::fmt;
+use std::sync::Arc;
+use std::sync::Mutex;
+
 use super::errors::JobHandleError;
 use super::traits::JobResult;
 
 /// represents completion state of a job
-#[derive(Debug, strum::Display)]
+#[derive(strum::Display)]
 pub enum JobCompletion {
     /// The job finished processing normally.
     Finished(Box<dyn JobResult>),
@@ -15,6 +19,26 @@ pub enum JobCompletion {
     /// the payload comes from [tokio::task::JoinError::into_panic()]
     /// and can be used as input to [std::panic::resume_unwind()]
     Panicked(Box<dyn std::any::Any + Send + 'static>),
+}
+
+impl fmt::Debug for JobCompletion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            JobCompletion::Finished(result) => {
+                // Attempt to downcast and debug if the underlying JobResult implements Debug
+                if let Some(debuggable) = result
+                    .as_any()
+                    .downcast_ref::<Box<dyn fmt::Debug + Send + Sync>>()
+                {
+                    write!(f, "Finished({:?})", debuggable)
+                } else {
+                    write!(f, "Finished(Box<dyn JobResult>)")
+                }
+            }
+            JobCompletion::Cancelled => write!(f, "Cancelled"),
+            JobCompletion::Panicked(_) => write!(f, "Panicked(<payload>)"),
+        }
+    }
 }
 
 impl<T: JobResult> From<T> for JobCompletion {
@@ -32,11 +56,49 @@ impl TryFrom<JobCompletion> for Box<dyn JobResult> {
 }
 
 impl JobCompletion {
+    /// convert into a JobResult fallibly.
     pub fn result(self) -> Result<Box<dyn JobResult>, JobHandleError> {
         match self {
             JobCompletion::Finished(r) => Ok(r),
             JobCompletion::Cancelled => Err(JobHandleError::JobCancelled),
-            JobCompletion::Panicked(e) => Err(JobHandleError::JobPanicked(e)),
+            JobCompletion::Panicked(e) => Err(JobHandleError::JobPanicked(Arc::new(Mutex::new(e)))),
         }
+    }
+
+    /// obtain a JobResult reference fallibly
+    pub fn result_ref(&self) -> Option<&dyn JobResult> {
+        match self {
+            JobCompletion::Finished(r) => Some(&**r),
+            _ => None,
+        }
+    }
+
+    /// convert into a JobResult.  panics if job did not finish.
+    pub fn unwrap(self) -> Box<dyn JobResult> {
+        self.result()
+            .unwrap_or_else(|e| panic!("Job did not finish. no result available. {}", e))
+    }
+
+    /// indicates if job finished successfully or not.
+    ///
+    /// if true, [Self::unwrap()] is guaranteed to succeed.
+    /// if false [Self::unwrap_err()] is guaranteed to succeed.
+    pub fn finished(&self) -> bool {
+        match self {
+            JobCompletion::Finished(_) => true,
+            JobCompletion::Cancelled => false,
+            JobCompletion::Panicked(_) => false,
+        }
+    }
+
+    // convert into JobHandleError. panics if job Finished.
+    pub fn unwrap_err(self) -> JobHandleError {
+        self.err()
+            .unwrap_or_else(|| panic!("Job finished. no error available"))
+    }
+
+    // fallibly convert into JobHandleError
+    pub fn err(self) -> Option<JobHandleError> {
+        self.result().err()
     }
 }

--- a/src/job_queue/job_handle.rs
+++ b/src/job_queue/job_handle.rs
@@ -87,13 +87,13 @@ impl JobHandle {
     /// use neptune_cash::job_queue::JobQueue;
     /// use neptune_cash::job_queue::JobCompletion;
     /// use neptune_cash::job_queue::traits::Job;
-    /// use neptune_cash::job_queue::errors::JobHandleErrorSync;
+    /// use neptune_cash::job_queue::errors::JobHandleError;
     ///
     /// async fn do_some_work(
     ///     job_queue: &mut JobQueue<u8>,
     ///     job: Box<dyn Job>,
     ///     cancel_work_rx: tokio::sync::oneshot::Receiver<()>,
-    /// ) -> Result<JobCompletion, JobHandleErrorSync> {
+    /// ) -> Result<JobCompletion, JobHandleError> {
     ///
     ///     // add the job to queue
     ///     let job_priority: u8 = 10;
@@ -110,15 +110,13 @@ impl JobHandle {
     ///
     ///         // case: sender cancelled, or sender dropped.
     ///         _ = cancel_work_rx => {
-    ///             job_handle.cancel().map_err(|e| e.into_sync())?;
+    ///             job_handle.cancel()?;
     ///             job_handle.await
     ///         }
     ///     };
     ///     job_completion_result
-    ///         .map_err(|e| e.into_sync())
     /// }
     /// ```
-    /// *note: also demonstrates mapping JobHandleError to JobHandleErrorSync which implements Send+Sync.*
     pub fn cancel(&self) -> Result<(), JobHandleError> {
         let result = self.cancel_tx.send(()).map_err(JobHandleError::from);
 

--- a/src/job_queue/job_result_wrapper.rs
+++ b/src/job_queue/job_result_wrapper.rs
@@ -1,0 +1,267 @@
+//! This module provides type `JobResultWrapper` to enhance the ergonomics of
+//! working with job-specific result types which must implement the `JobResult`
+//! trait.
+//!
+//! It is useful for:
+//!
+//! 1. returning job results of type T as `Box<dyn JobResults>` when implementing
+//!    the `Job` trait.
+//!
+//! 2. converting the `Box<dyn JobResults>` from a completed `Job` back into `T`.
+//!
+//! See [module docs](super) for usage examples.
+use std::any::Any;
+use std::cmp::Ordering;
+use std::fmt::Debug;
+use std::fmt::Display;
+use std::ops::Deref;
+use std::ops::DerefMut;
+
+use super::errors::JobHandleError;
+use super::traits::JobResult;
+use super::JobCompletion;
+
+/// A generic wrapper around a job-specific result type `T` that implements the
+/// [`JobResult`] trait.
+///
+/// This wrapper simplifies the process of:
+///
+/// * Returning concrete job results (`T`) as trait objects (`Box<dyn JobResult>`).
+/// * Attempting to convert a `Box<dyn JobResult>` back into the original concrete type `T`.
+///
+/// # Type Parameters
+///
+/// * `T`: The specific type of the job result being wrapped. This type must be
+///   `'static`, `Send`, and `Sync`.
+///
+/// `JobResultWrapper` also implements the following traits if T
+/// implements the trait:
+///   Debug, Clone, Copy, Display, PartialOrd, Ord, PartialEq, Eq,
+pub struct JobResultWrapper<T>(T);
+
+impl<T: 'static + Send + Sync> JobResult for JobResultWrapper<T> {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn into_any(self: Box<Self>) -> Box<dyn Any> {
+        self
+    }
+}
+
+impl<T> Deref for JobResultWrapper<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for JobResultWrapper<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T: 'static> TryFrom<JobCompletion> for JobResultWrapper<T> {
+    type Error = JobHandleError;
+
+    fn try_from(job_completion: JobCompletion) -> Result<Self, Self::Error> {
+        JobResultWrapper::try_from_completion(job_completion)
+    }
+}
+
+impl<'a, T: 'static> TryFrom<&'a JobCompletion> for &'a JobResultWrapper<T> {
+    type Error = JobHandleError;
+
+    fn try_from(job_completion: &'a JobCompletion) -> Result<Self, Self::Error> {
+        JobResultWrapper::try_from_completion_ref(job_completion)
+    }
+}
+
+impl<T: 'static> TryFrom<Box<dyn JobResult>> for JobResultWrapper<T> {
+    type Error = JobHandleError;
+
+    fn try_from(job_result: Box<dyn JobResult>) -> Result<Self, Self::Error> {
+        JobResultWrapper::try_from_boxed_job_result(job_result)
+    }
+}
+
+impl<'a, T: 'static> TryFrom<&'a dyn JobResult> for &'a JobResultWrapper<T> {
+    type Error = JobHandleError;
+
+    fn try_from(job_result: &'a dyn JobResult) -> Result<Self, Self::Error> {
+        JobResultWrapper::try_from_boxed_job_result_ref(job_result)
+    }
+}
+
+impl<T: 'static + Send + Sync> From<JobResultWrapper<T>> for Box<dyn JobResult> {
+    fn from(wrapper: JobResultWrapper<T>) -> Self {
+        Box::new(wrapper) as Box<dyn JobResult>
+    }
+}
+
+impl<T: Debug> Debug for JobResultWrapper<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("JobResultWrapper").field(&self.0).finish()
+    }
+}
+
+impl<T: Display> Display for JobResultWrapper<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+// Clippy warns about a manual Clone impl on a Copy type, but this is necessary
+// to handle the case where T is Clone but not Copy.
+//
+// Ideally, this could be expressed more clearly using negative trait bounds
+// (#[feature(negative_impls)]), like this:
+//
+// impl<T: Clone + !Copy> Clone for JobResultWrapper<T> {..}
+// impl<T: Clone + Copy> Clone for JobResultWrapper<T> {..}
+//
+// However, negative trait bounds are not yet stable in Rust as of rustc
+// v1.86.0.
+#[allow(clippy::expl_impl_clone_on_copy)]
+impl<T: Clone> Clone for JobResultWrapper<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T: Copy> Copy for JobResultWrapper<T> {}
+
+impl<T: PartialOrd> PartialOrd for JobResultWrapper<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.0.partial_cmp(&other.0)
+    }
+}
+
+impl<T: Ord> Ord for JobResultWrapper<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl<T: PartialEq> PartialEq for JobResultWrapper<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.eq(&other.0)
+    }
+}
+
+impl<T: Eq> Eq for JobResultWrapper<T> {}
+
+impl<T> JobResultWrapper<T> {
+    /// convert into inner `T`
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+impl<T: 'static> JobResultWrapper<T> {
+    /// instantiate new wrapper from job results
+    pub fn new(job_result: T) -> Self {
+        Self(job_result)
+    }
+
+    /// fallibly convert a [JobCompletion] into a `JobResultWrapper<T>`.
+    fn try_from_completion(job_completion: JobCompletion) -> Result<Self, JobHandleError> {
+        Self::try_from_boxed_job_result(job_completion.result()?)
+    }
+
+    /// fallibly convert a [JobCompletion] into a `JobResultWrapper<T>`.
+    fn try_from_completion_ref(job_completion: &JobCompletion) -> Result<&Self, JobHandleError> {
+        Self::try_from_boxed_job_result_ref(job_completion.result_ref().unwrap())
+    }
+
+    /// fallibly convert a `Box<dyn JobResult>` into a `JobResultWrapper<T>`.
+    fn try_from_boxed_job_result(
+        boxed_trait_object: Box<dyn JobResult>,
+    ) -> Result<Self, JobHandleError> {
+        let any = boxed_trait_object.into_any(); // Convert Box<dyn JobResult> to Box<dyn Any>
+        if let Ok(concrete_wrapper) = any.downcast::<JobResultWrapper<T>>() {
+            Ok(*concrete_wrapper) // Dereference the Box to get JobResultWrapper<T>
+        } else {
+            Err(JobHandleError::JobResultWrapperError {
+                from: std::any::type_name::<dyn JobResult>(),
+                to: std::any::type_name::<JobResultWrapper<T>>(),
+            })
+        }
+    }
+
+    /// fallibly convert an `&dyn JobResult` reference into a `JobResultWrapper<T>`.
+    fn try_from_boxed_job_result_ref(
+        boxed_trait_object: &dyn JobResult,
+    ) -> Result<&Self, JobHandleError> {
+        let any = boxed_trait_object.as_any();
+        if let Some(concrete_wrapper) = any.downcast_ref::<JobResultWrapper<T>>() {
+            Ok(concrete_wrapper)
+        } else {
+            Err(JobHandleError::JobResultWrapperError {
+                from: std::any::type_name::<dyn JobResult>(),
+                to: std::any::type_name::<JobResultWrapper<T>>(),
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    pub fn basic_conversions() {
+        type MyJobResult = u64;
+        type MyJobResultWrapper = JobResultWrapper<MyJobResult>;
+
+        let result: MyJobResult = 5;
+
+        let wrapper = MyJobResultWrapper::new(result);
+
+        // JobResult for JobResultWrapper<T>
+        let _ = wrapper.as_any();
+        let _ = Box::new(MyJobResultWrapper::new(result)).into_any();
+
+        // Deref, DerefMut for JobResultWrapper<T>
+        assert_eq!(&*wrapper, &mut *MyJobResultWrapper::new(result));
+
+        let completion: JobCompletion = wrapper.into();
+
+        // TryFrom<&JobCompletion> for &JobResultWrapper<T>
+        let _ = <&MyJobResultWrapper>::try_from(&completion).unwrap();
+
+        // TryFrom<JobCompletion> for JobResultWrapper<T>
+        let _ = MyJobResultWrapper::try_from(completion).unwrap();
+
+        // From<JobResultWrapper<T>> for Box<dyn JobResult>
+        let boxed: Box<dyn JobResult> = MyJobResultWrapper::new(5).into();
+
+        // TryFrom<&dyn JobResult> for &JobResultWrapper<T>
+        let _ = <&JobResultWrapper<u64>>::try_from(boxed.as_ref()).unwrap();
+
+        // TryFrom<Box<dyn JobResult>> for JobResultWrapper<T>
+        let _ = MyJobResultWrapper::try_from(boxed).unwrap();
+    }
+
+    #[test]
+    pub fn optional_traits() {
+        type MyJobResult = u64;
+
+        let wrapper = JobResultWrapper::<MyJobResult>::new(5);
+
+        // impl PartialEq, Eq, Clone, Copy for JobResultWrapper<T>
+        let copy = wrapper;
+        assert_eq!(wrapper, copy);
+
+        // impl Debug for JobResultWrapper<T>
+        let _ = format!("{:?}", wrapper);
+
+        // impl Display for JobResultWrapper<T>
+        assert_eq!(wrapper.to_string(), 5.to_string());
+
+        // impl PartialOrd, Ord for JobResultWrapper<T>
+        assert!(wrapper > JobResultWrapper::<MyJobResult>::new(2));
+    }
+}

--- a/src/job_queue/mod.rs
+++ b/src/job_queue/mod.rs
@@ -1,13 +1,14 @@
 //! This module implements a prioritized, heterogenous job queue that sends
-//! completed job results to the initiator/caller.
+//! completed job results of arbitrary type to the initiator/caller.
 //!
 //! This is intended for running heavy multi-threaded jobs that should be run
 //! one at a time to avoid resource contention.  By using this queue, multiple
 //! (async) tasks can initiate these tasks and wait for results without need
 //! of any other synchronization.
 //!
-//! note: Other rust job queues I found either did not support waiting for job
-//! results or else were overly complicated, requiring backend database, etc.
+//! note: Other rust job queues investigated cerca 2024 either did not support
+//! waiting for job results or else were overly complicated, requiring backend
+//! database, etc.
 //!
 //! Both blocking and non-blocking (async) jobs are supported.  Non-blocking jobs
 //! are called inside spawn_blocking() in order to execute on tokio's blocking
@@ -23,8 +24,354 @@
 //! Jobs may be of mixed (heterogenous) types in a single [JobQueue] instance.
 //! Any type that implements the [Job](traits::Job) trait may be a job.
 //!
+//! Jobs may be async or blocking.  Both types can be run in the same JobQueue
+//! instance concurrently.
+//!
+//! Job results also may be of any type.  Typically each type of Job will return
+//! a single concrete result type.  A [JobResultWrapper] is provided to
+//! facilitate this usage pattern.
+//!
 //! Each Job has an associated [JobHandle] that is used to await or cancel the
 //! job.  If the `JobHandle` is dropped, the job will be cancelled.
+//!
+//! ## hello job-queue world.
+//!
+//! Here we demonstrate the most basic usage by creating a `HelloJobAsync` job
+//! and running it once in the JobQueue.
+//!
+//! We choose an async job for this example because it's a little bit simpler.
+//! We don't have to check for job-cancellation in the job itself.
+//!
+//! ```
+//! use neptune_cash::job_queue::JobResultWrapper;
+//! use neptune_cash::job_queue::JobQueue;
+//! use neptune_cash::job_queue::traits::*;
+//!
+//! // define our custom job type that just returns "hello <name>"
+//! pub struct HelloJobAsync(String);
+//!
+//! // implement Job trait.
+//! #[async_trait::async_trait]
+//! impl Job for HelloJobAsync {
+//!     // indicate that we are an async Job
+//!     fn is_async(&self) -> bool {
+//!         true
+//!     }
+//!
+//!     // as an async job we must impl run_async() or run_async_cancellable()
+//!     async fn run_async(&self) -> Box<dyn JobResult> {
+//!         let job_result = format!("hello {}", self.0);
+//!         JobResultWrapper::<String>::new(job_result).into()
+//!     }
+//! }
+//!
+//! #[tokio::main]
+//! async fn main() -> anyhow::Result<()> {
+//!     // we choose a simple u8 for prioritizing jobs in this queue.
+//!     type QueuePriority = u8;
+//!
+//!     // start the JobQueue running.
+//!     let mut job_queue = JobQueue::<QueuePriority>::start();
+//!
+//!     let job = HelloJobAsync("world".to_string());
+//!     let job_handle = job_queue.add_job_mut(job, 1)?;
+//!
+//!     // await job to complete and obtain the (wrapped) job result
+//!     let completion = job_handle.await?;
+//!     let output = JobResultWrapper::<String>::try_from(completion)?.into_inner();
+//!
+//!     assert_eq!("hello world", output);
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
+//! ## async vs blocking Job.
+//!
+//! To demonstrate the difference, we will implement an example job first as an
+//! async job and then as a blocking job.
+//!
+//! The example job finds all the prime numbers in a provided range.
+//!
+//! We create 100 jobs, each searching a range of 100 numbers. So the first
+//! 10000 integers are searched by all jobs.
+//!
+//! We use a `JobQueue<QueueJobPriority>` where `QueueJobPriority` is an enum we
+//! define that simply has `Low` and `High` variants.
+//!
+//! The jobs are added to the queue in ascending order but each is assigned a
+//! random job priority (either High or Low).  High priority jobs will process
+//! first, thus queue-processing order will not match the order of adding jobs.
+//!
+//! In this example, job results are obtained by awaiting each JobHandle in the
+//! order it was added.  Thus results are obtained in FIFO order despite the
+//! out-of-order processing.
+//!
+//! Alternatively a JoinSet or join_all() could be used to await all job-handles
+//! simultaneously and obtain results in queue-processing order as they complete.
+//!
+//! Likewise in an application with many concurrent tasks, each task might be
+//! submitting a job and immediately awaiting the JobHandle.  In that scenario
+//! whichever task has submitted the highest priority job will obtain results
+//! first.
+//!
+//! ### Async Job considerations
+//!
+//! 1. the Job::is_async() impl returns true.
+//! 2. Job::run_async() or Job::run_async_cancellable() must be implemented.
+//!
+//! It is important the job yield regularly to the async runtime.  Our
+//! processing is inherently blocking, so we accomplish this simply by making
+//! the is_prime() fn async, which is called in every loop iteration.
+//!
+//! ### Blocking job considerations
+//!
+//! 1. the Job::is_async() impl returns false.
+//! 2. Job::run() must be implemented.
+//! 3. it is necessary to regularly poll for a job-cancellation message in the
+//!    job's main processing loop.
+//!
+//! ### Example
+//!
+//! ```
+//! use neptune_cash::job_queue::JobCompletion;
+//! use neptune_cash::job_queue::JobResultWrapper;
+//! use neptune_cash::job_queue::JobQueue;
+//! use neptune_cash::job_queue::channels::JobCancelReceiver;
+//! use neptune_cash::job_queue::traits::*;
+//! use rand::Rng;
+//!
+//! // ### First lets define some common types ###
+//! // -------------------------------------------
+//!
+//! // define job priority levels for this job-queue.
+//! // note that the queue could process only one type of
+//! // job, or mixed job types.
+//! #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+//! enum QueueJobPriority {
+//!     Low = 1,
+//!     High = 2,
+//! }
+//! impl QueueJobPriority {
+//!     pub fn random() -> Self {
+//!         let variants = [QueueJobPriority::Low, QueueJobPriority::High];
+//!         variants[rand::rng().random_range(0..variants.len())]
+//!     }
+//! }
+//!
+//! // define type alias for a wrapper around the data returned by our
+//! // job type. The wrapper is not required, but simplifies
+//! // conversions.
+//! type FindPrimesJobResult = JobResultWrapper<Vec<u64>>;
+//!
+//!
+//! // ### Now we define an async Job ###
+//! // ----------------------------------
+//!
+//! // define our custom job type that finds prime numbers within a range
+//! #[derive(Debug)]
+//! pub struct FindPrimesJobAsync {
+//!     start: u64,
+//!     len: u64,
+//! }
+//!
+//! // The prime-number finding algorithm can be described as:
+//! // Trial Division with Square Root Limit and 6k ± 1 Optimization
+//! //
+//! // we make the functions async because our "impl Job"
+//! // defines this as an async job and thus the runtime needs
+//! // some await points for cancellation and cooperating with
+//! // other async tasks.
+//! impl FindPrimesJobAsync {
+//!     async fn is_prime(num: u64) -> bool {
+//!         if num <= 1 {
+//!             return false;
+//!         }
+//!         if num <= 3 {
+//!             return true;
+//!         }
+//!         if num % 2 == 0 || num % 3 == 0 {
+//!             return false;
+//!         }
+//!         let mut i = 5;
+//!         while i * i <= num {
+//!             if num % i == 0 || num % (i + 2) == 0 {
+//!                 return false;
+//!             }
+//!             i += 6;
+//!         }
+//!         true
+//!     }
+//!
+//!     async fn find_primes(&self) -> Vec<u64> {
+//!         let mut primes = Vec::new();
+//!         for num in self.start..=self.start + self.len {
+//!             if Self::is_prime(num).await {
+//!                 primes.push(num);
+//!             }
+//!         }
+//!
+//!         primes
+//!     }
+//! }
+//!
+//! // implement Job trait.
+//! #[async_trait::async_trait]
+//! impl Job for FindPrimesJobAsync {
+//!     // we are an async Job, so we must impl the run_async method
+//!     fn is_async(&self) -> bool {
+//!         true
+//!     }
+//!
+//!     async fn run_async(&self) -> Box<dyn JobResult> {
+//!         let found_primes = self.find_primes().await;
+//!         FindPrimesJobResult::new(found_primes).into()
+//!     }
+//! }
+//!
+//! // ### Define an equivalent blocking job ###
+//! // -----------------------------------------
+//!
+//! // define our custom job type that finds prime numbers within a range
+//! #[derive(Debug)]
+//! pub struct FindPrimesJob {
+//!     start: u64,
+//!     len: u64,
+//! }
+//!
+//! // The prime-number finding algorithm can be described as:
+//! // Trial Division with Square Root Limit and 6k ± 1 Optimization
+//! //
+//! // None of the functions are async because our "impl Job"
+//! // defines this as blocking job.  It will be run in tokio's blocking
+//! // threadpool via a spawn_blocking() call in the job-queue.
+//! impl FindPrimesJob {
+//!     fn is_prime(num: u64) -> bool {
+//!         if num <= 1 {
+//!             return false;
+//!         }
+//!         if num <= 3 {
+//!             return true;
+//!         }
+//!         if num % 2 == 0 || num % 3 == 0 {
+//!             return false;
+//!         }
+//!         let mut i = 5;
+//!         while i * i <= num {
+//!             if num % i == 0 || num % (i + 2) == 0 {
+//!                 return false;
+//!             }
+//!             i += 6;
+//!         }
+//!         true
+//!     }
+//! }
+//!
+//! // implement Job trait.
+//! #[async_trait::async_trait]
+//! impl Job for FindPrimesJob {
+//!     // we are *not* an async Job.
+//!     fn is_async(&self) -> bool {
+//!         false
+//!     }
+//!
+//!     // as a blocking job we must impl the run() method
+//!     fn run(&self, cancel_rx: JobCancelReceiver) -> JobCompletion {
+//!         let mut primes = Vec::new();
+//!
+//!         // this is the main processing loop of our job, so it should poll for
+//!         // a cancellation message.  It could be more efficient and poll
+//!         // every 100 iterations or n milliseconds, etc.
+//!         for num in self.start..=self.start + self.len {
+//!
+//!             match cancel_rx.has_changed() {
+//!                 Ok(changed) if changed => return JobCompletion::Cancelled,
+//!                 Err(_) => return JobCompletion::Cancelled,
+//!                 _ => {}
+//!             }
+//!
+//!             if Self::is_prime(num) {
+//!                 primes.push(num);
+//!             }
+//!         }
+//!
+//!         JobCompletion::Finished(FindPrimesJobResult::new(primes).into())
+//!     }
+//! }
+//!
+//! // Now let's run these jobs.
+//! // -------------------------
+//!
+//! // Note that we will be mixing jobs of two different types.
+//! // Result processing is simplified because they both return the same
+//! // result type but that's not necessary.
+//!
+//! #[tokio::main]
+//! async fn main() -> anyhow::Result<()> {
+//!     // setup
+//!     const NUM_PRIMES_PER_JOB: u64 = 100;
+//!     let mut job_handles = vec![];
+//!
+//!     // start the JobQueue running.
+//!     let mut job_queue = JobQueue::<QueueJobPriority>::start();
+//!
+//!     // start 100 jobs, each searching 100 numbers for primes, with random job priorities
+//!     // note that jobs begin processing right away while this loop is running.
+//!     for n in 0..100 {
+//!         let job_handle = if n % 2 == 0 {
+//!             let job = FindPrimesJob {
+//!                 start: n * NUM_PRIMES_PER_JOB,
+//!                 len: NUM_PRIMES_PER_JOB,
+//!             };
+//!             job_queue.add_job_mut(job, QueueJobPriority::random())?
+//!         } else {
+//!             let job = FindPrimesJobAsync {
+//!                 start: n * NUM_PRIMES_PER_JOB,
+//!                 len: NUM_PRIMES_PER_JOB,
+//!             };
+//!             job_queue.add_job_mut(job, QueueJobPriority::random())?
+//!         };
+//!
+//!         job_handles.push(job_handle);
+//!     }
+//!
+//!     // await all the jobs to complete.  note that:
+//!     // 1. jobs will be processed in a different order than they were added due to the random priorities
+//!     // 2. we are awaiting the job_handles in the order of adding, thus results are printed
+//!     //    sequentially from lowest primes to highest.
+//!     // 3. if we moved the println!() inside FindPrimesJob::run_async() we would see the
+//!     //    order of processing, with prime ranges out-of-order.
+//!     let mut max: u64 = 0;
+//!     for job_handle in job_handles {
+//!         let job_id = job_handle.job_id();
+//!
+//!         // await job to complete and obtain the (wrapped) job result
+//!         let completion = job_handle.await?;
+//!         let found_primes = FindPrimesJobResult::try_from(completion)?.into_inner();
+//!
+//!         // check for last (highest) prime in the result set
+//!         if let Some(last_found) = found_primes.last() {
+//!             // verify that max of each set is larger than previous set.
+//!             // which indicates that job results are in same order as jobs were added.
+//!             assert!(*last_found > max);
+//!
+//!             max = std::cmp::max(max, *last_found);
+//!         }
+//!
+//!         println!(
+//!             "job {} found {} primes: {:?}",
+//!             job_id,
+//!             found_primes.len(),
+//!             found_primes
+//!         );
+//!     }
+//!
+//!     // verify
+//!     assert_eq!(9973, max); // 9973 is the largest prime number below 10000
+//!
+//!     Ok(())
+//! }
+//! ```
 
 // please note that the job_queue module has zero neptune-core specific
 // code in it.  It is intended/planned to move job_queue into its own
@@ -35,10 +382,12 @@ pub mod errors;
 mod job_completion;
 mod job_handle;
 mod job_id;
+mod job_result_wrapper;
 mod queue;
 pub mod traits;
 
 pub use job_completion::JobCompletion;
 pub use job_handle::JobHandle;
 pub use job_id::JobId;
+pub use job_result_wrapper::JobResultWrapper;
 pub use queue::JobQueue;

--- a/src/job_queue/traits.rs
+++ b/src/job_queue/traits.rs
@@ -4,7 +4,7 @@ use super::channels::JobCancelReceiver;
 use super::job_completion::JobCompletion;
 
 /// represents a job result, which can be any type.
-pub trait JobResult: Any + Send + Sync + std::fmt::Debug {
+pub trait JobResult: Any + Send + Sync {
     fn as_any(&self) -> &dyn Any;
     fn into_any(self: Box<Self>) -> Box<dyn Any>;
 }
@@ -41,5 +41,15 @@ pub trait Job: Send + Sync {
     /// implement this method to perform the work of the job.
     async fn run_async(&self) -> Box<dyn JobResult> {
         unimplemented!()
+    }
+}
+
+// so we can do eg:
+//   job_queue.add_job(job, priority);
+// instead of:
+//   job_queue.add_job(Box::new(job), priority);
+impl<T: Job + 'static> From<T> for Box<dyn Job> {
+    fn from(job: T) -> Self {
+        Box::new(job) as Box<dyn Job>
     }
 }

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -33,7 +33,7 @@ use crate::api::tx_initiation::builder::transaction_proof_builder::TransactionPr
 use crate::api::tx_initiation::builder::triton_vm_proof_job_options_builder::TritonVmProofJobOptionsBuilder;
 use crate::api::tx_initiation::error::CreateProofError;
 use crate::config_models::network::Network;
-use crate::job_queue::errors::JobHandleErrorSync;
+use crate::job_queue::errors::JobHandleError;
 use crate::models::blockchain::block::block_height::BlockHeight;
 use crate::models::blockchain::block::block_kernel::BlockKernel;
 use crate::models::blockchain::block::block_kernel::BlockKernelField;
@@ -874,7 +874,7 @@ pub(crate) async fn mine(
                     // The remaining sources of cancellation are:
                     // 1. mining loop exits, eg during graceful shutdown.
                     // 2. some future change to codebase
-                    Some(CreateProofError::JobHandleError(JobHandleErrorSync::JobCancelled)) => {
+                    Some(CreateProofError::JobHandleError(JobHandleError::JobCancelled)) => {
                         debug!("composer job was cancelled. continuing normal operation");
                     }
                     _ => {
@@ -1044,7 +1044,7 @@ pub(crate) mod tests {
     use crate::config_models::cli_args;
     use crate::config_models::fee_notification_policy::FeeNotificationPolicy;
     use crate::config_models::network::Network;
-    use crate::job_queue::errors::JobHandleErrorSync;
+    use crate::job_queue::errors::JobHandleError;
     use crate::models::blockchain::block::validity::block_primitive_witness::tests::deterministic_block_primitive_witness;
     use crate::models::blockchain::transaction::validity::single_proof::SingleProof;
     use crate::models::blockchain::type_scripts::native_currency_amount::NativeCurrencyAmount;
@@ -2046,7 +2046,7 @@ pub(crate) mod tests {
         let job_cancelled = matches!(
             error.root_cause().downcast_ref::<CreateProofError>(),
             Some(CreateProofError::JobHandleError(
-                JobHandleErrorSync::JobCancelled
+                JobHandleError::JobCancelled
             ))
         );
 


### PR DESCRIPTION
note: this PR does not change neptune-core logic.  Only JobQueue API.  I am intending to merge it immediately once CI is happy.  I am making it a PR for a) CI checks, b) to document, and c) in case anyone wishes to review/comment post-hoc.

-------------------

This is a follow-up to #579 that implements some ergonomic improvements to the JobQueue especially with regards to JobResult conversions.

A key features of the JobQueue is that a single JobQueue can accept Jobs of arbitrary (dyn) type and those jobs can return results of arbitrary (dyn) type.  This flexibility comes at a cost:  The type returned by each Job must impl the JobResult trait.  And the caller awaiting the job must downcast the result into the expected type, which is verbose/ugly and kind of uncommon.

The key innovation in this PR is to introduce a new type JobResultWrapper<T> that implements JobResult and provides TryFrom conversions for JobCompletion and `Box<dyn JobResult>`.  This enables:
1. The Job can return results without manually implementing JobResult
2. The Job initiator can easily/cleanly obtain results from the JobCompletion as the expected type T.

Another nice cleanup: I figured out how to make JobHandleError impl Sync.  So we get rid of the ugly JobHandleErrorSync type and all the `map_err(|e| e.into_sync())` when obtaining job results.

Finally, this adds a "hello world" doctest example as well as a more detailed example that implements both a blocking job and an async job that each finds prime numbers and runs them in the same JobQueue.

A few other ergonomic niceties are included, listed below.

Changes:

+ add JobResultWrapper to simplify working with job-specific result types so Job's don't need to manually impl JobResult and callers avoid downcasting results.
+ add simple hello_world JobQueue usage example at job_queue module root.
+ add detailed JobQueue usage example at job_queue module root.
+ make JobHandleError Sync
+ remove JobHandleErrorSync
+ add JobHandleError::is_panic(), into_panic(), try_into_panic() panic_message(), each with doctest example.
+ remove Debug bound from JobResult trait
+ custom impl Debug for JobCompletion
+ add JobQueue::add_job_mut() for explicit mutability usage.
+ add_job and add_job_mut() accept `Into<Box<dyn Job>>` so usage can be add_job(job) instead of add_job(Box::new(job).
+ new tests and new/improved doc-comments