### PR TITLE
Gracefully catch errors resulting from invalid blocks

### DIFF
--- a/benches/wallet_state.rs
+++ b/benches/wallet_state.rs
@@ -133,7 +133,7 @@ mod maintain_membership_proofs {
             rt.block_on(async {
                 wallet_state
                     .update_wallet_state_with_new_block(
-                        &genesis.mutator_set_accumulator_after(),
+                        &genesis.mutator_set_accumulator_after().unwrap(),
                         &block1,
                     )
                     .await
@@ -156,7 +156,7 @@ mod maintain_membership_proofs {
                 rt.block_on(async {
                     wallet_state
                         .update_wallet_state_with_new_block(
-                            &block1.mutator_set_accumulator_after(),
+                            &block1.mutator_set_accumulator_after().unwrap(),
                             &block2,
                         )
                         .await

--- a/src/api/regtest/regtest_impl.rs
+++ b/src/api/regtest/regtest_impl.rs
@@ -122,7 +122,7 @@ impl RegTestPrivate {
             SIZE_20MB_IN_BYTES,
             Some(MAX_NUM_TXS_TO_MERGE),
             true, //only_merge_single_proofs
-            tip_block.mutator_set_accumulator_after().hash(),
+            tip_block.mutator_set_accumulator_after().unwrap().hash(),
         );
 
         drop(gs);

--- a/src/api/tx_initiation/builder/transaction_details_builder.rs
+++ b/src/api/tx_initiation/builder/transaction_details_builder.rs
@@ -259,7 +259,7 @@ impl TransactionDetailsBuilder {
             timestamp,
             tip_block
                 .mutator_set_accumulator_after()
-                .expect("Block from state must be valid"),
+                .expect("Block from state must have mutator set after"),
             state_lock.cli().network,
         ))
     }

--- a/src/api/tx_initiation/builder/transaction_details_builder.rs
+++ b/src/api/tx_initiation/builder/transaction_details_builder.rs
@@ -257,7 +257,9 @@ impl TransactionDetailsBuilder {
             fee,
             coinbase,
             timestamp,
-            tip_block.mutator_set_accumulator_after(),
+            tip_block
+                .mutator_set_accumulator_after()
+                .expect("Block from state must be valid"),
             state_lock.cli().network,
         ))
     }

--- a/src/bench_helpers.rs
+++ b/src/bench_helpers.rs
@@ -111,7 +111,7 @@ pub async fn next_block_incoming_utxos(
         .sum::<NativeCurrencyAmount>()
         + fee;
 
-    let msa = parent.mutator_set_accumulator_after();
+    let msa = parent.mutator_set_accumulator_after().unwrap();
     let wallet_status = sender.get_wallet_status(parent.hash(), &msa).await;
     let available_balance = wallet_status.synced_unspent_available_amount(timestamp);
     let change_amt = available_balance.checked_sub(&intermediate_spend).unwrap();

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -896,7 +896,7 @@ impl MainLoopHandler {
                         block.header().prev_block_digest,
                         block
                             .total_guesser_reward()
-                            .expect("block received by main loop should be valid"),
+                            .expect("block received by main loop must have guesser reward"),
                     );
                     if let Err(reject_reason) = verdict {
                         warn!("main loop got unfavorable block proposal. Reason: {reject_reason}");

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -893,8 +893,10 @@ impl MainLoopHandler {
                     info!("Received new favorable block proposal for mining operation.");
                     let mut global_state_mut = self.global_state_lock.lock_guard_mut().await;
                     let verdict = global_state_mut.favor_incoming_block_proposal(
-                        block.header().height,
-                        block.total_guesser_reward(),
+                        block.header().prev_block_digest,
+                        block
+                            .total_guesser_reward()
+                            .expect("block received by main loop should be valid"),
                     );
                     if let Err(reject_reason) = verdict {
                         warn!("main loop got unfavorable block proposal. Reason: {reject_reason}");

--- a/src/main_loop/proof_upgrader.rs
+++ b/src/main_loop/proof_upgrader.rs
@@ -381,7 +381,7 @@ impl UpgradeJob {
                     .chain
                     .light_state()
                     .mutator_set_accumulator_after()
-                    .expect("Block from state must be valid");
+                    .expect("Block from state must have mutator set after");
 
                 let transaction_is_up_to_date =
                     upgraded.kernel.mutator_set_hash == tip_mutator_set.hash();
@@ -742,7 +742,7 @@ pub(super) fn get_upgrade_task_from_mempool(
         .chain
         .light_state()
         .mutator_set_accumulator_after()
-        .expect("Block from state must be valid");
+        .expect("Block from state must have mutator set after");
     let gobbling_fraction = global_state.gobbling_fraction();
     let min_gobbling_fee = global_state.min_gobbling_fee();
     let num_proofs_threshold = global_state.max_num_proofs();

--- a/src/main_loop/proof_upgrader.rs
+++ b/src/main_loop/proof_upgrader.rs
@@ -380,7 +380,8 @@ impl UpgradeJob {
                 let tip_mutator_set = global_state
                     .chain
                     .light_state()
-                    .mutator_set_accumulator_after();
+                    .mutator_set_accumulator_after()
+                    .expect("Block from state must be valid");
 
                 let transaction_is_up_to_date =
                     upgraded.kernel.mutator_set_hash == tip_mutator_set.hash();
@@ -740,7 +741,8 @@ pub(super) fn get_upgrade_task_from_mempool(
     let tip_mutator_set = global_state
         .chain
         .light_state()
-        .mutator_set_accumulator_after();
+        .mutator_set_accumulator_after()
+        .expect("Block from state must be valid");
     let gobbling_fraction = global_state.gobbling_fraction();
     let min_gobbling_fee = global_state.min_gobbling_fee();
     let num_proofs_threshold = global_state.max_num_proofs();
@@ -1123,7 +1125,8 @@ mod tests {
                 .await
                 .chain
                 .light_state()
-                .mutator_set_accumulator_after();
+                .mutator_set_accumulator_after()
+                .unwrap();
             assert!(mempool_tx.is_confirmable_relative_to(&mutator_set_accumulator_after));
         }
     }

--- a/src/mine_loop.rs
+++ b/src/mine_loop.rs
@@ -530,7 +530,7 @@ pub(crate) fn composer_outputs(
 ///
 /// # Panics
 ///
-///  - If `latest_block` is invalid.
+///  - If `latest_block` has a negative transaction fee
 pub(super) fn prepare_coinbase_transaction_stateless(
     latest_block: &Block,
     composer_parameters: ComposerParameters,
@@ -596,7 +596,7 @@ pub(crate) async fn create_block_transaction(
 }
 
 /// # Panics
-///  - If predecessor is invalid
+///  - If predecessor has a negative transaction fee
 pub(crate) async fn create_block_transaction_from(
     predecessor_block: &Block,
     global_state_lock: &GlobalStateLock,

--- a/src/models/blockchain/block/mock_block_generator.rs
+++ b/src/models/blockchain/block/mock_block_generator.rs
@@ -146,7 +146,7 @@ impl MockBlockGenerator {
             // create the nop-tx and merge into the coinbase transaction to set the
             // merge bit to allow the tx to be included in a block.
             let nop_details = TransactionDetails::nop(
-                predecessor_block.mutator_set_accumulator_after(),
+                predecessor_block.mutator_set_accumulator_after().unwrap(),
                 timestamp,
                 network,
             );

--- a/src/models/blockchain/block/validity/block_primitive_witness.rs
+++ b/src/models/blockchain/block/validity/block_primitive_witness.rs
@@ -74,12 +74,15 @@ impl BlockPrimitiveWitness {
         )
     }
 
+    /// # Panics
+    ///
+    ///  - If predecessor has negative transaction fee
     pub(crate) fn body(&self) -> &BlockBody {
         self.maybe_body.get_or_init(|| {
             let predecessor_msa = self
                 .predecessor_block
                 .mutator_set_accumulator_after()
-                .expect("Predecessor must be valid");
+                .expect("Predecessor must have mutator set after");
             let predecessor_msa_digest = predecessor_msa
                 .hash();
             let tx_msa_digest = self.transaction.kernel.mutator_set_hash;

--- a/src/models/blockchain/block/validity/block_primitive_witness.rs
+++ b/src/models/blockchain/block/validity/block_primitive_witness.rs
@@ -76,9 +76,12 @@ impl BlockPrimitiveWitness {
 
     pub(crate) fn body(&self) -> &BlockBody {
         self.maybe_body.get_or_init(|| {
-            let predecessor_msa_digest = self.predecessor_block
-            .mutator_set_accumulator_after()
-            .hash();
+            let predecessor_msa = self
+                .predecessor_block
+                .mutator_set_accumulator_after()
+                .expect("Predecessor must be valid");
+            let predecessor_msa_digest = predecessor_msa
+                .hash();
             let tx_msa_digest = self.transaction.kernel.mutator_set_hash;
             assert_eq!(
                 predecessor_msa_digest,
@@ -87,7 +90,7 @@ impl BlockPrimitiveWitness {
                 \nPredecessor block had {predecessor_msa_digest};\ntransaction had {tx_msa_digest}\n\n"
             );
 
-            let mut mutator_set = self.predecessor_block.mutator_set_accumulator_after();
+            let mut mutator_set = predecessor_msa;
             let mutator_set_update = MutatorSetUpdate::new(
                 self.transaction.kernel.inputs.clone(),
                 self.transaction.kernel.outputs.clone(),
@@ -317,8 +320,9 @@ pub(crate) mod tests {
                                         let timestamp = predecessor_block.header().timestamp
                                             + network.target_block_interval();
 
-                                        let miner_fee_records =
-                                            predecessor_block.guesser_fee_addition_records();
+                                        let miner_fee_records = predecessor_block
+                                            .guesser_fee_addition_records()
+                                            .unwrap();
 
                                         let mut mutator_set_accumulator_after_block =
                                             intermediate_mutator_set_accumulator.clone();

--- a/src/models/blockchain/block/validity/block_program.rs
+++ b/src/models/blockchain/block/validity/block_program.rs
@@ -531,8 +531,8 @@ pub(crate) mod tests {
         let later = now + Timestamp::months(1);
         let tx = Transaction::new_with_updated_mutator_set_records_given_proof(
             tx.kernel,
-            &genesis_block.mutator_set_accumulator_after(),
-            &block1.mutator_set_update(),
+            &genesis_block.mutator_set_accumulator_after().unwrap(),
+            &block1.mutator_set_update().unwrap(),
             tx.proof.into_single_proof(),
             TritonVmJobQueue::get_instance(),
             TritonVmJobPriority::default().into(),

--- a/src/models/blockchain/transaction/mod.rs
+++ b/src/models/blockchain/transaction/mod.rs
@@ -454,7 +454,7 @@ pub(crate) mod tests {
                 mined.mutator_set_accumulator,
                 Network::Main,
             );
-            let ms_update = block.mutator_set_update();
+            let ms_update = block.mutator_set_update().unwrap();
             Transaction::new_with_primitive_witness_ms_data(
                 to_be_updated,
                 ms_update.additions,

--- a/src/models/state/archival_state.rs
+++ b/src/models/state/archival_state.rs
@@ -315,10 +315,11 @@ impl ArchivalState {
         self: &mut ArchivalState,
         new_block: &Block,
     ) -> Result<Vec<(BlockIndexKey, BlockIndexValue)>> {
-        // abort early if block is invalid
+        // abort early if mutator set update is invalid.
         if new_block.mutator_set_update().is_err() {
             bail!("invalid block: could not get mutator set update");
         }
+
         // Fetch last file record to find disk location to store block.
         // This record must exist in the DB already, unless this is the first block
         // stored on disk.
@@ -408,7 +409,7 @@ impl ArchivalState {
         let block_record_key: BlockIndexKey = BlockIndexKey::Block(new_block.hash());
         let num_additions: u64 = new_block
             .mutator_set_update()
-            .expect("New block must be valid")
+            .expect("MS update for new block must exist")
             .additions
             .len()
             .try_into()
@@ -422,7 +423,7 @@ impl ArchivalState {
             },
             min_aocl_index: new_block
                 .mutator_set_accumulator_after()
-                .expect("New block must be valid")
+                .expect("MS update for new block must exist")
                 .aocl
                 .num_leafs()
                 - num_additions,

--- a/src/models/state/block_proposal.rs
+++ b/src/models/state/block_proposal.rs
@@ -1,9 +1,11 @@
 use std::fmt;
 
+use tasm_lib::prelude::Digest;
+
+use crate::api::export::BlockHeight;
 use crate::models::blockchain::block::Block;
 use crate::models::blockchain::type_scripts::native_currency_amount::NativeCurrencyAmount;
 use crate::models::state::wallet::expected_utxo::ExpectedUtxo;
-use crate::models::state::BlockHeight;
 
 /// A proposed block to extend the block chain with.
 ///
@@ -85,7 +87,10 @@ pub(crate) enum BlockProposalRejectError {
     /// Denotes that this instance is itself composing blocks
     Composing,
 
-    /// Incoming block proposal does not have height matching current tip
+    /// Incoming block proposal does not have prev_block_digest matching current tip
+    WrongParent { received: Digest, expected: Digest },
+
+    /// Incoming block proposal wrong height
     WrongHeight {
         received: BlockHeight,
         expected: BlockHeight,
@@ -105,6 +110,11 @@ impl fmt::Display for BlockProposalRejectError {
             BlockProposalRejectError::WrongHeight { received, expected } => write!(
                 f,
                 "Expected block height: {}\nProposal block height: {}",
+                expected, received
+            ),
+            BlockProposalRejectError::WrongParent { received, expected } => write!(
+                f,
+                "Expected block prev_block_digest: {}\nProposal prev_block_digest: {}",
                 expected, received
             ),
             BlockProposalRejectError::InsufficientFee { current, received } => write!(

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -703,7 +703,9 @@ impl Mempool {
         let mut events = self.retain(keep);
 
         // Prepare a mutator set update to be applied to all retained items
-        let mutator_set_update = new_block.mutator_set_update();
+        let mutator_set_update = new_block
+            .mutator_set_update()
+            .expect("New block must be valid");
 
         // Update policy:
         // We update transaction if either of these conditions are true:
@@ -711,8 +713,10 @@ impl Mempool {
         // b) We initiated this transaction *and* client is capable of creating
         //    these proofs.
         // If we cannot update the transaction, we kick it out regardless.
-        let previous_mutator_set_accumulator =
-            predecessor_block.mutator_set_accumulator_after().clone();
+        let previous_mutator_set_accumulator = predecessor_block
+            .mutator_set_accumulator_after()
+            .expect("Predecessor block must be valid")
+            .clone();
         let mut kick_outs = Vec::with_capacity(self.tx_dictionary.len());
         let mut update_jobs = vec![];
         for (tx_id, tx) in &mut self.tx_dictionary {
@@ -947,7 +951,7 @@ mod tests {
     ) -> Mempool {
         let mut mempool = Mempool::new(ByteSize::gb(1), None, sync_block.hash());
         let txs = make_plenty_mock_transaction_supported_by_primitive_witness(transactions_count);
-        let mutator_set_hash = sync_block.mutator_set_accumulator_after().hash();
+        let mutator_set_hash = sync_block.mutator_set_accumulator_after().unwrap().hash();
         for mut tx in txs {
             tx.kernel = TransactionKernelModifier::default()
                 .mutator_set_hash(mutator_set_hash)
@@ -998,7 +1002,7 @@ mod tests {
         let network = Network::Main;
         let sync_block = Block::genesis(network);
         let mempool = setup_mock_mempool(num_txs, TransactionOrigin::Foreign, &sync_block);
-        let mutator_set_hash = sync_block.mutator_set_accumulator_after().hash();
+        let mutator_set_hash = sync_block.mutator_set_accumulator_after().unwrap().hash();
 
         let max_fee_density: FeeDensity = FeeDensity::new(BigInt::from(u128::MAX), BigInt::from(1));
         let mut prev_fee_density = max_fee_density;
@@ -1021,7 +1025,7 @@ mod tests {
         let network = Network::Main;
         let sync_block = Block::genesis(network);
         let mempool = setup_mock_mempool(num_txs, TransactionOrigin::Foreign, &sync_block);
-        let mutator_set_hash = sync_block.mutator_set_accumulator_after().hash();
+        let mutator_set_hash = sync_block.mutator_set_accumulator_after().unwrap().hash();
 
         let max_fee_density: FeeDensity = FeeDensity::new(BigInt::from(u128::MAX), BigInt::from(1));
         let mut prev_fee_density = max_fee_density;
@@ -1119,7 +1123,7 @@ mod tests {
         let sync_block = Block::genesis(network);
         let num_txs = 12;
         let mempool = setup_mock_mempool(num_txs, TransactionOrigin::Foreign, &sync_block);
-        let mutator_set_hash = sync_block.mutator_set_accumulator_after().hash();
+        let mutator_set_hash = sync_block.mutator_set_accumulator_after().unwrap().hash();
 
         for i in 0..num_txs {
             assert_eq!(
@@ -1440,7 +1444,7 @@ mod tests {
 
         // Create a new block to verify that the non-mined transaction contains
         // updated and valid-again mutator set data
-        let block2_msa = block_2.mutator_set_accumulator_after();
+        let block2_msa = block_2.mutator_set_accumulator_after().unwrap();
         let mut tx_by_alice_updated: Transaction =
             mempool.get_transactions_for_block(usize::MAX, None, true, block2_msa.hash())[0]
                 .clone();
@@ -1475,7 +1479,10 @@ mod tests {
             usize::MAX,
             None,
             true,
-            previous_block.mutator_set_accumulator_after().hash(),
+            previous_block
+                .mutator_set_accumulator_after()
+                .unwrap()
+                .hash(),
         )[0]
         .clone();
         let block_5_timestamp = previous_block.header().timestamp + Timestamp::hours(1);
@@ -1682,9 +1689,8 @@ mod tests {
             .unwrap()
             .transaction;
         assert!(unmined_tx.is_valid(network).await);
-        assert!(
-            unmined_tx.is_confirmable_relative_to(&genesis_block.mutator_set_accumulator_after())
-        );
+        assert!(unmined_tx
+            .is_confirmable_relative_to(&genesis_block.mutator_set_accumulator_after().unwrap()));
 
         alice
             .lock_guard_mut()
@@ -1715,7 +1721,7 @@ mod tests {
             mocked_mempool_update_handler(update_jobs, &mut alice.lock_guard_mut().await.mempool)
                 .await;
 
-            let mutator_set_hash = next_block.mutator_set_accumulator_after().hash();
+            let mutator_set_hash = next_block.mutator_set_accumulator_after().unwrap().hash();
             let mempool_txs = alice.lock_guard().await.mempool.get_transactions_for_block(
                 usize::MAX,
                 None,
@@ -1728,8 +1734,9 @@ mod tests {
                 "The inserted tx must stay in the mempool"
             );
             assert!(
-                mempool_txs[0]
-                    .is_confirmable_relative_to(&next_block.mutator_set_accumulator_after()),
+                mempool_txs[0].is_confirmable_relative_to(
+                    &next_block.mutator_set_accumulator_after().unwrap()
+                ),
                 "Mempool tx must stay confirmable after new block of height {} has been applied",
                 next_block.header().height
             );
@@ -1763,7 +1770,7 @@ mod tests {
 
         // Verify that all retained txs (if any) are confirmable against
         // the new tip.
-        let mutator_set_hash = block_1b.mutator_set_accumulator_after().hash();
+        let mutator_set_hash = block_1b.mutator_set_accumulator_after().unwrap().hash();
         assert!(
             alice
                 .lock_guard()
@@ -1771,7 +1778,9 @@ mod tests {
                 .mempool
                 .get_transactions_for_block(usize::MAX, None, false, mutator_set_hash)
                 .iter()
-                .all(|tx| tx.is_confirmable_relative_to(&block_1b.mutator_set_accumulator_after())),
+                .all(|tx| tx.is_confirmable_relative_to(
+                    &block_1b.mutator_set_accumulator_after().unwrap()
+                )),
             "All retained txs in the mempool must be confirmable relative to the new block.
              Or the mempool must be empty."
         );
@@ -1885,7 +1894,10 @@ mod tests {
         let network = Network::Main;
         let genesis_block = Block::genesis(network);
         let mempool = setup_mock_mempool(11, TransactionOrigin::Foreign, &genesis_block);
-        let mutator_set_hash = genesis_block.mutator_set_accumulator_after().hash();
+        let mutator_set_hash = genesis_block
+            .mutator_set_accumulator_after()
+            .unwrap()
+            .hash();
 
         assert!(mempool
             .get_transactions_for_block(usize::MAX, None, true, mutator_set_hash)

--- a/src/models/state/mempool.rs
+++ b/src/models/state/mempool.rs
@@ -713,7 +713,7 @@ impl Mempool {
         // If we cannot update the transaction, we kick it out regardless.
         let previous_mutator_set_accumulator = predecessor_block
             .mutator_set_accumulator_after()
-            .expect("Predecessor block must be valid")
+            .expect("Predecessor block must have mutator set after")
             .clone();
         let mut kick_outs = Vec::with_capacity(self.tx_dictionary.len());
         let mut update_jobs = vec![];

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -705,7 +705,7 @@ impl GlobalState {
             .chain
             .light_state()
             .mutator_set_accumulator_after()
-            .expect("block in state should be valid");
+            .expect("block in state must have mutator set after");
         self.wallet_state
             .get_wallet_status(tip_digest, &mutator_set_accumulator)
             .await
@@ -947,7 +947,7 @@ impl GlobalState {
             .chain
             .light_state()
             .mutator_set_accumulator_after()
-            .expect("block from state should be valid");
+            .expect("block from state must have mutator set after");
 
         let monitored_utxos = self.wallet_state.wallet_db.monitored_utxos();
 
@@ -1384,7 +1384,7 @@ impl GlobalState {
                     .expect("All blocks that are reverted must have a parent, since genesis block can never be reverted.");
                 let previous_mutator_set = revert_block_parent
                     .mutator_set_accumulator_after()
-                    .expect("block from state should be valid")
+                    .expect("block from state must have mutator set after")
                     .clone();
 
                 debug!("MUTXO confirmed at height {confirming_block_height}, reverting for height {} on abandoned chain", revert_block.kernel.header.height);
@@ -1434,7 +1434,7 @@ impl GlobalState {
                 let mut block_msa = match &predecessor_block {
                     Some(block) => block
                         .mutator_set_accumulator_after()
-                        .expect("block from archival state should be valid")
+                        .expect("block from archival state must have mutator set after")
                         .clone(),
                     None => MutatorSetAccumulator::default(),
                 };
@@ -1443,7 +1443,7 @@ impl GlobalState {
                     mut removals,
                 } = apply_block
                     .mutator_set_update()
-                    .expect("block from archival state should be valid");
+                    .expect("block from archival state must have mutator set update");
 
                 // apply additions
                 for addition_record in &additions {
@@ -1479,10 +1479,7 @@ impl GlobalState {
 
                 assert_eq!(
                     block_msa.hash(),
-                    apply_block
-                        .mutator_set_accumulator_after()
-                        .expect("block from archival state should be valid")
-                        .hash()
+                    apply_block.mutator_set_accumulator_after().unwrap().hash()
                 );
             }
 
@@ -1683,7 +1680,7 @@ impl GlobalState {
         );
         let previous_ms_accumulator = tip_parent
             .mutator_set_accumulator_after()
-            .expect("block from archival state should be valid")
+            .expect("block from archival state must have mutator set after")
             .clone();
 
         // Update mempool with UTXOs from this block. This is done by

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -1662,8 +1662,7 @@ impl GlobalState {
         self.chain
             .archival_state_mut()
             .update_mutator_set(&new_block)
-            .await
-            .expect("Updating mutator set must succeed");
+            .await?;
 
         // Get parent of tip for mutator-set data needed for various updates. Parent of the
         // stored block will always exist since all blocks except the genesis block have a
@@ -1696,7 +1695,7 @@ impl GlobalState {
             &tip_parent,
             self.proving_capability(),
             self.cli().compose,
-        );
+        )?;
 
         // update wallet state with relevant UTXOs from this block
         self.wallet_state

--- a/src/models/state/mod.rs
+++ b/src/models/state/mod.rs
@@ -701,7 +701,11 @@ impl GlobalState {
 
     pub async fn get_wallet_status_for_tip(&self) -> WalletStatus {
         let tip_digest = self.chain.light_state().hash();
-        let mutator_set_accumulator = self.chain.light_state().mutator_set_accumulator_after();
+        let mutator_set_accumulator = self
+            .chain
+            .light_state()
+            .mutator_set_accumulator_after()
+            .expect("block in state should be valid");
         self.wallet_state
             .get_wallet_status(tip_digest, &mutator_set_accumulator)
             .await
@@ -784,7 +788,11 @@ impl GlobalState {
     /// Returns true iff the incoming block proposal is more favorable than the
     /// one we're currently working on. Returns false if client is a composer,
     /// as it's assumed that they prefer guessing on their own block.
-    pub(crate) fn favor_incoming_block_proposal(
+    ///
+    /// Favor [`Self::favor_incoming_block_proposal`] whenever the digests are
+    /// available, as this function can return false positives in case of a
+    /// reorganization.
+    pub(crate) fn favor_incoming_block_proposal_legacy(
         &self,
         incoming_block_height: BlockHeight,
         incoming_guesser_fee: NativeCurrencyAmount,
@@ -801,10 +809,46 @@ impl GlobalState {
             });
         }
 
-        let maybe_existing_fee = self
-            .mining_state
-            .block_proposal
-            .map(|x| x.total_guesser_reward());
+        let maybe_existing_fee = self.mining_state.block_proposal.map(|x| {
+            x.total_guesser_reward()
+                .expect("block in state must be valid")
+        });
+        if maybe_existing_fee.is_some_and(|current| current >= incoming_guesser_fee)
+            || incoming_guesser_fee.is_zero()
+        {
+            Err(BlockProposalRejectError::InsufficientFee {
+                current: maybe_existing_fee,
+                received: incoming_guesser_fee,
+            })
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Returns true iff the incoming block proposal is more favorable than the
+    /// one we're currently working on. Returns false if client is a composer,
+    /// as it's assumed that they prefer guessing on their own block.
+    pub(crate) fn favor_incoming_block_proposal(
+        &self,
+        incoming_proposal_prev_block_digest: Digest,
+        incoming_guesser_fee: NativeCurrencyAmount,
+    ) -> Result<(), BlockProposalRejectError> {
+        if self.cli().compose {
+            return Err(BlockProposalRejectError::Composing);
+        }
+
+        let current_tip_digest = self.chain.light_state().hash();
+        if incoming_proposal_prev_block_digest != current_tip_digest {
+            return Err(BlockProposalRejectError::WrongParent {
+                received: incoming_proposal_prev_block_digest,
+                expected: current_tip_digest,
+            });
+        }
+
+        let maybe_existing_fee = self.mining_state.block_proposal.map(|x| {
+            x.total_guesser_reward()
+                .expect("block in state must be valid")
+        });
         if maybe_existing_fee.is_some_and(|current| current >= incoming_guesser_fee)
             || incoming_guesser_fee.is_zero()
         {
@@ -899,7 +943,11 @@ impl GlobalState {
         &self,
     ) -> Vec<(Digest, Timestamp, BlockHeight, NativeCurrencyAmount)> {
         let current_tip_digest = self.chain.light_state().hash();
-        let current_msa = self.chain.light_state().mutator_set_accumulator_after();
+        let current_msa = self
+            .chain
+            .light_state()
+            .mutator_set_accumulator_after()
+            .expect("block from state should be valid");
 
         let monitored_utxos = self.wallet_state.wallet_db.monitored_utxos();
 
@@ -1334,8 +1382,10 @@ impl GlobalState {
                     .get_block(revert_block.kernel.header.prev_block_digest)
                     .await?
                     .expect("All blocks that are reverted must have a parent, since genesis block can never be reverted.");
-                let previous_mutator_set =
-                    revert_block_parent.mutator_set_accumulator_after().clone();
+                let previous_mutator_set = revert_block_parent
+                    .mutator_set_accumulator_after()
+                    .expect("block from state should be valid")
+                    .clone();
 
                 debug!("MUTXO confirmed at height {confirming_block_height}, reverting for height {} on abandoned chain", revert_block.kernel.header.height);
 
@@ -1382,13 +1432,18 @@ impl GlobalState {
                     .get_block(apply_block.kernel.header.prev_block_digest)
                     .await?;
                 let mut block_msa = match &predecessor_block {
-                    Some(block) => block.mutator_set_accumulator_after().clone(),
+                    Some(block) => block
+                        .mutator_set_accumulator_after()
+                        .expect("block from archival state should be valid")
+                        .clone(),
                     None => MutatorSetAccumulator::default(),
                 };
                 let MutatorSetUpdate {
                     additions,
                     mut removals,
-                } = apply_block.mutator_set_update();
+                } = apply_block
+                    .mutator_set_update()
+                    .expect("block from archival state should be valid");
 
                 // apply additions
                 for addition_record in &additions {
@@ -1422,10 +1477,12 @@ impl GlobalState {
                     block_msa.remove(&current_removal_record);
                 }
 
-                // sanity check
                 assert_eq!(
                     block_msa.hash(),
-                    apply_block.mutator_set_accumulator_after().hash()
+                    apply_block
+                        .mutator_set_accumulator_after()
+                        .expect("block from archival state should be valid")
+                        .hash()
                 );
             }
 
@@ -1625,7 +1682,10 @@ impl GlobalState {
             new_block.header().prev_block_digest,
             "Tip parent has must match indicated parent hash"
         );
-        let previous_ms_accumulator = tip_parent.mutator_set_accumulator_after().clone();
+        let previous_ms_accumulator = tip_parent
+            .mutator_set_accumulator_after()
+            .expect("block from archival state should be valid")
+            .clone();
 
         // Update mempool with UTXOs from this block. This is done by
         // removing all transaction that became invalid/was mined by this
@@ -2464,6 +2524,7 @@ mod tests {
                         .chain
                         .light_state()
                         .mutator_set_accumulator_after()
+                        .unwrap()
                         .verify(
                             ms_item,
                             &mutxo.get_latest_membership_proof_entry().unwrap().1,
@@ -2626,7 +2687,7 @@ mod tests {
                         .wallet_state
                         .get_wallet_status(
                             mock_block_1a.hash(),
-                            &mock_block_1a.mutator_set_accumulator_after()
+                            &mock_block_1a.mutator_set_accumulator_after().unwrap()
                         )
                         .await
                         .synced_unspent
@@ -2664,7 +2725,7 @@ mod tests {
                     .wallet_state
                     .get_wallet_status(
                         parent_block.hash(),
-                        &parent_block.mutator_set_accumulator_after(),
+                        &parent_block.mutator_set_accumulator_after().unwrap(),
                     )
                     .await;
                 assert_eq!(1, alice_wallet_status_after_reorg.synced_unspent.len());
@@ -2719,7 +2780,8 @@ mod tests {
                     let mut spendable_utxos: Vec<(Utxo, MsMembershipProof, AdditionRecord)> =
                         vec![];
                     for _ in 0..num_blocks_per_branch {
-                        let mut mutator_set_accumulator = block.mutator_set_accumulator_after();
+                        let mut mutator_set_accumulator =
+                            block.mutator_set_accumulator_after().unwrap();
 
                         // produce removal records
                         let num_removal_records = rng.random_range(0..=spendable_utxos.len());
@@ -2772,11 +2834,11 @@ mod tests {
                         )
                         .await;
                         ret.push(next_block.clone());
-                        let mut test_msa = block.mutator_set_accumulator_after();
+                        let mut test_msa = block.mutator_set_accumulator_after().unwrap();
                         block = next_block;
 
                         // update membership proofs
-                        let mutator_set_update = block.mutator_set_update();
+                        let mutator_set_update = block.mutator_set_update().unwrap();
                         let MutatorSetUpdate {
                             additions,
                             mut removals,
@@ -2854,6 +2916,7 @@ mod tests {
 
                         block
                             .mutator_set_update()
+                            .unwrap()
                             .apply_to_accumulator(&mut test_msa)
                             .unwrap();
                         assert_eq!(mutator_set_accumulator, test_msa);
@@ -2904,7 +2967,7 @@ mod tests {
                             .wallet_state
                             .get_wallet_status(
                                 block_1.hash(),
-                                &block_1.mutator_set_accumulator_after()
+                                &block_1.mutator_set_accumulator_after().unwrap()
                             )
                             .await
                             .synced_unspent
@@ -2960,7 +3023,7 @@ mod tests {
                     .wallet_state
                     .get_wallet_status(
                         fork_a_block.hash(),
-                        &fork_a_block.mutator_set_accumulator_after(),
+                        &fork_a_block.mutator_set_accumulator_after().unwrap(),
                     )
                     .await;
 
@@ -2977,7 +3040,7 @@ mod tests {
                     .wallet_state
                     .get_wallet_status(
                         fork_b_block.hash(),
-                        &fork_b_block.mutator_set_accumulator_after(),
+                        &fork_b_block.mutator_set_accumulator_after().unwrap(),
                     )
                     .await;
                 assert_eq!(
@@ -3008,7 +3071,7 @@ mod tests {
                     .wallet_state
                     .get_wallet_status(
                         fork_b_block.hash(),
-                        &fork_b_block.mutator_set_accumulator_after(),
+                        &fork_b_block.mutator_set_accumulator_after().unwrap(),
                     )
                     .await;
                 assert_eq!(
@@ -3034,7 +3097,7 @@ mod tests {
                     .wallet_state
                     .get_wallet_status(
                         fork_c_block.hash(),
-                        &fork_c_block.mutator_set_accumulator_after(),
+                        &fork_c_block.mutator_set_accumulator_after().unwrap(),
                     )
                     .await;
                 assert_eq!(
@@ -3066,7 +3129,7 @@ mod tests {
                     .wallet_state
                     .get_wallet_status(
                         fork_c_block.hash(),
-                        &fork_c_block.mutator_set_accumulator_after(),
+                        &fork_c_block.mutator_set_accumulator_after().unwrap(),
                     )
                     .await;
                 assert_eq!(1, alice_ws_c_after_resync.synced_unspent.len());
@@ -3141,7 +3204,7 @@ mod tests {
 
         assert!(coinbase_transaction.is_valid(network).await);
         assert!(coinbase_transaction
-            .is_confirmable_relative_to(&genesis_block.mutator_set_accumulator_after()));
+            .is_confirmable_relative_to(&genesis_block.mutator_set_accumulator_after().unwrap()));
 
         // Send two outputs each to Alice and Bob, from genesis receiver
         let sender_randomness: Digest = rng.random();
@@ -3212,7 +3275,7 @@ mod tests {
 
         assert!(tx_to_alice_and_bob.is_valid(network).await);
         assert!(tx_to_alice_and_bob
-            .is_confirmable_relative_to(&genesis_block.mutator_set_accumulator_after()));
+            .is_confirmable_relative_to(&genesis_block.mutator_set_accumulator_after().unwrap()));
 
         // Expect change output
         premine_receiver
@@ -3239,7 +3302,7 @@ mod tests {
             .unwrap();
         assert!(block_transaction.is_valid(network).await);
         assert!(block_transaction
-            .is_confirmable_relative_to(&genesis_block.mutator_set_accumulator_after()));
+            .is_confirmable_relative_to(&genesis_block.mutator_set_accumulator_after().unwrap()));
 
         let block_1 = Block::compose(
             &genesis_block,
@@ -3395,7 +3458,8 @@ mod tests {
         );
 
         assert!(tx_from_alice.is_valid(network).await);
-        assert!(tx_from_alice.is_confirmable_relative_to(&block_1.mutator_set_accumulator_after()));
+        assert!(tx_from_alice
+            .is_confirmable_relative_to(&block_1.mutator_set_accumulator_after().unwrap()));
 
         // make bob's transaction
         let tx_outputs_from_bob = vec![
@@ -3441,7 +3505,8 @@ mod tests {
         );
 
         assert!(tx_from_bob.is_valid(network).await);
-        assert!(tx_from_bob.is_confirmable_relative_to(&block_1.mutator_set_accumulator_after()));
+        assert!(tx_from_bob
+            .is_confirmable_relative_to(&block_1.mutator_set_accumulator_after().unwrap()));
 
         // Make block_2 with tx that contains:
         // - 4 inputs: 2 from Alice and 2 from Bob
@@ -3462,7 +3527,7 @@ mod tests {
         .unwrap();
         assert!(coinbase_transaction2.is_valid(network).await);
         assert!(coinbase_transaction2
-            .is_confirmable_relative_to(&block_1.mutator_set_accumulator_after()));
+            .is_confirmable_relative_to(&block_1.mutator_set_accumulator_after().unwrap()));
 
         let block_transaction2 = coinbase_transaction2
             .merge_with(
@@ -3482,9 +3547,8 @@ mod tests {
             .await
             .unwrap();
         assert!(block_transaction2.is_valid(network).await);
-        assert!(
-            block_transaction2.is_confirmable_relative_to(&block_1.mutator_set_accumulator_after())
-        );
+        assert!(block_transaction2
+            .is_confirmable_relative_to(&block_1.mutator_set_accumulator_after().unwrap()));
 
         let block_2 = Block::compose(
             &block_1,
@@ -3591,7 +3655,9 @@ mod tests {
         )
         .await;
         let small_guesser_fraction = block1_proposal(&global_state_lock_small).await;
+        let small_prev_block_digest = small_guesser_fraction.header().prev_block_digest;
         let big_guesser_fraction = block1_proposal(&global_state_lock_big).await;
+        let big_prev_block_digest = big_guesser_fraction.header().prev_block_digest;
 
         let mut state = global_state_lock_small
             .global_state_lock
@@ -3600,8 +3666,8 @@ mod tests {
         assert!(
             state
                 .favor_incoming_block_proposal(
-                    small_guesser_fraction.header().height,
-                    small_guesser_fraction.total_guesser_reward()
+                    small_prev_block_digest,
+                    small_guesser_fraction.total_guesser_reward().unwrap()
                 )
                 .is_ok(),
             "Must favor low guesser fee over none"
@@ -3612,8 +3678,8 @@ mod tests {
         assert!(
             state
                 .favor_incoming_block_proposal(
-                    big_guesser_fraction.header().height,
-                    big_guesser_fraction.total_guesser_reward()
+                    big_prev_block_digest,
+                    big_guesser_fraction.total_guesser_reward().unwrap()
                 )
                 .is_ok(),
             "Must favor big guesser fee over low"
@@ -3623,13 +3689,13 @@ mod tests {
             BlockProposal::foreign_proposal(big_guesser_fraction.clone());
         assert_eq!(
             BlockProposalRejectError::InsufficientFee {
-                current: Some(big_guesser_fraction.total_guesser_reward()),
-                received: big_guesser_fraction.total_guesser_reward()
+                current: Some(big_guesser_fraction.total_guesser_reward().unwrap()),
+                received: big_guesser_fraction.total_guesser_reward().unwrap()
             },
             state
                 .favor_incoming_block_proposal(
-                    big_guesser_fraction.header().height,
-                    big_guesser_fraction.total_guesser_reward()
+                    big_prev_block_digest,
+                    big_guesser_fraction.total_guesser_reward().unwrap()
                 )
                 .unwrap_err(),
             "Must favor existing over incoming equivalent"
@@ -3663,7 +3729,7 @@ mod tests {
                 "Archival state must have expected sync-label",
             );
             assert_eq!(
-                expected_tip.mutator_set_accumulator_after(),
+                expected_tip.mutator_set_accumulator_after().unwrap(),
                 global_state
                     .chain
                     .archival_state()
@@ -3743,7 +3809,10 @@ mod tests {
             );
 
             // Peek into wallet
-            let tip_msa = expected_tip.mutator_set_accumulator_after().clone();
+            let tip_msa = expected_tip
+                .mutator_set_accumulator_after()
+                .unwrap()
+                .clone();
             let mutxos = global_state
                 .wallet_state
                 .wallet_db
@@ -4271,7 +4340,7 @@ mod tests {
             let tip = old_state.chain.light_state();
             assert_eq!(*tip, new_state.chain.archival_state().get_tip().await);
             assert_eq!(*tip, old_state.chain.archival_state().get_tip().await);
-            let msa = tip.mutator_set_accumulator_after();
+            let msa = tip.mutator_set_accumulator_after().unwrap();
             assert_eq!(
                 old_state
                     .wallet_state

--- a/src/models/state/wallet/mod.rs
+++ b/src/models/state/wallet/mod.rs
@@ -121,7 +121,7 @@ mod tests {
                 next_block = nb;
                 alice
                     .update_wallet_state_with_new_block(
-                        &previous_block.mutator_set_accumulator_after(),
+                        &previous_block.mutator_set_accumulator_after().unwrap(),
                         &next_block,
                     )
                     .await
@@ -142,6 +142,7 @@ mod tests {
             assert!(
                 next_block
                     .mutator_set_accumulator_after()
+                    .unwrap()
                     .verify(Hash::hash(&genesis_block_utxo), &ms_membership_proof),
                 "Membership proof must be valid after updating wallet state with generated blocks"
             );
@@ -180,7 +181,7 @@ mod tests {
         );
         alice_wallet
             .update_wallet_state_with_new_block(
-                &genesis_block.mutator_set_accumulator_after(),
+                &genesis_block.mutator_set_accumulator_after().unwrap(),
                 &block_1,
             )
             .await
@@ -218,9 +219,10 @@ mod tests {
                         .unwrap(),
                 )
             });
-        assert!(items_and_msmps_block1
-            .clone()
-            .all(|(item, msmp)| block_1.mutator_set_accumulator_after().verify(item, &msmp)));
+        assert!(items_and_msmps_block1.clone().all(|(item, msmp)| block_1
+            .mutator_set_accumulator_after()
+            .unwrap()
+            .verify(item, &msmp)));
 
         // Create new blocks, verify that the membership proofs are *not* valid
         // under this block as tip
@@ -229,17 +231,24 @@ mod tests {
 
         // TODO: Is this assertion correct? Do we need to check if an auth path
         // is empty?
-        assert!(!items_and_msmps_block1
-            .clone()
-            .all(|(item, msmp)| block_3.mutator_set_accumulator_after().verify(item, &msmp)));
+        assert!(!items_and_msmps_block1.clone().all(|(item, msmp)| block_3
+            .mutator_set_accumulator_after()
+            .unwrap()
+            .verify(item, &msmp)));
 
         // Verify that the membership proof is valid *after* running the updater
         alice_wallet
-            .update_wallet_state_with_new_block(&block_1.mutator_set_accumulator_after(), &block_2)
+            .update_wallet_state_with_new_block(
+                &block_1.mutator_set_accumulator_after().unwrap(),
+                &block_2,
+            )
             .await
             .unwrap();
         alice_wallet
-            .update_wallet_state_with_new_block(&block_2.mutator_set_accumulator_after(), &block_3)
+            .update_wallet_state_with_new_block(
+                &block_2.mutator_set_accumulator_after().unwrap(),
+                &block_3,
+            )
             .await
             .unwrap();
 
@@ -257,9 +266,10 @@ mod tests {
                         .unwrap(),
                 )
             });
-        assert!(items_and_msmps_block3
-            .clone()
-            .all(|(item, msmp)| block_3.mutator_set_accumulator_after().verify(item, &msmp)));
+        assert!(items_and_msmps_block3.clone().all(|(item, msmp)| block_3
+            .mutator_set_accumulator_after()
+            .unwrap()
+            .verify(item, &msmp)));
     }
 
     #[traced_test]
@@ -307,7 +317,8 @@ mod tests {
                         alice_global_state
                             .chain
                             .light_state()
-                            .mutator_set_accumulator_after(),
+                            .mutator_set_accumulator_after()
+                            .unwrap(),
                     )
                 })
                 .await;
@@ -420,7 +431,7 @@ mod tests {
             .allocate_sufficient_input_funds(
                 liquid_mining_reward.scalar_mul(2),
                 next_block.hash(),
-                &next_block.mutator_set_accumulator_after(),
+                &next_block.mutator_set_accumulator_after().unwrap(),
                 now,
             )
             .await
@@ -432,7 +443,7 @@ mod tests {
         );
 
         // This block throws away four UTXOs.
-        let msa_tip_previous = next_block.mutator_set_accumulator_after().clone();
+        let msa_tip_previous = next_block.mutator_set_accumulator_after().unwrap().clone();
         let output_utxo = Utxo::new_native_currency(
             LockScript::anyone_can_spend(),
             NativeCurrencyAmount::coins(200),
@@ -453,7 +464,7 @@ mod tests {
         let tx = make_mock_transaction_with_mutator_set_hash(
             removal_records,
             addition_records,
-            next_block.mutator_set_accumulator_after().hash(),
+            next_block.mutator_set_accumulator_after().unwrap().hash(),
         );
 
         let next_block = Block::block_template_invalid_proof(
@@ -474,7 +485,7 @@ mod tests {
                 .wallet_state
                 .get_wallet_status(
                     next_block.hash(),
-                    &next_block.mutator_set_accumulator_after(),
+                    &next_block.mutator_set_accumulator_after().unwrap(),
                 )
                 .await;
             ags.wallet_state
@@ -642,7 +653,7 @@ mod tests {
         // Verify that all monitored UTXOs have valid membership proofs
         for monitored_utxo in alice_monitored_utxos {
             assert!(
-                block_1.mutator_set_accumulator_after().verify(
+                block_1.mutator_set_accumulator_after().unwrap().verify(
                     Hash::hash(&monitored_utxo.utxo),
                     &monitored_utxo
                         .get_membership_proof_for_block(block_1.hash())
@@ -692,6 +703,7 @@ mod tests {
             assert!(
                 first_block_after_spree
                     .mutator_set_accumulator_after()
+                    .unwrap()
                     .verify(
                         Hash::hash(&monitored_utxo.utxo),
                         &monitored_utxo
@@ -718,7 +730,9 @@ mod tests {
             .wallet_state
             .get_wallet_status(
                 first_block_after_spree.hash(),
-                &first_block_after_spree.mutator_set_accumulator_after(),
+                &first_block_after_spree
+                    .mutator_set_accumulator_after()
+                    .unwrap(),
             )
             .await;
         assert_eq!(
@@ -763,7 +777,7 @@ mod tests {
         // Verify that all monitored UTXOs (with synced MPs) have valid membership proofs
         for monitored_utxo in &alice_monitored_utxos_at_2b {
             assert!(
-                block_2_b.mutator_set_accumulator_after().verify(
+                block_2_b.mutator_set_accumulator_after().unwrap().verify(
                     Hash::hash(&monitored_utxo.utxo),
                     &monitored_utxo
                         .get_membership_proof_for_block(block_2_b.hash())
@@ -788,7 +802,9 @@ mod tests {
             .await
             .wallet_state
             .update_wallet_state_with_new_block(
-                &first_block_after_spree.mutator_set_accumulator_after(),
+                &first_block_after_spree
+                    .mutator_set_accumulator_after()
+                    .unwrap(),
                 &first_block_continuing_spree,
             )
             .await
@@ -812,6 +828,7 @@ mod tests {
             assert!(
                 first_block_continuing_spree
                     .mutator_set_accumulator_after()
+                    .unwrap()
                     .verify(
                         Hash::hash(&monitored_utxo.utxo),
                         &monitored_utxo
@@ -919,7 +936,7 @@ mod tests {
             .await
             .wallet_state
             .update_wallet_state_with_new_block(
-                &block_2_b.mutator_set_accumulator_after(),
+                &block_2_b.mutator_set_accumulator_after().unwrap(),
                 &block_3_b,
             )
             .await
@@ -949,7 +966,7 @@ mod tests {
         for monitored_utxo in alice_monitored_utxos_3b {
             assert!(
                 monitored_utxo.spent_in_block.is_some()
-                    || block_3_b.mutator_set_accumulator_after().verify(
+                    || block_3_b.mutator_set_accumulator_after().unwrap().verify(
                         Hash::hash(&monitored_utxo.utxo),
                         &monitored_utxo
                             .get_membership_proof_for_block(block_3_b.hash())
@@ -973,7 +990,9 @@ mod tests {
             .await
             .wallet_state
             .update_wallet_state_with_new_block(
-                &first_block_continuing_spree.mutator_set_accumulator_after(),
+                &first_block_continuing_spree
+                    .mutator_set_accumulator_after()
+                    .unwrap(),
                 &second_block_continuing_spree,
             )
             .await
@@ -997,6 +1016,7 @@ mod tests {
                 monitored_utxo.spent_in_block.is_some()
                     || second_block_continuing_spree
                         .mutator_set_accumulator_after()
+                        .unwrap()
                         .verify(
                             Hash::hash(&monitored_utxo.utxo),
                             &monitored_utxo
@@ -1274,7 +1294,7 @@ mod tests {
                     .wallet_state
                     .get_wallet_status(
                         genesis_block.hash(),
-                        &genesis_block.mutator_set_accumulator_after(),
+                        &genesis_block.mutator_set_accumulator_after().unwrap(),
                     )
                     .await;
 

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -1439,7 +1439,7 @@ impl WalletState {
         let MutatorSetUpdate {
             additions: addition_records,
             removals: _removal_records,
-        } = new_block.mutator_set_update().expect("Block must be valid");
+        } = new_block.mutator_set_update()?;
 
         let offchain_received_outputs = self
             .scan_for_expected_utxos(&addition_records)

--- a/src/models/state/wallet/wallet_state.rs
+++ b/src/models/state/wallet/wallet_state.rs
@@ -887,7 +887,7 @@ impl WalletState {
             let sender_randomness = block.hash();
             block
                 .guesser_fee_utxos()
-                .expect("Block must be valid")
+                .expect("Block argument must have guesser fee UTXOs")
                 .into_iter()
                 .map(|utxo| IncomingUtxo {
                     utxo,
@@ -1672,10 +1672,10 @@ impl WalletState {
 
         // Sanity check that `msa_state` agrees with the mutator set from the applied block
         assert_eq!(
-            new_block.mutator_set_accumulator_after().expect("Block must be valid").clone().hash(),
+            new_block.mutator_set_accumulator_after().expect("Block must have mutator set after").clone().hash(),
             msa_state.hash(),
             "\n\nMutator set in applied block:\n{}\n\nmust agree with that in wallet handler:\n{}\n\n",
-            new_block.mutator_set_accumulator_after().expect("Block must be valid").clone().hash(),
+            new_block.mutator_set_accumulator_after().expect("Block must have mutator set after").clone().hash(),
             msa_state.hash(),
         );
 

--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -1299,7 +1299,11 @@ impl PeerLoopHandler {
 
                     (
                         state.chain.light_state().hash(),
-                        state.chain.light_state().mutator_set_accumulator_after(),
+                        state
+                            .chain
+                            .light_state()
+                            .mutator_set_accumulator_after()
+                            .expect("Block from state must be valid"),
                     )
                 };
                 if !transaction.is_confirmable_relative_to(&mutator_set_accumulator_after) {
@@ -1425,6 +1429,7 @@ impl PeerLoopHandler {
                         .chain
                         .light_state()
                         .mutator_set_accumulator_after()
+                        .expect("Block from state must be valid")
                         .hash()
                         != tx_notification.mutator_set_hash
                     {
@@ -1464,7 +1469,7 @@ impl PeerLoopHandler {
                     .global_state_lock
                     .lock_guard()
                     .await
-                    .favor_incoming_block_proposal(
+                    .favor_incoming_block_proposal_legacy(
                         block_proposal_notification.height,
                         block_proposal_notification.guesser_fee,
                     );
@@ -1506,59 +1511,57 @@ impl PeerLoopHandler {
 
                 Ok(KEEP_CONNECTION_ALIVE)
             }
-            PeerMessage::BlockProposal(block) => {
+            PeerMessage::BlockProposal(new_proposal) => {
                 info!("Got block proposal from peer.");
 
-                let should_punish = {
-                    log_slow_scope!(fn_name!() + "::PeerMessage::BlockProposal::should_punish");
+                // Is the proposal valid?
+                // Lock needs to be held here because race conditions: otherwise
+                // the block proposal that was validated might not match with
+                // the one whose favorability is being computed.
+                let state = self.global_state_lock.lock_guard().await;
+                let tip = state.chain.light_state();
+                let proposal_is_valid = new_proposal
+                    .is_valid(tip, self.now(), self.global_state_lock.cli().network)
+                    .await;
+                if !proposal_is_valid {
+                    drop(state);
+                    self.punish(NegativePeerSanction::InvalidBlockProposal)
+                        .await?;
+                    return Ok(KEEP_CONNECTION_ALIVE);
+                }
 
-                    let (verdict, tip) = {
-                        let state = self.global_state_lock.lock_guard().await;
+                // Is block proposal favorable?
+                let is_favorable = state.favor_incoming_block_proposal(
+                    new_proposal.header().prev_block_digest,
+                    new_proposal
+                        .total_guesser_reward()
+                        .expect("Block was validated"),
+                );
+                drop(state);
 
-                        let verdict = state.favor_incoming_block_proposal(
-                            block.header().height,
-                            block.total_guesser_reward(),
-                        );
-                        let tip = state.chain.light_state().to_owned();
-                        (verdict, tip)
-                    };
-
-                    if let Err(rejection_reason) = verdict {
-                        match rejection_reason {
-                            // no need to punish and log if the fees are equal.  we just ignore the incoming proposal.
-                            BlockProposalRejectError::InsufficientFee { current, received }
-                                if Some(received) == current =>
-                            {
-                                debug!("ignoring new block proposal because the fee is equal to the present one");
-                                None
-                            }
-                            _ => {
-                                warn!("Rejecting new block proposal:\n{rejection_reason}");
-                                Some(NegativePeerSanction::NonFavorableBlockProposal)
-                            }
-                        }
-                    } else {
-                        // Verify validity and that proposal is child of current tip
-                        if block
-                            .is_valid(&tip, self.now(), self.global_state_lock.cli().network)
-                            .await
+                if let Err(rejection_reason) = is_favorable {
+                    match rejection_reason {
+                        // no need to punish and log if the fees are equal.  we just ignore the incoming proposal.
+                        BlockProposalRejectError::InsufficientFee { current, received }
+                            if Some(received) == current =>
                         {
-                            None // all is well, no punishment.
-                        } else {
-                            Some(NegativePeerSanction::InvalidBlockProposal)
+                            debug!("ignoring new block proposal because the fee is equal to the present one");
+                            return Ok(KEEP_CONNECTION_ALIVE);
+                        }
+                        _ => {
+                            warn!("Rejecting new block proposal:\n{rejection_reason}");
+                            self.punish(NegativePeerSanction::NonFavorableBlockProposal)
+                                .await?;
+                            return Ok(KEEP_CONNECTION_ALIVE);
                         }
                     }
                 };
 
-                if let Some(sanction) = should_punish {
-                    self.punish(sanction).await?;
-                } else {
-                    self.send_to_main(PeerTaskToMain::BlockProposal(block), line!())
-                        .await?;
+                self.send_to_main(PeerTaskToMain::BlockProposal(new_proposal), line!())
+                    .await?;
 
-                    // Valuable, new, hard-to-produce information. Reward peer.
-                    self.reward(PositivePeerSanction::NewBlockProposal).await?;
-                }
+                // Valuable, new, hard-to-produce information. Reward peer.
+                self.reward(PositivePeerSanction::NewBlockProposal).await?;
 
                 Ok(KEEP_CONNECTION_ALIVE)
             }

--- a/src/peer_loop.rs
+++ b/src/peer_loop.rs
@@ -1303,7 +1303,7 @@ impl PeerLoopHandler {
                             .chain
                             .light_state()
                             .mutator_set_accumulator_after()
-                            .expect("Block from state must be valid"),
+                            .expect("Block from state must have mutator set after"),
                     )
                 };
                 if !transaction.is_confirmable_relative_to(&mutator_set_accumulator_after) {
@@ -1429,7 +1429,7 @@ impl PeerLoopHandler {
                         .chain
                         .light_state()
                         .mutator_set_accumulator_after()
-                        .expect("Block from state must be valid")
+                        .expect("Block from state must have mutator set after")
                         .hash()
                         != tx_notification.mutator_set_hash
                     {

--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -241,7 +241,7 @@ impl ProofOfWorkPuzzle {
     fn new(block_proposal: Block, latest_block_header: BlockHeader) -> Self {
         let guesser_reward = block_proposal
             .total_guesser_reward()
-            .expect("Block proposal must be valid");
+            .expect("Block proposal must have well-defined guesser reward");
         let (kernel_auth_path, header_auth_path) = precalculate_block_auth_paths(&block_proposal);
         let threshold = latest_block_header.difficulty.target();
         let prev_block = block_proposal.header().prev_block_digest;
@@ -2097,13 +2097,13 @@ impl NeptuneRPCServer {
                     // Find matching AOCL leaf index that must be in this block
                     let last_aocl_index_in_block = block
                         .mutator_set_accumulator_after()
-                        .expect("Block from state must be valid")
+                        .expect("Block from state must have mutator set after")
                         .aocl
                         .num_leafs()
                         - 1;
                     let num_outputs_in_block: u64 = block
                         .mutator_set_update()
-                        .expect("Block from state must be valid")
+                        .expect("Block from state must have mutator set update")
                         .additions
                         .len()
                         .try_into()
@@ -3340,7 +3340,7 @@ impl RPC for NeptuneRPCServer {
         let tip_hash = tip.hash();
         let tip_msa = tip
             .mutator_set_accumulator_after()
-            .expect("Block from state must be valid");
+            .expect("Block from state must have mutator set after");
 
         Ok(state
             .wallet_state
@@ -3554,7 +3554,7 @@ impl RPC for NeptuneRPCServer {
             .chain
             .light_state()
             .mutator_set_accumulator_after()
-            .expect("Block from state must be valid")
+            .expect("Block from state must have mutator set after")
             .hash();
 
         let mempool_transactions = mempool_txkids

--- a/src/tests/shared.rs
+++ b/src/tests/shared.rs
@@ -242,10 +242,6 @@ pub(crate) async fn mock_genesis_global_state_with_block(
     assert_eq!(archival_state.get_tip().await.hash(), genesis_block.hash());
 
     let light_state: LightState = LightState::from(genesis_block.to_owned());
-    println!(
-        "Genesis light state MSA hash: {}",
-        light_state.mutator_set_accumulator_after().unwrap().hash()
-    );
     let chain = BlockchainState::Archival(Box::new(BlockchainArchivalState {
         light_state,
         archival_state,


### PR DESCRIPTION
The peer loop should act as a robust firewall against invalid blocks.
Nevertheless, it is worth ensuring that handlers behind that firewall
cannot crash even for invalid blocks.

In particular, function `Block::total_guesser_reward` and other
helper functions downstream from there, are undefined for
un-validated blocks. The result should be wrapped in a `Result`, in
order to avoid passing inconsistent values up the call graph. This
change cascades into many function return type modifications
and many `.unwrap`s and `.expect`s downstream.

The inconsistency was exposed by test
`rpc_server::rpc_server_tests::public_announcements_in_block_test`
which is now fixed instead of ignored. Thanks to @skaunov for PR #543
and the effort leading to this exposition.

Also:
 - Change logic for computing block proposal favorability: use
   `prev_block_digest` instead of block height. However, the old
   method (now suffixed with `_legacy`) continues to exist to
   enable unmodified processing of `PeerMessage`
   `BlockProposalNotification`, which comes with a block height and
   not a digest. (We cannot change `PeerMessage`, unfortunately.)
 - Rewrite handler for `PeerMessage` `BlockProposal`. Simplify and
   reduce indentation.