### PR TITLE
feat: padded height specific tvm env vars

### DIFF
--- a/neptune-core/src/api/tx_initiation/builder/triton_vm_proof_job_options_builder.rs
+++ b/neptune-core/src/api/tx_initiation/builder/triton_vm_proof_job_options_builder.rs
@@ -1,6 +1,7 @@
 //! This module implements a builder for [TritonVmProofJobOptions]
 
 use crate::config_models::network::Network;
+use crate::config_models::triton_vm_env_vars::TritonVmEnvVars;
 use crate::models::blockchain::transaction::transaction_proof::TransactionProofType;
 use crate::models::proof_abstractions::tasm::program::TritonVmProofJobOptions;
 use crate::models::proof_abstractions::tasm::prover_job::ProverJobSettings;
@@ -62,6 +63,7 @@ pub struct TritonVmProofJobOptionsBuilder {
     network: Option<Network>,
     tx_proving_capability: Option<TxProvingCapability>,
     proof_type: Option<TransactionProofType>,
+    triton_vm_env_vars: TritonVmEnvVars,
 }
 
 impl TritonVmProofJobOptionsBuilder {
@@ -215,6 +217,7 @@ impl TritonVmProofJobOptionsBuilder {
             network,
             tx_proving_capability,
             proof_type,
+            triton_vm_env_vars,
         } = self;
 
         let job_priority = job_priority.unwrap_or_default();
@@ -227,6 +230,7 @@ impl TritonVmProofJobOptionsBuilder {
             network,
             tx_proving_capability,
             proof_type,
+            triton_vm_env_vars,
         };
 
         TritonVmProofJobOptions {

--- a/neptune-core/src/config_models/mod.rs
+++ b/neptune-core/src/config_models/mod.rs
@@ -2,3 +2,4 @@ pub mod cli_args;
 pub mod data_directory;
 pub(crate) mod fee_notification_policy;
 pub mod network;
+pub mod triton_vm_env_vars;

--- a/neptune-core/src/config_models/triton_vm_env_vars.rs
+++ b/neptune-core/src/config_models/triton_vm_env_vars.rs
@@ -1,0 +1,128 @@
+use std::collections::HashMap;
+use std::str::FromStr;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+/// A mapping from log2 padded height to the environment variables to set for
+/// the Triton VM proving process for proofs of this size.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct TritonVmEnvVars(HashMap<u8, Vec<(String, String)>>);
+
+impl FromStr for TritonVmEnvVars {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            return Ok(Self::default());
+        }
+
+        let mut map = HashMap::new();
+
+        // Split by commas to separate the u8:"VAR1=VAL1 VAR2=VAL2" entries
+        for entry in s.split(',') {
+            let (key_str, vars_str) = entry
+                .split_once(':')
+                .ok_or_else(|| format!("TVM env var: Invalid entry (missing ':'): '{}'", entry))?;
+
+            let key: u8 = key_str
+                .trim()
+                .parse()
+                .map_err(|_| format!("TVM env var: Invalid u8 key: '{}'", key_str))?;
+            if !(8..=31).contains(&key) {
+                return Err(format!("TVM env var: {key} not in range 8..=31"));
+            }
+
+            // Remove optional surrounding quotes from vars_str
+            let vars_str = vars_str.trim();
+            let vars_str = vars_str
+                .strip_prefix('"')
+                .and_then(|v| v.strip_suffix('"'))
+                .unwrap_or(vars_str);
+            let vars_str = vars_str
+                .strip_prefix("'")
+                .and_then(|v| v.strip_suffix("'"))
+                .unwrap_or(vars_str);
+
+            // Split space-separated VAR=VAL pairs
+            let mut pairs = Vec::new();
+            for var_val in vars_str.split_whitespace() {
+                let (var, val) = var_val
+                    .split_once('=')
+                    .ok_or_else(|| format!("TVM env var: Invalid VAR=VAL: '{}'", var_val))?;
+                pairs.push((var.to_string(), val.to_string()));
+            }
+
+            map.insert(key, pairs);
+        }
+
+        Ok(TritonVmEnvVars(map))
+    }
+}
+
+impl TritonVmEnvVars {
+    pub fn get(&self, log2_padded_height: &u8) -> Option<&Vec<(String, String)>> {
+        self.0.get(log2_padded_height)
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn parses_no_entries() {
+        let parsed = TritonVmEnvVars::from_str("").unwrap();
+        assert_eq!(HashMap::default(), parsed.0);
+    }
+
+    #[test]
+    fn parses_single_entry() {
+        let input = r#"24:"RAYON_NUM_THREADS=50 TVM_LDE_TRACE=no_cache""#;
+        let parsed = TritonVmEnvVars::from_str(input).unwrap();
+
+        let mut expected = HashMap::new();
+        expected.insert(
+            24,
+            vec![
+                ("RAYON_NUM_THREADS".to_string(), "50".to_string()),
+                ("TVM_LDE_TRACE".to_string(), "no_cache".to_string()),
+            ],
+        );
+
+        assert_eq!(expected, parsed.0);
+    }
+
+    #[test]
+    fn parses_multiple_entries() {
+        let input = r#"24:"RAYON_NUM_THREADS=50 TVM_LDE_TRACE=no_cache",25:"RAYON_NUM_THREADS=20 TVM_LDE_TRACE=no_cache""#;
+        let parsed = TritonVmEnvVars::from_str(input).unwrap();
+
+        let mut expected = HashMap::new();
+        expected.insert(
+            24,
+            vec![
+                ("RAYON_NUM_THREADS".to_string(), "50".to_string()),
+                ("TVM_LDE_TRACE".to_string(), "no_cache".to_string()),
+            ],
+        );
+        expected.insert(
+            25,
+            vec![
+                ("RAYON_NUM_THREADS".to_string(), "20".to_string()),
+                ("TVM_LDE_TRACE".to_string(), "no_cache".to_string()),
+            ],
+        );
+
+        assert_eq!(expected, parsed.0);
+    }
+}

--- a/neptune-core/src/models/proof_abstractions/tasm/program.rs
+++ b/neptune-core/src/models/proof_abstractions/tasm/program.rs
@@ -189,6 +189,7 @@ pub mod tests {
 
     use super::*;
     use crate::api::export::Network;
+    use crate::config_models::triton_vm_env_vars::TritonVmEnvVars;
     use crate::models::blockchain::shared::Hash;
     use crate::models::blockchain::transaction::transaction_proof::TransactionProofType;
     use crate::models::proof_abstractions::tasm::environment;
@@ -237,6 +238,7 @@ pub mod tests {
                     network: Default::default(),
                     tx_proving_capability: TxProvingCapability::SingleProof,
                     proof_type: TransactionProofType::SingleProof,
+                    triton_vm_env_vars: TritonVmEnvVars::default(),
                 },
                 cancel_job_rx: None,
             }


### PR DESCRIPTION
Allow the user to specify a list of environment variables for a given padded height. This allows the user to build bigger proofs than they otherwise could by ensuring that very big proofs can be generated without running out of RAM. On our machines, values like "24:RAYON_NUM_THREADS=50 TVM_LDE_TRACE=no_cache" allow for the construction of proofs of a log2 padded height of 24, a proof generation that would otherwise use more than the available RAM. Powerusers can play around with these values to find their optimal setup.