### PR TITLE
devops: Faster compilation by lowering some `opt-level`s

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,9 +64,9 @@ verbose_bit_mask = "warn"
 # transaction with STARK proofs. The other flags are there to make compilation
 # of Triton VM faster.
 [profile.dev.package.triton-vm]
-opt-level = 3
+opt-level = 0
 debug = false
-incremental = false
+incremental = true
 debug-assertions = false
 overflow-checks = false
 
@@ -85,9 +85,9 @@ debug-assertions = false
 overflow-checks = false
 
 [profile.test.package.triton-vm]
-opt-level = 3
+opt-level = 1
 debug = false
-incremental = false
+incremental = true
 debug-assertions = false
 overflow-checks = false
 
@@ -95,7 +95,7 @@ overflow-checks = false
 # that should run with `opt-level=3` set.
 [profile.test]
 build-override.opt-level = 3
-opt-level = 3                # Set to make execution of tests in this crate faster. Cf: https://github.com/Neptune-Crypto/neptune-core/issues/204
+opt-level = 2                # Set to make execution of tests in this crate faster. Cf: https://github.com/Neptune-Crypto/neptune-core/issues/204
 
 [profile.release]
 build-override.opt-level = 3


### PR DESCRIPTION
Also make use of incremental compilation in dev and test profiles.

Since we usually do not have to create Triton VM proofs when the tests are running, we might as well compile with less optimization. I personally only ever use the dev profile in my IDE, so that should compile as fast as possible, without regard to the performance of the compiler output.