### PR TITLE
feat(mutator_set): Privacy-preserving membership recovery

### DIFF
--- a/neptune-core/src/protocol/consensus/transaction/validity/removal_records_integrity.rs
+++ b/neptune-core/src/protocol/consensus/transaction/validity/removal_records_integrity.rs
@@ -1393,7 +1393,7 @@ mod tests {
         // ensure entire data structure is hashed and compared. Missing just one
         // word in the hashing would make this snippet (and the entire
         // blockchain) unsound.
-        let original_minimum = bad_inputs[mutated_input].absolute_indices.get_minimum();
+        let original_minimum = bad_inputs[mutated_input].absolute_indices.minimum();
         for term in [1, 1 << 32, 1 << 64, 1 << 96] {
             bad_inputs[mutated_input]
                 .absolute_indices

--- a/neptune-core/src/util_types/mutator_set.rs
+++ b/neptune-core/src/util_types/mutator_set.rs
@@ -38,6 +38,10 @@ pub enum MutatorSetError {
         current_max_chunk_index: u64,
         saw_chunk_index: u64,
     },
+    AbsoluteIndexExceedsTheoreticalBound,
+    RequestedAoclAuthPathNotContainedInResponse {
+        request_aocl_leaf_index: u64,
+    },
 }
 
 /// Generates an addition record from an item and explicit random-

--- a/neptune-core/src/util_types/mutator_set/mutator_set_accumulator.rs
+++ b/neptune-core/src/util_types/mutator_set/mutator_set_accumulator.rs
@@ -990,7 +990,8 @@ mod tests {
                 ) {
                     assert!(accumulator.verify(item, mp_batch));
 
-                    // Verify that the membership proof can be restored from an archival instance
+                    // Verify that the membership proof can be restored from an archival instance,
+                    // both without and with privacy.
                     let arch_mp = archival_after_remove
                         .restore_membership_proof(
                             item,
@@ -1000,6 +1001,17 @@ mod tests {
                         )
                         .await
                         .unwrap();
+                    let arch_mp_alt = archival_after_remove
+                        .restore_membership_proof_privacy_preserving(arch_mp.compute_indices(item))
+                        .await
+                        .unwrap()
+                        .extract_ms_membership_proof(
+                            mp_batch.aocl_leaf_index,
+                            sender_randomness,
+                            receiver_preimage,
+                        )
+                        .unwrap();
+                    assert_eq!(arch_mp, arch_mp_alt);
                     assert_eq!(arch_mp, mp_batch.to_owned());
 
                     // Verify that sequential and batch update produces the same membership proofs

--- a/neptune-core/src/util_types/mutator_set/removal_record/absolute_index_set.rs
+++ b/neptune-core/src/util_types/mutator_set/removal_record/absolute_index_set.rs
@@ -158,31 +158,105 @@ impl AbsoluteIndexSet {
 
         Ok((inactive, active))
     }
+
+    /// Return the range as a min/max pair (both inclusive) from which the
+    /// absolute index set could have come from.
+    ///
+    /// The return value refers to the AOCL leaf indices from which the
+    /// absolute index set could have been derived. In other words, this
+    /// function returns the range of possible AOCL leaf indices that this set
+    /// of Bloom filter indices spends. So after applying this index set to the
+    /// mutator set, an AOCL leaf in this range will have been spent.
+    ///
+    /// Does not take the actual length of the AOCL into account, so a caller
+    /// may want to further restrict the maximum in this range to the actual,
+    /// current length of the AOCL.
+    pub(crate) fn aocl_range(&self) -> Result<(u64, u64), MutatorSetError> {
+        let max_offset: u128 = (*self.distances.iter().max().unwrap()).into();
+        if max_offset >= u128::from(WINDOW_SIZE) {
+            return Err(MutatorSetError::AbsoluteIndexExceedsTheoreticalBound);
+        }
+
+        let max_bf_index = max_offset + self.minimum;
+        let min_active_window_start_on_insertion = (max_bf_index
+            .saturating_sub(u128::from(WINDOW_SIZE) - 1))
+        .next_multiple_of(u128::from(CHUNK_SIZE));
+        let Ok(min_batch_index_on_insertion): Result<u64, _> =
+            (min_active_window_start_on_insertion / (u128::from(CHUNK_SIZE))).try_into()
+        else {
+            return Err(MutatorSetError::AbsoluteIndexExceedsTheoreticalBound);
+        };
+
+        let Some(min_aocl_index) = min_batch_index_on_insertion.checked_mul(u64::from(BATCH_SIZE))
+        else {
+            return Err(MutatorSetError::AbsoluteIndexExceedsTheoreticalBound);
+        };
+
+        let min_bf_index = self.minimum;
+
+        let max_active_window_end_on_insertion = (min_bf_index + (u128::from(WINDOW_SIZE)) + 1)
+            .next_multiple_of(u128::from(CHUNK_SIZE))
+            - u128::from(CHUNK_SIZE);
+
+        let Ok(max_batch_index_on_insertion): Result<u64, _> = ((max_active_window_end_on_insertion
+            .saturating_sub(u128::from(WINDOW_SIZE)))
+            / (u128::from(CHUNK_SIZE)))
+        .try_into() else {
+            return Err(MutatorSetError::AbsoluteIndexExceedsTheoreticalBound);
+        };
+
+        let Some(max_aocl_index) = max_batch_index_on_insertion
+            .checked_mul(u64::from(BATCH_SIZE))
+            .and_then(|prod| prod.checked_add(u64::from(BATCH_SIZE) - 1))
+        else {
+            return Err(MutatorSetError::AbsoluteIndexExceedsTheoreticalBound);
+        };
+
+        Ok((min_aocl_index, max_aocl_index))
+    }
 }
 
 #[cfg(any(test, feature = "arbitrary-impls"))]
 impl<'a> Arbitrary<'a> for AbsoluteIndexSet {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
         let aocl_index = u64::arbitrary(u)? >> 1;
-        let window_start = u128::from(aocl_index) / u128::from(BATCH_SIZE) * u128::from(CHUNK_SIZE);
-        let mut relative_indices = vec![];
-        for _ in 0..NUM_TRIALS {
-            let index = u32::arbitrary(u)? & (super::super::shared::WINDOW_SIZE - 1);
-            relative_indices.push(index);
+        Self::arbitrary_from_aocl_index(u, aocl_index)
+    }
+}
+
+#[cfg(any(test, feature = "arbitrary-impls"))]
+mod neptune_arbitrary {
+    use super::*;
+
+    impl<'a> AbsoluteIndexSet {
+        pub(crate) fn arbitrary_from_aocl_index(
+            u: &mut Unstructured<'a>,
+            aocl_index: u64,
+        ) -> Result<Self> {
+            let window_start =
+                u128::from(aocl_index) / u128::from(BATCH_SIZE) * u128::from(CHUNK_SIZE);
+            let mut relative_indices = vec![];
+            for _ in 0..NUM_TRIALS {
+                let index =
+                    u32::arbitrary(u)? & (crate::util_types::mutator_set::shared::WINDOW_SIZE - 1);
+                relative_indices.push(index);
+            }
+            let absolute_indices = relative_indices
+                .into_iter()
+                .map(|ri| u128::from(ri) + window_start)
+                .collect_vec()
+                .try_into()
+                .unwrap();
+            Ok(Self::new(absolute_indices))
         }
-        let absolute_indices = relative_indices
-            .into_iter()
-            .map(|ri| u128::from(ri) + window_start)
-            .collect_vec()
-            .try_into()
-            .unwrap();
-        Ok(Self::new(absolute_indices))
     }
 }
 
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use proptest::prelude::TestCaseError;
+    use proptest::prop_assert;
     use proptest::prop_assert_eq;
     use proptest_arbitrary_interop::arb;
     use test_strategy::proptest;
@@ -208,7 +282,7 @@ mod tests {
             self.minimum = new_minimum;
         }
 
-        pub(crate) fn get_minimum(&self) -> u128 {
+        pub(crate) fn minimum(&self) -> u128 {
             self.minimum
         }
 
@@ -229,5 +303,159 @@ mod tests {
 
         let as_array_again = as_ais_again.to_array();
         prop_assert_eq!(as_array_again, as_array);
+    }
+
+    #[test]
+    fn range_fails_if_offset_too_big() {
+        assert!(
+            AbsoluteIndexSet::new_raw(0, [WINDOW_SIZE - 1; NUM_TRIALS as usize])
+                .aocl_range()
+                .is_ok()
+        );
+        assert!(
+            AbsoluteIndexSet::new_raw(0, [WINDOW_SIZE; NUM_TRIALS as usize])
+                .aocl_range()
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn can_handle_max_abs_index() {
+        let max_aocl_leaf_index = u64::MAX;
+        let max_batch_index = u128::from(max_aocl_leaf_index) / u128::from(BATCH_SIZE);
+        let max_abs_index = max_batch_index * u128::from(CHUNK_SIZE) - 1;
+        assert!(
+            AbsoluteIndexSet::new_raw(max_abs_index, [0; NUM_TRIALS as usize])
+                .aocl_range()
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn range_with_aocl_leaf_index_0() {
+        let ais =
+            AbsoluteIndexSet::compute(Digest::default(), Digest::default(), Digest::default(), 0);
+        let (min, _max) = ais.aocl_range().unwrap();
+        assert_eq!(0, min);
+    }
+
+    #[test]
+    fn individual_cases() {
+        let all_zeros = AbsoluteIndexSet::new_raw(0, [0; _]);
+        let mut range = all_zeros.aocl_range().unwrap();
+        assert_eq!(0, range.0);
+        assert_eq!(7, range.1);
+
+        let all_ones = AbsoluteIndexSet::new_raw(1, [0; _]);
+        range = all_ones.aocl_range().unwrap();
+        assert_eq!(0, range.0);
+        assert_eq!(7, range.1);
+
+        let all_chunk_size_minus_1 = AbsoluteIndexSet::new_raw(u128::from(CHUNK_SIZE) - 1, [0; _]);
+        range = all_chunk_size_minus_1.aocl_range().unwrap();
+        assert_eq!(0, range.0);
+        assert_eq!(7, range.1);
+
+        let all_chunk_size = AbsoluteIndexSet::new_raw(u128::from(CHUNK_SIZE), [0; _]);
+        range = all_chunk_size.aocl_range().unwrap();
+        assert_eq!(0, range.0);
+        assert_eq!(15, range.1);
+
+        let all_2x_chunk_size_minus_one =
+            AbsoluteIndexSet::new_raw(2 * u128::from(CHUNK_SIZE) - 1, [0; _]);
+        range = all_2x_chunk_size_minus_one.aocl_range().unwrap();
+        assert_eq!(0, range.0);
+        assert_eq!(15, range.1);
+
+        let all_2x_chunk_size = AbsoluteIndexSet::new_raw(2 * u128::from(CHUNK_SIZE), [0; _]);
+        range = all_2x_chunk_size.aocl_range().unwrap();
+        assert_eq!(0, range.0);
+        assert_eq!(23, range.1);
+
+        let all_last_in_1st_window = AbsoluteIndexSet::new_raw(u128::from(WINDOW_SIZE) - 1, [0; _]);
+        range = all_last_in_1st_window.aocl_range().unwrap();
+        assert_eq!(0, range.0);
+        assert_eq!(256 * u64::from(BATCH_SIZE) - 1, range.1);
+
+        let all_first_in_2nd_window = AbsoluteIndexSet::new_raw(u128::from(WINDOW_SIZE), [0; _]);
+        range = all_first_in_2nd_window.aocl_range().unwrap();
+        assert_eq!(8, range.0);
+        assert_eq!(257 * u64::from(BATCH_SIZE) - 1, range.1);
+    }
+
+    #[test]
+    fn range_with_aocl_leaf_indices_ms_beginning() {
+        for leaf_index in 0..100 {
+            let ais = AbsoluteIndexSet::compute(
+                Digest::default(),
+                Digest::default(),
+                Digest::default(),
+                leaf_index,
+            );
+            let (min, max) = ais.aocl_range().unwrap();
+            assert!(leaf_index >= min);
+            assert!(leaf_index <= max);
+        }
+    }
+
+    #[proptest]
+    fn test_arbitrary_from_aocl_index_u8(
+        #[strategy(arb::<Vec<u8>>())] data: Vec<u8>,
+        #[strategy(0..(u64::from(u8::MAX)))] aocl_index: u64,
+    ) {
+        range_prop(data, aocl_index)?;
+    }
+
+    #[proptest]
+    fn test_arbitrary_from_aocl_index_u16(
+        #[strategy(arb::<Vec<u8>>())] data: Vec<u8>,
+        #[strategy(0..(u64::from(u16::MAX)))] aocl_index: u64,
+    ) {
+        range_prop(data, aocl_index)?;
+    }
+
+    #[proptest]
+    fn test_arbitrary_from_aocl_index_u32(
+        #[strategy(arb::<Vec<u8>>())] data: Vec<u8>,
+        #[strategy(0..(u64::from(u32::MAX)))] aocl_index: u64,
+    ) {
+        range_prop(data, aocl_index)?;
+    }
+
+    #[proptest]
+    fn test_arbitrary_from_aocl_index_full_range(
+        #[strategy(arb::<Vec<u8>>())] data: Vec<u8>,
+        #[strategy(arb())] aocl_index: u64,
+    ) {
+        range_prop(data, aocl_index)?;
+    }
+
+    fn range_prop(data: Vec<u8>, aocl_index: u64) -> std::result::Result<(), TestCaseError> {
+        // Create an Unstructured instance from the arbitrary data
+        let mut unstructured = Unstructured::new(&data);
+
+        // Call the function
+        let (min, max) = AbsoluteIndexSet::arbitrary_from_aocl_index(&mut unstructured, aocl_index)
+            .unwrap()
+            .aocl_range()
+            .unwrap();
+
+        prop_assert!(aocl_index >= min);
+        prop_assert!(aocl_index <= max);
+        prop_assert!(max > min);
+        let anonymity_set_size = max - min + 1;
+        prop_assert!(
+            anonymity_set_size >= u64::from(BATCH_SIZE),
+            "Minimum anonymity set is BATCH_SIZE"
+        );
+
+        let max_anonymity_size =
+            (2 * (u64::from(WINDOW_SIZE) / u64::from(CHUNK_SIZE)) - 1) * u64::from(BATCH_SIZE);
+        prop_assert!(
+            anonymity_set_size <= max_anonymity_size,
+            "Anonymity set size ({anonymity_set_size}) cannot exceed max size ({max_anonymity_size})"
+        );
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Add a method `restore_membership_proof_privacy_preserving` to `ArchivalMutatorSet` that returns the required data to restore a mutator set membership proof, without the caller leaking any privacy other than the fuzzy timestamp that is present when the input gets mined. This works by taking an absolute index set and returning all the AOCL authentication paths that this absolute index set could be associated with.

Adds RPC endpoints for this process also, and a way to extract the actual membership proof from the returned data.

Most complicated function added in this commit is
`AbsoluteIndexSet::aocl_range` which returns the range of AOCL leafs from which the absolute index set *could* have been derived.