### PR TITLE
684 ams batch remove

### DIFF
--- a/neptune-core/Cargo.toml
+++ b/neptune-core/Cargo.toml
@@ -181,6 +181,11 @@ path = "benchmark/benches/fast_kernel_mast_hash.rs"
 harness = false
 
 [[bench]]
+name = "set_new_tip"
+path = "benchmark/benches/set_new_tip.rs"
+harness = false
+
+[[bench]]
 name = "wallet_state"
 path = "benchmark/benches/wallet_state.rs"
 harness = false

--- a/neptune-core/benchmark/benches/set_new_tip.rs
+++ b/neptune-core/benchmark/benches/set_new_tip.rs
@@ -1,0 +1,72 @@
+use divan::Bencher;
+use neptune_cash::api::export::KeyType;
+use neptune_cash::api::export::Network;
+use neptune_cash::api::export::Timestamp;
+use neptune_cash::bench_helpers::devops_global_state_genesis;
+use neptune_cash::bench_helpers::next_block_incoming_utxos;
+use neptune_cash::protocol::consensus::block::Block;
+
+fn main() {
+    divan::main();
+}
+
+mod set_new_tip {
+    use super::*;
+
+    fn update_state(bencher: Bencher) {
+        // The goal is to benchmark how long it takes to run `set_new_tip` when
+        //  a block has many inputs. To build a block with many inputs, we first
+        // need to get the wallet to a state where it has many UTXOs.
+        const NUM_INPUTS_IN_TX: usize = 1000;
+        const NUM_OUTPUTS_IN_TX: usize = 1000;
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let network = Network::Main;
+
+        let mut global_state_lock = rt.block_on(devops_global_state_genesis(network));
+        let mut global_state = rt.block_on(global_state_lock.lock_guard_mut());
+        let genesis = Block::genesis(network);
+        let own_address = rt
+            .block_on(
+                global_state
+                    .wallet_state
+                    .next_unused_spending_key(KeyType::Generation),
+            )
+            .to_address();
+        let block1_time = network.launch_date() + Timestamp::months(7);
+        let block1 = rt.block_on(next_block_incoming_utxos(
+            &genesis,
+            own_address.clone(),
+            NUM_INPUTS_IN_TX,
+            &global_state.wallet_state,
+            block1_time,
+            network,
+        ));
+
+        rt.block_on(global_state.set_new_tip(block1.clone()))
+            .unwrap();
+
+        // Wallet now has N inputs it can spend
+        let block2_time = block1_time + Timestamp::hours(1);
+        let block2 = rt.block_on(next_block_incoming_utxos(
+            &block1,
+            own_address,
+            NUM_OUTPUTS_IN_TX,
+            &global_state.wallet_state,
+            block2_time,
+            network,
+        ));
+
+        bencher.bench_local(|| {
+            rt.block_on(global_state.set_new_tip(block1.clone()))
+                .unwrap();
+
+            rt.block_on(global_state.set_new_tip(block2.clone()))
+                .unwrap();
+        });
+    }
+
+    #[divan::bench(sample_count = 10)]
+    fn set_new_tip(bencher: Bencher) {
+        update_state(bencher);
+    }
+}

--- a/neptune-core/src/application/rpc/server/mempool_transaction_info.rs
+++ b/neptune-core/src/application/rpc/server/mempool_transaction_info.rs
@@ -1,5 +1,6 @@
 use num_traits::Zero;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 
 use crate::api::export::NativeCurrencyAmount;
 use crate::api::export::Transaction;

--- a/neptune-core/src/state/archival_state.rs
+++ b/neptune-core/src/state/archival_state.rs
@@ -1376,16 +1376,10 @@ impl ArchivalState {
             }
 
             // Remove items, thus removing the input UTXOs from the mutator set
-            while let Some(removal_record) = removals_mutable.pop() {
-                // Batch-update all removal records to keep them valid after next removal
-                RemovalRecord::batch_update_from_remove(&mut removals_mutable, removal_record);
-
-                // Remove the element from the mutator set
-                self.archival_mutator_set
-                    .ams_mut()
-                    .remove(removal_record)
-                    .await;
-            }
+            self.archival_mutator_set
+                .ams_mut()
+                .batch_remove(removals)
+                .await;
         }
 
         // Sanity check that archival mutator set has been updated consistently with the new block

--- a/neptune-core/src/util_types/mutator_set/removal_record/chunk.rs
+++ b/neptune-core/src/util_types/mutator_set/removal_record/chunk.rs
@@ -106,6 +106,11 @@ impl Chunk {
         ret
     }
 
