### PR TITLE
composing node relays BlockProposal to peers

### DIFF
--- a/neptune-core/src/models/state/block_proposal.rs
+++ b/neptune-core/src/models/state/block_proposal.rs
@@ -74,7 +74,7 @@ impl BlockProposal {
 
 /// Enumerates the reason that a specific block proposal was rejected. The
 /// block proposal is most likely from another peer.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, strum::EnumIs)]
 pub(crate) enum BlockProposalRejectError {
     /// Denotes that this instance is itself composing blocks
     Composing,

--- a/neptune-core/src/models/state/mining_status.rs
+++ b/neptune-core/src/models/state/mining_status.rs
@@ -42,7 +42,7 @@ impl ComposingWorkInfo {
     }
 }
 
-#[derive(Debug, Default, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Copy, Clone, Serialize, Deserialize, strum::EnumIs)]
 pub enum MiningStatus {
     Guessing(GuessingWorkInfo),
     Composing(ComposingWorkInfo),


### PR DESCRIPTION
addresses #682

## commit msg

If a composing node has peers then it should still relay a BlockProposal to them even though the proposal is not useful to the node itself.

This is particulary useful when --restrict-peers-to-list is in use.

## notes

* without this, guessing nodes will not receive any BlockProposal if relying on composing node for internet comms.
* this is quick n dirty, made for my needs.  seems to work.  It could likely be more elegant.
* there is no CLI option to enable/disable relay behavior.  that could be added as per comments in #682
* feel free to edit however suits project's needs, or close if not wanted.
