### PR TITLE
Test real blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,9 @@ target/
 /makefile-target
 /makefile-target-opt-level3
 
-# git shouldn't see the proof files. Bc big.
+# git shouldn't see the proof files, or block files. Bc big.
 /test_data/*.proof
+/test_data/blk*.dat
 
 # Remove Cargo.lock from gitignore if creating an executable, leave it for libraries
 # More information here https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,9 +44,7 @@ pub mod util_types;
 #[cfg_attr(coverage_nightly, coverage(off))]
 pub mod tests;
 
-use std::collections::HashMap;
 use std::env;
-use std::net::SocketAddr;
 use std::path::PathBuf;
 
 use anyhow::Context;
@@ -62,7 +60,6 @@ use futures::StreamExt;
 use models::blockchain::block::Block;
 use models::blockchain::shared::Hash;
 use models::peer::handshake_data::HandshakeData;
-use models::peer::peer_info::PeerInfo;
 use models::state::wallet::wallet_file::WalletFileContext;
 use prelude::tasm_lib;
 use prelude::triton_vm;
@@ -88,11 +85,6 @@ use crate::models::channel::MinerToMain;
 use crate::models::channel::PeerTaskToMain;
 use crate::models::channel::RPCServerToMain;
 use crate::models::state::archival_state::ArchivalState;
-use crate::models::state::blockchain_state::BlockchainArchivalState;
-use crate::models::state::blockchain_state::BlockchainState;
-use crate::models::state::light_state::LightState;
-use crate::models::state::mempool::Mempool;
-use crate::models::state::networking_state::NetworkingState;
 use crate::models::state::wallet::wallet_state::WalletState;
 use crate::models::state::GlobalStateLock;
 use crate::rpc_server::RPC;
@@ -125,41 +117,16 @@ pub async fn initialize(cli_args: cli_args::Args) -> Result<MainLoopHandler> {
     DataDirectory::create_dir_if_not_exists(&data_directory.root_dir_path()).await?;
     info!("Data directory is {}", data_directory);
 
-    // Get wallet object, create various wallet secret files
-    let wallet_dir = data_directory.wallet_directory_path();
-    DataDirectory::create_dir_if_not_exists(&wallet_dir).await?;
-    let wallet_file_context =
-        WalletFileContext::read_from_file_or_create(&data_directory.wallet_directory_path())?;
-    info!("Now getting wallet state. This may take a while if the database needs pruning.");
-    let wallet_state =
-        WalletState::try_new_from_context(&data_directory, wallet_file_context, &cli_args).await?;
-    info!("Got wallet state.");
-
-    // Connect to or create databases for block index, peers, mutator set, block sync
-
-    let peer_databases = NetworkingState::initialize_peer_databases(&data_directory).await?;
-    info!("Got peer database");
-
+    let (rpc_server_to_main_tx, rpc_server_to_main_rx) =
+        mpsc::channel::<RPCServerToMain>(RPC_CHANNEL_CAPACITY);
     let genesis = Block::genesis(cli_args.network);
-    let archival_state = ArchivalState::new(data_directory.clone(), genesis).await;
-    info!("Got archival state");
-
-    // Get latest block. Use hardcoded genesis block if nothing is in database.
-    let latest_block: Block = archival_state.get_tip().await;
-
-    // Bind socket to port on this machine, to handle incoming connections from peers
-    let incoming_peer_listener = if let Some(incoming_peer_listener) = cli_args.own_listen_port() {
-        let ret = TcpListener::bind((cli_args.listen_addr, incoming_peer_listener))
-           .await
-           .with_context(|| format!("Failed to bind to local TCP port {}:{}. Is an instance of this program already running?", cli_args.listen_addr, incoming_peer_listener))?;
-        info!("Now listening for incoming peer-connections");
-        ret
-    } else {
-        info!("Not accepting incoming peer-connections");
-        TcpListener::bind("127.0.0.1:0").await?
-    };
-
-    let peer_map: HashMap<SocketAddr, PeerInfo> = HashMap::new();
+    let mut global_state_lock = GlobalStateLock::new(
+        data_directory.clone(),
+        genesis,
+        cli_args.clone(),
+        rpc_server_to_main_tx.clone(),
+    )
+    .await?;
 
     // Construct the broadcast channel to communicate from the main task to peer tasks
     let (main_to_peer_broadcast_tx, _main_to_peer_broadcast_rx) =
@@ -168,32 +135,6 @@ pub async fn initialize(cli_args: cli_args::Args) -> Result<MainLoopHandler> {
     // Add the MPSC (multi-producer, single consumer) channel for peer-task-to-main communication
     let (peer_task_to_main_tx, peer_task_to_main_rx) =
         mpsc::channel::<PeerTaskToMain>(PEER_CHANNEL_CAPACITY);
-
-    let networking_state = NetworkingState::new(peer_map, peer_databases);
-
-    let light_state: LightState = LightState::from(latest_block);
-    let blockchain_archival_state = BlockchainArchivalState {
-        light_state,
-        archival_state,
-    };
-    let blockchain_state = BlockchainState::Archival(Box::new(blockchain_archival_state));
-    let mempool = Mempool::new(
-        cli_args.max_mempool_size,
-        cli_args.max_mempool_num_tx,
-        blockchain_state.light_state().hash(),
-    );
-
-    let (rpc_server_to_main_tx, rpc_server_to_main_rx) =
-        mpsc::channel::<RPCServerToMain>(RPC_CHANNEL_CAPACITY);
-
-    let mut global_state_lock = GlobalStateLock::new(
-        wallet_state,
-        blockchain_state,
-        networking_state,
-        cli_args,
-        mempool,
-        rpc_server_to_main_tx.clone(),
-    );
 
     if let Some(bootstrap_directory) = global_state_lock.cli().bootstrap_from_directory.clone() {
         info!(
@@ -218,6 +159,18 @@ pub async fn initialize(cli_args: cli_args::Args) -> Result<MainLoopHandler> {
         .restore_monitored_utxos_from_recovery_data()
         .await?;
     info!("UTXO restoration check complete");
+
+    // Bind socket to port on this machine, to handle incoming connections from peers
+    let incoming_peer_listener = if let Some(incoming_peer_listener) = cli_args.own_listen_port() {
+        let ret = TcpListener::bind((cli_args.listen_addr, incoming_peer_listener))
+           .await
+           .with_context(|| format!("Failed to bind to local TCP port {}:{}. Is an instance of this program already running?", cli_args.listen_addr, incoming_peer_listener))?;
+        info!("Now listening for incoming peer-connections");
+        ret
+    } else {
+        info!("Not accepting incoming peer-connections");
+        TcpListener::bind("127.0.0.1:0").await?
+    };
 
     // Connect to peers, and provide each peer task with a thread-safe copy of the state
     let own_handshake_data: HandshakeData =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,26 +136,13 @@ pub async fn initialize(cli_args: cli_args::Args) -> Result<MainLoopHandler> {
     info!("Got wallet state.");
 
     // Connect to or create databases for block index, peers, mutator set, block sync
-    let block_index_db = ArchivalState::initialize_block_index_database(&data_directory).await?;
-    info!("Got block index database");
 
     let peer_databases = NetworkingState::initialize_peer_databases(&data_directory).await?;
     info!("Got peer database");
 
-    let archival_mutator_set = ArchivalState::initialize_mutator_set(&data_directory).await?;
-    info!("Got archival mutator set");
-
-    let archival_block_mmr = ArchivalState::initialize_archival_block_mmr(&data_directory).await?;
-    info!("Got archival block MMR");
-
-    let archival_state = ArchivalState::new(
-        data_directory.clone(),
-        block_index_db,
-        archival_mutator_set,
-        archival_block_mmr,
-        cli_args.network,
-    )
-    .await;
+    let genesis = Block::genesis(cli_args.network);
+    let archival_state = ArchivalState::new(data_directory.clone(), genesis).await;
+    info!("Got archival state");
 
     // Get latest block. Use hardcoded genesis block if nothing is in database.
     let latest_block: Block = archival_state.get_tip().await;

--- a/src/main_loop/proof_upgrader.rs
+++ b/src/main_loop/proof_upgrader.rs
@@ -901,12 +901,11 @@ mod tests {
         // expiry of timelock). Rando is not premine recipient.
         let cli_args = cli_args::Args {
             min_gobbling_fee: NativeCurrencyAmount::from_nau(5),
-            network: Network::Main,
+            network,
             ..Default::default()
         };
         let alice =
-            mock_genesis_global_state(network, 2, WalletEntropy::devnet_wallet(), cli_args.clone())
-                .await;
+            mock_genesis_global_state(2, WalletEntropy::devnet_wallet(), cli_args.clone()).await;
         let pc_tx_low_fee = transaction_from_state(
             alice.clone(),
             512777439428,
@@ -916,13 +915,8 @@ mod tests {
         .await;
 
         for tx_origin in [TransactionOrigin::Own, TransactionOrigin::Foreign] {
-            let mut rando = mock_genesis_global_state(
-                network,
-                2,
-                WalletEntropy::new_random(),
-                cli_args.clone(),
-            )
-            .await;
+            let mut rando =
+                mock_genesis_global_state(2, WalletEntropy::new_random(), cli_args.clone()).await;
             let mut rando = rando.lock_guard_mut().await;
             rando
                 .mempool_insert(pc_tx_low_fee.clone().into(), tx_origin)

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -1156,10 +1156,9 @@ pub(crate) mod tests {
         let mut rng = rand::rng();
         let network = Network::RegTest;
         let global_state_lock = mock_genesis_global_state(
-            network,
             2,
             WalletEntropy::devnet_wallet(),
-            cli_args::Args::default(),
+            cli_args::Args::default_with_network(network),
         )
         .await;
 
@@ -1224,11 +1223,12 @@ pub(crate) mod tests {
         let guesser_fee_fraction = 0.0;
         let cli_args = cli_args::Args {
             guesser_fraction: guesser_fee_fraction,
+            network,
             ..Default::default()
         };
 
         let global_state_lock =
-            mock_genesis_global_state(network, 2, WalletEntropy::devnet_wallet(), cli_args).await;
+            mock_genesis_global_state(2, WalletEntropy::devnet_wallet(), cli_args).await;
         let tick = std::time::SystemTime::now();
         let (transaction, _coinbase_utxo_info) = make_coinbase_transaction_from_state(
             &genesis_block,
@@ -1259,10 +1259,9 @@ pub(crate) mod tests {
         // Verify that a block template made with transaction from the mempool is a valid block
         let network = Network::Main;
         let mut alice = mock_genesis_global_state(
-            network,
             2,
             WalletEntropy::devnet_wallet(),
-            cli_args::Args::default(),
+            cli_args::Args::default_with_network(network),
         )
         .await;
         let genesis_block = Block::genesis(network);
@@ -1439,11 +1438,11 @@ pub(crate) mod tests {
         // force SingleProof capability.
         let cli = cli_args::Args {
             tx_proving_capability: Some(TxProvingCapability::SingleProof),
+            network,
             ..Default::default()
         };
 
-        let mut alice =
-            mock_genesis_global_state(network, 2, WalletEntropy::devnet_wallet(), cli).await;
+        let mut alice = mock_genesis_global_state(2, WalletEntropy::devnet_wallet(), cli).await;
         let genesis_block = Block::genesis(network);
         let mocked_now = genesis_block.header().timestamp + Timestamp::months(7);
 
@@ -1502,10 +1501,11 @@ pub(crate) mod tests {
         let network = Network::Main;
         let cli_args = cli_args::Args {
             guesser_fraction: 0.0,
+            network,
             ..Default::default()
         };
         let global_state_lock =
-            mock_genesis_global_state(network, 2, WalletEntropy::devnet_wallet(), cli_args).await;
+            mock_genesis_global_state(2, WalletEntropy::devnet_wallet(), cli_args).await;
         let tip_block_orig = Block::genesis(network);
         let launch_date = tip_block_orig.header().timestamp;
         let (worker_task_tx, worker_task_rx) = oneshot::channel::<NewBlockFound>();
@@ -1574,10 +1574,11 @@ pub(crate) mod tests {
         let network = Network::Main;
         let cli_args = cli_args::Args {
             guesser_fraction: 0.0,
+            network,
             ..Default::default()
         };
         let global_state_lock =
-            mock_genesis_global_state(network, 2, WalletEntropy::devnet_wallet(), cli_args).await;
+            mock_genesis_global_state(2, WalletEntropy::devnet_wallet(), cli_args).await;
         let (worker_task_tx, worker_task_rx) = oneshot::channel::<NewBlockFound>();
 
         let tip_block_orig = global_state_lock
@@ -1682,10 +1683,9 @@ pub(crate) mod tests {
     ) -> Result<()> {
         let network = Network::RegTest;
         let global_state_lock = mock_genesis_global_state(
-            network,
             2,
             WalletEntropy::devnet_wallet(),
-            cli_args::Args::default(),
+            cli_args::Args::default_with_network(network),
         )
         .await;
 
@@ -1905,11 +1905,11 @@ pub(crate) mod tests {
             let cli_args = cli_args::Args {
                 guesser_fraction: 0.0,
                 fee_notification: notification_policy,
+                network,
                 ..Default::default()
             };
             let global_state_lock =
-                mock_genesis_global_state(network, 2, WalletEntropy::devnet_wallet(), cli_args)
-                    .await;
+                mock_genesis_global_state(2, WalletEntropy::devnet_wallet(), cli_args).await;
             let genesis_block = Block::genesis(network);
             let launch_date = genesis_block.header().timestamp;
 
@@ -2035,12 +2035,13 @@ pub(crate) mod tests {
                 let cli_args = cli_args::Args {
                     guesser_fraction,
                     fee_notification: notification_policy,
+                    network,
                     ..Default::default()
                 };
                 let global_state_lock =
-                    mock_genesis_global_state(network, 2, WalletEntropy::devnet_wallet(), cli_args)
+                    mock_genesis_global_state(2, WalletEntropy::devnet_wallet(), cli_args.clone())
                         .await;
-                let genesis_block = Block::genesis(network);
+                let genesis_block = Block::genesis(cli_args.network);
                 let launch_date = genesis_block.header().timestamp;
 
                 let (transaction, expected_utxos) = make_coinbase_transaction_from_state(
@@ -2150,11 +2151,11 @@ pub(crate) mod tests {
         let network = Network::Main;
         let cli_args = cli_args::Args {
             compose: true,
+            network,
             ..Default::default()
         };
         let global_state_lock =
-            mock_genesis_global_state(network, 2, WalletEntropy::devnet_wallet(), cli_args.clone())
-                .await;
+            mock_genesis_global_state(2, WalletEntropy::devnet_wallet(), cli_args.clone()).await;
 
         let (cancel_job_tx, cancel_job_rx) = tokio::sync::watch::channel(());
 
@@ -2221,10 +2222,11 @@ pub(crate) mod tests {
         let network = Network::Main;
         let cli_args = cli_args::Args {
             compose: true,
+            network,
             ..Default::default()
         };
         let global_state_lock =
-            mock_genesis_global_state(network, 2, WalletEntropy::devnet_wallet(), cli_args).await;
+            mock_genesis_global_state(2, WalletEntropy::devnet_wallet(), cli_args).await;
 
         let (miner_to_main_tx, _miner_to_main_rx) =
             mpsc::channel::<MinerToMain>(MINER_CHANNEL_CAPACITY);
@@ -2345,10 +2347,9 @@ pub(crate) mod tests {
 
         // obtain global state
         let global_state_lock = mock_genesis_global_state(
-            network,
             2,
             WalletEntropy::devnet_wallet(),
-            cli_args::Args::default(),
+            cli_args::Args::default_with_network(network),
         )
         .await;
 

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -1495,11 +1495,11 @@ pub(crate) mod tests {
 
             let alice_wallet = WalletEntropy::devnet_wallet();
             let mut alice = mock_genesis_global_state(
-                network,
                 3,
                 alice_wallet.clone(),
                 cli_args::Args {
                     guesser_fraction: 0.5,
+                    network,
                     ..Default::default()
                 },
             )
@@ -1531,10 +1531,9 @@ pub(crate) mod tests {
             for i in 0..10 {
                 println!("i: {i}");
                 alice = mock_genesis_global_state(
-                    network,
                     3,
                     alice_wallet.clone(),
-                    cli_args::Args::default(),
+                    cli_args::Args::default_with_network(network),
                 )
                 .await;
                 alice.set_new_tip(block1.clone()).await.unwrap();
@@ -1862,9 +1861,12 @@ pub(crate) mod tests {
             let alice_wallet = WalletEntropy::devnet_wallet();
             let alice_key = alice_wallet.nth_generation_spending_key(0);
             let alice_address = alice_key.to_address();
-            let mut alice =
-                mock_genesis_global_state(network, 0, alice_wallet, cli_args::Args::default())
-                    .await;
+            let mut alice = mock_genesis_global_state(
+                0,
+                alice_wallet,
+                cli_args::Args::default_with_network(network),
+            )
+            .await;
 
             let output = TxOutput::offchain_native_currency(
                 NativeCurrencyAmount::coins(4),
@@ -1952,8 +1954,12 @@ pub(crate) mod tests {
         let mut rng = StdRng::seed_from_u64(893423984854);
         let network = Network::Main;
         let devnet_wallet = WalletEntropy::devnet_wallet();
-        let mut alice =
-            mock_genesis_global_state(network, 0, devnet_wallet, cli_args::Args::default()).await;
+        let mut alice = mock_genesis_global_state(
+            0,
+            devnet_wallet,
+            cli_args::Args::default_with_network(network),
+        )
+        .await;
 
         let job_queue = TritonVmJobQueue::get_instance();
 

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -1156,7 +1156,7 @@ pub(crate) mod tests {
 
     #[cfg(test)]
     impl Block {
-        fn with_difficulty(mut self, difficulty: Difficulty) -> Self {
+        pub(crate) fn with_difficulty(mut self, difficulty: Difficulty) -> Self {
             self.kernel.header.difficulty = difficulty;
             self.unset_digest();
             self

--- a/src/models/blockchain/block/validity/block_program.rs
+++ b/src/models/blockchain/block/validity/block_program.rs
@@ -496,10 +496,9 @@ pub(crate) mod tests {
         let mut rng: StdRng = SeedableRng::seed_from_u64(2225550001);
         let alice_wallet = WalletEntropy::devnet_wallet();
         let alice = mock_genesis_global_state(
-            network,
             3,
             WalletEntropy::devnet_wallet(),
-            cli_args::Args::default(),
+            cli_args::Args::default_with_network(network),
         )
         .await;
 

--- a/src/models/state/archival_state.rs
+++ b/src/models/state/archival_state.rs
@@ -1292,9 +1292,9 @@ pub(super) mod tests {
         // Verify that a restored archival mutator set is populated with the right `sync_label`
         let network = Network::Beta;
         let mut archival_state = make_test_archival_state(network).await;
-        let cli_args = cli_args::Args::default();
+        let cli_args = cli_args::Args::default_with_network(network);
         let genesis_wallet_state =
-            mock_genesis_wallet_state(WalletEntropy::devnet_wallet(), network, &cli_args).await;
+            mock_genesis_wallet_state(WalletEntropy::devnet_wallet(), &cli_args).await;
         let (mock_block_1, _) = make_mock_block(
             network,
             &archival_state.genesis_block,
@@ -1334,9 +1334,9 @@ pub(super) mod tests {
         let mut rng = StdRng::seed_from_u64(107221549301u64);
         let cli_args = cli_args::Args::default_with_network(network);
         let alice_wallet =
-            mock_genesis_wallet_state(WalletEntropy::devnet_wallet(), network, &cli_args).await;
+            mock_genesis_wallet_state(WalletEntropy::devnet_wallet(), &cli_args).await;
         let alice_wallet = alice_wallet.wallet_entropy;
-        let mut alice = mock_genesis_global_state(network, 0, alice_wallet, cli_args).await;
+        let mut alice = mock_genesis_global_state(0, alice_wallet, cli_args).await;
         let alice_key = alice
             .lock_guard()
             .await
@@ -1477,7 +1477,7 @@ pub(super) mod tests {
         let alice_key = alice_wallet.nth_generation_spending_key_for_tests(0);
         let alice_address = alice_key.to_address();
         let cli_args = cli_args::Args::default_with_network(network);
-        let mut alice = mock_genesis_global_state(network, 42, alice_wallet, cli_args).await;
+        let mut alice = mock_genesis_global_state(42, alice_wallet, cli_args).await;
         let genesis_block = Block::genesis(network);
 
         let num_premine_utxos = Block::premine_utxos(network).len();
@@ -1573,7 +1573,7 @@ pub(super) mod tests {
         let alice_key = alice_wallet.nth_generation_spending_key_for_tests(0);
         let alice_address = alice_key.to_address();
         let cli_args = cli_args::Args::default_with_network(network);
-        let mut alice = mock_genesis_global_state(network, 42, alice_wallet, cli_args).await;
+        let mut alice = mock_genesis_global_state(42, alice_wallet, cli_args).await;
 
         let mut expected_num_utxos = Block::premine_utxos(network).len();
         let mut previous_block = genesis_block.clone();
@@ -1745,16 +1745,16 @@ pub(super) mod tests {
     async fn allow_multiple_inputs_and_outputs_in_block() {
         // Test various parts of the state update when a block contains multiple inputs and outputs
         let network = Network::Main;
-        let cli_args = cli_args::Args::default();
+        let cli_args = cli_args::Args::default_with_network(network);
         let premine_rec_ws =
-            mock_genesis_wallet_state(WalletEntropy::devnet_wallet(), network, &cli_args).await;
+            mock_genesis_wallet_state(WalletEntropy::devnet_wallet(), &cli_args).await;
         let premine_rec_spending_key = premine_rec_ws.wallet_entropy.nth_generation_spending_key(0);
         let mut premine_rec = mock_genesis_global_state(
-            network,
             3,
             premine_rec_ws.wallet_entropy,
             cli_args::Args {
                 guesser_fraction: 0.0,
+                network,
                 ..Default::default()
             },
         )
@@ -1775,15 +1775,11 @@ pub(super) mod tests {
         let mut rng = StdRng::seed_from_u64(41251549301u64);
         let wallet_secret_alice = WalletEntropy::new_pseudorandom(rng.random());
         let alice_spending_key = wallet_secret_alice.nth_generation_spending_key(0);
-        let mut alice =
-            mock_genesis_global_state(network, 3, wallet_secret_alice, cli_args::Args::default())
-                .await;
+        let mut alice = mock_genesis_global_state(3, wallet_secret_alice, cli_args.clone()).await;
 
         let wallet_secret_bob = WalletEntropy::new_pseudorandom(rng.random());
         let bob_spending_key = wallet_secret_bob.nth_generation_spending_key(0);
-        let mut bob =
-            mock_genesis_global_state(network, 3, wallet_secret_bob, cli_args::Args::default())
-                .await;
+        let mut bob = mock_genesis_global_state(3, wallet_secret_bob, cli_args.clone()).await;
 
         let genesis_block = Block::genesis(network);
         let launch_date = genesis_block.header().timestamp;

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -1050,10 +1050,9 @@ mod tests {
         let bob_wallet_secret = WalletEntropy::devnet_wallet();
         let bob_spending_key = bob_wallet_secret.nth_generation_spending_key_for_tests(0);
         let bob = mock_genesis_global_state(
-            network,
             2,
             bob_wallet_secret.clone(),
-            cli_args::Args::default(),
+            cli_args::Args::default_with_network(network),
         )
         .await;
         let in_seven_months = genesis_block.kernel.header.timestamp + Timestamp::months(7);
@@ -1277,32 +1276,19 @@ mod tests {
         let network = Network::Main;
         let bob_wallet_secret = WalletEntropy::devnet_wallet();
         let bob_spending_key = bob_wallet_secret.nth_generation_spending_key_for_tests(0);
-        let mut bob = mock_genesis_global_state(
+        let cli_args = cli_args::Args {
+            guesser_fraction: 0.0,
             network,
-            2,
-            bob_wallet_secret,
-            cli_args::Args {
-                guesser_fraction: 0.0,
-                ..Default::default()
-            },
-        )
-        .await;
+            ..Default::default()
+        };
+        let mut bob = mock_genesis_global_state(2, bob_wallet_secret, cli_args.clone()).await;
 
         let bob_address = bob_spending_key.to_address();
 
         let alice_wallet = WalletEntropy::new_pseudorandom(rng.random());
         let alice_key = alice_wallet.nth_generation_spending_key_for_tests(0);
         let alice_address = alice_key.to_address();
-        let mut alice = mock_genesis_global_state(
-            network,
-            2,
-            alice_wallet,
-            cli_args::Args {
-                guesser_fraction: 0.0,
-                ..Default::default()
-            },
-        )
-        .await;
+        let mut alice = mock_genesis_global_state(2, alice_wallet, cli_args.clone()).await;
 
         // Ensure that both wallets have a non-zero balance by letting Alice
         // mine a block.
@@ -1654,10 +1640,10 @@ mod tests {
         let proving_capability = TxProvingCapability::SingleProof;
         let cli_with_proof_capability = cli_args::Args {
             tx_proving_capability: Some(proving_capability),
+            network,
             ..Default::default()
         };
-        let mut alice =
-            mock_genesis_global_state(network, 2, alice_wallet, cli_with_proof_capability).await;
+        let mut alice = mock_genesis_global_state(2, alice_wallet, cli_with_proof_capability).await;
 
         let mut rng: StdRng = StdRng::seed_from_u64(u64::from_str_radix("42", 6).unwrap());
         let bob_wallet_secret = WalletEntropy::new_pseudorandom(rng.random());
@@ -1797,10 +1783,9 @@ mod tests {
         // Create a global state object, controlled by a preminer who receives a premine-UTXO.
         let network = Network::Main;
         let mut preminer = mock_genesis_global_state(
-            network,
             2,
             WalletEntropy::devnet_wallet(),
-            cli_args::Args::default(),
+            cli_args::Args::default_with_network(network),
         )
         .await;
         let premine_spending_key = preminer
@@ -2022,10 +2007,9 @@ mod tests {
             let bob_wallet_secret = WalletEntropy::devnet_wallet();
             let bob_spending_key = bob_wallet_secret.nth_generation_spending_key_for_tests(0);
             let bob = mock_genesis_global_state(
-                network,
                 2,
                 bob_wallet_secret.clone(),
-                cli_args::Args::default(),
+                cli_args::Args::default_with_network(network),
             )
             .await;
             let in_seven_months = genesis_block.kernel.header.timestamp + Timestamp::months(7);

--- a/src/models/state/wallet/transaction_output.rs
+++ b/src/models/state/wallet/transaction_output.rs
@@ -707,11 +707,11 @@ mod tests {
 
     #[apply(shared_tokio_runtime)]
     async fn test_utxoreceiver_auto_not_owned_output() {
+        let network = Network::RegTest;
         let global_state_lock = mock_genesis_global_state(
-            Network::RegTest,
             2,
             WalletEntropy::devnet_wallet(),
-            cli_args::Args::default(),
+            cli_args::Args::default_with_network(network),
         )
         .await;
 
@@ -756,11 +756,11 @@ mod tests {
 
     #[apply(shared_tokio_runtime)]
     async fn test_utxoreceiver_auto_owned_output() {
+        let network = Network::RegTest;
         let mut global_state_lock = mock_genesis_global_state(
-            Network::RegTest,
             2,
             WalletEntropy::devnet_wallet(),
-            cli_args::Args::default(),
+            cli_args::Args::default_with_network(network),
         )
         .await;
 

--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -3719,9 +3719,12 @@ mod tests {
         ) -> Transaction {
             let wallet_secret = WalletEntropy::devnet_wallet();
             let alice_key = wallet_secret.nth_generation_spending_key_for_tests(0);
-            let alice_gsl =
-                mock_genesis_global_state(network, 1, wallet_secret, cli_args::Args::default())
-                    .await;
+            let alice_gsl = mock_genesis_global_state(
+                1,
+                wallet_secret,
+                cli_args::Args::default_with_network(network),
+            )
+            .await;
             let alice = alice_gsl.lock_guard().await;
             let genesis_block = alice.chain.light_state();
             let in_seven_months = genesis_block.header().timestamp + Timestamp::months(7);

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -1,11 +1,14 @@
 use std::collections::HashMap;
 use std::env;
 use std::fmt::Debug;
+use std::fs::File;
+use std::io::Read;
 use std::net::SocketAddr;
 use std::path::Path;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::str::FromStr;
+use std::time::Duration;
 use std::time::SystemTime;
 
 use anyhow::bail;
@@ -28,6 +31,7 @@ use rand::distr::Alphanumeric;
 use rand::distr::SampleString;
 use rand::random;
 use rand::rngs::StdRng;
+use rand::seq::SliceRandom;
 use rand::Rng;
 use rand::RngCore;
 use rand::SeedableRng;
@@ -40,6 +44,8 @@ use tokio_serde::formats::SymmetricalBincode;
 use tokio_serde::Serializer;
 use tokio_util::codec::Encoder;
 use tokio_util::codec::LengthDelimitedCodec;
+use tracing::debug;
+use tracing::Span;
 use twenty_first::math::b_field_element::BFieldElement;
 use twenty_first::math::digest::Digest;
 use twenty_first::util_types::mmr::mmr_trait::Mmr;
@@ -429,6 +435,160 @@ impl<Item> stream::Stream for Mock<Item> {
             Poll::Ready(Some(Err(MockError::UnexpectedRead)))
         }
     }
+}
+
+/// Return path for the directory containing test data, like proofs and block
+/// data.
+pub(crate) fn test_helper_data_dir() -> PathBuf {
+    const TEST_DATA_DIR_NAME: &str = "test_data/";
+    let mut path = PathBuf::new();
+    path.push(TEST_DATA_DIR_NAME);
+    path
+}
+
+/// Load a list of proof-servers from test data directory
+fn load_servers() -> Vec<String> {
+    let mut server_list_path = test_helper_data_dir();
+    server_list_path.push(Path::new("proof_servers").with_extension("txt"));
+    let Ok(mut input_file) = File::open(server_list_path.clone()) else {
+        debug!(
+            "cannot proof-server list '{}' -- file might not exist",
+            server_list_path.display()
+        );
+        return vec![];
+    };
+    let mut file_contents = vec![];
+    if input_file.read_to_end(&mut file_contents).is_err() {
+        debug!("cannot read file '{}'", server_list_path.display());
+        return vec![];
+    }
+    let Ok(file_as_string) = String::from_utf8(file_contents) else {
+        debug!(
+            "cannot parse file '{}' -- is it valid utf8?",
+            server_list_path.display()
+        );
+        return vec![];
+    };
+    file_as_string.lines().map(|s| s.to_string()).collect()
+}
+
+/// Tries to load a file from disk, returns the bytes if successful.
+pub(crate) fn try_load_file_from_disk(path: &Path) -> Option<Vec<u8>> {
+    let Ok(mut input_file) = File::open(path) else {
+        debug!("cannot open file '{}' -- might not exist", path.display());
+        return None;
+    };
+
+    let mut file_contents = vec![];
+    if input_file.read_to_end(&mut file_contents).is_err() {
+        debug!("cannot read file '{}'", path.display());
+        return None;
+    }
+
+    Some(file_contents)
+}
+
+/// Return the specified file from a server, along with the name of the server
+/// providing the result.
+pub(crate) fn try_fetch_file_from_server(filename: String) -> Option<(Vec<u8>, String)> {
+    const TEST_NAME_HTTP_HEADER_KEY: &str = "Test-Name";
+
+    fn get_test_name_from_tracing() -> String {
+        match Span::current().metadata().map(|x| x.name()) {
+            Some(test_name) => test_name.to_owned(),
+            None => "unknown".to_owned(),
+        }
+    }
+
+    fn attempt_to_get_test_name() -> String {
+        let thread = std::thread::current();
+        match thread.name() {
+            Some(test_name) => {
+                if test_name.eq("tokio-runtime-worker") {
+                    get_test_name_from_tracing()
+                } else {
+                    test_name.to_owned()
+                }
+            }
+            None => get_test_name_from_tracing(),
+        }
+    }
+
+    let mut servers = load_servers();
+    servers.shuffle(&mut rand::rng());
+
+    // Add test name to request allow server to see which test requires this
+    // file.
+    let mut headers = clienter::HttpHeaders::default();
+    headers.insert(
+        TEST_NAME_HTTP_HEADER_KEY.to_string(),
+        attempt_to_get_test_name(),
+    );
+
+    for server in servers {
+        let server_ = server.clone();
+        let filename_ = filename.clone();
+        let headers_ = headers.clone();
+        let handle = std::thread::spawn(move || {
+            let url = format!("{}{}", server_, filename_);
+
+            debug!("requesting: <{url}>");
+
+            let uri: clienter::Uri = url.into();
+
+            let mut http_client = clienter::HttpClient::new();
+            http_client.timeout = Some(Duration::from_secs(10));
+            http_client.headers = headers_;
+            let request = http_client.request(clienter::HttpMethod::GET, uri);
+
+            // note: send() blocks
+            let Ok(mut response) = http_client.send(&request) else {
+                println!(
+                    "server '{}' failed for file '{}'; trying next ...",
+                    server_.clone(),
+                    filename_
+                );
+
+                return None;
+            };
+
+            // only retrieve body if we got a 2xx code.
+            // addresses #477
+            // https://github.com/Neptune-Crypto/neptune-core/issues/477
+            let body = if response.status.is_success() {
+                response.body()
+            } else {
+                Ok(vec![])
+            };
+
+            Some((response.status, body))
+        });
+
+        let Some((status_code, body)) = handle.join().unwrap() else {
+            eprintln!("Could not connect to server {server}.");
+            continue;
+        };
+
+        if !status_code.is_success() {
+            eprintln!("{server} responded with {status_code}");
+            continue;
+        }
+
+        let Ok(file_contents) = body else {
+            eprintln!(
+                "error reading file '{}' from server '{}'; trying next ...",
+                filename, server
+            );
+
+            continue;
+        };
+
+        return Some((file_contents, server));
+    }
+
+    println!("No known servers serve file `{}`", filename);
+
+    None
 }
 
 pub fn pseudorandom_option<T>(seed: [u8; 32], thing: T) -> Option<T> {
@@ -1303,4 +1463,16 @@ where
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
     }
     Ok(())
+}
+
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_load_servers() {
+        let servers = load_servers();
+        for server in servers {
+            println!("read server: {}", server);
+        }
+    }
 }

--- a/src/util_types/mutator_set/chunk.rs
+++ b/src/util_types/mutator_set/chunk.rs
@@ -132,16 +132,20 @@ impl<'a> Arbitrary<'a> for Chunk {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
-    use std::collections::{HashMap, HashSet};
+    use std::collections::HashMap;
+    use std::collections::HashSet;
 
     use num_traits::Zero;
-    use rand::{rng, RngCore};
-    use statrs::distribution::{ContinuousCDF, Normal};
+    use rand::rng;
+    use rand::RngCore;
+    use statrs::distribution::ContinuousCDF;
+    use statrs::distribution::Normal;
     use twenty_first::math::b_field_element::BFieldElement;
 
-    use crate::util_types::mutator_set::shared::{BATCH_SIZE, NUM_TRIALS, WINDOW_SIZE};
-
     use super::*;
+    use crate::util_types::mutator_set::shared::BATCH_SIZE;
+    use crate::util_types::mutator_set::shared::NUM_TRIALS;
+    use crate::util_types::mutator_set::shared::WINDOW_SIZE;
 
     #[test]
     fn chunk_is_reversible_bloom_filter() {


### PR DESCRIPTION
test: Recover state from real main net blocks
    
Add a test of `GlobalState::bootstrap_from_directory` using real data
from main net. The test uses the `blk0.dat` file from a node that has
been online since genesis, thus containing reorganizations that some
previously untested branches of `GlobalState::bootstrap_from_directory`.
    
This test also serves as a check that the first 113 main net blocks are
still considered valid by future versions of the software.

Closes #515 

This PR introduces a big file, `blk0.dat`, added with `git lfs`. But an alternative would be to download the `blk0.dat` from our test servers instead, and store it in `test_data` so that it would only ever have to be downloaded once.