### PR TITLE
feat: implement testnet-mock

### DIFF
--- a/scripts/linux/run-multiple-instances-from-genesis.sh
+++ b/scripts/linux/run-multiple-instances-from-genesis.sh
@@ -13,7 +13,7 @@ then
 fi
 
 
-NETWORK="testnet"
+NETWORK="testnet-mock"
 NIGHTLY=""
 RELEASE=""
 FEATURES=""

--- a/src/api/tx_initiation/builder/proof_builder.rs
+++ b/src/api/tx_initiation/builder/proof_builder.rs
@@ -58,7 +58,7 @@ pub struct ProofBuilder<'a> {
     valid_mock: Option<bool>,
 }
 
-impl<'a> fmt::Debug for ProofBuilder<'a> {
+impl fmt::Debug for ProofBuilder<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ProofBuilder")
             .field("program", &self.program)

--- a/src/config_models/network.rs
+++ b/src/config_models/network.rs
@@ -8,17 +8,27 @@ use serde::Serialize;
 use strum::EnumIter;
 use tasm_lib::twenty_first::math::b_field_element::BFieldElement;
 
-use crate::models::blockchain::block::block_header;
+use crate::models::blockchain::block::difficulty_control::Difficulty;
 use crate::models::proof_abstractions::timestamp::Timestamp;
 
+// p2p warning: #[non_exhaustive] added after v0.2.2.  (probably in v0.3.0).
+// v0.2.2 and below are not able to deserialize this type if new variants are
+// added.
+//
+// therefore: new variants cannot be added until entire network has upgraded to
+// v0.3.0 or higher.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Default, EnumIter)]
+#[non_exhaustive]
 pub enum Network {
     /// Main net. Feature-complete. Fixed launch date.
     #[default]
     Main,
 
-    /// First iteration of testnet. Not feature-complete.
-    Alpha,
+    /// Public test network that utilizes mock proofs and difficulty resets so
+    /// that mining is possible without high-end hardware.  Intended for staging
+    /// of release candidates prior to release and for the community to try out
+    /// release candidates and report issues.
+    TestnetMock,
 
     /// 2nd iteration of integration testing. Not feature-complete either but
     /// more than Alpha.
@@ -53,38 +63,10 @@ impl Network {
                 Timestamp(BFieldElement::new(now_rounded))
             }
             // 11 Feb 2025, noon UTC
-            Network::Alpha | Network::Testnet | Network::Beta | Network::Main => {
+            Network::TestnetMock | Network::Testnet | Network::Beta | Network::Main => {
                 Timestamp(BFieldElement::new(1739275200000u64))
             }
         }
-    }
-
-    pub(crate) fn minimum_block_time(&self) -> Timestamp {
-        if self.is_regtest() {
-            block_header::MINIMUM_BLOCK_TIME_REGTEST
-        } else {
-            block_header::MINIMUM_BLOCK_TIME
-        }
-    }
-
-    pub(crate) fn target_block_interval(&self) -> Timestamp {
-        if self.is_regtest() {
-            block_header::TARGET_BLOCK_INTERVAL_REGTEST
-        } else {
-            block_header::TARGET_BLOCK_INTERVAL
-        }
-    }
-
-    pub fn is_mainnet(&self) -> bool {
-        matches!(self, Self::Main)
-    }
-
-    pub fn is_testnet(&self) -> bool {
-        matches!(self, Self::Testnet)
-    }
-
-    pub fn is_regtest(&self) -> bool {
-        matches!(self, Self::RegTest)
     }
 
     /// indicates if the network uses mock proofs
@@ -96,6 +78,90 @@ impl Network {
     /// change in the future so it is best use this method rather than checking
     /// for is_regtest().
     pub fn use_mock_proof(&self) -> bool {
+        matches!(self, Self::RegTest | Self::TestnetMock)
+    }
+
+    /// indicates max duration between blocks before difficulty reset, if any.
+    ///
+    /// The difficulty is reset to genesis difficulty on testnet network(s) any
+    /// time the duration between a block and the previous block is >= twice the
+    /// target interval ie 19.6 minutes.
+    ///
+    /// testnet, testnet-mock: Some(19.6 minutes)
+    /// mainnet, others: None
+    pub fn difficulty_reset_interval(&self) -> Option<Timestamp> {
+        match *self {
+            Self::Testnet | Self::TestnetMock => Some(self.target_block_interval() * 2),
+            _ => None,
+        }
+    }
+
+    /// indicates if peer discovery should be performed by nodes on this network
+    ///
+    /// regtest: false
+    /// mainnet and others: true
+    pub fn perform_peer_discovery(&self) -> bool {
+        // disable peer-discovery for regtest only (so far)
+        !self.is_regtest()
+    }
+
+    /// difficulty setting for the Genesis block
+    ///
+    /// regtest: [Difficulty::MINIMUM]
+    /// mainnet and others: 1,000,000,000
+    pub fn genesis_difficulty(&self) -> Difficulty {
+        match *self {
+            Self::RegTest => Difficulty::MINIMUM,
+            Self::Testnet | Self::TestnetMock => Difficulty::new([1_000_000, 0, 0, 0, 0]),
+            Self::Main | Self::Beta => Difficulty::new([1_000_000_000, 0, 0, 0, 0]),
+        }
+    }
+
+    /// minimum time between blocks.
+    ///
+    /// Blocks spaced apart by less than this amount of time are not valid.
+    ///
+    /// for regtest: 1 milli
+    /// for testnet-mock: 100 milli
+    /// for mainnet and others: 60 seconds
+    pub fn minimum_block_time(&self) -> Timestamp {
+        match *self {
+            Self::RegTest => Timestamp::millis(1),
+            Self::TestnetMock => Timestamp::millis(100),
+            Self::Main | Self::Beta | Self::Testnet => Timestamp::seconds(60),
+        }
+    }
+
+    /// desired/average time between blocks.
+    ///
+    /// for regtest: 100 milliseconds.
+    /// for mainnet and others: 588000 milliseconds equals 9.8 minutes.
+    pub fn target_block_interval(&self) -> Timestamp {
+        match *self {
+            Self::RegTest => Timestamp::millis(100),
+            Self::Main | Self::Beta | Self::Testnet | Self::TestnetMock => {
+                Timestamp::millis(588000)
+            }
+        }
+    }
+
+    /// indicates if mainnet
+    pub fn is_mainnet(&self) -> bool {
+        matches!(self, Self::Main)
+    }
+
+    /// indicates if testnet
+    pub fn is_testnet(&self) -> bool {
+        matches!(self, Self::Testnet)
+    }
+
+    /// indicates if testnet-mock
+    pub fn is_testnet_mock(&self) -> bool {
+        matches!(self, Self::TestnetMock)
+    }
+
+    /// indicates if regtest
+    pub fn is_regtest(&self) -> bool {
         matches!(self, Self::RegTest)
     }
 }
@@ -103,7 +169,7 @@ impl Network {
 impl fmt::Display for Network {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let string = match self {
-            Network::Alpha => "alpha".to_string(),
+            Network::TestnetMock => "testnet-mock".to_string(),
             Network::Testnet => "testnet".to_string(),
             Network::RegTest => "regtest".to_string(),
             Network::Beta => "beta".to_string(),
@@ -117,7 +183,7 @@ impl FromStr for Network {
     type Err = String;
     fn from_str(input: &str) -> Result<Network, Self::Err> {
         match input {
-            "alpha" => Ok(Network::Alpha),
+            "testnet-mock" => Ok(Network::TestnetMock),
             "testnet" => Ok(Network::Testnet),
             "regtest" => Ok(Network::RegTest),
             "beta" => Ok(Network::Beta),

--- a/src/connect_to_peers.rs
+++ b/src/connect_to_peers.rs
@@ -589,7 +589,7 @@ mod tests {
     #[traced_test]
     #[apply(shared_tokio_runtime)]
     async fn test_outgoing_connection_succeed() -> Result<()> {
-        let network = Network::Alpha;
+        let network = Network::Beta;
         let other_handshake = get_dummy_handshake_data_for_genesis(network);
         let own_handshake = get_dummy_handshake_data_for_genesis(network);
         let mock = Builder::new()
@@ -609,7 +609,7 @@ mod tests {
             .build();
 
         let (_peer_broadcast_tx, from_main_rx_clone, to_main_tx, _to_main_rx1, state, _hsd) =
-            get_test_genesis_setup(Network::Alpha, 0, cli_args::Args::default()).await?;
+            get_test_genesis_setup(Network::Beta, 0, cli_args::Args::default()).await?;
         call_peer_inner(
             mock,
             state.clone(),
@@ -660,7 +660,7 @@ mod tests {
     #[traced_test]
     #[apply(shared_tokio_runtime)]
     async fn test_get_connection_status() -> Result<()> {
-        let network = Network::Alpha;
+        let network = Network::Beta;
         let (_, _, _, _, mut state_lock, own_handshake) =
             get_test_genesis_setup(network, 1, cli_args::Args::default()).await?;
 
@@ -876,7 +876,7 @@ mod tests {
         // the connection. If this sequence is not followed, the `mock`
         // object will panic, and the `await` operator will evaluate
         // to Error.
-        let network = Network::Alpha;
+        let network = Network::Beta;
         let other_handshake = get_dummy_handshake_data_for_genesis(network);
         let own_handshake = get_dummy_handshake_data_for_genesis(network);
         let mock = Builder::new()
@@ -917,7 +917,7 @@ mod tests {
     #[traced_test]
     #[apply(shared_tokio_runtime)]
     async fn test_incoming_connection_fail_bad_magic_value() -> Result<()> {
-        let network = Network::Alpha;
+        let network = Network::Beta;
         let other_handshake = get_dummy_handshake_data_for_genesis(network);
         let own_handshake = get_dummy_handshake_data_for_genesis(network);
         let mock = Builder::new()
@@ -948,7 +948,7 @@ mod tests {
     #[apply(shared_tokio_runtime)]
     async fn test_incoming_connection_fail_bad_network() -> Result<()> {
         let other_handshake = get_dummy_handshake_data_for_genesis(Network::Testnet);
-        let own_handshake = get_dummy_handshake_data_for_genesis(Network::Alpha);
+        let own_handshake = get_dummy_handshake_data_for_genesis(Network::Beta);
         let mock = Builder::new()
             .read(&to_bytes(&PeerMessage::Handshake(Box::new((
                 MAGIC_STRING_REQUEST.to_vec(),
@@ -961,7 +961,7 @@ mod tests {
             .build();
 
         let (_peer_broadcast_tx, from_main_rx_clone, to_main_tx, _to_main_rx1, state, _hsd) =
-            get_test_genesis_setup(Network::Alpha, 0, cli_args::Args::default()).await?;
+            get_test_genesis_setup(Network::Beta, 0, cli_args::Args::default()).await?;
 
         let answer = answer_peer_inner(
             mock,
@@ -982,7 +982,7 @@ mod tests {
     async fn test_incoming_connection_fail_bad_version() {
         let mut other_handshake = get_dummy_handshake_data_for_genesis(Network::Testnet);
         let (_peer_broadcast_tx, from_main_rx_clone, to_main_tx, _to_main_rx1, state_lock, _hsd) =
-            get_test_genesis_setup(Network::Alpha, 0, cli_args::Args::default())
+            get_test_genesis_setup(Network::Beta, 0, cli_args::Args::default())
                 .await
                 .unwrap();
         let state = state_lock.lock_guard().await;
@@ -1048,7 +1048,7 @@ mod tests {
     async fn test_incoming_connection_fail_max_peers_exceeded() -> Result<()> {
         // In this scenario a node attempts to make an ingoing connection but the max
         // peer count should prevent a new incoming connection from being accepted.
-        let network = Network::Alpha;
+        let network = Network::Beta;
         let other_handshake = get_dummy_handshake_data_for_genesis(network);
         let own_handshake = get_dummy_handshake_data_for_genesis(network);
         let mock = Builder::new()
@@ -1072,7 +1072,7 @@ mod tests {
             _to_main_rx1,
             mut state_lock,
             _hsd,
-        ) = get_test_genesis_setup(Network::Alpha, 2, cli_args::Args::default()).await?;
+        ) = get_test_genesis_setup(Network::Beta, 2, cli_args::Args::default()).await?;
 
         // set max_peers to 2 to ensure failure on next connection attempt
         let mut cli = state_lock.cli().clone();
@@ -1174,7 +1174,7 @@ mod tests {
     async fn disallow_ingoing_connections_from_banned_peers_test() -> Result<()> {
         // In this scenario a peer has been banned, and is attempting to make an ingoing
         // connection. This should not be possible.
-        let network = Network::Alpha;
+        let network = Network::Beta;
         let other_handshake = get_dummy_handshake_data_for_genesis(network);
         let own_handshake = get_dummy_handshake_data_for_genesis(network);
         let mock = Builder::new()
@@ -1200,7 +1200,7 @@ mod tests {
             mut state_lock,
             _hsd,
         ) = get_test_genesis_setup(
-            Network::Alpha,
+            Network::Beta,
             peer_count_before_incoming_connection_request,
             cli_args::Args::default(),
         )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,18 +113,9 @@ pub async fn initialize(cli_args: cli_args::Args) -> Result<MainLoopHandler> {
         tokio::spawn(fut);
     }
 
-    if cli_args.mine() && cli_args.network.is_regtest() {
-        // note: disable auto-mining in regtest mode because it doesn't work
-        // (yet) once it is working, we can remove the bail!() and uncomment the
-        // warning below.
-        anyhow::bail!("Automatic mining in regtest mode is not supported.  Try again without --compose or --guess flags.");
-
-        //        tracing::warn!(
-        //            "Automatic mining in regtest mode is generally not recommended.
-        //This mode provides APIs for generating blocks programmatically in a controlled fashion.
-        //Automatic mining adds randomly generated blocks which makes the blockchain non-deterministic.
-        //"
-        //        );
+    // see comment for Network::performs_automated_mining()
+    if cli_args.mine() && !cli_args.network.performs_automated_mining() {
+        anyhow::bail!("Automatic mining is not supported for network {}.  Try again without --compose or --guess flags.", cli_args.network);
     }
 
     info!("Starting neptune-core node on {}.", cli_args.network);

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -1617,8 +1617,8 @@ impl MainLoopHandler {
                     // because no regtest nodes attempt to discover eachother, so the only
                     // peers are those that are manually added.
                     // see: https://github.com/Neptune-Crypto/neptune-core/issues/539#issuecomment-2764701027
-                    if self.global_state_lock.cli().network.use_mock_proof() {
-                        debug!("peer discovery disabled when network uses mock proofs (eg regtest)")
+                    if !self.global_state_lock.cli().network.perform_peer_discovery() {
+                        debug!("peer discovery disabled for network {}", self.global_state_lock.cli().network);
                     } else {
                         self.prune_peers().await?;
                         self.reconnect(&mut main_loop_state).await?;
@@ -1966,7 +1966,7 @@ mod tests {
         let network = main_loop_handler.global_state_lock.cli().network;
         let mut mutable_main_loop_state = main_loop_handler.mutable();
 
-        let block1 = invalid_empty_block(&Block::genesis(network));
+        let block1 = invalid_empty_block(network, &Block::genesis(network));
 
         assert!(
             main_loop_handler

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -1617,12 +1617,12 @@ impl MainLoopHandler {
                     // because no regtest nodes attempt to discover eachother, so the only
                     // peers are those that are manually added.
                     // see: https://github.com/Neptune-Crypto/neptune-core/issues/539#issuecomment-2764701027
-                    if !self.global_state_lock.cli().network.perform_peer_discovery() {
-                        debug!("peer discovery disabled for network {}", self.global_state_lock.cli().network);
-                    } else {
+                    if self.global_state_lock.cli().network.performs_peer_discovery() {
                         self.prune_peers().await?;
                         self.reconnect(&mut main_loop_state).await?;
                         self.discover_peers(&mut main_loop_state).await?;
+                    } else {
+                        debug!("peer discovery disabled for network {}", self.global_state_lock.cli().network);
                     }
                 }
 

--- a/src/main_loop/proof_upgrader.rs
+++ b/src/main_loop/proof_upgrader.rs
@@ -1075,7 +1075,8 @@ mod tests {
             // Before handle upgrade completes, a new block comes in. Making the
             // method have to do more work.
             let genesis_block = Block::genesis(network);
-            let block1 = invalid_empty_block_with_timestamp(&genesis_block, pwtx.kernel.timestamp);
+            let block1 =
+                invalid_empty_block_with_timestamp(network, &genesis_block, pwtx.kernel.timestamp);
             alice.set_new_tip(block1).await.unwrap();
 
             upgrade_job

--- a/src/models/blockchain/block/block_height.rs
+++ b/src/models/blockchain/block/block_height.rs
@@ -149,7 +149,7 @@ mod tests {
     use super::*;
     use crate::models::blockchain::block::tests::PREMINE_MAX_SIZE;
     use crate::models::blockchain::block::Block;
-    use crate::models::blockchain::block::TARGET_BLOCK_INTERVAL;
+    use crate::models::blockchain::block::Network;
     use crate::models::blockchain::type_scripts::native_currency_amount::NativeCurrencyAmount;
     use crate::models::proof_abstractions::timestamp::Timestamp;
     use crate::tests::shared_tokio_runtime;
@@ -163,7 +163,9 @@ mod tests {
 
     #[test]
     fn block_interval_times_generation_count_is_three_years() {
-        let calculated_halving_time = TARGET_BLOCK_INTERVAL * (BLOCKS_PER_GENERATION as usize);
+        let network = Network::Main;
+        let calculated_halving_time =
+            network.target_block_interval() * (BLOCKS_PER_GENERATION as usize);
         let calculated_halving_time = calculated_halving_time.to_millis();
         let three_years = Timestamp::years(3);
         let three_years = three_years.to_millis();

--- a/src/models/blockchain/block/block_kernel.rs
+++ b/src/models/blockchain/block/block_kernel.rs
@@ -66,15 +66,17 @@ mod tests {
     use super::*;
     use crate::models::blockchain::block::validity::block_primitive_witness::tests::deterministic_block_primitive_witness;
     use crate::models::blockchain::block::Block;
+    use crate::models::blockchain::block::Network;
     use crate::models::proof_abstractions::timestamp::Timestamp;
 
     #[test]
     fn kernel_hash_calculation() {
+        let network = Network::Main;
         let block_primitive_witness = deterministic_block_primitive_witness();
         let invalid_block = Block::block_template_invalid_proof_from_witness(
             block_primitive_witness,
             Timestamp::now(),
-            None,
+            network.target_block_interval(),
         );
         let calculated = invalid_block.hash();
         let merkle_tree_leafs = [

--- a/src/models/blockchain/block/block_validation_error.rs
+++ b/src/models/blockchain/block/block_validation_error.rs
@@ -3,7 +3,7 @@
 ///
 /// Conversely, defines what it means for a block to be "valid".
 #[derive(Debug, Clone, Copy, thiserror::Error)]
-pub(super) enum BlockValidationError {
+pub enum BlockValidationError {
     // 0. `previous_block` is consistent with current block
     ///   0.a) Block height is previous plus one
     #[error("block height must equal that of predecessor plus one")]

--- a/src/models/blockchain/block/mock_block_generator.rs
+++ b/src/models/blockchain/block/mock_block_generator.rs
@@ -43,7 +43,7 @@ impl MockBlockGenerator {
 
         let body = primitive_witness.body().to_owned();
         let mut header =
-            primitive_witness.header(timestamp, Some(Network::RegTest.target_block_interval()));
+            primitive_witness.header(timestamp, Network::RegTest.target_block_interval());
         header.guesser_digest = guesser_key.after_image();
         let (appendix, proof) = {
             let block_proof_witness = BlockProofWitness::produce(primitive_witness);
@@ -58,6 +58,7 @@ impl MockBlockGenerator {
     /// Create a block from a transaction without the hassle of proving but such
     /// that it appears valid.
     pub fn mock_block_from_tx(
+        network: Network,
         predecessor: Arc<Block>,
         tx: Transaction,
         guesser_key: HashLockKey,
@@ -69,7 +70,7 @@ impl MockBlockGenerator {
         let mut rng = StdRng::from_seed(seed);
 
         // mining (guessing) loop.
-        while !block.has_proof_of_work(predecessor.header()) {
+        while !block.has_proof_of_work(network, predecessor.header()) {
             let nonce = rng.random();
             block.set_header_nonce(nonce);
         }
@@ -196,7 +197,7 @@ impl MockBlockGenerator {
         let prev = predecessor.clone();
 
         let block = if with_valid_pow {
-            Self::mock_block_from_tx(predecessor, block_tx, guesser_key, rng.random())
+            Self::mock_block_from_tx(network, predecessor, block_tx, guesser_key, rng.random())
         } else {
             Self::mock_block_from_tx_without_pow((*predecessor).clone(), block_tx, guesser_key)
         };

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -911,16 +911,23 @@ impl Block {
         Ok(())
     }
 
+    /// indicates if a difficulty reset should be performed.
+    ///
+    /// Reset only occurs for network(s) that define a difficulty-reset-interval,
+    /// typically testnet(s).
+    ///
+    /// A reset should be performed any time the interval between a block
+    /// and its parent block is >= the network's reset interval.
     pub(crate) fn should_reset_difficulty(
         network: Network,
         current_block_timestamp: Timestamp,
         previous_block_timestamp: Timestamp,
     ) -> bool {
-        if let Some(reset_interval) = network.difficulty_reset_interval() {
-            let elapsed_interval = current_block_timestamp - previous_block_timestamp;
-            return elapsed_interval >= reset_interval;
-        }
-        false
+        let Some(reset_interval) = network.difficulty_reset_interval() else {
+            return false;
+        };
+        let elapsed_interval = current_block_timestamp - previous_block_timestamp;
+        elapsed_interval >= reset_interval
     }
 
     /// Determine whether the proof-of-work puzzle was solved correctly.
@@ -1301,7 +1308,7 @@ pub(crate) mod tests {
                     block.kernel.header.timestamp,
                     block_prev.header().timestamp,
                     block_prev.header().difficulty,
-                    network.target_block_interval(), // target_block_interval
+                    network.target_block_interval(),
                     block_prev.header().height,
                 );
                 assert_eq!(block.kernel.header.difficulty, control);

--- a/src/models/blockchain/block/validity/block_primitive_witness.rs
+++ b/src/models/blockchain/block/validity/block_primitive_witness.rs
@@ -62,7 +62,7 @@ impl BlockPrimitiveWitness {
     pub(crate) fn header(
         &self,
         timestamp: Timestamp,
-        target_block_interval: Option<Timestamp>,
+        target_block_interval: Timestamp,
     ) -> BlockHeader {
         let parent_header = self.predecessor_block.header();
         let parent_digest = self.predecessor_block.hash();
@@ -137,7 +137,7 @@ pub(crate) mod tests {
     use crate::models::blockchain::block::block_kernel::BlockKernel;
     use crate::models::blockchain::block::Block;
     use crate::models::blockchain::block::BlockProof;
-    use crate::models::blockchain::block::TARGET_BLOCK_INTERVAL;
+    use crate::models::blockchain::block::Network;
     use crate::models::blockchain::transaction::lock_script::LockScript;
     use crate::models::blockchain::transaction::lock_script::LockScriptAndWitness;
     use crate::models::blockchain::transaction::primitive_witness::PrimitiveWitness;
@@ -230,6 +230,8 @@ pub(crate) mod tests {
 
         pub(crate) fn arbitrary() -> BoxedStrategy<BlockPrimitiveWitness> {
             const NUM_INPUTS: usize = 2;
+            let network = Network::Main;
+
             (
                 NativeCurrencyAmount::arbitrary_non_negative(),
                 vec(0f64..1f64, NUM_INPUTS - 1),
@@ -239,7 +241,7 @@ pub(crate) mod tests {
                 0..u64::MAX,
             )
                 .prop_flat_map(
-                    |(
+                    move |(
                         total_input,
                         input_distribution,
                         hash_lock_keys,
@@ -313,7 +315,7 @@ pub(crate) mod tests {
                                             predecessor_block.header().height.next(),
                                         );
                                         let timestamp = predecessor_block.header().timestamp
-                                            + TARGET_BLOCK_INTERVAL;
+                                            + network.target_block_interval();
 
                                         let miner_fee_records =
                                             predecessor_block.guesser_fee_addition_records();

--- a/src/models/blockchain/block/validity/block_program.rs
+++ b/src/models/blockchain/block/validity/block_program.rs
@@ -485,7 +485,6 @@ pub(crate) mod tests {
                 predecessor,
                 block_tx,
                 timestamp,
-                None,
                 TritonVmJobQueue::get_instance(),
                 TritonVmProofJobOptions::default(),
             )

--- a/src/models/blockchain/transaction/lock_script.rs
+++ b/src/models/blockchain/transaction/lock_script.rs
@@ -167,7 +167,7 @@ impl LockScriptAndWitness {
         ProofBuilder::new()
             .program(self.program.clone())
             .claim(claim)
-            .nondeterminism(self.nondeterminism())
+            .nondeterminism(|| self.nondeterminism())
             .job_queue(triton_vm_job_queue)
             .proof_job_options(proof_job_options)
             .build()

--- a/src/models/blockchain/transaction/mod.rs
+++ b/src/models/blockchain/transaction/mod.rs
@@ -604,7 +604,7 @@ pub(crate) mod tests {
     //         .unwrap();
 
     //     let genesis_block = Block::genesis_block();
-    //     let (block_1, _, _) = make_mock_block(
+    //     let (block_1, _, _) = make_mock_block(network,
     //         &genesis_block,
     //         None,
     //         other_wallet.nth_generation_spending_key(0).to_address(),
@@ -618,7 +618,7 @@ pub(crate) mod tests {
     //     transaction.update_mutator_set_records(&block_1).unwrap();
 
     //     // Insert the updated transaction into block 2 and verify that this block is valid
-    //     let mut block_2 = make_mock_block(&block_1, None, other_wallet.get_public_key());
+    //     let mut block_2 = make_mock_block(network, &block_1, None, other_wallet.get_public_key());
     //     block_2.authority_merge_transaction(updated_tx.clone());
     //     assert!(block_2.is_valid_for_devnet(&block_1));
 
@@ -628,12 +628,12 @@ pub(crate) mod tests {
     //     let mut _previous_block = next_block.clone();
     //     for _ in 0..26 {
     //         _previous_block = next_block;
-    //         next_block = make_mock_block(&_previous_block, None, other_wallet.get_public_key());
+    //         next_block = make_mock_block(network, &_previous_block, None, other_wallet.get_public_key());
     //         updated_tx.update_ms_data(&next_block).unwrap();
     //     }
 
     //     _previous_block = next_block.clone();
-    //     next_block = make_mock_block(&next_block, None, other_wallet.get_public_key());
+    //     next_block = make_mock_block(network, &next_block, None, other_wallet.get_public_key());
     //     next_block.authority_merge_transaction(updated_tx.clone());
     //     assert!(next_block.is_valid_for_devnet(&_previous_block));
 
@@ -668,8 +668,8 @@ pub(crate) mod tests {
     //     // Create next block and verify that transaction is not valid with this block as tip
     //     let genesis_block = Block::genesis_block();
     //     let other_wallet = WalletSecret::new(generate_secret_key());
-    //     let block_1 = make_mock_block(&genesis_block, None, own_wallet_secret.get_public_key());
-    //     let block_2 = make_mock_block(&block_1, None, other_wallet.get_public_key());
+    //     let block_1 = make_mock_block(network, &genesis_block, None, own_wallet_secret.get_public_key());
+    //     let block_2 = make_mock_block(network, &block_1, None, other_wallet.get_public_key());
     //     assert!(
     //         block_1.is_valid_for_devnet(&genesis_block),
     //         "Block 1 must be valid with only coinbase output"
@@ -755,7 +755,7 @@ pub(crate) mod tests {
     //             .create_transaction(vec![utxo_a, utxo_b, utxo_c], 1.into())
     //             .await
     //             .unwrap();
-    //         next_block = make_mock_block(&_previous_block, None, other_wallet.get_public_key());
+    //         next_block = make_mock_block(network, &_previous_block, None, other_wallet.get_public_key());
 
     //         next_block.authority_merge_transaction(other_transaction);
     //         assert!(
@@ -788,7 +788,7 @@ pub(crate) mod tests {
     //     }
 
     //     _previous_block = next_block.clone();
-    //     next_block = make_mock_block(&next_block, None, other_wallet.get_public_key());
+    //     next_block = make_mock_block(network, &next_block, None, other_wallet.get_public_key());
     //     next_block.authority_merge_transaction(updated_tx.clone());
     //     assert!(
     //         next_block.is_valid_for_devnet(&_previous_block),

--- a/src/models/blockchain/transaction/validity/single_proof.rs
+++ b/src/models/blockchain/transaction/validity/single_proof.rs
@@ -243,13 +243,11 @@ impl SingleProof {
         let single_proof_witness = SingleProofWitness::from_collection(proof_collection);
         let claim = single_proof_witness.claim();
 
-        let nondeterminism = single_proof_witness.nondeterminism();
-
         info!("Start: generate single proof");
         let proof = ProofBuilder::new()
             .program(SingleProof.program())
             .claim(claim)
-            .nondeterminism(nondeterminism)
+            .nondeterminism(|| single_proof_witness.nondeterminism())
             .job_queue(triton_vm_job_queue)
             .proof_job_options(proof_job_options)
             .build()

--- a/src/models/blockchain/type_scripts/mod.rs
+++ b/src/models/blockchain/type_scripts/mod.rs
@@ -119,7 +119,7 @@ impl TypeScriptAndWitness {
         ProofBuilder::new()
             .program(self.program.clone())
             .claim(claim)
-            .nondeterminism(self.nondeterminism())
+            .nondeterminism(|| self.nondeterminism())
             .job_queue(triton_vm_job_queue)
             .proof_job_options(proof_job_options)
             .build()

--- a/src/models/peer.rs
+++ b/src/models/peer.rs
@@ -710,7 +710,7 @@ impl SyncChallengeResponse {
 
     /// Determine whether the `SyncChallengeResponse` answers the given
     /// `IssuedSyncChallenge`, and not some other one.
-    pub(crate) fn matches(&self, issued_challenge: IssuedSyncChallenge) -> bool {
+    pub(crate) fn matches(&self, network: Network, issued_challenge: IssuedSyncChallenge) -> bool {
         let Ok(tip_parent) = Block::try_from(self.tip_parent.clone()) else {
             return false;
         };
@@ -727,7 +727,7 @@ impl SyncChallengeResponse {
             .all(|((_, child), challenge_height)| child.header.height == *challenge_height)
             && issued_challenge.challenge.tip_digest == tip.hash()
             && issued_challenge.accumulated_pow == tip.header().cumulative_proof_of_work
-            && tip.has_proof_of_work(tip_parent.header())
+            && tip.has_proof_of_work(network, tip_parent.header())
             && pow_witnesses_form_chain_from_tip
     }
 
@@ -741,7 +741,7 @@ impl SyncChallengeResponse {
             return false;
         };
         if !tip.is_valid(&tip_predecessor, now, network).await
-            || !tip.has_proof_of_work(tip_predecessor.header())
+            || !tip.has_proof_of_work(network, tip_predecessor.header())
         {
             return false;
         }
@@ -768,7 +768,7 @@ impl SyncChallengeResponse {
             };
 
             if !child.is_valid(&parent, now, network).await
-                || !child.has_proof_of_work(parent.header())
+                || !child.has_proof_of_work(network, parent.header())
             {
                 return false;
             }

--- a/src/models/peer/transfer_block.rs
+++ b/src/models/peer/transfer_block.rs
@@ -89,13 +89,14 @@ mod tests {
 
     #[test]
     fn cannot_transfer_blocks_that_are_not_single_proof_supported() {
-        let genesis = Block::genesis(Network::Main);
+        let network = Network::Main;
+        let genesis = Block::genesis(network);
         let tblock_genesis: Result<TransferBlock> = (&genesis).try_into();
         assert!(
             tblock_genesis.is_err(),
             "Transferring genesis block is disallowed"
         );
-        let invalid_block_1 = invalid_empty_block(&genesis);
+        let invalid_block_1 = invalid_empty_block(network, &genesis);
         let tblock_1 = TransferBlock::try_from(invalid_block_1);
         assert!(
             tblock_1.is_err(),

--- a/src/models/proof_abstractions/tasm/program.rs
+++ b/src/models/proof_abstractions/tasm/program.rs
@@ -72,7 +72,7 @@ where
         ProofBuilder::new()
             .program(self.program())
             .claim(claim)
-            .nondeterminism(nondeterminism)
+            .nondeterminism(|| nondeterminism)
             .job_queue(triton_vm_job_queue)
             .proof_job_options(proof_job_options)
             .build()

--- a/src/models/proof_abstractions/timestamp.rs
+++ b/src/models/proof_abstractions/timestamp.rs
@@ -3,6 +3,7 @@ use std::ops::Add;
 use std::ops::AddAssign;
 use std::ops::Mul;
 use std::ops::Sub;
+use std::time::Duration;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
@@ -154,6 +155,63 @@ impl Timestamp {
             Some(dt) => dt.format(format_descriptor).to_string(),
             None => "".to_string(),
         }
+    }
+
+    pub fn as_duration(&self) -> Duration {
+        Duration::from_millis(self.to_millis())
+    }
+
+    pub fn format_human_duration(&self) -> String {
+        let duration = self.as_duration();
+        let total_seconds = duration.as_secs();
+
+        let weeks = total_seconds / (60 * 60 * 24 * 7);
+        let remaining_seconds = total_seconds % (60 * 60 * 24 * 7);
+
+        let days = remaining_seconds / (60 * 60 * 24);
+        let remaining_seconds = remaining_seconds % (60 * 60 * 24);
+
+        let hours = remaining_seconds / (60 * 60);
+        let remaining_seconds = remaining_seconds % (60 * 60);
+
+        let minutes = remaining_seconds / 60;
+        let seconds = remaining_seconds % 60;
+
+        let mut parts = Vec::new();
+
+        if weeks > 0 {
+            parts.push(format!(
+                "{} week{}",
+                weeks,
+                if weeks == 1 { "" } else { "s" }
+            ));
+        }
+        if days > 0 {
+            parts.push(format!("{} day{}", days, if days == 1 { "" } else { "s" }));
+        }
+        if hours > 0 {
+            parts.push(format!(
+                "{} hour{}",
+                hours,
+                if hours == 1 { "" } else { "s" }
+            ));
+        }
+        if minutes > 0 {
+            parts.push(format!(
+                "{} minute{}",
+                minutes,
+                if minutes == 1 { "" } else { "s" }
+            ));
+        }
+        if seconds > 0 || parts.is_empty() {
+            parts.push(format!(
+                "{} second{}",
+                seconds,
+                if seconds == 1 { "" } else { "s" }
+            ));
+        }
+
+        parts.join(", ")
     }
 
     pub fn standard_format(&self) -> String {

--- a/src/models/proof_abstractions/timestamp.rs
+++ b/src/models/proof_abstractions/timestamp.rs
@@ -184,10 +184,12 @@ impl Timestamp {
     /// # Examples
     ///
     /// ```
-    /// let timestamp = Timestamp::millis(1234567*1000); // Roughly 2 weeks, 1 day, 2 hours, 56 minutes, 7 seconds
-    /// assert_eq!(timestamp.format_human_duration(), "2 weeks, 1 day, 2 hours, 56 minutes, 7 seconds");
+    /// use neptune_cash::api::export::Timestamp;
     ///
-    /// let short_ts = Timestamp::millis(65*1000); // 1 minute, 5 seconds
+    /// let timestamp = Timestamp::millis(1234567*1000);
+    /// assert_eq!(timestamp.format_human_duration(), "2 weeks, 6 hours, 56 minutes, 7 seconds");
+    ///
+    /// let short_ts = Timestamp::millis(65*1000);
     /// assert_eq!(short_ts.format_human_duration(), "1 minute, 5 seconds");
     ///
     /// let zero_ts = Timestamp::millis(150);

--- a/src/models/state/archival_state/bootstrap_from_block_files.rs
+++ b/src/models/state/archival_state/bootstrap_from_block_files.rs
@@ -167,7 +167,7 @@ mod tests {
     async fn get_blocks_directly_from_file_without_database() {
         let network = Network::Main;
         let mut archival_state = make_test_archival_state(network).await;
-        let blocks = invalid_empty_blocks(&archival_state.genesis_block, 10);
+        let blocks = invalid_empty_blocks(network, &archival_state.genesis_block, 10);
 
         for i in 0..10 {
             archival_state

--- a/src/models/state/wallet/address/common.rs
+++ b/src/models/state/wallet/address/common.rs
@@ -17,8 +17,9 @@ use crate::prelude::twenty_first;
 /// returns human-readable-prefix for the given network
 pub(crate) fn network_hrp_char(network: Network) -> char {
     match network {
-        Network::Alpha | Network::Beta | Network::Main => 'm',
+        Network::Beta | Network::Main => 'm',
         Network::Testnet => 't',
+        Network::TestnetMock => 'z',
         Network::RegTest => 'r',
     }
 }

--- a/src/models/state/wallet/address/generation_address.rs
+++ b/src/models/state/wallet/address/generation_address.rs
@@ -186,9 +186,9 @@ impl GenerationSpendingKey {
         // Sanity check that spending key's receiver address can be encoded to
         // bech32m without loss of information.
         let receiving_address = spending_key.to_address();
-        let encoded_address = receiving_address.to_bech32m(Network::Alpha).unwrap();
+        let encoded_address = receiving_address.to_bech32m(Network::Beta).unwrap();
         let decoded_address =
-            GenerationReceivingAddress::from_bech32m(&encoded_address, Network::Alpha).unwrap();
+            GenerationReceivingAddress::from_bech32m(&encoded_address, Network::Beta).unwrap();
         assert_eq!(
             receiving_address, decoded_address,
             "encoding/decoding from bech32m must succeed. Receiving address was: {receiving_address:#?}"

--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -295,7 +295,10 @@ impl PeerLoopHandler {
         debug!("validating with respect to current timestamp {now}");
         let mut previous_block = &parent_of_first_block;
         for new_block in &received_blocks {
-            let new_block_has_proof_of_work = new_block.has_proof_of_work(previous_block.header());
+            let new_block_has_proof_of_work = new_block.has_proof_of_work(
+                self.global_state_lock.cli().network,
+                previous_block.header(),
+            );
             debug!("new block has proof of work? {new_block_has_proof_of_work}");
             let new_block_is_valid = new_block
                 .is_valid(previous_block, now, self.global_state_lock.cli().network)
@@ -788,7 +791,9 @@ impl PeerLoopHandler {
                 peer_state_info.sync_challenge = None;
 
                 // Does response match issued challenge?
-                if !challenge_response.matches(issued_challenge) {
+                if !challenge_response
+                    .matches(self.global_state_lock.cli().network, issued_challenge)
+                {
                     self.punish(NegativePeerSanction::InvalidSyncChallengeResponse)
                         .await?;
                     return Ok(KEEP_CONNECTION_ALIVE);
@@ -1945,7 +1950,6 @@ mod tests {
     use super::*;
     use crate::config_models::cli_args;
     use crate::config_models::network::Network;
-    use crate::models::blockchain::block::block_header::TARGET_BLOCK_INTERVAL;
     use crate::models::blockchain::type_scripts::native_currency_amount::NativeCurrencyAmount;
     use crate::models::peer::peer_block_notifications::PeerBlockNotification;
     use crate::models::peer::transaction_notification::TransactionNotification;
@@ -1970,7 +1974,7 @@ mod tests {
         let mock = Mock::new(vec![Action::Read(PeerMessage::Bye)]);
 
         let (peer_broadcast_tx, _from_main_rx_clone, to_main_tx, _to_main_rx1, state_lock, hsd) =
-            get_test_genesis_setup(Network::Alpha, 2, cli_args::Args::default()).await?;
+            get_test_genesis_setup(Network::Beta, 2, cli_args::Args::default()).await?;
 
         let peer_address = get_dummy_socket_address(2);
         let from_main_rx_clone = peer_broadcast_tx.subscribe();
@@ -1993,7 +1997,7 @@ mod tests {
     #[apply(shared_tokio_runtime)]
     async fn test_peer_loop_peer_list() {
         let (peer_broadcast_tx, _from_main_rx_clone, to_main_tx, _to_main_rx1, state_lock, _hsd) =
-            get_test_genesis_setup(Network::Alpha, 2, cli_args::Args::default())
+            get_test_genesis_setup(Network::Beta, 2, cli_args::Args::default())
                 .await
                 .unwrap();
 
@@ -2015,7 +2019,7 @@ mod tests {
             peer_infos[1].instance_id(),
         );
 
-        let (hsd2, sa2) = get_dummy_peer_connection_data_genesis(Network::Alpha, 2);
+        let (hsd2, sa2) = get_dummy_peer_connection_data_genesis(Network::Beta, 2);
         let expected_response = vec![
             (peer_address0, instance_id0),
             (peer_address1, instance_id1),
@@ -2937,7 +2941,7 @@ mod tests {
         cli.sync_mode_threshold = 2;
         state_lock.set_cli(cli).await;
 
-        let (hsd1, peer_address1) = get_dummy_peer_connection_data_genesis(Network::Alpha, 1);
+        let (hsd1, peer_address1) = get_dummy_peer_connection_data_genesis(Network::Beta, 1);
         let [block_1, _block_2, block_3, block_4] = fake_valid_sequence_of_blocks_for_tests(
             &genesis_block,
             Timestamp::hours(1),
@@ -4031,7 +4035,7 @@ mod tests {
             // with this block notification.
             let blocks = fake_valid_sequence_of_blocks_for_tests_dyn(
                 &block_1,
-                TARGET_BLOCK_INTERVAL,
+                network.target_block_interval(),
                 rng.random(),
                 network,
                 rng.random_range(ALICE_SYNC_MODE_THRESHOLD + 1..20),

--- a/src/rpc_auth.rs
+++ b/src/rpc_auth.rs
@@ -358,7 +358,7 @@ mod tests {
         ///  2. Cookie::auth() returns AuthError::InvalidCookie for invalid cookie
         #[apply(shared_tokio_runtime)]
         pub async fn auth() -> anyhow::Result<()> {
-            let data_dir = unit_test_data_directory(Network::Alpha)?;
+            let data_dir = unit_test_data_directory(Network::Beta)?;
 
             let valid_cookie = Cookie::try_new(&data_dir).await?;
             let valid_cookie_loaded = Cookie::try_load(&data_dir).await?;

--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -3889,7 +3889,7 @@ mod tests {
     async fn balance_is_zero_at_init() -> Result<()> {
         // Verify that a wallet not receiving a premine is empty at startup
         let rpc_server = test_rpc_server(
-            Network::Alpha,
+            Network::Beta,
             WalletEntropy::new_random(),
             2,
             cli_args::Args::default(),
@@ -3909,7 +3909,7 @@ mod tests {
     #[apply(shared_tokio_runtime)]
     async fn clear_ip_standing_test() -> Result<()> {
         let mut rpc_server = test_rpc_server(
-            Network::Alpha,
+            Network::Beta,
             WalletEntropy::new_random(),
             2,
             cli_args::Args::default(),
@@ -4068,7 +4068,7 @@ mod tests {
     async fn clear_all_standings_test() -> Result<()> {
         // Create initial conditions
         let mut rpc_server = test_rpc_server(
-            Network::Alpha,
+            Network::Beta,
             WalletEntropy::new_random(),
             2,
             cli_args::Args::default(),
@@ -4197,7 +4197,7 @@ mod tests {
     #[apply(shared_tokio_runtime)]
     async fn utxo_digest_test() {
         let rpc_server = test_rpc_server(
-            Network::Alpha,
+            Network::Beta,
             WalletEntropy::new_random(),
             2,
             cli_args::Args::default(),
@@ -4501,7 +4501,7 @@ mod tests {
         // the RPC call returns `None`, so we only verify that the call doesn't
         // crash the host machine, we don't verify that any value is returned.
         let rpc_server = test_rpc_server(
-            Network::Alpha,
+            Network::Beta,
             WalletEntropy::new_random(),
             2,
             cli_args::Args::default(),
@@ -4560,7 +4560,7 @@ mod tests {
         fn pow_puzzle_is_consistent_with_block_hash() {
             let network = Network::Main;
             let genesis = Block::genesis(network);
-            let mut block1 = invalid_empty_block(&genesis);
+            let mut block1 = invalid_empty_block(network, &genesis);
             let hash_lock_key = HashLockKey::from_preimage(random());
             block1.set_header_guesser_digest(hash_lock_key.after_image());
 
@@ -4615,7 +4615,7 @@ mod tests {
             let mut bob = test_rpc_server(network, bob.clone(), 2, cli_args::Args::default()).await;
 
             let genesis = Block::genesis(network);
-            let block1 = invalid_empty_block(&genesis);
+            let block1 = invalid_empty_block(network, &genesis);
             bob.state
                 .lock_mut(|x| {
                     x.mining_state.block_proposal =
@@ -4667,6 +4667,7 @@ mod tests {
             );
         }
 
+        #[traced_test]
         #[apply(shared_tokio_runtime)]
         async fn exported_pow_puzzle_is_consistent_with_block_hash() {
             let network = Network::Main;
@@ -4675,7 +4676,7 @@ mod tests {
             let bob_token = cookie_token(&bob).await;
 
             let genesis = Block::genesis(network);
-            let mut block1 = invalid_empty_block(&genesis);
+            let mut block1 = invalid_empty_block(network, &genesis);
             bob.state
                 .lock_mut(|x| {
                     x.mining_state.block_proposal =
@@ -4901,7 +4902,8 @@ mod tests {
 
                     let cb_key = wallet_entropy.nth_generation_spending_key(0);
                     let (block1, composer_expected_utxos) =
-                        make_mock_block(&genesis_block, None, cb_key, Default::default()).await;
+                        make_mock_block(network, &genesis_block, None, cb_key, Default::default())
+                            .await;
                     blocks.push(block1.clone());
 
                     rpc_server
@@ -4929,7 +4931,7 @@ mod tests {
                         &block1,
                         tx_artifacts.transaction.clone().into(),
                     );
-                    let block3 = invalid_empty_block(&block2);
+                    let block3 = invalid_empty_block(network, &block2);
 
                     // mine two blocks, the first will include the transaction
                     blocks.push(block2);
@@ -5046,7 +5048,8 @@ mod tests {
                 let bob_key = bob_wallet.nth_generation_spending_key(0);
                 let genesis_block = Block::genesis(network);
                 let (block1, composer_expected_utxos) =
-                    make_mock_block(&genesis_block, None, bob_key, Default::default()).await;
+                    make_mock_block(network, &genesis_block, None, bob_key, Default::default())
+                        .await;
 
                 bob.state
                     .set_new_self_composed_tip(block1.clone(), composer_expected_utxos)
@@ -5099,7 +5102,7 @@ mod tests {
                     &block1,
                     tx_artifacts.transaction.clone().into(),
                 );
-                let block3 = invalid_empty_block(&block2);
+                let block3 = invalid_empty_block(network, &block2);
 
                 if claim_after_mined {
                     // bob applies the blocks before claiming utxos.
@@ -5395,7 +5398,8 @@ mod tests {
                 // wallet ---
                 let timestamp = network.launch_date() + Timestamp::days(1);
                 let (block_1, composer_utxos) =
-                    make_mock_block(&genesis_block, Some(timestamp), key, rng.random()).await;
+                    make_mock_block(network, &genesis_block, Some(timestamp), key, rng.random())
+                        .await;
 
                 {
                     let state_lock = rpc_server.state.lock_guard().await;


### PR DESCRIPTION
closes #591
closes #595

I would ask reviewers to in particular double-check the logic of the difficulty reset mechanism in Block::should_reset_difficulty(), mine_loop::guess_worker() and Block::validate().  and also the test case for it: testnet_mock_reset_difficulty() in mine_loop.rs.

The difficulty resets occur (for testnet, testnet-mock) when interval between blocks is >= 2x the target-block-interval.  In bitcoin-core this is known as the 20 minute rule.  In neptune, since the target interval is 9.8 minutes, the reset interval is 19.6 minutes.

Another thing to ponder/decide: I've renamed Alpha to TestnetMock and left Testnet mostly alone (except adding difficulty-reset behavior).   Yet if we are going to be using this a lot and *not* using 'Testnet', then perhaps we should just make 'Testnet' behave as TestnetMock does, with mock proofs, etc.  We could always make a different testnet with real proofs later if need be.

------------

edit: here is a screenshot of a non-mining node that just received 25 testnet-mock NPT (confirmed) from a mining node.   Thus demonstrating that core payment functionality works between nodes on testnet-mock network.

![screen](https://github.com/user-attachments/assets/0e87c118-4375-4559-9c40-408f590e06e7)

------------

Introduces `Network::TestnetMock` variant described as:

 Public test network that utilizes mock proofs and difficulty resets so
 that mining is possible without high-end hardware.  Intended for staging
 of release candidates prior to release and for the community to try out
 release candidates and report issues.

Includes necessary refactors to enable the difficulty reset functionality, in particular moving hard-coded blockchain parameters into methods of Network.

Includes a new unit test of the difficulty reset functionality in mine_loop.rs.

Changes:

+ ProofBuilder::nondeterminism() accepts a closure which is called during build() for real proofs but not for mock proofs
+ fixes panic in mining loop when network uses mock proofs
+ Update ProofBuilder call-sites to use closure for nondeterminism
+ add #[non_exhaustive] marker to Network.  Once all nodes are upgraded, new variants can be added.
+ rename Network::Alpha to TestnetMock
+ update Network with blockchain params:
  + use_mock_proof() returns true for TestnetMock
  + add difficulty_reset_interval(&self) -> Option<Timestamp>
  + add perform_peer_discovery(&self) -> bool
  + add genesis_difficulty(&self) -> Difficulty
  + update minimum_block_time(&self) -> Timestamp
  + update target_block_interval(&self) -> Timestamp
+ remove hard-coded defaults such as TARGET_BLOCK_INTERVAL and MINIMUM_BLOCK_TIME.
  pass target_block_interval: Timestamp instead of Option<Timestamp>
+ make BlockValidationError pub
+ rename Block::is_valid_internal to Block::validate() and make pub
+ add difficulty reset mechanism. (enabled for Testnet and Testnet-mock)
+ add Timestamp::as_duration() and format_human_duration()
+ add mine_loop test: testnet_mock_reset_difficulty()