### PR TITLE
ci: Skip flaky test with timeout

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,6 +42,7 @@ jobs:
           --skip blocks_with_0_to_10_inputs_and_successors_are_valid
           --skip can_cancel_preprocess_within_one_second
           --skip can_cancel_merkle_tree_construction_within_two_seconds
+          --skip alice_updates_mutator_set_data_on_own_transaction
 
       - name: Upload coverage to coveralls.io
         uses: coverallsapp/github-action@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,7 @@ jobs:
           --skip blocks_with_0_to_10_inputs_and_successors_are_valid
           --skip can_cancel_preprocess_within_one_second
           --skip can_cancel_merkle_tree_construction_within_two_seconds
+          --skip alice_updates_mutator_set_data_on_own_transaction
 
         # `--doc` cannot be mixed with other target option
       - name: Run documentation tests


### PR DESCRIPTION
For some reason, this test is flaky in a multithreaded environment. Have tried fiddling with the timeout time (currently at 15 seconds) but was unable to remove flakyness. And since I'm tired of these false negatives in the CI, I opted to just disable this test in CI.