### PR TITLE
fix: ensure block data written before db

### DIFF
--- a/neptune-core/src/models/state/mod.rs
+++ b/neptune-core/src/models/state/mod.rs
@@ -662,11 +662,13 @@ impl GlobalState {
         cli: cli_args::Args,
         wallet_state: WalletState,
     ) -> Result<Self> {
-        let archival_state = ArchivalState::new(data_directory.clone(), genesis, cli.network).await;
+        let mut archival_state =
+            ArchivalState::new(data_directory.clone(), genesis, cli.network).await;
         debug!("Got archival state");
 
         // Get latest block. Use hardcoded genesis block if nothing is in database.
-        let latest_block: Block = archival_state.get_tip().await;
+        let max_tip_rollback = 1;
+        let latest_block: Block = archival_state.get_tip_or_rollback(max_tip_rollback).await?;
 
         let peer_map: HashMap<SocketAddr, PeerInfo> = HashMap::new();
         let peer_databases = NetworkingState::initialize_peer_databases(&data_directory).await?;


### PR DESCRIPTION
fixes #471

The issue was that block records were being written to DB before written to blkXX.dat files on disk, which resulted in mis-match when power is lost during a call to ArchivalState::store_block().  Upon startup, a SIGBUS occurs when reading the non-existent mmap'd data for the tip block that is referred to by the DB.

In the code it appears that the blkXX.dat files were being written first. However it was not flushing/syncing, and thus the OS is free to buffer for indeterminate amount of time, and in actuality the DB data was being written first.  (note that we use fsync flag for db writes).

Fixes:

1. root cause: calls mmap.flush() after writing block to ensure it is written to disk before writing matching record to DB.

2. avoid SIGBUS: verifies we do not attempt to read past end of file. Returns error with diagnostic info if so, which gets logged.

3. fix db: for situations where the mis-match has somehow occurred, it now detects the error and rolls the tip back by one block in the block_index DB in an attempt to fix.

---------------------

notes:

1. this PR is a bit quick/dirty.  Consider it a draft.   It fixed the issue for me, but does not include any tests.  Also, it would be nicer if get_tip_from_disk() would return an enum (thiserror) error for get_tip_or_rollback() to check instead of ugly check of err msg.

2. fix (3) is kind of optional.   With fixes (1) and (2) in place, theoretically it should never be necessary.  For me it was necessary because the DB was already borked.

3. fix (3) required two starts of neptune-core.  On the first start it fixed the block_index DB but then reported a mismatch with mutator-set DB and recommended to wipe all databases (yikes), and exited.   I started it a second time and everything loaded seemingly correctly and my wallet balance appears.

4. I have not tested that the mmap.flush() actually fixes the root cause.  However, it seems correct to me, and also I showed the code to an LLM that verified the problem and the fix.

5. reviewers:  edit/modify as you please.  I won't be making further changes to the PR.   It works for me to solve a problem, so I'm contributing it, but not going to spend further time on it.

