### PR TITLE
test: re-enable test that first blk-file contains valid blocks

### DIFF
--- a/neptune-core/src/models/blockchain/block/mod.rs
+++ b/neptune-core/src/models/blockchain/block/mod.rs
@@ -1243,12 +1243,6 @@ pub(crate) mod tests {
     pub(crate) const PREMINE_MAX_SIZE: NativeCurrencyAmount = NativeCurrencyAmount::coins(831488);
 
     impl Block {
-        pub(crate) fn with_difficulty(mut self, difficulty: Difficulty) -> Self {
-            self.kernel.header.difficulty = difficulty;
-            self.unset_digest();
-            self
-        }
-
         pub(crate) fn set_proof(&mut self, proof: BlockProof) {
             self.proof = proof;
             self.unset_digest();

--- a/neptune-core/src/models/state/mod.rs
+++ b/neptune-core/src/models/state/mod.rs
@@ -1951,7 +1951,7 @@ impl GlobalState {
     /// where blocks are mined locally or received from peers.
     ///
     /// Returns the number of blocks read from the directory.
-    pub(crate) async fn import_blocks_from_directory(
+    pub async fn import_blocks_from_directory(
         &mut self,
         directory: &Path,
         flush_period: usize,
@@ -4223,14 +4223,9 @@ mod tests {
     }
 
     mod import_blocks_from_directory {
-        use std::fs::File;
-        use std::io::Write;
 
         use super::*;
         use crate::tests::shared::blocks::invalid_empty_blocks_with_proof_size;
-        use crate::tests::shared::files::test_helper_data_dir;
-        use crate::tests::shared::files::try_fetch_file_from_server;
-        use crate::tests::shared::globalstate::mock_genesis_global_state_with_block;
 
         async fn state_with_three_big_mocked_blocks(network: Network) -> GlobalStateLock {
             // Ensure more than one file is used to store blocks.
@@ -4327,77 +4322,6 @@ mod tests {
                     .await
                     .synced_unspent,
                 "Restored wallet state must agree with original state"
-            );
-        }
-
-        // TODO: Remove this ignore ASAP
-        #[ignore = "ignore until we have enough blocks on reboot"]
-        #[traced_test]
-        #[apply(shared_tokio_runtime)]
-        async fn can_restore_from_real_mainnet_data_with_reorganizations() {
-            let expected_blk_files = ["blk0.dat"];
-            let network = Network::Main;
-
-            // We need to override difficulty since it's different when the
-            // test flag is set. We need the real main net block.
-            let mainnets_real_genesis_block =
-                Block::genesis(network).with_difficulty(network.genesis_difficulty());
-
-            // Use at least four MPs per UTXO, otherwise they get unsynced.
-            let cli = cli_args::Args {
-                network,
-                number_of_mps_per_utxo: 4,
-                ..Default::default()
-            };
-            let peer_count = 0;
-
-            let mut state = mock_genesis_global_state_with_block(
-                peer_count,
-                WalletEntropy::devnet_wallet(),
-                cli,
-                mainnets_real_genesis_block,
-            )
-            .await;
-            let mut state = state.lock_guard_mut().await;
-
-            // Are the required blk files present on disk? If not, fetch them
-            // from a server.
-            let test_data_dir = test_helper_data_dir();
-            for blk_file_name in expected_blk_files {
-                let mut path = test_data_dir.clone();
-                path.push(blk_file_name);
-                if File::open(&path).is_err() {
-                    // Try fetching file from server and write it to disk.
-                    let (file, _server) = try_fetch_file_from_server(blk_file_name.to_owned())
-                        .unwrap_or_else(|| {
-                            panic!("File {blk_file_name} must be available from a server")
-                        });
-                    let mut f = File::create_new(&path).unwrap();
-                    f.write_all(&file).unwrap();
-                }
-            }
-
-            let validate_blocks = true;
-            state
-                .import_blocks_from_directory(&test_data_dir, 0, validate_blocks)
-                .await
-                .unwrap();
-            let restored_block_height = state.chain.light_state().header().height;
-            assert_eq!(
-                BlockHeight::new(bfe!(113)),
-                restored_block_height,
-                "Expected block height not reached in state-recovery"
-            );
-
-            let wallet_status = state.get_wallet_status_for_tip().await;
-            let balance = state.wallet_state.confirmed_available_balance(
-                &wallet_status,
-                network.launch_date() + Timestamp::months(7),
-            );
-            assert_eq!(
-                NativeCurrencyAmount::coins(20),
-                balance,
-                "Expected balance must be available after state-recovery"
             );
         }
     }

--- a/neptune-core/src/models/state/wallet/mod.rs
+++ b/neptune-core/src/models/state/wallet/mod.rs
@@ -15,7 +15,7 @@ pub(crate) mod unlocked_utxo;
 pub mod utxo_notification;
 pub(crate) mod wallet_configuration;
 pub(crate) mod wallet_db_tables;
-pub(crate) mod wallet_entropy;
+pub mod wallet_entropy;
 pub mod wallet_file;
 pub(crate) mod wallet_state;
 pub mod wallet_status;

--- a/neptune-core/src/models/state/wallet/wallet_entropy.rs
+++ b/neptune-core/src/models/state/wallet/wallet_entropy.rs
@@ -33,7 +33,7 @@ impl WalletEntropy {
     }
 
     /// Create a `WalletEntropy` object with a fixed digest
-    pub(crate) fn devnet_wallet() -> Self {
+    pub fn devnet_wallet() -> Self {
         let secret_seed = SecretKeyMaterial(xfe!([
             12063201067205522823_u64,
             1529663126377206632_u64,

--- a/neptune-core/tests/common/genesis_node.rs
+++ b/neptune-core/tests/common/genesis_node.rs
@@ -49,8 +49,12 @@ impl GenesisNode {
 
     /// provides default neptune-core cli arguments for typical integration tests.
     pub fn default_args() -> Args {
+        Self::default_args_with_network(Network::RegTest)
+    }
+
+    pub fn default_args_with_network(network: Network) -> Args {
         let mut args = Args::default();
-        args.network = Network::RegTest;
+        args.network = network;
 
         // ensure we bind to localhost so windows firewall does not prevent/block
         args.listen_addr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));

--- a/neptune-core/tests/consensus_rules_unchanged.rs
+++ b/neptune-core/tests/consensus_rules_unchanged.rs
@@ -40,7 +40,7 @@ pub fn genesis_block_hasnt_changed_testnet_0() {
     );
 }
 
-/// test: Verify that first ~120 blocks on main net are still considered valid,
+/// test: Verify that first ~250 blocks on main net are still considered valid,
 /// and that a global state can be restored from it.
 #[tokio::test(flavor = "multi_thread")]
 async fn can_restore_from_real_mainnet_data_with_reorganizations() {
@@ -183,7 +183,7 @@ async fn can_restore_from_real_mainnet_data_with_reorganizations() {
 
     logging::tracing_logger();
 
-    let expected_blk_files = ["blk0.dat"];
+    let expected_blk_files = ["blk0.dat", "blk1.dat"];
 
     let network = Network::Main;
     let cli = GenesisNode::default_args_with_network_and_devnet_wallet(network).await;
@@ -212,8 +212,9 @@ async fn can_restore_from_real_mainnet_data_with_reorganizations() {
         .await
         .unwrap();
     let restored_block_height = state.chain.light_state().header().height;
+    println!("restored_block_height: {restored_block_height}");
     assert_eq!(
-        BlockHeight::new(bfe!(127)),
+        BlockHeight::new(bfe!(250)),
         restored_block_height,
         "Expected block height not reached in state-recovery. Reached: {restored_block_height}"
     );

--- a/neptune-core/tests/consensus_rules_unchanged.rs
+++ b/neptune-core/tests/consensus_rules_unchanged.rs
@@ -1,5 +1,24 @@
+mod common;
+
+use std::fs::File;
+use std::io::Read;
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use neptune_cash::api::export::BlockHeight;
 use neptune_cash::api::export::Network;
 use neptune_cash::models::blockchain::block::Block;
+use tasm_lib::twenty_first::math::b_field_element::BFieldElement;
+
+use common::logging;
+use rand::seq::SliceRandom;
+use tasm_lib::twenty_first::bfe;
+use tracing::debug;
+use tracing::Span;
+
+use crate::common::genesis_node::GenesisNode;
 
 /// test: Verify that the genesis block on main net has not changed.
 #[test]
@@ -16,5 +35,182 @@ pub fn genesis_block_hasnt_changed_testnet_0() {
     assert_eq!(
         "bb1fa49a35a294dd2c09811c648c4d76f6ea17acc61fe7a6f1c3c8d81c967bc68e7cdb41f472544e",
         Block::genesis(Network::Testnet(0)).hash().to_hex()
+    );
+}
+
+/// test: Verify that first ~120 blocks on main net are still considered valid,
+/// and that a global state can be restored from it.
+#[tokio::test(flavor = "multi_thread")]
+async fn can_restore_from_real_mainnet_data_with_reorganizations() {
+    // TODO: Local functions copied from elsewhere because
+    // they're under the test flag the other place. Solution?
+    fn test_helper_data_dir() -> PathBuf {
+        const TEST_DATA_DIR_NAME: &str = "test_data/";
+        let mut path = PathBuf::new();
+        path.push(TEST_DATA_DIR_NAME);
+        path
+    }
+
+    fn try_fetch_file_from_server(filename: String) -> Option<(Vec<u8>, String)> {
+        const TEST_NAME_HTTP_HEADER_KEY: &str = "Test-Name";
+
+        fn get_test_name_from_tracing() -> String {
+            match Span::current().metadata().map(|x| x.name()) {
+                Some(test_name) => test_name.to_owned(),
+                None => "unknown".to_owned(),
+            }
+        }
+
+        fn attempt_to_get_test_name() -> String {
+            let thread = std::thread::current();
+            match thread.name() {
+                Some(test_name) => {
+                    if test_name.eq("tokio-runtime-worker") {
+                        get_test_name_from_tracing()
+                    } else {
+                        test_name.to_owned()
+                    }
+                }
+                None => get_test_name_from_tracing(),
+            }
+        }
+
+        fn load_servers() -> Vec<String> {
+            let mut server_list_path = test_helper_data_dir();
+            server_list_path.push(Path::new("proof_servers").with_extension("txt"));
+            let Ok(mut input_file) = File::open(server_list_path.clone()) else {
+                debug!(
+                    "cannot proof-server list '{}' -- file might not exist",
+                    server_list_path.display()
+                );
+                return vec![];
+            };
+            let mut file_contents = vec![];
+            if input_file.read_to_end(&mut file_contents).is_err() {
+                debug!("cannot read file '{}'", server_list_path.display());
+                return vec![];
+            }
+            let Ok(file_as_string) = String::from_utf8(file_contents) else {
+                debug!(
+                    "cannot parse file '{}' -- is it valid utf8?",
+                    server_list_path.display()
+                );
+                return vec![];
+            };
+            file_as_string.lines().map(|s| s.to_string()).collect()
+        }
+
+        let mut servers = load_servers();
+        servers.shuffle(&mut rand::rng());
+
+        // Add test name to request allow server to see which test requires this
+        // file.
+        let mut headers = clienter::HttpHeaders::default();
+        headers.insert(
+            TEST_NAME_HTTP_HEADER_KEY.to_string(),
+            attempt_to_get_test_name(),
+        );
+
+        for server in servers {
+            let server_ = server.clone();
+            let filename_ = filename.clone();
+            let headers_ = headers.clone();
+            let handle = std::thread::spawn(move || {
+                let url = format!("{}{}", server_, filename_);
+
+                debug!("requesting: <{url}>");
+
+                let uri: clienter::Uri = url.into();
+
+                let mut http_client = clienter::HttpClient::new();
+                http_client.timeout = Some(Duration::from_secs(10));
+                http_client.headers = headers_;
+                let request = http_client.request(clienter::HttpMethod::GET, uri);
+
+                // note: send() blocks
+                let Ok(mut response) = http_client.send(&request) else {
+                    println!(
+                        "server '{}' failed for file '{}'; trying next ...",
+                        server_.clone(),
+                        filename_
+                    );
+
+                    return None;
+                };
+
+                // only retrieve body if we got a 2xx code.
+                // addresses #477
+                // https://github.com/Neptune-Crypto/neptune-core/issues/477
+                let body = if response.status.is_success() {
+                    response.body()
+                } else {
+                    Ok(vec![])
+                };
+
+                Some((response.status, body))
+            });
+
+            let Some((status_code, body)) = handle.join().unwrap() else {
+                eprintln!("Could not connect to server {server}.");
+                continue;
+            };
+
+            if !status_code.is_success() {
+                eprintln!("{server} responded with {status_code}");
+                continue;
+            }
+
+            let Ok(file_contents) = body else {
+                eprintln!(
+                    "error reading file '{}' from server '{}'; trying next ...",
+                    filename, server
+                );
+
+                continue;
+            };
+
+            return Some((file_contents, server));
+        }
+
+        println!("No known servers serve file `{}`", filename);
+
+        None
+    }
+
+    logging::tracing_logger();
+
+    let expected_blk_files = ["blk0.dat"];
+
+    let network = Network::Main;
+    let cli = GenesisNode::default_args_with_network(network);
+    let mut alice = GenesisNode::start_node(cli).await.unwrap();
+
+    let mut state = alice.gsl.lock_guard_mut().await;
+
+    // Are the required blk files present on disk? If not, fetch them
+    // from a server.
+    let test_data_dir = test_helper_data_dir();
+    for blk_file_name in expected_blk_files {
+        let mut path = test_data_dir.clone();
+        path.push(blk_file_name);
+        if File::open(&path).is_err() {
+            // Try fetching file from server and write it to disk.
+            let (file, _server) = try_fetch_file_from_server(blk_file_name.to_owned())
+                .unwrap_or_else(|| panic!("File {blk_file_name} must be available from a server"));
+            let mut f = File::create_new(&path).unwrap();
+            f.write_all(&file).unwrap();
+        }
+    }
+
+    let validate_blocks = true;
+    state
+        .import_blocks_from_directory(&test_data_dir, 0, validate_blocks)
+        .await
+        .unwrap();
+    let restored_block_height = state.chain.light_state().header().height;
+    assert_eq!(
+        BlockHeight::new(bfe!(124)),
+        restored_block_height,
+        "Expected block height not reached in state-recovery. Reached: {restored_block_height}"
     );
 }


### PR DESCRIPTION
Since the block structure is different in production from what it is under the test flag, this tests, that checks the validity of the first ~120 mainnet blocks, cannot live under the test flag. So it's added as an integration test.

Unfortunately some test helper function were needed for this test to work, and since they can't be under the test flag, they are added as local functions in the new test. The alternative seems to be to pull the test helper functions in question out from under the test flag but that would require new dependencies in production code (namely HTTP client 'clienter') which I think is not preferable. So local functions was the best compromise I could come up with. Happy to have other people give me better ideas.