### PR TITLE
feat: add flag --restrict-peers-to-list

### DIFF
--- a/neptune-core/src/config_models/cli_args.rs
+++ b/neptune-core/src/config_models/cli_args.rs
@@ -83,6 +83,12 @@ pub struct Args {
     )]
     pub(crate) peer_tolerance: u16,
 
+    /// Only connect to the peers specified by --peer.
+    /// When this flag is set, peer discovery is disabled and
+    /// incoming connections from unlisted peers are rejected.
+    #[arg(long)]
+    pub restrict_peers_to_list: bool,
+
     /// Maximum number of peers to accept connections from.
     ///
     /// Will not prevent outgoing connections made with `--peers`.


### PR DESCRIPTION
## commit msg

When  --restrict-peers-to-list is present the node will avoid connecting to any peer that is not included in a --peer flag, nor will it accept a connection from any other peer, nor will it perform peer discovery.

It essentially turns --peer into a whitelist.

One use case is to have a single node on a subnet that connects to the outside world while all the subnet nodes connect to eachother.  Thus reducing bandwidth over external link and improving message propagation times to all local nodes.

## Notes

This is another "it's useful for me" change that I decided to contribute in case it may be useful for others.   no tests except that I observe it works correctly on my nodes:   I have a single node with connections to internet peers and other nodes that connect only to that peer and eachother.   So they all share a single WAN connection.   Have run it for about 48 hours and observe no internet peers connected to the nodes started with --restrict-peers-to-list, as intended.

I am running this against v0.3.0.   For the PR I applied the patch to master.   It passes cargo check and cargo fmt without issue, but I have not tested any further.

Feel free to modify PR in any way that suits project needs, or close it if not wanted.