### PR TITLE
ci: Fix cmake version problem

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,7 +5,10 @@ rustflags = ["--cfg", "tokio_unstable"]
 
 [env]
 # workaround for rustc 1.80 running out of stack space when building triton-vm
-RUST_MIN_STACK="33554432"
-# so that anyhow errors automatically display stack trace
-RUST_BACKTRACE="1"
+RUST_MIN_STACK = "33554432"
 
+# so that anyhow errors automatically display stack trace
+RUST_BACKTRACE = "1"
+
+# workaround for dependency `leveldb-sys v2.0.9`
+CMAKE_POLICY_VERSION_MINIMUM = "3.5"


### PR DESCRIPTION
Implementing suggested fix in CI's build error message: Setting an environment variable to force a newer version of cmake to be used.

Error in CI:
```
 error: failed to run custom build command for `leveldb-sys v2.0.9`

Caused by:
  process didn't exit successfully: `/home/runner/work/neptune-core/neptune-core/target/debug/build/leveldb-sys-adc7eb3218f47677/build-script-build` (exit status: 101)
  --- stdout
  [build] Started
  [snappy] Building
  CMAKE_TOOLCHAIN_FILE_x86_64-unknown-linux-gnu = None
  CMAKE_TOOLCHAIN_FILE_x86_64_unknown_linux_gnu = None
  HOST_CMAKE_TOOLCHAIN_FILE = None
  CMAKE_TOOLCHAIN_FILE = None
  CMAKE_GENERATOR_x86_64-unknown-linux-gnu = None
  CMAKE_GENERATOR_x86_64_unknown_linux_gnu = None
  HOST_CMAKE_GENERATOR = None
  CMAKE_GENERATOR = None
  CMAKE_PREFIX_PATH_x86_64-unknown-linux-gnu = None
  CMAKE_PREFIX_PATH_x86_64_unknown_linux_gnu = None
  HOST_CMAKE_PREFIX_PATH = None
  CMAKE_PREFIX_PATH = None
  CMAKE_x86_64-unknown-linux-gnu = None
  CMAKE_x86_64_unknown_linux_gnu = None
  HOST_CMAKE = None
  CMAKE = None
  running: cd "/home/runner/work/neptune-core/neptune-core/target/debug/build/leveldb-sys-83a0fb7288cc3018/out/build" && CMAKE_PREFIX_PATH="" LC_ALL="C" "cmake" "/home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/leveldb-sys-2.0.9/deps/snappy-1.1.7" "-DBUILD_SHARED_LIBS=OFF" "-DSNAPPY_BUILD_TESTS=OFF" "-DHAVE_LIBZ=OFF" "-DCMAKE_INSTALL_LIBDIR=/home/runner/work/neptune-core/neptune-core/target/debug/build/leveldb-sys-83a0fb7288cc3018/out/lib" "-DCMAKE_INSTALL_PREFIX=/home/runner/work/neptune-core/neptune-core/target/debug/build/leveldb-sys-83a0fb7288cc3018/out" "-DCMAKE_C_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64" "-DCMAKE_C_COMPILER=/usr/bin/cc" "-DCMAKE_CXX_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64" "-DCMAKE_CXX_COMPILER=/usr/bin/c++" "-DCMAKE_ASM_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64" "-DCMAKE_ASM_COMPILER=/usr/bin/cc" "-DCMAKE_BUILD_TYPE=Debug"
  -- Configuring incomplete, errors occurred!

  --- stderr
  CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
    Compatibility with CMake < 3.5 has been removed from CMake.

    Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
    to tell CMake that the project requires at least <min> but has been updated
    to work with policies introduced by <max> or earlier.

    Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```