+    /// Remove the indices in a chunk from a chunk.
+    ///
+    /// /// # Panics
+    ///
+    /// - If one of the subtracted indices are not present in the chunk.
     pub fn subtract(&mut self, other: Self) {
         for remove_index in other.relative_indices {
             // Find the 1st match and remove that

--- a/neptune-core/src/util_types/mutator_set/removal_record/chunk_dictionary.rs
+++ b/neptune-core/src/util_types/mutator_set/removal_record/chunk_dictionary.rs
@@ -43,6 +43,7 @@ impl ChunkDictionary {
         dictionary.sort_by_key(|(k, _v)| *k);
         Self { dictionary }
     }
+
     pub fn indices_and_leafs(&self) -> Vec<(ChunkIndex, Digest)> {
         self.dictionary
             .iter()

--- a/neptune-dashboard/src/address_screen.rs
+++ b/neptune-dashboard/src/address_screen.rs
@@ -31,10 +31,9 @@ use tokio::task::JoinHandle;
 use tokio::time::sleep;
 use unicode_width::UnicodeWidthStr;
 
-use crate::dashboard_rpc_client::DashboardRpcClient;
-
 use super::dashboard_app::DashboardEvent;
 use super::screen::Screen;
+use crate::dashboard_rpc_client::DashboardRpcClient;
 
 type AddressUpdate = SpendingKey;
 type AddressUpdateArc = Arc<std::sync::Mutex<Vec<AddressUpdate>>>;

--- a/neptune-dashboard/src/dashboard_app.rs
+++ b/neptune-dashboard/src/dashboard_app.rs
@@ -48,9 +48,6 @@ use strum::IntoEnumIterator;
 use tokio::sync::Mutex;
 use tokio::time::sleep;
 
-use crate::dashboard_rpc_client::DashboardRpcClient;
-use crate::utxos_screen::UtxosScreen;
-
 use super::address_screen::AddressScreen;
 use super::history_screen::HistoryScreen;
 use super::mempool_screen::MempoolScreen;
@@ -61,6 +58,8 @@ use super::peers_screen::SortOrder;
 use super::receive_screen::ReceiveScreen;
 use super::screen::Screen;
 use super::send_screen::SendScreen;
+use crate::dashboard_rpc_client::DashboardRpcClient;
+use crate::utxos_screen::UtxosScreen;
 
 #[derive(Debug, Parser, Clone)]
 #[clap(name = "neptune-dashboard", about = "Terminal user interface")]

--- a/neptune-dashboard/src/dashboard_rpc_client.rs
+++ b/neptune-dashboard/src/dashboard_rpc_client.rs
@@ -1,3 +1,4 @@
+use std::net::SocketAddr;
 use std::ops::Deref;
 
 use neptune_cash::api::export::BlockHeight;
@@ -17,7 +18,6 @@ use neptune_cash::application::rpc::server::ui_utxo::UiUtxo;
 use neptune_cash::application::rpc::server::RPCClient;
 use neptune_cash::application::rpc::server::RpcResult;
 use neptune_cash::protocol::peer::peer_info::PeerInfo;
-use std::net::SocketAddr;
 use tasm_lib::prelude::Digest;
 
 #[derive(Debug, Clone)]

--- a/neptune-dashboard/src/history_screen.rs
+++ b/neptune-dashboard/src/history_screen.rs
@@ -32,10 +32,9 @@ use tokio::task::JoinHandle;
 use tokio::time::sleep;
 use unicode_width::UnicodeWidthStr;
 
-use crate::dashboard_rpc_client::DashboardRpcClient;
-
 use super::dashboard_app::DashboardEvent;
 use super::screen::Screen;
+use crate::dashboard_rpc_client::DashboardRpcClient;
 
 type BalanceUpdate = (
     BlockHeight,

--- a/neptune-dashboard/src/mempool_screen.rs
+++ b/neptune-dashboard/src/mempool_screen.rs
@@ -24,10 +24,9 @@ use tokio::task::JoinHandle;
 use tokio::time::sleep;
 use unicode_width::UnicodeWidthStr;
 
-use crate::dashboard_rpc_client::DashboardRpcClient;
-
 use super::dashboard_app::DashboardEvent;
 use super::screen::Screen;
+use crate::dashboard_rpc_client::DashboardRpcClient;
 
 const PAGE_SIZE: usize = 20;
 

--- a/neptune-dashboard/src/mock_rpc_client.rs
+++ b/neptune-dashboard/src/mock_rpc_client.rs
@@ -1,9 +1,19 @@
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::net::IpAddr;
+use std::net::Ipv4Addr;
+use std::net::SocketAddr;
 
-use neptune_cash::api::export::{
-    BlockHeight, ChangePolicy, GenerationSpendingKey, KeyType, NativeCurrencyAmount, Network,
-    OutputFormat, ReceivingAddress, SpendingKey, SymmetricKey, Timestamp, TxCreationArtifacts,
-};
+use neptune_cash::api::export::BlockHeight;
+use neptune_cash::api::export::ChangePolicy;
+use neptune_cash::api::export::GenerationSpendingKey;
+use neptune_cash::api::export::KeyType;
+use neptune_cash::api::export::NativeCurrencyAmount;
+use neptune_cash::api::export::Network;
+use neptune_cash::api::export::OutputFormat;
+use neptune_cash::api::export::ReceivingAddress;
+use neptune_cash::api::export::SpendingKey;
+use neptune_cash::api::export::SymmetricKey;
+use neptune_cash::api::export::Timestamp;
+use neptune_cash::api::export::TxCreationArtifacts;
 use neptune_cash::application::rpc::auth;
 use neptune_cash::application::rpc::server::error::RpcError;
 use neptune_cash::application::rpc::server::mempool_transaction_info::MempoolTransactionInfo;
@@ -12,9 +22,11 @@ use neptune_cash::application::rpc::server::ui_utxo::UiUtxo;
 use neptune_cash::application::rpc::server::RpcResult;
 use neptune_cash::protocol::peer::peer_info::PeerInfo;
 use neptune_cash::state::wallet::address::generation_address::GenerationReceivingAddress;
+use rand::rng;
 use rand::rngs::StdRng;
-use rand::{rng, Rng};
-use rand::{RngCore, SeedableRng};
+use rand::Rng;
+use rand::RngCore;
+use rand::SeedableRng;
 use tasm_lib::prelude::Digest;
 
 #[derive(Debug, Clone)]

--- a/neptune-dashboard/src/overview_screen.rs
+++ b/neptune-dashboard/src/overview_screen.rs
@@ -29,10 +29,9 @@ use tokio::select;
 use tokio::task::JoinHandle;
 use tokio::time;
 
-use crate::dashboard_rpc_client::DashboardRpcClient;
-
 use super::dashboard_app::DashboardEvent;
 use super::screen::Screen;
+use crate::dashboard_rpc_client::DashboardRpcClient;
 
 #[derive(Debug, Clone, Default)]
 pub struct OverviewData {

--- a/neptune-dashboard/src/peers_screen.rs
+++ b/neptune-dashboard/src/peers_screen.rs
@@ -32,12 +32,11 @@ use tokio::task::JoinHandle;
 use tokio::time::sleep;
 use unicode_width::UnicodeWidthStr;
 
-use crate::dashboard_rpc_client::DashboardRpcClient;
-
 use super::dashboard_app::Config;
 use super::dashboard_app::DashboardEvent;
 use super::overview_screen::VerticalRectifier;
 use super::screen::Screen;
+use crate::dashboard_rpc_client::DashboardRpcClient;
 
 type PeerInfoArc = Arc<std::sync::Mutex<Vec<PeerInfo>>>;
 type DashboardEventArc = Arc<std::sync::Mutex<Option<DashboardEvent>>>;

--- a/neptune-dashboard/src/receive_screen.rs
+++ b/neptune-dashboard/src/receive_screen.rs
@@ -22,12 +22,11 @@ use ratatui::widgets::Paragraph;
 use ratatui::widgets::Widget;
 use tarpc::context;
 
-use crate::dashboard_rpc_client::DashboardRpcClient;
-
 use super::dashboard_app::ConsoleIO;
 use super::dashboard_app::DashboardEvent;
 use super::overview_screen::VerticalRectifier;
 use super::screen::Screen;
+use crate::dashboard_rpc_client::DashboardRpcClient;
 
 #[derive(Debug, Clone)]
 pub struct ReceiveScreen {

--- a/neptune-dashboard/src/send_screen.rs
+++ b/neptune-dashboard/src/send_screen.rs
@@ -30,12 +30,11 @@ use ratatui::widgets::Wrap;
 use tarpc::context;
 use tokio::sync::Mutex;
 
-use crate::dashboard_rpc_client::DashboardRpcClient;
-
 use super::dashboard_app::ConsoleIO;
 use super::dashboard_app::DashboardEvent;
 use super::overview_screen::VerticalRectifier;
 use super::screen::Screen;
+use crate::dashboard_rpc_client::DashboardRpcClient;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum SendScreenWidget {


### PR DESCRIPTION
1. Fix broken `ArchivalMutatorSet::batch_remove`
2. Use `batch_remove` to speed up the update of archival mutator set, leading to a 3x speedup of `set_new_tip`, for a block with 1000 inputs and 1000 outputs!