### PR TITLE
Introduce new type `UtxoTriple`

### DIFF
--- a/src/models/blockchain/block/mod.rs
+++ b/src/models/blockchain/block/mod.rs
@@ -1907,6 +1907,7 @@ pub(crate) mod tests {
 
     mod guesser_fee_utxos {
         use super::*;
+        use crate::models::blockchain::transaction::utxo_triple::UtxoTriple;
         use crate::models::state::tx_creation_config::TxCreationConfig;
         use crate::models::state::wallet::address::generation_address::GenerationSpendingKey;
         use crate::tests::shared::blocks::make_mock_block_with_puts_and_guesser_preimage_and_guesser_fraction;
@@ -1937,7 +1938,14 @@ pub(crate) mod tests {
                 .guesser_fee_utxos()
                 .unwrap()
                 .iter()
-                .map(|utxo| commit(Tip5::hash(utxo), block1.hash(), guesser_preimage.hash()))
+                .map(|utxo| {
+                    UtxoTriple {
+                        utxo: utxo.clone(),
+                        sender_randomness: block1.hash(),
+                        receiver_digest: guesser_preimage.hash(),
+                    }
+                    .addition_record()
+                })
                 .collect_vec();
             assert_eq!(ars, ars_from_wallet);
 

--- a/src/models/blockchain/transaction/mod.rs
+++ b/src/models/blockchain/transaction/mod.rs
@@ -17,6 +17,7 @@ pub mod primitive_witness;
 pub mod transaction_kernel;
 pub mod transaction_proof;
 pub mod utxo;
+pub(crate) mod utxo_triple;
 pub mod validity;
 
 use anyhow::ensure;
@@ -284,13 +285,13 @@ pub(crate) mod tests {
     use proptest::test_runner::TestRunner;
     use rand::random;
     use tasm_lib::prelude::Digest;
-    use tasm_lib::triton_vm::prelude::Tip5;
     use tests::primitive_witness::SaltedUtxos;
     use tests::utxo::Utxo;
     use tracing_test::traced_test;
 
     use super::*;
     use crate::config_models::network::Network;
+    use crate::models::blockchain::transaction::utxo_triple::UtxoTriple;
     use crate::models::blockchain::type_scripts::native_currency_amount::NativeCurrencyAmount;
     use crate::models::proof_abstractions::timestamp::Timestamp;
     use crate::tests::shared::blocks::mock_block_from_transaction_and_msa;
@@ -298,7 +299,6 @@ pub(crate) mod tests {
     use crate::tests::shared_tokio_runtime;
     use crate::triton_vm_job_queue::TritonVmJobPriority;
     use crate::util_types::mutator_set::addition_record::AdditionRecord;
-    use crate::util_types::mutator_set::commit;
     use crate::util_types::mutator_set::removal_record::RemovalRecord;
 
     impl Transaction {
@@ -361,7 +361,12 @@ pub(crate) mod tests {
             LockScript::anyone_can_spend(),
             NativeCurrencyAmount::coins(42),
         );
-        let ar = commit(Tip5::hash(&output_1), random(), random());
+        let ar = UtxoTriple {
+            utxo: output_1.clone(),
+            sender_randomness: random(),
+            receiver_digest: random(),
+        }
+        .addition_record();
 
         // Verify that a sane timestamp is returned. `make_mock_transaction` must follow
         // the correct time convention for this test to work.

--- a/src/models/blockchain/transaction/utxo_triple.rs
+++ b/src/models/blockchain/transaction/utxo_triple.rs
@@ -1,0 +1,41 @@
+use tasm_lib::prelude::Digest;
+use tasm_lib::prelude::Tip5;
+use tasm_lib::triton_vm::prelude::BFieldCodec;
+
+use crate::models::blockchain::transaction::utxo::Utxo;
+use crate::models::state::wallet::transaction_output::TxOutput;
+use crate::util_types::mutator_set::addition_record::AdditionRecord;
+use crate::util_types::mutator_set::commit;
+
+/// Represents the preimage of a transaction output, so not just the UTXO but
+/// also the randomnesses.
+#[derive(Debug, Clone, BFieldCodec)]
+pub(crate) struct UtxoTriple {
+    pub(crate) utxo: Utxo,
+    pub(crate) sender_randomness: Digest,
+    pub(crate) receiver_digest: Digest,
+}
+
+impl UtxoTriple {
+    pub(crate) fn addition_record(&self) -> AdditionRecord {
+        commit(
+            Tip5::hash(&self.utxo),
+            self.sender_randomness,
+            self.receiver_digest,
+        )
+    }
+
+    pub(crate) fn utxo(&self) -> Utxo {
+        self.utxo.clone()
+    }
+}
+
+impl From<TxOutput> for UtxoTriple {
+    fn from(value: TxOutput) -> Self {
+        Self {
+            utxo: value.utxo(),
+            sender_randomness: value.sender_randomness(),
+            receiver_digest: value.receiver_digest(),
+        }
+    }
+}

--- a/src/models/state/wallet/address/mod.rs
+++ b/src/models/state/wallet/address/mod.rs
@@ -104,8 +104,7 @@ mod tests {
     mod worker {
         use super::*;
         use crate::models::blockchain::transaction::transaction_kernel::TransactionKernelModifier;
-        use crate::prelude::twenty_first::prelude::Tip5;
-        use crate::util_types::mutator_set::commit;
+        use crate::models::blockchain::transaction::utxo_triple::UtxoTriple;
 
         /// this tests the generate_announcement() and
         /// scan_for_announced_utxos() methods with a [SpendingKey]
@@ -124,11 +123,12 @@ mod tests {
             let sender_randomness: Digest = random();
 
             // 3. create an addition record to verify against later.
-            let expected_addition_record = commit(
-                Tip5::hash(&utxo),
+            let utxo_triple = UtxoTriple {
+                utxo: utxo.clone(),
                 sender_randomness,
-                key.to_address().privacy_digest(),
-            );
+                receiver_digest: key.to_address().privacy_digest(),
+            };
+            let expected_addition_record = utxo_triple.addition_record();
 
             // 4. create a mock tx with no inputs or outputs
             let mut mock_tx = make_mock_transaction(vec![], vec![]);

--- a/src/models/state/wallet/expected_utxo.rs
+++ b/src/models/state/wallet/expected_utxo.rs
@@ -5,12 +5,11 @@ use serde::Deserialize;
 use serde::Serialize;
 use twenty_first::prelude::Digest;
 
-use crate::models::blockchain::shared::Hash;
 use crate::models::blockchain::transaction::utxo::Utxo;
+use crate::models::blockchain::transaction::utxo_triple::UtxoTriple;
 use crate::models::proof_abstractions::timestamp::Timestamp;
 use crate::prelude::twenty_first;
 use crate::util_types::mutator_set::addition_record::AdditionRecord;
-use crate::util_types::mutator_set::commit;
 
 /// represents utxo and secrets necessary for recipient to claim it.
 ///
@@ -65,11 +64,12 @@ impl ExpectedUtxo {
         received_from: UtxoNotifier,
     ) -> Self {
         Self {
-            addition_record: commit(
-                Hash::hash(&utxo),
+            addition_record: UtxoTriple {
+                utxo: utxo.clone(),
                 sender_randomness,
-                receiver_preimage.hash(),
-            ),
+                receiver_digest: receiver_preimage.hash(),
+            }
+            .addition_record(),
             utxo,
             sender_randomness,
             receiver_preimage,

--- a/src/models/state/wallet/incoming_utxo.rs
+++ b/src/models/state/wallet/incoming_utxo.rs
@@ -5,10 +5,9 @@ use tasm_lib::prelude::Digest;
 use super::expected_utxo::UtxoNotifier;
 use super::utxo_notification::UtxoNotificationPayload;
 use crate::models::blockchain::transaction::utxo::Utxo;
+use crate::models::blockchain::transaction::utxo_triple::UtxoTriple;
 use crate::models::state::ExpectedUtxo;
-use crate::models::state::Tip5;
 use crate::util_types::mutator_set::addition_record::AdditionRecord;
-use crate::util_types::mutator_set::commit;
 
 /// A [`Utxo`] along with associated data necessary for a recipient to claim it.
 ///
@@ -39,12 +38,15 @@ impl From<&ExpectedUtxo> for IncomingUtxo {
 }
 
 impl IncomingUtxo {
+    pub(crate) fn utxo_triple(&self) -> UtxoTriple {
+        UtxoTriple {
+            utxo: self.utxo.clone(),
+            sender_randomness: self.sender_randomness,
+            receiver_digest: self.receiver_preimage.hash(),
+        }
+    }
     pub(crate) fn addition_record(&self) -> AdditionRecord {
-        commit(
-            Tip5::hash(&self.utxo),
-            self.sender_randomness,
-            self.receiver_preimage.hash(),
-        )
+        self.utxo_triple().addition_record()
     }
 
     /// Returns true iff this UTXO is a guesser reward.

--- a/src/models/state/wallet/transaction_output.rs
+++ b/src/models/state/wallet/transaction_output.rs
@@ -8,9 +8,9 @@ use serde::Serialize;
 
 use super::utxo_notification::UtxoNotifyMethod;
 use crate::config_models::network::Network;
-use crate::models::blockchain::shared::Hash;
 use crate::models::blockchain::transaction::announcement::Announcement;
 use crate::models::blockchain::transaction::utxo::Utxo;
+use crate::models::blockchain::transaction::utxo_triple::UtxoTriple;
 use crate::models::blockchain::type_scripts::native_currency_amount::NativeCurrencyAmount;
 use crate::models::proof_abstractions::timestamp::Timestamp;
 use crate::models::state::wallet::address::ReceivingAddress;
@@ -22,7 +22,6 @@ use crate::models::state::wallet::utxo_notification::UtxoNotificationPayload;
 use crate::models::state::wallet::wallet_state::WalletState;
 use crate::prelude::twenty_first::prelude::Digest;
 use crate::util_types::mutator_set::addition_record::AdditionRecord;
-use crate::util_types::mutator_set::commit;
 
 /// represents a transaction output, as used by
 /// [TransactionDetailsBuilder](crate::api::tx_initiation::builder::transaction_details_builder::TransactionDetailsBuilder)
@@ -92,14 +91,9 @@ mod fix_552 {
 }
 */
 
-impl From<&TxOutput> for AdditionRecord {
-    /// retrieves announcements from possible sub-set of the list
-    fn from(txo: &TxOutput) -> Self {
-        commit(
-            Hash::hash(&txo.utxo),
-            txo.sender_randomness,
-            txo.receiver_digest,
-        )
+impl TxOutput {
+    fn addition_record(&self) -> AdditionRecord {
+        UtxoTriple::from(self.clone()).addition_record()
     }
 }
 
@@ -544,7 +538,7 @@ impl TxOutputList {
 
     /// retrieves addition_records
     pub fn addition_records_iter(&self) -> impl IntoIterator<Item = AdditionRecord> + '_ {
-        self.0.iter().map(|u| u.into())
+        self.0.iter().map(|u| u.addition_record())
     }
 
     /// retrieves addition_records


### PR DESCRIPTION
This PR is a follow-up to #630 (assuming that that will be merged mostly without changes) but conceptually separate.

Introduce a new type `UtxoTriple` containing the preimage to the addition record -- which is to say, the UTXO, the sender randomness, and the receiver digest. This triple appears all over the place. Now it has a name. As a side effect, many calls to `mutator_set::commit` can now be funneled through the new struct: 1) create a `UtxoTriple` object, and 2) invoke convenience function `addition_record()`.

This type does not already exist. Near misses:
 - `TxOutput` -- contains other fields.
 - `IncomingUtxo` -- contains the receiver *preimage* not receiver *digest*.
 - `ExpectedUtxo` -- both.
