### PR TITLE
feat: add dump-db command to neptune-cli

### DIFF
--- a/src/bin/neptune-cli.rs
+++ b/src/bin/neptune-cli.rs
@@ -21,6 +21,8 @@ use itertools::Itertools;
 use neptune_cash::api::tx_initiation::builder::tx_output_list_builder::OutputFormat;
 use neptune_cash::config_models::data_directory::DataDirectory;
 use neptune_cash::config_models::network::Network;
+use neptune_cash::database::storage::storage_schema::RustyKey;
+use neptune_cash::database::NeptuneLevelDb;
 use neptune_cash::models::blockchain::block::block_selector::BlockSelector;
 use neptune_cash::models::blockchain::type_scripts::native_currency_amount::NativeCurrencyAmount;
 use neptune_cash::models::state::wallet::address::KeyType;
@@ -37,6 +39,8 @@ use neptune_cash::models::state::wallet::wallet_status::WalletStatusExportFormat
 use neptune_cash::rpc_auth;
 use neptune_cash::rpc_server::error::RpcError;
 use neptune_cash::rpc_server::RPCClient;
+
+use neptune_cash::database::storage::storage_schema::RustyValue;
 use rand::Rng;
 use regex::Regex;
 use serde::Deserialize;
@@ -124,6 +128,27 @@ impl TransactionOutput {
     }
 }
 
+#[derive(Debug, Clone, Parser, strum::EnumIs, clap::ValueEnum)]
+enum LevelDbStore {
+    ArchivalBlockMmr,
+    BannedIps,
+    BlockIndex,
+    MutatorSet,
+    Wallet,
+}
+
+impl LevelDbStore {
+    pub fn dir(&self, data_dir: &DataDirectory) -> PathBuf {
+        match *self {
+            Self::ArchivalBlockMmr => data_dir.archival_block_mmr_dir_path(),
+            Self::BannedIps => data_dir.banned_ips_database_dir_path(),
+            Self::BlockIndex => data_dir.block_index_database_dir_path(),
+            Self::MutatorSet => data_dir.mutator_set_database_dir_path(),
+            Self::Wallet => data_dir.wallet_database_dir_path(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Parser)]
 enum Command {
     /// Dump shell completions.
@@ -158,6 +183,12 @@ enum Command {
 
     /// retrieve info about peers
     PeerInfo,
+
+    /// dump all key/val pairs in the indicated database
+    DumpDb {
+        network: Network,
+        db_store: LevelDbStore,
+    },
 
     /// retrieve list of punished peers
     AllPunishedPeers,
@@ -723,6 +754,22 @@ async fn main() -> Result<()> {
 
             return Ok(());
         }
+
+        Command::DumpDb { network, db_store } => {
+            let data_dir = DataDirectory::get(args.data_dir.clone(), *network)?;
+            let dir_path = db_store.dir(&data_dir);
+
+            match NeptuneLevelDb::<RustyKey, RustyValue>::new(
+                &dir_path,
+                &leveldb::options::Options::new(),
+            )
+            .await
+            {
+                Ok(db) => db.dump_database().await,
+                Err(e) => eprintln!("Unable to open database. {}", e),
+            }
+            return Ok(());
+        }
         _ => {}
     }
 
@@ -768,6 +815,7 @@ async fn main() -> Result<()> {
         | Command::ShamirCombine { .. }
         | Command::ShamirShare { .. }
         | Command::NthReceivingAddress { .. }
+        | Command::DumpDb { .. }
         | Command::PremineReceivingAddress { .. } => {
             unreachable!("Case should be handled earlier.")
         }


### PR DESCRIPTION
context: 

I added this command to neptune-cli in case it is helpful for debugging issues with user's databases.

Both keys and values are stored as bytes inside level-db and are output (dumped) as hex encoded byte strings, with a space between each byte so it is easy to see visually identify each byte.

It requires an understanding of the expected data types to interpret the dumped data.

Example usage and output:

```
target/debug/neptune-cli dump-db testnet wallet`
Key (hex): 01 00 00 00 00 00 00 00 00
Value (hex): 28 00 00 00 00 00 00 00 d9 86 e9 b2 29 83 1f 77 9c ee 1a 55 6f 2a 63 d2 46 31 55 9e b9 b3 bb 8c 3d ac a8 d6 5d 1f 66 ac ca 1d 10 02 66 98 ad a8

Key (hex): 01 00 00 00 00 00 00 00 03
Value (hex): 28 00 00 00 00 00 00 00 d9 86 e9 b2 29 83 1f 77 9c ee 1a 55 6f 2a 63 d2 46 31 55 9e b9 b3 bb 8c 3d ac a8 d6 5d 1f 66 ac ca 1d 10 02 66 98 ad a8

Key (hex): 01 00 00 00 00 00 00 00 05
Value (hex): 08 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00

Key (hex): 01 00 00 00 00 00 00 00 06
Value (hex): 08 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00

Key (hex): 01 00 00 00 00 00 00 00 08
Value (hex): 02 00 00 00 00 00 00 00 01 00
```

commit message follows.

-----------------

This command enables dumping key/val pairs of all values in a given leveldb database as hex.

```
Usage: neptune-cli dump-db <NETWORK> <DB_STORE>

Arguments:
  <NETWORK>
  <DB_STORE>  [possible values: archival-block-mmr, banned-ips, block-index, mutator-set, wallet]
```