### PR TITLE
refactor(peer_loop): Reduce block batch size

### DIFF
--- a/neptune-core/src/application/loops/peer_loop.rs
+++ b/neptune-core/src/application/loops/peer_loop.rs
@@ -62,7 +62,7 @@ use crate::state::GlobalState;
 use crate::state::GlobalStateLock;
 use crate::util_types::mutator_set::removal_record::RemovalRecordValidityError;
 
-const STANDARD_BLOCK_BATCH_SIZE: usize = 250;
+const STANDARD_BLOCK_BATCH_SIZE: usize = 35;
 const MAX_PEER_LIST_LENGTH: usize = 10;
 const MINIMUM_BLOCK_BATCH_SIZE: usize = 2;
 


### PR DESCRIPTION
Reduce the number of blocks returned and requested in a batch request, from 250 blocks to 35 blocks.

In retrospect, 250 blocks is way too much as each block is at least 1MB, meaning that the message size is above 250MB. Such big messages cannot be sent or received within the `INDIVIDUAL_PEER_SYNCHRONIZATION_TIMEOUT` interval, 120 seconds, on weak connections, as the required transfer speed is above 2MB/s, not including the time it takes for the peer to read all the blocks from disk. This new standard size of 35 blocks only requires a transfer speed of 290kB/s, which is probably more reasonable.

This is just an iterative improvement for initial block download. Other important steps are the upcoming parallel downloading of blocks from multiple peers and potentially the switch to libp2p.

Addresses #634 and #585.