### PR TITLE
add granularity to `MainToMinerChannel::send`

### DIFF
--- a/neptune-core/src/main_loop.rs
+++ b/neptune-core/src/main_loop.rs
@@ -99,15 +99,11 @@ struct MainToMinerChannel(Option<mpsc::Sender<MainToMiner>>);
 
 impl MainToMinerChannel {
     /// Send a message to the miner task (if any).
-    fn send(&self, message: MainToMiner) {
-        // Do no use the async `send` function because it blocks until there
-        // is spare capacity on the channel. Messages to the miner are not
-        // critical so if there is no capacity left, just log an error
-        // message.
+    async fn send(&self, message: MainToMiner) {
         if let Some(channel) = &self.0 {
-            if let Err(e) = channel.try_send(message) {
-                error!("Failed to send pause message to miner thread:\n{e}");
-            }
+            if channel.capacity() > 0 {
+                channel.send(message).await.err().into_iter().for_each(|e| {error!("Failed to send pause message to miner thread:\n{e}")})
+            } else {tracing::warn!("no capacity to send to the miner: {message}")}
         }
     }
 }


### PR DESCRIPTION
@aszepieniec , Are you sure `capacity` is the reason? I mean if so, the `.await` from <commit:25495f17d880f422b75be001688838ef740314af> can be streamlined back; and if not: `await.` >> `try_` should be returned here. **The answer would promote the PR from draft.**