### PR TITLE
test genesis block hash of all networks

### DIFF
--- a/src/config_models/network.rs
+++ b/src/config_models/network.rs
@@ -1,7 +1,5 @@
 use std::fmt;
 use std::str::FromStr;
-use std::time::SystemTime;
-use std::time::UNIX_EPOCH;
 
 use serde::Deserialize;
 use serde::Serialize;
@@ -52,23 +50,9 @@ pub enum Network {
 }
 
 impl Network {
-    pub(crate) fn launch_date(&self) -> Timestamp {
-        match self {
-            Network::RegTest => {
-                const SEVEN_DAYS: u64 = 1000 * 60 * 60 * 24 * 7;
-
-                let now = SystemTime::now()
-                    .duration_since(UNIX_EPOCH)
-                    .unwrap()
-                    .as_millis() as u64;
-                let now_rounded = (now / SEVEN_DAYS) * SEVEN_DAYS;
-                Timestamp(BFieldElement::new(now_rounded))
-            }
-            // 11 Feb 2025, noon UTC
-            Network::TestnetMock | Network::Testnet | Network::Beta | Network::Main => {
-                Timestamp(BFieldElement::new(1739275200000u64))
-            }
-        }
+    pub fn launch_date(&self) -> Timestamp {
+        // 11 Feb 2025, noon UTC (same for all networks)
+        Timestamp(BFieldElement::new(1739275200000u64))
     }
 
     /// indicates if the network uses mock proofs

--- a/src/config_models/network.rs
+++ b/src/config_models/network.rs
@@ -145,11 +145,12 @@ impl Network {
 
     /// indicates if automated mining should be performed by this network
     ///
-    /// note: we disable auto-mining in regtest mode because it generates blocks
+    /// note: We disable auto-mining in regtest mode because it generates blocks
     /// very quickly and that is not a good fit when mining is enabled for
-    /// duration of the neptune-core process as blockchain grows very quickly.
+    /// duration of the neptune-core process since the blockchain grows very
+    /// quickly.
     ///
-    /// instead developers are encouraged to use [crate::api::regtest] module to
+    /// Instead developers are encouraged to use [crate::api::regtest] module to
     /// generate any number of blocks in a controlled, deterministic fashion.
     //
     // bitcoin-core does not use cli flags, but rather RPC commands to
@@ -193,6 +194,43 @@ mod tests {
     use num_traits::Zero;
 
     use super::*;
+    use crate::twenty_first::prelude::Digest;
+
+    impl Network {
+        /// returns known genesis block hash
+        ///
+        /// These hashes were all determined and placed here as of 2025-05-25.
+        ///
+        /// The initial/primary purpose is for the test
+        /// genesis_block_hasnt_changed() so it can verify that code changes do
+        /// not modify the genesis hash for each network.
+        ///
+        /// If the genesis block is intentionally changed for any network, or a
+        /// network is added, then this fn needs to be updated, with a comment
+        /// noting the date, old and new hash, and reason for the change.
+        ///
+        /// * 2025-05-25: Testnet hash has changed:
+        ///   old: d986e9b229831f779cee1a556f2a63d24631559eb9b3bb8c3daca8d65d1f66acca1d10026698ada8
+        ///   new: 380df1ec5895553d056acb7a35a6eb9967c893ccc1e7c6e86995459e4d20e4f99800f04c86711d53
+        ///   reason: lower genesis difficulty, add difficulty-reset mechanism and restart Testnet network.
+        ///   commit: 1293adaff5df7be02382b867424fca2604692eac
+        ///
+        /// * 2025-05-25: TestnetMock hash has changed:
+        ///   old: unknown.
+        ///   new: 6c9605ab77ecfdfedfc8a2beb09863de38c4c63523364bf5d9c0eb30ad63b8b53cf1f37ef036ebda
+        ///   reason: repurpose 'Alpha' to 'TestnetMock', lower genesis difficulty, and impl difficulty-reset and mock-proofs.
+        ///   commit: 1293adaff5df7be02382b867424fca2604692eac
+        pub fn genesis_block_known_hash(&self) -> Digest {
+            let hex = match *self {
+                Self::Main => "3eeaed3acdd8765b9a3e689d74f745365d6a3de57fb4a9a19c46ac432ce419a92fb82d47dc0d3f54",
+                Self::TestnetMock => "6c9605ab77ecfdfedfc8a2beb09863de38c4c63523364bf5d9c0eb30ad63b8b53cf1f37ef036ebda",
+                Self::Beta => "fc3ccb02b5491028e7d2620fd788806c79317f8bd481e4cbc9d690efeac1de2c7df7fde25bfa33b9",
+                Self::Testnet => "380df1ec5895553d056acb7a35a6eb9967c893ccc1e7c6e86995459e4d20e4f99800f04c86711d53",
+                Self::RegTest => "67d1ce0d5fe62582e7156494b36b1cd80888f1b259e003410204a72276f96fb6f8f8272e820f4dd9",
+            };
+            Digest::try_from_hex(hex).unwrap()
+        }
+    }
 
     #[test]
     fn main_variant_is_zero() {

--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -1167,20 +1167,28 @@ pub(crate) mod tests {
         }
     }
 
+    /// This test verifies that genesis block hash does not accidentally change.
+    ///
+    /// For every network it compares a known hash of the genesis block with
+    /// the current hash of the genesis block, which must match.
+    ///
+    /// See Network::genesis_block_known_hash() for details of the known hashes.
     #[test]
     fn genesis_block_hasnt_changed() {
-        // Ensure that code changes does not modify the hash of main net's
-        // genesis block.
+        for network in Network::iter() {
+            // Insert the real difficulty such that the block's hash can be
+            // compared to the one found in block explorers and other real
+            // instances, otherwise the hash would only be valid for test code.
+            let genesis_block =
+                Block::genesis(network).with_difficulty(network.genesis_difficulty());
 
-        // Insert the real difficulty such that the block's hash can be
-        // compared to the one found in block explorers and other real
-        // instances, otherwise the hash would only be valid for test code.
-        let network = Network::Main;
-        let genesis_block = Block::genesis(network).with_difficulty(network.genesis_difficulty());
-        assert_eq!(
-            "3eeaed3acdd8765b9a3e689d74f745365d6a3de57fb4a9a19c46ac432ce419a92fb82d47dc0d3f54",
-            genesis_block.hash().to_hex()
-        );
+            assert_eq!(
+                network.genesis_block_known_hash().to_hex(),
+                genesis_block.hash().to_hex(),
+                "genesis-block known hash must match actual hash for network {}",
+                network,
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
This is a small PR that only affects a single test.  If not reviewed in 24 hours and passing CI, I'll just merge it.

-------------------

addresses #599 [review comment](https://github.com/Neptune-Crypto/neptune-core/pull/599#discussion_r2100234950)

Updates test `genesis_block_hasnt_changed()` to verify the current hash of the genesis block to a known hash, for each network.

The test already existed for `Network::Main` only.  This adds the other networks in an extensible way.