### PR TITLE
test(`Chunk`): Add test computing statistics of `Chunk` lengths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,6 +426,12 @@ name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
+name = "bytemuck"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
 
 [[package]]
 name = "byteorder"
@@ -1817,6 +1832,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "nalgebra"
+version = "0.33.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26aecdf64b707efd1310e3544d709c5c0ac61c13756046aaaba41be5c4f66a3b"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "rand 0.8.5",
+ "rand_distr",
+ "simba",
+ "typenum",
+]
+
+[[package]]
 name = "ndarray"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1886,6 +1918,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha3",
+ "statrs",
  "strum 0.27.0",
  "strum_macros 0.27.0",
  "sysinfo",
@@ -2713,6 +2746,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2842,6 +2884,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "simba"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a386a501cd104797982c15ae17aafe8b9261315b5d07e3ec803f2ea26be0fa"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2877,6 +2932,18 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "statrs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
+dependencies = [
+ "approx",
+ "nalgebra",
+ "num-traits",
+ "rand 0.8.5",
+]
 
 [[package]]
 name = "strsim"
@@ -3845,6 +3912,16 @@ checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b5576b9a81633f3e8df296ce0063042a73507636cbe956c61133dd7034ab22"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,6 +148,7 @@ proptest = { version = "1.5" }
 proptest-arbitrary-interop = { version = "0.1" }
 rand_distr = "0.4.3"
 rayon = "1.10"
+statrs = "0.18.0"
 test-strategy = "0.3"
 tokio-test = "0.4"
 

--- a/src/util_types/mutator_set/chunk.rs
+++ b/src/util_types/mutator_set/chunk.rs
@@ -315,6 +315,36 @@ mod tests {
         assert_eq!(chunk, decoded);
     }
 
+    /// Collect statistics about the typical number of elements in a `Chunk`.
+    ///
+    /// This information is relevant in the context of densly representing
+    /// `Chunk`s -- in particular, for answering the question, "how many bits
+    /// should we use to encode the length?". The simplest proposal is to use 12
+    /// bits -- the same as the bit length used for elements. However, there is
+    /// a nonzero probability that a `Chunk` becomes so full that 12 bits is not
+    /// enough to encode its length. We want to bound that probability to a
+    /// negligible quantity.
+    ///
+    /// Using the Chernoff bound for binomial distributions, it is possible to
+    /// bound this tail event probability to 2^-4367 [1]. However, this analysis
+    /// might be wrong somewhere, so it's useful to have an independent piece of
+    /// evidence (in the form of a unit test) supporting the viability of 12
+    /// bits.
+    ///
+    /// If these statistics are correct --
+    ///
+    /// ```notest
+    /// mean: 360.03576
+    /// variance: 359.3943412223999
+    /// stddev: 18.95769873224068
+    /// ```
+    ///
+    /// -- then heuristically bound the tail end of the probability distribution
+    /// by approximating it as a Gaussian. In fact, right off the bat, 4096 is
+    /// around 185 standard deviations away from the mean. This number is a far
+    /// cry from the standard 3-4-5 simgas in the 3-4-5 sigma rule. So maybe the
+    /// 4367 bits is not too far off. But let's try and compute this probability
+    /// anyway.
     #[ignore = "informative statistics"]
     #[test]
     fn chunk_length_statistics() {


### PR DESCRIPTION
Add a test that computes statistics about the number of elements in `Chunk`s. Based on these statistics, it is justifiable to use 12 bits to store the length.