### PR TITLE
feat: Add tx filter for proof upgrading

### DIFF
--- a/neptune-core/src/config_models/mod.rs
+++ b/neptune-core/src/config_models/mod.rs
@@ -3,3 +3,4 @@ pub mod data_directory;
 pub(crate) mod fee_notification_policy;
 pub mod network;
 pub mod triton_vm_env_vars;
+pub mod tx_upgrade_filter;

--- a/neptune-core/src/config_models/tx_upgrade_filter.rs
+++ b/neptune-core/src/config_models/tx_upgrade_filter.rs
@@ -1,0 +1,139 @@
+use std::str::FromStr;
+
+use tasm_lib::prelude::Digest;
+
+use crate::api::export::TransactionKernelId;
+
+/// Filter rule for TXIDs: Only upgrade transaction if
+/// `txid % divisor == remainder`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TxUpgradeFilter {
+    /// Divisor in `txid % divisor` expression.
+    divisor: u8,
+
+    /// Remainder after `txid % divisor` division. Must be less than
+    /// [`Self::divisor`].
+    remainder: u8,
+}
+
+impl FromStr for TxUpgradeFilter {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Support format "4:2"
+        let parts: Vec<&str> = s.split(':').collect();
+
+        if parts.len() != 2 {
+            return Err(format!(
+                "Expected two integers separated by ':', got '{}'",
+                s
+            ));
+        }
+
+        let divisor = parts[0].parse::<u8>().map_err(|e| e.to_string())?;
+        let remainder = parts[1].parse::<u8>().map_err(|e| e.to_string())?;
+
+        if remainder >= divisor {
+            return Err(format!(
+                "Invalid filter: remainder ({}) must be less than divisor ({})",
+                remainder, divisor
+            ));
+        }
+
+        if 0 == divisor {
+            return Err("Invalid filter: divisor may not be zero.".to_owned());
+        }
+
+        Ok(TxUpgradeFilter { divisor, remainder })
+    }
+}
+
+impl TxUpgradeFilter {
+    /// Return the transaction upgrade filter that matches all transactions.
+    pub(crate) fn match_all() -> Self {
+        Self {
+            divisor: 1u8,
+            remainder: 0u8,
+        }
+    }
+
+    pub(crate) fn matches(&self, txid: TransactionKernelId) -> bool {
+        let txid: Digest = txid.into();
+        let txid: [u8; Digest::BYTES] = txid.into();
+
+        txid.last().unwrap() % self.divisor == self.remainder
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::random;
+
+    use super::*;
+
+    #[test]
+    fn parses_valid_tx_filter() {
+        let f: TxUpgradeFilter = "4:2".parse().unwrap();
+        assert_eq!(f.divisor, 4);
+        assert_eq!(f.remainder, 2);
+    }
+
+    #[test]
+    fn parses_match_all_filter() {
+        assert_eq!(TxUpgradeFilter::match_all(), "1:0".parse().unwrap());
+    }
+
+    #[test]
+    fn rejects_invalid_tx_filter() {
+        let err = "4:7".parse::<TxUpgradeFilter>().unwrap_err();
+        assert!(
+            err.contains("remainder (7) must be less than divisor (4)"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn match_all_filter_matches_all() {
+        let num_tests = 50;
+
+        let match_all = TxUpgradeFilter::match_all();
+        for _ in 0..num_tests {
+            let txid: TransactionKernelId = random();
+            assert!(match_all.matches(txid));
+        }
+    }
+
+    #[test]
+    fn matches_half_filter_approximately_half_the_time() {
+        let mut matches_1st = 0;
+        let mut matches_2nd = 0;
+
+        let first = TxUpgradeFilter {
+            divisor: 2,
+            remainder: 0,
+        };
+        let second = TxUpgradeFilter {
+            divisor: 2,
+            remainder: 1,
+        };
+
+        let num_tests = 1000;
+        for _ in 0..num_tests {
+            let txid: TransactionKernelId = random();
+            if first.matches(txid) {
+                assert!(!second.matches(txid));
+                matches_1st += 1;
+            } else if second.matches(txid) {
+                assert!(!first.matches(txid));
+                matches_2nd += 1;
+            } else {
+                unreachable!("Math just broke");
+            }
+        }
+
+        // Probability of failure: Less than 10^(-35)
+        assert!(matches_1st < 700);
+        assert!(matches_2nd < 700);
+    }
+}

--- a/neptune-core/src/mine_loop.rs
+++ b/neptune-core/src/mine_loop.rs
@@ -31,6 +31,7 @@ use crate::api::tx_initiation::builder::transaction_proof_builder::TransactionPr
 use crate::api::tx_initiation::builder::triton_vm_proof_job_options_builder::TritonVmProofJobOptionsBuilder;
 use crate::api::tx_initiation::error::CreateProofError;
 use crate::config_models::network::Network;
+use crate::config_models::tx_upgrade_filter::TxUpgradeFilter;
 use crate::job_queue::errors::JobHandleError;
 use crate::main_loop::proof_upgrader::UpgradeJob;
 use crate::models::blockchain::block::block_header::BlockPow;
@@ -590,7 +591,7 @@ pub(crate) async fn create_block_transaction_from(
         let update_job = global_state_lock
             .lock_guard_mut()
             .await
-            .preferred_update_job_from_mempool(min_gobbling_fee)
+            .preferred_update_job_from_mempool(min_gobbling_fee, TxUpgradeFilter::match_all())
             .await;
         let update_job = update_job.map(UpgradeJob::UpdateMutatorSetData);
         if let Some(update_job) = update_job {
@@ -1043,6 +1044,7 @@ pub(crate) mod tests {
     use crate::config_models::cli_args;
     use crate::config_models::fee_notification_policy::FeeNotificationPolicy;
     use crate::config_models::network::Network;
+    use crate::config_models::tx_upgrade_filter::TxUpgradeFilter;
     use crate::job_queue::errors::JobHandleError;
     use crate::models::blockchain::block::mock_block_generator::MockBlockGenerator;
     use crate::models::blockchain::transaction::transaction_kernel::TransactionKernelProxy;
@@ -1279,7 +1281,7 @@ pub(crate) mod tests {
                 .lock_guard_mut()
                 .await
                 .mempool
-                .preferred_update()
+                .preferred_update(TxUpgradeFilter::match_all())
                 .is_some(),
             "Must have unsynced tx in mempool"
         );

--- a/neptune-core/src/models/blockchain/transaction/validity/proof_collection.rs
+++ b/neptune-core/src/models/blockchain/transaction/validity/proof_collection.rs
@@ -485,9 +485,30 @@ pub mod tests {
 
     use super::*;
     use crate::api::export::NativeCurrencyAmount;
+    use crate::api::export::NeptuneProof;
     use crate::models::proof_abstractions::tasm::program::tests::ConsensusProgramSpecification;
     use crate::tests::shared_tokio_runtime;
     use crate::triton_vm_job_queue::vm_job_queue;
+
+    impl ProofCollection {
+        /// Return an invalid proof collection for testing purposes
+        pub(crate) fn invalid() -> Self {
+            Self {
+                removal_records_integrity: NeptuneProof::invalid(),
+                collect_lock_scripts: NeptuneProof::invalid(),
+                lock_scripts_halt: vec![],
+                kernel_to_outputs: NeptuneProof::invalid(),
+                collect_type_scripts: NeptuneProof::invalid(),
+                type_scripts_halt: vec![],
+                lock_script_hashes: vec![],
+                type_script_hashes: vec![],
+                kernel_mast_hash: Digest::default(),
+                salted_inputs_hash: Digest::default(),
+                salted_outputs_hash: Digest::default(),
+                merge_bit_mast_path: vec![],
+            }
+        }
+    }
 
     #[traced_test]
     #[apply(shared_tokio_runtime)]

--- a/neptune-core/src/models/state/mod.rs
+++ b/neptune-core/src/models/state/mod.rs
@@ -73,6 +73,7 @@ use crate::api;
 use crate::api::export::NeptuneProof;
 use crate::config_models::cli_args;
 use crate::config_models::data_directory::DataDirectory;
+use crate::config_models::tx_upgrade_filter::TxUpgradeFilter;
 use crate::database::storage::storage_schema::traits::StorageWriter as SW;
 use crate::database::storage::storage_vec::traits::*;
 use crate::database::storage::storage_vec::Index;
@@ -2100,8 +2101,10 @@ impl GlobalState {
     pub(crate) async fn preferred_update_job_from_mempool(
         &mut self,
         min_gobbling_fee: NativeCurrencyAmount,
+        tx_upgrade_filter: TxUpgradeFilter,
     ) -> Option<UpdateMutatorSetDataJob> {
-        let (old_kernel, old_proof, upgrade_priority) = self.mempool.preferred_update()?;
+        let (old_kernel, old_proof, upgrade_priority) =
+            self.mempool.preferred_update(tx_upgrade_filter)?;
 
         let gobbling_potential = NativeCurrencyAmount::zero();
         let upgrade_incentive =


### PR DESCRIPTION
To avoid double work if the same entity is controlling multiple nodes that are performing proof upgrades, a filter is introduced. The filter looks at the `TransactionKernelId` value and performs a modulus operation and compares the remainder with that set in the filter. If the transaction is not a match, no proof upgrading is done (unless the node has a financial interest in the transaction).

If an entity is controlling three proof upgrading nodes, values for this filter could be set to "3:0" on the 1st machine, "3:1" on the 2nd, and "3:2" on the 3rd machine. This way, the entity avoids that the machines do duplicate work, *and* they cover all transactions on the network.