### PR TITLE
Features for RPC APIs and BlockBody

### DIFF
--- a/src/models/blockchain/block/block_body.rs
+++ b/src/models/blockchain/block/block_body.rs
@@ -114,6 +114,10 @@ impl BlockBody {
             merkle_tree: OnceLock::default(), // calc'd in merkle_tree()
         }
     }
+
+    pub fn kernel(&self) -> TransactionKernel {
+        self.transaction_kernel.clone()
+    }
 }
 
 impl MastHash for BlockBody {

--- a/src/models/blockchain/block/block_body.rs
+++ b/src/models/blockchain/block/block_body.rs
@@ -115,8 +115,8 @@ impl BlockBody {
         }
     }
 
-    pub fn kernel(&self) -> TransactionKernel {
-        self.transaction_kernel.clone()
+    pub fn transaction_kernel(&self) -> &TransactionKernel {
+        &self.transaction_kernel
     }
 }
 


### PR DESCRIPTION
Added to RPC server APIs:
block_body: to get full Block information
mempool_tx: to get full Transaction from mempool by txid

Added to BlockBody struct:
public transaction_kernel() method to extract TransactionKernel from BlockBody