### PR TITLE
fix: ensure block data written before db

### DIFF
--- a/neptune-core/src/state/archival_state.rs
+++ b/neptune-core/src/state/archival_state.rs
@@ -429,6 +429,13 @@ impl ArchivalState {
             };
             let mut mmap: memmap2::MmapMut = mmap.make_mut().unwrap();
             mmap.deref_mut()[..].copy_from_slice(&serialized_block);
+
+            // Flush the memory-mapped pages to the physical disk.
+            // This call will block until the data is safely persisted.
+            // This ensures block data is written to the blkXX.dat file before
+            // updating the DB.  Otherwise we can have situations where the DB
+            // references a block that does not exist on disk.
+            mmap.flush().unwrap();
         })
         .await?;
 
@@ -597,46 +604,45 @@ impl ArchivalState {
     }
 
     async fn get_block_from_block_record(&self, block_record: BlockRecord) -> Result<Block> {
-        // Get path of file for block
         let block_file_path: PathBuf = self
             .data_dir
             .block_file_path(block_record.file_location.file_index);
 
-        // Open file as read-only
-        let block_file: tokio::fs::File = match tokio::fs::OpenOptions::new()
-            .read(true)
-            .open(block_file_path.clone())
-            .await
-        {
-            Ok(file) => file,
-            Err(e) => {
+        tokio::task::spawn_blocking(move || {
+            let block_file = std::fs::File::open(&block_file_path)?;
+
+            // 1. Get file metadata to find its actual size on disk.
+            let metadata = block_file.metadata()?;
+            let file_size = metadata.len();
+
+            // 2. validate that the requested slice is within the file's bounds.
+            // See: https://github.com/Neptune-Crypto/neptune-core/issues/471
+            let requested_end = block_record.file_location.offset
+                .saturating_add(block_record.file_location.block_length as u64);
+
+            if requested_end > file_size {
                 bail!(
-                    "Could not open block file {}: {e}",
-                    block_file_path.as_path().to_string_lossy()
+                    "Data corruption: Attempted to read beyond end of file '{}'. (Size: {}, Requested End: {})",
+                    block_file_path.display(), file_size, requested_end
                 );
             }
-        };
 
-        // Read the file into memory, set the offset and length indicated in the block record
-        // to avoid using more memory than needed
-        // we use spawn_blocking to make the blocking mmap async-friendly.
-
-        tokio::task::spawn_blocking(move || {
+            // 3. The slice is valid, so we can safely memory-map it.
             let mmap = unsafe {
                 MmapOptions::new()
                     .offset(block_record.file_location.offset)
                     .len(block_record.file_location.block_length)
                     .map(&block_file)?
             };
-            let block: Block = match bincode::deserialize(&mmap) {
-                Ok(b) => b,
-                Err(e) => {
-                    panic!("Could not deserialize block file into `Block`.\n\
-                            Block files may be corrupt, out of date, or incompatible with current version of neptune-core.\n\
-                            Error was: {e}");
-                }
-            };
-            Ok(block)
+
+            // 4. deserialize directly from the validated mmap slice.
+            bincode::deserialize(&mmap).map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to deserialize block from file {}. Data may be corrupt or incompatible\
+                     with current version of neptune-core. Error: {}",
+                    block_file_path.display(), e
+                )
+            })
         })
         .await?
     }


### PR DESCRIPTION
fixes #471

The issue was that block records were being written to DB before written to blkXX.dat files on disk, which resulted in mis-match when power is lost during a call to ArchivalState::store_block().  Upon startup, a SIGBUS occurs when reading the mmap'd data.

Fixes:

1. root cause: calls mmap.flush() after writing block to ensure it is written to disk before writing matching record to DB.

2. avoid SIGBUS: verifies we do not attempt to read past end of file. Returns error with diagnostic info if so, which gets logged.