### PR TITLE
`libp2p` for running in parallel with the current peer loop

### DIFF
--- a/neptune-core-cli/src/main.rs
+++ b/neptune-core-cli/src/main.rs
@@ -1183,7 +1183,7 @@ async fn main() -> Result<()> {
                         &data_directory,
                         network,
                         tx_artifacts.all_offchain_notifications(),
-                        None, //  parse receiver tags from cmd-line.
+                        None, // todo:  parse receiver tags from cmd-line.
                     )?
                 }
                 Err(e) => eprintln!("{e}"),
@@ -1415,7 +1415,8 @@ fn process_utxo_notifications(
         println!("\n*** Utxo Transfer Files ***\n");
     }
 
-    // It would be better if this timestamp was read from the created transaction.
+    // TODO: It would be better if this timestamp was read from the created
+    // transaction.
     let timestamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()

--- a/neptune-core/src/api/regtest/regtest_impl.rs
+++ b/neptune-core/src/api/regtest/regtest_impl.rs
@@ -211,9 +211,10 @@ impl RegTestPrivate {
 
         let block_hash = block.hash();
 
-        /* inform main-loop.  to add to mempool and broadcast.
-
-        ideally we would pass a listener here to wait on, so that once the block is added we get notified, rather than polling. */
+        // inform main-loop.  to add to mempool and broadcast.
+        //
+        // todo: ideally we would pass a listener here to wait on, so that
+        // once the block is added we get notified, rather than polling.
         self.global_state_lock.rpc_server_to_main_tx()
             .send(RPCServerToMain::ProofOfWorkSolution(Box::new(block)))
             .await

--- a/neptune-core/src/application/config/data_directory.rs
+++ b/neptune-core/src/application/config/data_directory.rs
@@ -24,7 +24,7 @@ const UTXO_TRANSFER_DIRECTORY: &str = "utxo-transfer";
 const RPC_COOKIE_FILE_NAME: &str = ".cookie"; // matches bitcoin-core name.
 const DB_MIGRATION_BACKUPS_DIR: &str = "migration_backups";
 
-/// Add `rusty_leveldb::Options` and `fs::OpenOptions` here too, since they keep being repeated.
+// TODO: Add `rusty_leveldb::Options` and `fs::OpenOptions` here too, since they keep being repeated.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DataDirectory {
     data_dir: PathBuf,

--- a/neptune-core/src/application/database/neptune_leveldb.rs
+++ b/neptune-core/src/application/database/neptune_leveldb.rs
@@ -225,9 +225,9 @@ where
     /// ALSO: this calls allocates all DB keys.  For large databases
     /// this could be problematic and is best to avoid.
     ///
-    // can we avoid allocating keys with collect()?
-    // can we create a true async iterator?
-    // perhaps refactor neptune, so it does not need/use a level-db iterator.
+    // todo: can we avoid allocating keys with collect()?
+    // todo: can we create a true async iterator?
+    // todo: perhaps refactor neptune, so it does not need/use a level-db iterator.
     pub fn iter(&self) -> Box<dyn Iterator<Item = (Key, Value)> + '_> {
         let inner = self.0.clone();
         let keys: Vec<_> = inner.database.keys_iter(&ReadOptions::new()).collect();
@@ -388,7 +388,7 @@ where
 // and Cache is not `Send`.  We can't do anything about that, so instead we
 // send this OptionsAsync between threads, which does not have a Cache field.
 //
-// add a cache_size option specified in bytes.
+// todo:  add a cache_size option specified in bytes.
 pub(super) struct OptionsAsync {
     pub create_if_missing: bool,
     pub error_if_exists: bool,

--- a/neptune-core/src/application/database/storage/storage_schema/dbtsingleton.rs
+++ b/neptune-core/src/application/database/storage/storage_schema/dbtsingleton.rs
@@ -16,7 +16,7 @@ use crate::application::locks::tokio::AtomicRw;
 /// levelDb database.
 #[derive(Debug)]
 pub struct DbtSingleton<V> {
-    /// unify inner.  no longer necessary.
+    // todo: unify inner.  no longer necessary.
     inner: DbtSingletonPrivate<V>,
 }
 

--- a/neptune-core/src/application/database/storage/storage_schema/dbtvec.rs
+++ b/neptune-core/src/application/database/storage/storage_schema/dbtvec.rs
@@ -18,7 +18,7 @@ use crate::application::locks::tokio::AtomicRw;
 /// Data stored in a DbtVec gets persisted to a levelDb database.
 #[derive(Debug)]
 pub struct DbtVec<V> {
-    /// merge DbtVecPrivate into DbtVec
+    // todo: merge DbtVecPrivate into DbtVec
     inner: DbtVecPrivate<V>,
 }
 

--- a/neptune-core/src/application/database/storage/storage_schema/rusty_key.rs
+++ b/neptune-core/src/application/database/storage/storage_schema/rusty_key.rs
@@ -3,7 +3,7 @@ use leveldb::error::Error;
 use serde::Deserialize;
 use serde::Serialize;
 
-//       consider making RustyKey a newtype for RustyValue and auto derive all its From impls
+// Todo: consider making RustyKey a newtype for RustyValue and auto derive all its From impls
 //       using either `derive_more` or `newtype_derive` crate
 
 /// Represents a database key as bytes

--- a/neptune-core/src/application/database/storage/storage_schema/rusty_value.rs
+++ b/neptune-core/src/application/database/storage/storage_schema/rusty_value.rs
@@ -31,7 +31,7 @@
 // Before making final decision(s), we should benchmark our
 // code with real data and try out different crates/options.
 //
-// consider moving the serialization functions, or perhaps all
+// todo: consider moving the serialization functions, or perhaps all
 // of rusty_value.rs to a top level module, eg twenty-first::serialization.
 
 use std::fmt::Debug;
@@ -102,9 +102,9 @@ impl RustyValue {
 /// At present `bincode` is used for de/serialization, but this could
 /// change in the future.  No guarantee is made as the to serialization format.
 ///
-// consider compressing serialized bytes with zlib, or similar.
+// todo: consider compressing serialized bytes with zlib, or similar.
 //       see comments at top of file.
-// consider moving this fn, or perhaps all of rusty_value.rs
+// todo: consider moving this fn, or perhaps all of rusty_value.rs
 //       to a top level module, eg twenty-first::serialization
 #[inline]
 pub fn serialize<T: Serialize>(value: &T) -> Vec<u8> {
@@ -120,9 +120,9 @@ pub fn serialize<T: Serialize>(value: &T) -> Vec<u8> {
 /// At present `bincode` is used for de/serialization, but this could
 /// change in the future.  No guarantee is made as the to serialization format.
 ///
-// consider decompressing serialized bytes with zlib, or similar.
+// todo: consider decompressing serialized bytes with zlib, or similar.
 //       see comments at top of file.
-// consider moving this fn, or perhaps all of rusty_value.rs
+// todo: consider moving this fn, or perhaps all of rusty_value.rs
 //       to a top level module, eg twenty-first::serialization
 #[inline]
 pub fn deserialize<T: DeserializeOwned>(bytes: &[u8]) -> T {

--- a/neptune-core/src/application/database/storage/storage_schema/schema.rs
+++ b/neptune-core/src/application/database/storage/storage_schema/schema.rs
@@ -78,7 +78,7 @@ pub struct DbtSchema {
     /// Pending writes for all tables in this Schema.
     /// These get written/cleared by StorageWriter::persist()
     ///
-    /// Can we get rid of this lock?
+    /// todo: Can we get rid of this lock?
     pub(super) pending_writes: AtomicRw<PendingWrites>,
 
     /// Database Reader

--- a/neptune-core/src/application/loops/connect_to_peers.rs
+++ b/neptune-core/src/application/loops/connect_to_peers.rs
@@ -159,7 +159,7 @@ async fn check_if_connection_is_allowed(
             );
 
             // A “wrong” reason is given because of backwards compatibility.
-            // Use next breaking release to give a more accurate reason here.
+            // todo: Use next breaking release to give a more accurate reason here.
             let reason = ConnectionRefusedReason::MaxPeerNumberExceeded;
             return InternalConnectionStatus::Refused(reason);
         }

--- a/neptune-core/src/application/loops/handle_tx_from_peer.rs
+++ b/neptune-core/src/application/loops/handle_tx_from_peer.rs
@@ -88,6 +88,7 @@ pub(crate) async fn the(
                             )
                     {
                         warn!("Received too old tx");
+                        // "TODO: Consider punishing here" #fromPeerLoop
                         Some(None)
                     } else if transaction.kernel.timestamp
                         >= now + crate::protocol::consensus::block::FUTUREDATING_LIMIT
@@ -97,6 +98,7 @@ pub(crate) async fn the(
                             "Received tx too far into the future. Got timestamp: {:?}",
                             transaction.kernel.timestamp
                         );
+                        // "TODO: Consider punishing here" #fromPeerLoop
                         Some(None)
                     } else {
                         // Otherwise, relay to main.

--- a/neptune-core/src/application/loops/main_loop.rs
+++ b/neptune-core/src/application/loops/main_loop.rs
@@ -407,7 +407,7 @@ fn stay_in_sync_mode(
 }
 
 impl MainLoopHandler {
-    // find a way to avoid triggering lint
+    // todo: find a way to avoid triggering lint
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
         incoming_peer_listener: TcpListener,
@@ -942,7 +942,7 @@ impl MainLoopHandler {
                 }
 
                 // Spawn task to handle mempool tx-updating after new blocks.
-                // Do clever trick to collapse all jobs relating to the same transaction,
+                // TODO: Do clever trick to collapse all jobs relating to the same transaction,
                 //       identified by transaction-ID, into *one* update job.
                 self.spawn_mempool_txs_update_job(main_loop_state, update_jobs);
 
@@ -1068,7 +1068,7 @@ impl MainLoopHandler {
                         (&pt2m_transaction.transaction).try_into()?,
                     ));
 
-                    // `Swarm` shares right after sending it here
+                    // `Swarm` have been share already, right after sending that here
                     // self.main_to_peer_broadcast(MainToPeerTask::NewTransaction((&pt2m_transaction.transaction).try_into()?));
                 }
             }
@@ -2408,7 +2408,7 @@ mod tests {
                 );
 
                 if tx_proving_capability != TxProvingCapability::PrimitiveWitness {
-                    //account for the one sent to `Swarm`
+                    // account for the one sent to `Swarm`
                     main_to_peer_rx.recv().await.unwrap();
 
                     let MainToPeerTask::TransactionNotification(tx_notification) =

--- a/neptune-core/src/application/loops/main_loop/p2p/behaviour/swarmutil/swarm.rs
+++ b/neptune-core/src/application/loops/main_loop/p2p/behaviour/swarmutil/swarm.rs
@@ -1,4 +1,4 @@
-//! spawning subtasks here seems to have no advantage as `Runtime` is not single-threaded, and most of the module actions are sequential / potentially depending on a previous message 
+//! spawning subtasks here seems to have no advantage as `Runtime` is not single-threaded, and most of the module actions are sequential / potentially depending on a previous message
 //! in `loop` hence even if something blocks the thread (currently `bincode` feels as a most heavy operation) for a few millisecs -- the other Tokio threads would steal most of the tasks
 
 use std::collections::{HashMap, HashSet};

--- a/neptune-core/src/application/loops/main_loop/proof_upgrader.rs
+++ b/neptune-core/src/application/loops/main_loop/proof_upgrader.rs
@@ -255,7 +255,7 @@ impl UpgradeJob {
             TxProvingCapability::PrimitiveWitness => {
                 panic!("Client cannot have primitive witness capability only")
             }
-            TxProvingCapability::LockScript => unimplemented!("Add support for this"),
+            TxProvingCapability::LockScript => todo!("TODO: Add support for this"),
         }
     }
 

--- a/neptune-core/src/application/loops/peer_loop.rs
+++ b/neptune-core/src/application/loops/peer_loop.rs
@@ -874,7 +874,7 @@ impl PeerLoopHandler {
 
                 match block {
                     None => {
-                        // Consider punishing here
+                        // TODO: Consider punishing here
                         warn!("Peer requested unknown block with hash {:x}", block_digest);
                         Ok(KEEP_CONNECTION_ALIVE)
                     }
@@ -1125,7 +1125,7 @@ impl PeerLoopHandler {
                         .await?
                 } else {
                     // Verify that we are in fact in syncing mode.
-                    // Separate peer messages into those allowed under syncing and those that are not.
+                    // TODO: Separate peer messages into those allowed under syncing and those that are not.
                     if self
                         .global_state_lock
                         .lock_guard()
@@ -3853,7 +3853,7 @@ mod tests {
                 ..Default::default()
             };
             let not_whitelisted = cli_args::Args {
-                whitelisted_composers: ["/ip4/255.254.253.252".parse().unwrap()].into(),
+                whitelisted_composers: ["255.254.253.252".parse().unwrap()].into(),
                 network,
                 ..Default::default()
             };

--- a/neptune-core/src/application/rpc/server.rs
+++ b/neptune-core/src/application/rpc/server.rs
@@ -1028,7 +1028,7 @@ pub trait RPC {
     /// ```
     async fn mempool_tx_count(token: auth::Token) -> RpcResult<usize>;
 
-    /// Change to return current size and max size
+    // TODO: Change to return current size and max size
     async fn mempool_size(token: auth::Token) -> RpcResult<usize>;
 
     async fn mempool_tx_ids(token: auth::Token) -> RpcResult<Vec<TransactionKernelId>>;
@@ -1368,7 +1368,7 @@ pub trait RPC {
         guesser_fee_address: ReceivingAddress,
     ) -> RpcResult<Option<(Block, ProofOfWorkPuzzle)>>;
 
-    ///docs.
+    /// todo: docs.
     ///
     /// meanwhile see [tx_initiation::initiator::TransactionInitiator::spendable_inputs()]
     async fn spendable_inputs(token: auth::Token) -> RpcResult<TxInputList>;
@@ -1383,7 +1383,7 @@ pub trait RPC {
     ///     ByUtxoSize(SortOrder),
     /// }
     ///
-    ///docs.
+    /// todo: docs.
     ///
     /// meanwhile see [tx_initiation::initiator::TransactionInitiator::select_spendable_inputs()]
     async fn select_spendable_inputs(
@@ -1397,7 +1397,7 @@ pub trait RPC {
     /// OutputFormat can be address:amount, address:amount:medium, address:utxo,
     /// address:utxo:medium, tx_output, etc.
     ///
-    ///docs.
+    /// todo: docs.
     ///
     /// meanwhile see [tx_initiation::initiator::TransactionInitiator::generate_tx_outputs()]
     async fn generate_tx_outputs(
@@ -1418,7 +1418,7 @@ pub trait RPC {
         fee: NativeCurrencyAmount,
     ) -> RpcResult<TransactionDetails>;
 
-    ///docs.
+    /// todo: docs.
     ///
     /// meanwhile see [tx_initiation::initiator::TransactionInitiator::generate_witness_proof()]
     async fn generate_witness_proof(
@@ -1428,7 +1428,7 @@ pub trait RPC {
 
     /// assemble a transaction from TransactionDetails and a TransactionProof.
     ///
-    ///docs.
+    /// todo: docs.
     ///
     /// meanwhile see [tx_initiation::initiator::TransactionInitiator::assemble_transaction()]
     async fn assemble_transaction(
@@ -1439,7 +1439,7 @@ pub trait RPC {
 
     /// assemble transaction artifacts from TransactionDetails and a TransactionProof.
     ///
-    ///docs.
+    /// todo: docs.
     ///
     /// meanwhile see [tx_initiation::initiator::TransactionInitiator::assemble_transaction_artifacts()]
     async fn assemble_transaction_artifacts(
@@ -1448,7 +1448,7 @@ pub trait RPC {
         transaction_proof: TransactionProof,
     ) -> RpcResult<TxCreationArtifacts>;
 
-    ///docs.
+    /// todo: docs.
     ///
     /// meanwhile see [tx_initiation::initiator::TransactionInitiator::proof_type()]
     async fn proof_type(
@@ -1598,7 +1598,7 @@ pub trait RPC {
 
     /// record transaction and initiate broadcast to peers
     ///
-    ///docs.
+    /// todo: docs.
     ///
     /// meanwhile see [tx_initiation::initiator::TransactionInitiator::record_and_broadcast_transaction()]
     async fn record_and_broadcast_transaction(
@@ -6444,7 +6444,7 @@ mod tests {
                     .await;
 
                 let SpendingKey::Generation(key) = wallet_spending_key else {
-                    // make_mock_block should accept a `SpendingKey`.
+                    // todo: make_mock_block should accept a SpendingKey.
                     panic!("must be generation key");
                 };
 

--- a/neptune-core/src/application/triton_vm_job_queue/mod.rs
+++ b/neptune-core/src/application/triton_vm_job_queue/mod.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use super::job_queue::JobQueue;
 
-// maybe we want to have more levels or just make it an integer eg u8.
+// todo: maybe we want to have more levels or just make it an integer eg u8.
 // or maybe name the levels by type/usage of job/proof.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub enum TritonVmJobPriority {

--- a/neptune-core/src/bin/triton-vm-prover.rs
+++ b/neptune-core/src/bin/triton-vm-prover.rs
@@ -16,7 +16,7 @@ use tasm_lib::triton_vm::vm::VM;
 use thread_priority::set_current_thread_priority;
 use thread_priority::ThreadPriority;
 
-// Replace by value exposed in Triton VM
+// TODO: Replace by value exposed in Triton VM
 const LDE_TRACE_ENV_VAR: &str = "TVM_LDE_TRACE";
 
 fn set_environment_variables(env_vars: &[(String, String)]) {
@@ -99,7 +99,7 @@ fn execute(
 fn main() {
     // run with a low priority so that neptune-core can remain responsive.
     //
-    // we could accept a thread-prioritycli param (0..100) and
+    // todo: we could accept a thread-prioritycli param (0..100) and
     //       pass it with ThreadPriority::CrossPlatform(x).
     set_current_thread_priority(ThreadPriority::Min).unwrap();
 

--- a/neptune-core/src/protocol/consensus.rs
+++ b/neptune-core/src/protocol/consensus.rs
@@ -49,7 +49,7 @@ mod tests {
             transaction::validity::removal_records_integrity::RemovalRecordsIntegrity,
             transaction::validity::single_proof::SingleProof,
             type_scripts::time_lock::TimeLock,
-            // what about those?
+            // todo: what about those?
             // block_validity::coinbase_is_valid::CoinbaseIsValid,
             // block_validity::correct_control_parameter_update::CorrectControlParameterUpdate,
             // block_validity::correct_mmr_update::CorrectMmrUpdate,

--- a/neptune-core/src/protocol/consensus/block/difficulty_control.rs
+++ b/neptune-core/src/protocol/consensus/block/difficulty_control.rs
@@ -452,7 +452,7 @@ pub(crate) fn difficulty_control(
 /// Determine an upper bound for the maximum possible cumulative proof-of-work
 /// after n blocks given the start conditions.
 ///
-/// this should accept target_block_interval and minimum_block_time params.
+/// todo: this should accept target_block_interval and minimum_block_time params.
 pub(crate) fn max_cumulative_pow_after(
     cumulative_pow_start: ProofOfWork,
     difficulty_start: Difficulty,

--- a/neptune-core/src/protocol/consensus/block/mod.rs
+++ b/neptune-core/src/protocol/consensus/block/mod.rs
@@ -1478,7 +1478,7 @@ pub(crate) mod tests {
         let a_wallet_secret = WalletEntropy::new_random();
         let a_key = a_wallet_secret.nth_generation_spending_key_for_tests(0);
 
-        // Can this outer-loop be parallelized?
+        // TODO: Can this outer-loop be parallelized?
         for multiplier in [1, 10, 100, 1_000, 10_000, 100_000, 1_000_000] {
             let mut block_prev = Block::genesis(network);
             let mut now = block_prev.kernel.header.timestamp;

--- a/neptune-core/src/protocol/consensus/block/validity.rs
+++ b/neptune-core/src/protocol/consensus/block/validity.rs
@@ -63,26 +63,39 @@ pub struct PrincipalBlockValidationWitness {
 
 impl SecretWitness for PrincipalBlockValidationWitness {
     fn standard_input(&self) -> PublicInput {
-        unimplemented!()
+        todo!()
     }
 
     fn program(&self) -> Program {
-        unimplemented!()
+        todo!()
     }
 
     fn nondeterminism(&self) -> NonDeterminism {
-        unimplemented!()
+        todo!()
     }
 }
 
 impl ConsensusProgram for PrincipalBlockValidationLogic {
     fn library_and_code(&self) -> (Library, Vec<LabelledInstruction>) {
-        unimplemented!()
+        todo!()
     }
 
     fn hash(&self) -> Digest {
         static HASH: OnceLock<Digest> = OnceLock::new();
 
         *HASH.get_or_init(|| self.program().hash())
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use crate::protocol::proof_abstractions::tasm::program::tests::ConsensusProgramSpecification;
+
+    impl ConsensusProgramSpecification for PrincipalBlockValidationLogic {
+        fn source(&self) {
+            todo!()
+        }
     }
 }

--- a/neptune-core/src/protocol/consensus/block/validity/block_program.rs
+++ b/neptune-core/src/protocol/consensus/block/validity/block_program.rs
@@ -461,7 +461,7 @@ pub(crate) mod tests {
         );
     }
 
-    // Add test that verifies that double spends *within* one block is
+    // TODO: Add test that verifies that double spends *within* one block is
     //       disallowed.
 
     #[traced_test]

--- a/neptune-core/src/protocol/consensus/block/validity/coinbase_is_valid.rs
+++ b/neptune-core/src/protocol/consensus/block/validity/coinbase_is_valid.rs
@@ -19,15 +19,15 @@ pub struct CoinbaseIsValidWitness {
 
 impl SecretWitness for CoinbaseIsValidWitness {
     fn standard_input(&self) -> PublicInput {
-        unimplemented!()
+        todo!()
     }
 
     fn program(&self) -> Program {
-        unimplemented!()
+        todo!()
     }
 
     fn nondeterminism(&self) -> NonDeterminism {
-        unimplemented!()
+        todo!()
     }
 }
 
@@ -38,12 +38,25 @@ pub struct CoinbaseIsValid {
 
 impl ConsensusProgram for CoinbaseIsValid {
     fn library_and_code(&self) -> (Library, Vec<LabelledInstruction>) {
-        unimplemented!()
+        todo!()
     }
 
     fn hash(&self) -> Digest {
         static HASH: OnceLock<Digest> = OnceLock::new();
 
         *HASH.get_or_init(|| self.program().hash())
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+pub mod tests {
+    use super::*;
+    use crate::protocol::proof_abstractions::tasm::program::tests::ConsensusProgramSpecification;
+
+    impl ConsensusProgramSpecification for CoinbaseIsValid {
+        fn source(&self) {
+            todo!()
+        }
     }
 }

--- a/neptune-core/src/protocol/consensus/block/validity/correct_control_parameter_update.rs
+++ b/neptune-core/src/protocol/consensus/block/validity/correct_control_parameter_update.rs
@@ -18,15 +18,15 @@ pub struct CorrectControlParameterUpdateWitness {
 
 impl SecretWitness for CorrectControlParameterUpdateWitness {
     fn standard_input(&self) -> PublicInput {
-        unimplemented!()
+        todo!()
     }
 
     fn program(&self) -> Program {
-        unimplemented!()
+        todo!()
     }
 
     fn nondeterminism(&self) -> NonDeterminism {
-        unimplemented!()
+        todo!()
     }
 }
 
@@ -37,12 +37,25 @@ pub struct CorrectControlParameterUpdate {
 
 impl ConsensusProgram for CorrectControlParameterUpdate {
     fn library_and_code(&self) -> (Library, Vec<LabelledInstruction>) {
-        unimplemented!()
+        todo!()
     }
 
     fn hash(&self) -> Digest {
         static HASH: OnceLock<Digest> = OnceLock::new();
 
         *HASH.get_or_init(|| self.program().hash())
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+pub mod tests {
+    use super::*;
+    use crate::protocol::proof_abstractions::tasm::program::tests::ConsensusProgramSpecification;
+
+    impl ConsensusProgramSpecification for CorrectControlParameterUpdate {
+        fn source(&self) {
+            todo!()
+        }
     }
 }

--- a/neptune-core/src/protocol/consensus/block/validity/correct_mmr_update.rs
+++ b/neptune-core/src/protocol/consensus/block/validity/correct_mmr_update.rs
@@ -18,15 +18,15 @@ pub struct CorrectMmrUpdateWitness {
 
 impl SecretWitness for CorrectMmrUpdateWitness {
     fn standard_input(&self) -> PublicInput {
-        unimplemented!()
+        todo!()
     }
 
     fn program(&self) -> Program {
-        unimplemented!()
+        todo!()
     }
 
     fn nondeterminism(&self) -> NonDeterminism {
-        unimplemented!()
+        todo!()
     }
 }
 
@@ -37,12 +37,25 @@ pub struct CorrectMmrUpdate {
 
 impl ConsensusProgram for CorrectMmrUpdate {
     fn library_and_code(&self) -> (Library, Vec<LabelledInstruction>) {
-        unimplemented!()
+        todo!()
     }
 
     fn hash(&self) -> Digest {
         static HASH: OnceLock<Digest> = OnceLock::new();
 
         *HASH.get_or_init(|| self.program().hash())
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use crate::protocol::proof_abstractions::tasm::program::tests::ConsensusProgramSpecification;
+
+    impl ConsensusProgramSpecification for CorrectMmrUpdate {
+        fn source(&self) {
+            todo!()
+        }
     }
 }

--- a/neptune-core/src/protocol/consensus/block/validity/correct_mutator_set_update.rs
+++ b/neptune-core/src/protocol/consensus/block/validity/correct_mutator_set_update.rs
@@ -18,15 +18,15 @@ pub struct CorrectMutatorSetUpdateWitness {
 
 impl SecretWitness for CorrectMutatorSetUpdateWitness {
     fn nondeterminism(&self) -> NonDeterminism {
-        unimplemented!()
+        todo!()
     }
 
     fn standard_input(&self) -> PublicInput {
-        unimplemented!()
+        todo!()
     }
 
     fn program(&self) -> Program {
-        unimplemented!()
+        todo!()
     }
 }
 
@@ -37,12 +37,25 @@ pub struct CorrectMutatorSetUpdate {
 
 impl ConsensusProgram for CorrectMutatorSetUpdate {
     fn library_and_code(&self) -> (Library, Vec<LabelledInstruction>) {
-        unimplemented!()
+        todo!()
     }
 
     fn hash(&self) -> Digest {
         static HASH: OnceLock<Digest> = OnceLock::new();
 
         *HASH.get_or_init(|| self.program().hash())
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use crate::protocol::proof_abstractions::tasm::program::tests::ConsensusProgramSpecification;
+
+    impl ConsensusProgramSpecification for CorrectMutatorSetUpdate {
+        fn source(&self) {
+            todo!()
+        }
     }
 }

--- a/neptune-core/src/protocol/consensus/block/validity/mmr_membership.rs
+++ b/neptune-core/src/protocol/consensus/block/validity/mmr_membership.rs
@@ -18,15 +18,15 @@ pub struct MmrMembershipWitness {
 
 impl SecretWitness for MmrMembershipWitness {
     fn standard_input(&self) -> PublicInput {
-        unimplemented!()
+        todo!()
     }
 
     fn program(&self) -> Program {
-        unimplemented!()
+        todo!()
     }
 
     fn nondeterminism(&self) -> NonDeterminism {
-        unimplemented!()
+        todo!()
     }
 }
 
@@ -37,12 +37,25 @@ pub struct MmrMembership {
 
 impl ConsensusProgram for MmrMembership {
     fn library_and_code(&self) -> (Library, Vec<LabelledInstruction>) {
-        unimplemented!()
+        todo!()
     }
 
     fn hash(&self) -> Digest {
         static HASH: OnceLock<Digest> = OnceLock::new();
 
         *HASH.get_or_init(|| self.program().hash())
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use crate::protocol::proof_abstractions::tasm::program::tests::ConsensusProgramSpecification;
+
+    impl ConsensusProgramSpecification for MmrMembership {
+        fn source(&self) {
+            todo!()
+        }
     }
 }

--- a/neptune-core/src/protocol/consensus/block/validity/predecessor_is_valid.rs
+++ b/neptune-core/src/protocol/consensus/block/validity/predecessor_is_valid.rs
@@ -18,15 +18,15 @@ pub struct PredecessorIsValidWitness {
 
 impl SecretWitness for PredecessorIsValidWitness {
     fn standard_input(&self) -> PublicInput {
-        unimplemented!()
+        todo!()
     }
 
     fn program(&self) -> Program {
-        unimplemented!()
+        todo!()
     }
 
     fn nondeterminism(&self) -> NonDeterminism {
-        unimplemented!()
+        todo!()
     }
 }
 
@@ -37,12 +37,25 @@ pub struct PredecessorIsValid {
 
 impl ConsensusProgram for PredecessorIsValid {
     fn library_and_code(&self) -> (Library, Vec<LabelledInstruction>) {
-        unimplemented!()
+        todo!()
     }
 
     fn hash(&self) -> Digest {
         static HASH: OnceLock<Digest> = OnceLock::new();
 
         *HASH.get_or_init(|| self.program().hash())
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use crate::protocol::proof_abstractions::tasm::program::tests::ConsensusProgramSpecification;
+
+    impl ConsensusProgramSpecification for PredecessorIsValid {
+        fn source(&self) {
+            todo!()
+        }
     }
 }

--- a/neptune-core/src/protocol/consensus/transaction/primitive_witness.rs
+++ b/neptune-core/src/protocol/consensus/transaction/primitive_witness.rs
@@ -298,7 +298,7 @@ impl PrimitiveWitness {
             .zip_eq(&self.input_membership_proofs)
         {
             let item = Tip5::hash(input_utxo);
-            // write these functions in tasm
+            // TODO: write these functions in tasm
             if !self.mutator_set_accumulator.verify(item, membership_proof) {
                 let error = WitnessValidationError::InvalidMembershipProof {
                     witness_mutator_set_accumulator_hash: self.mutator_set_accumulator.hash(),

--- a/neptune-core/src/protocol/consensus/transaction/validity/tasm/compute_absolute_indices.rs
+++ b/neptune-core/src/protocol/consensus/transaction/validity/tasm/compute_absolute_indices.rs
@@ -268,7 +268,8 @@ mod tests {
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
         ) {
-            /// Use this function from `tasm-lib` once upgraded to latest version. And delete this locally declared function.
+            // TODO: Use this function from `tasm-lib` once upgraded to latest
+            // version. And delete this locally declared function.
             fn pop_encodable<T: BFieldCodec>(stack: &mut Vec<BFieldElement>) -> T {
                 let len = T::static_length().unwrap();
                 let limbs = (0..len).map(|_| stack.pop().unwrap()).collect_vec();

--- a/neptune-core/src/protocol/consensus/transaction/validity/tasm/single_proof/update_branch.rs
+++ b/neptune-core/src/protocol/consensus/transaction/validity/tasm/single_proof/update_branch.rs
@@ -966,7 +966,7 @@ pub(crate) mod tests {
         num_pub_announcements: usize,
         consensus_rule_set: ConsensusRuleSet,
     ) -> UpdateWitness {
-        // Currently only tests a new mutator set with more AOCL leafs.
+        // TODO: Currently only tests a new mutator set with more AOCL leafs.
         // Should also test for removed records in the new mutator set
         // accumulator.
         let mut test_runner = TestRunner::deterministic();

--- a/neptune-core/src/protocol/consensus/type_scripts/amount/mod.rs
+++ b/neptune-core/src/protocol/consensus/type_scripts/amount/mod.rs
@@ -10,4 +10,6 @@ const UTXO_SIZE_TOO_LARGE_ERROR: i128 = 1_000_401;
 const TOO_BIG_COIN_FIELD_SIZE_ERROR: i128 = 1_000_402;
 const STATE_LENGTH_FOR_TIME_LOCK_NOT_ONE_ERROR: i128 = 1_000_403;
 
-//  - support hardcoded digests for non-native-currency amount-like type scripts.
+// Todo:
+//  - support hardcoded digests for non-native-currency amount-like type
+//    scripts.

--- a/neptune-core/src/protocol/peer.rs
+++ b/neptune-core/src/protocol/peer.rs
@@ -543,8 +543,8 @@ pub(crate) enum PeerMessage {
     BlockRequestByHeight(BlockHeight),
     BlockRequestByHash(Digest),
 
-    BlockRequestBatch(BlockRequestBatch), // Consider restricting this in size
-    BlockResponseBatch(Vec<(TransferBlock, MmrMembershipProof)>), // Consider restricting this in size
+    BlockRequestBatch(BlockRequestBatch), // TODO: Consider restricting this in size
+    BlockResponseBatch(Vec<(TransferBlock, MmrMembershipProof)>), // TODO: Consider restricting this in size
     UnableToSatisfyBatchRequest,
 
     // TODO #libp2p_reqresp_Sync a kind of challenge (just a proof of tiny work probably) from a *requestor* is also needed when adapt syncing to #libp2p_reqresp_sync to avoid malicious asking for a block just to annoy the node

--- a/neptune-core/src/protocol/peer/peer_info.rs
+++ b/neptune-core/src/protocol/peer/peer_info.rs
@@ -143,7 +143,7 @@ impl PeerInfo {
         !self.connection_is_inbound()
     }
 
-    /// `neptune-core`` version-string reported by the peer.
+    /// `neptune-core` version-string reported by the peer.
     ///
     /// note: the peer might be not honest.
     pub fn version(&self) -> &str {

--- a/neptune-core/src/protocol/peer/transfer_transaction.rs
+++ b/neptune-core/src/protocol/peer/transfer_transaction.rs
@@ -16,7 +16,7 @@ use crate::protocol::consensus::transaction::TransactionProof;
 /// `ProofCollection` requires upgrade to `SingleProof` before mining, so it is of lover quality.
 #[derive(Clone, Copy, EnumIter, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum TransactionProofQuality {
-    // OnlyLockScripts, // Add this once `Transaction` has support
+    // OnlyLockScripts, // TODO: Add this once `Transaction` has support
     ProofCollection,
     SingleProof,
 }
@@ -28,7 +28,7 @@ pub(crate) enum TransactionProofQuality {
 /// peers, as this would leak secret key material.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) enum TransferTransactionProof {
-    //OnlyLockScripts(OnlyLockScriptWitness) Add when `Transaction` supports
+    //OnlyLockScripts(OnlyLockScriptWitness) TODO: Add when `Transaction` supports
     ProofCollection(Box<ProofCollection>),
     SingleProof(Proof),
 }

--- a/neptune-core/src/protocol/proof_abstractions/tasm/program.rs
+++ b/neptune-core/src/protocol/proof_abstractions/tasm/program.rs
@@ -452,8 +452,7 @@ pub mod tests {
     /// If a proof was found, returns it along with the URL of the server
     /// serving the proof. The caller should validate the proof. Does
     /// not store the proof to disk.
-    ///
-    /// Consider making this async.
+    /// TODO: Consider making this async.
     fn try_fetch_from_server_inner(filename: String) -> Option<(Proof, String)> {
         let (file_contents, server) = try_fetch_file_from_server(filename)?;
 

--- a/neptune-core/src/state/archival_state.rs
+++ b/neptune-core/src/state/archival_state.rs
@@ -1013,7 +1013,7 @@ impl ArchivalState {
 
     /// Return a boolean indicating if block belongs to most canonical chain.
     ///
-    /// Returns false if either the block is not known, or if it's known but
+    /// Returns `false` if either the block is not known, or if it's known but
     /// has been orphaned.
     pub(crate) async fn block_belongs_to_canonical_chain(&self, block_digest: Digest) -> bool {
         if let Some(block_header) = self.get_block_header(block_digest).await {
@@ -1029,20 +1029,21 @@ impl ArchivalState {
         }
     }
 
-    /// Return a list of digests of the ancestors to the requested digest. Does not include the input
-    /// digest. If no ancestors can be found, returns the empty list. The count is the maximum length
-    /// of the returned list. E.g. if the input digest corresponds to height 2 and count is 5, the
-    /// returned list will contain the digests of block 1 and block 0 (the genesis block).
-    /// The input block must correspond to a known block but it can be the genesis block in which case
-    /// the empty list will be returned.
+    /// Return a list of digests of the ancestors to the requested digest. Does not include the input digest.
+    /// If no ancestors can be found, returns the empty list. The count is the maximum length of the returned list.
+    /// E.g. if the input digest corresponds to height 2 and count is 5, the returned list will contain the digests of block 1 and block 0 (the genesis block).
+    /// The input block must correspond to a known block but it can be the genesis block in which case the empty list will be returned.
     pub(crate) async fn get_ancestor_block_digests(
         &self,
         block_digest: Digest,
         mut count: usize,
     ) -> Vec<Digest> {
-        let input_block_header = self.get_block_header(block_digest).await.unwrap();
-        let mut parent_digest = input_block_header.prev_block_digest;
-        let mut ret = vec![];
+        let mut parent_digest = self
+            .get_block_header(block_digest)
+            .await
+            .unwrap()
+            .prev_block_digest;
+        let mut ret = Vec::with_capacity(count);
         while let Some(parent) = self.get_block_header(parent_digest).await {
             if count == 0 {
                 break;

--- a/neptune-core/src/state/mempool/mempool_event.rs
+++ b/neptune-core/src/state/mempool/mempool_event.rs
@@ -11,8 +11,8 @@ use crate::protocol::proof_abstractions::mast_hash::MastHash;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MempoolEvent {
     /// a transaction was added to the mempool
-    ///
-    /// Consider adding proof type here in case any subscriber could use that.
+    // TODO: Consider adding proof type here in case any subscriber could use
+    // that.
     AddTx(TransactionKernel),
 
     /// a transaction was removed from the mempool

--- a/neptune-core/src/state/mod.rs
+++ b/neptune-core/src/state/mod.rs
@@ -1325,7 +1325,7 @@ impl GlobalState {
                     msmp.aocl_leaf_index,
                 ),
                 None => {
-                    // Fix this ugly hack. We probably need AOCL leaf index on the monitored
+                    // TODO: Fix this ugly hack. We probably need AOCL leaf index on the monitored
                     // UTXO structure to do that. And that requires a DB migration :(
                     let Some(new_utxos) = new_utxos.as_mut() else {
                         warn!("Monitored UTXO has no membership proof and no recovery data was provided.");
@@ -1931,7 +1931,7 @@ impl GlobalState {
         }
 
         // request blocks from peers
-        unimplemented!("We don't yet support non-archival nodes");
+        todo!("We don't yet support non-archival nodes");
     }
 
     pub(crate) async fn response_to_sync_challenge(
@@ -4072,7 +4072,7 @@ mod tests {
                 .await
                 .available_confirmed(in_seven_months)
         );
-        // No idea why this isn't working. It's off by 1 NAU?
+        // TODO: No idea why this isn't working. It's off by 1 NAU?
         // {
         //     let expected = NativeCurrencyAmount::coins(74);
         //     let got = premine_receiver

--- a/neptune-core/src/state/wallet/address/generation_address.rs
+++ b/neptune-core/src/state/wallet/address/generation_address.rs
@@ -68,7 +68,7 @@ pub struct GenerationSpendingKey {
 
 // manually impl Deserialize so we can derive all other fields from the seed.
 impl<'de> serde::de::Deserialize<'de> for GenerationSpendingKey {
-    // is there a more succinct way to impl this fn that works for
+    // todo: is there a more succinct way to impl this fn that works for
     // both sequential and map visitor access patterns?
     //
     // for seq access (bincode, postcard) we can simply do:

--- a/neptune-core/src/state/wallet/mod.rs
+++ b/neptune-core/src/state/wallet/mod.rs
@@ -241,7 +241,8 @@ mod tests {
         let (block_2, _) = make_mock_block(&block_1, None, bob_key, rng.random(), network).await;
         let (block_3, _) = make_mock_block(&block_2, None, bob_key, rng.random(), network).await;
 
-        // Is this assertion correct? Do we need to check if an auth path is empty?
+        // TODO: Is this assertion correct? Do we need to check if an auth path
+        // is empty?
         assert!(!items_and_msmps_block1.clone().all(|(item, msmp)| block_3
             .mutator_set_accumulator_after()
             .unwrap()

--- a/neptune-core/src/state/wallet/wallet_state.rs
+++ b/neptune-core/src/state/wallet/wallet_state.rs
@@ -1069,26 +1069,26 @@ impl WalletState {
         }
     }
 
-    /// These spending keys should probably be derived dynamically from some
-    /// state in the wallet.
-    ///
-    /// Probably the wallet should keep track of index of latest derived key
-    /// that has been requested by the user for purpose of receiving
-    /// funds.  We could also perform a sequential scan at startup (or import)
-    /// of keys that have received funds, up to some "gap".  In bitcoin/bip32
-    /// this gap is defined as 20 keys in a row that have never received funds.
+    // TODO: These spending keys should probably be derived dynamically from some
+    // state in the wallet.
+    //
+    // Probably the wallet should keep track of index of latest derived key
+    // that has been requested by the user for purpose of receiving
+    // funds.  We could also perform a sequential scan at startup (or import)
+    // of keys that have received funds, up to some "gap".  In bitcoin/bip32
+    // this gap is defined as 20 keys in a row that have never received funds.
     fn get_known_generation_spending_keys(&self) -> impl Iterator<Item = SpendingKey> + '_ {
         self.known_generation_keys.iter().copied()
     }
 
-    /// These spending keys should probably be derived dynamically from some
-    /// state in the wallet.
-    ///
-    /// Probably the wallet should keep track of index of latest derived key
-    /// that has been requested by the user for purpose of receiving
-    /// funds.  We could also perform a sequential scan at startup (or import)
-    /// of keys that have received funds, up to some "gap".  In bitcoin/bip32
-    /// this gap is defined as 20 keys in a row that have never received funds.
+    // TODO: These spending keys should probably be derived dynamically from some
+    // state in the wallet.
+    //
+    // Probably the wallet should keep track of index of latest derived key
+    // that has been requested by the user for purpose of receiving
+    // funds.  We could also perform a sequential scan at startup (or import)
+    // of keys that have received funds, up to some "gap".  In bitcoin/bip32
+    // this gap is defined as 20 keys in a row that have never received funds.
     fn get_known_symmetric_keys(&self) -> impl Iterator<Item = SpendingKey> + '_ {
         self.known_symmetric_keys.iter().copied()
     }
@@ -1563,7 +1563,7 @@ impl WalletState {
             // Batch update removal records to keep them valid after next removal
             RemovalRecord::batch_update_from_remove(&mut removal_records, removal_record);
 
-            // We mark membership proofs as spent, so they can be deleted. But
+            // TODO: We mark membership proofs as spent, so they can be deleted. But
             // how do we ensure that we can recover them in case of a fork? For now we maintain
             // them even if the are spent, and then, later, we can add logic to remove these
             // membership proofs of spent UTXOs once they have been spent for M blocks.

--- a/neptune-core/src/tests/shared.rs
+++ b/neptune-core/src/tests/shared.rs
@@ -109,7 +109,7 @@ pub enum Action<Item> {
     /// Simulates an error when reading the peer's message. Consider adding an
     /// error type here to better simulate e.g. a deserialization error.
     ReadError,
-    // Some tests with these things
+    // Todo: Some tests with these things
     // Wait(Duration),
     // ReadError(Option<Arc<io::Error>>),
     // WriteError(Option<Arc<io::Error>>),

--- a/neptune-core/src/tests/shared/strategies.rs
+++ b/neptune-core/src/tests/shared/strategies.rs
@@ -103,7 +103,7 @@ prop_compose! {
     }
 }
 
-/// Change this function into something more meaningful!
+// TODO: Change this function into something more meaningful!
 pub fn make_mock_transaction_with_wallet(
     inputs: Vec<RemovalRecord>,
     outputs: Vec<AdditionRecord>,

--- a/neptune-core/src/util_types/archival_mmr.rs
+++ b/neptune-core/src/util_types/archival_mmr.rs
@@ -245,7 +245,8 @@ impl<Storage: StorageVec<Digest>> ArchivalMmr<Storage> {
         leaf_index: u64,
         num_leafs: u64,
     ) -> MmrMembershipProof {
-        // Replace this local function with the one in `twenty_first` once available through never version.
+        // TODO: Replace this local function with the one in `twenty_first` once
+        // available through never version.
         fn auth_path_node_indices(num_leafs: u64, leaf_index: u64) -> Vec<u64> {
             assert!(
                 leaf_index < num_leafs,
@@ -357,7 +358,7 @@ impl<Storage: StorageVec<Digest>> ArchivalMmr<Storage> {
         let index_of_last_removal = leaf_index_to_node_index(num_leafs);
 
         while self.digests.len().await > index_of_last_removal {
-            // It would be faster to be able to prune here,
+            // TODO: It would be faster to be able to prune here,
             self.digests.pop().await.unwrap();
         }
     }

--- a/neptune-core/src/util_types/mutator_set/removal_record.rs
+++ b/neptune-core/src/util_types/mutator_set/removal_record.rs
@@ -400,7 +400,7 @@ mod tests {
 
     #[test]
     fn removal_record_serialization_test() {
-        // You could argue that this test doesn't belong here, as it tests the behavior of
+        // TODO: You could argue that this test doesn't belong here, as it tests the behavior of
         // an imported library. I included it here, though, because the setup seems a bit clumsy
         // to me so far.
 

--- a/neptune-core/src/util_types/mutator_set/removal_record/chunk.rs
+++ b/neptune-core/src/util_types/mutator_set/removal_record/chunk.rs
@@ -474,7 +474,7 @@ mod tests {
 
     #[test]
     fn serialization_test() {
-        // You could argue that this test doesn't belong here, as it tests the behavior of
+        // TODO: You could argue that this test doesn't belong here, as it tests the behavior of
         // an imported library. I included it here, though, because the setup seems a bit clumsy
         // to me so far.
         let chunk = Chunk::empty_chunk();

--- a/neptune-core/src/util_types/mutator_set/removal_record/chunk_dictionary.rs
+++ b/neptune-core/src/util_types/mutator_set/removal_record/chunk_dictionary.rs
@@ -250,7 +250,7 @@ pub mod tests {
 
     #[apply(shared_tokio_runtime)]
     async fn serialization_test() {
-        // You could argue that this test doesn't belong here, as it tests the behavior of
+        // TODO: You could argue that this test doesn't belong here, as it tests the behavior of
         // an imported library. I included it here, though, because the setup seems a bit clumsy
         // to me so far.
         let s_empty: ChunkDictionary = ChunkDictionary::empty();

--- a/neptune-dashboard/src/address_screen.rs
+++ b/neptune-dashboard/src/address_screen.rs
@@ -187,7 +187,7 @@ impl AddressScreen {
                     match key.code {
                         KeyCode::Down => self.events.next(),
                         KeyCode::Up => self.events.previous(),
-                        // PgUp,PgDn.  (but how to determine page size?  fixed n?)
+                        // todo: PgUp,PgDn.  (but how to determine page size?  fixed n?)
                         _ => {
                             escalate_event = Some(event);
                         }
@@ -256,6 +256,7 @@ impl Widget for AddressScreen {
 
         // chart
         // ?
+        // todo
 
         // table
         let style = Style::default().fg(self.fg).bg(self.bg);

--- a/neptune-dashboard/src/history_screen.rs
+++ b/neptune-dashboard/src/history_screen.rs
@@ -197,7 +197,7 @@ impl HistoryScreen {
                     match key.code {
                         KeyCode::Down => self.events.next(),
                         KeyCode::Up => self.events.previous(),
-                        // PgUp,PgDn.  (but how to determine page size?  fixed n?)
+                        // todo: PgUp,PgDn.  (but how to determine page size?  fixed n?)
                         _ => {
                             escalate_event = Some(event);
                         }
@@ -266,6 +266,7 @@ impl Widget for HistoryScreen {
 
         // chart
         // ?
+        // todo
 
         // table
         let style = Style::default().fg(self.fg).bg(self.bg);

--- a/neptune-dashboard/src/peers_screen.rs
+++ b/neptune-dashboard/src/peers_screen.rs
@@ -211,7 +211,7 @@ impl PeersScreen {
                     match key.code {
                         KeyCode::Down => self.events.next(),
                         KeyCode::Up => self.events.previous(),
-                        // PgUp,PgDn.  (but how to determine page size?  fixed n?)
+                        // todo: PgUp,PgDn.  (but how to determine page size?  fixed n?)
                         KeyCode::Char(c) => {
                             if self.set_sort_column(c) {
                                 return None;

--- a/neptune-dashboard/src/receive_screen.rs
+++ b/neptune-dashboard/src/receive_screen.rs
@@ -68,7 +68,7 @@ impl ReceiveScreen {
             let escalatable_event = self.escalatable_event.clone();
 
             tokio::spawn(async move {
-                // change to receive most recent wallet
+                // TODO: change to receive most recent wallet
                 let receiving_address = rpc_client
                     .next_receiving_address(context::current(), token, KeyType::Generation)
                     .await

--- a/neptune-dashboard/src/utxos_screen.rs
+++ b/neptune-dashboard/src/utxos_screen.rs
@@ -172,7 +172,7 @@ impl UtxosScreen {
                     match key.code {
                         KeyCode::Down => self.scrollable_table.next(),
                         KeyCode::Up => self.scrollable_table.previous(),
-                        // PgUp,PgDn.  (but how to determine page size?  fixed n?)
+                        // todo: PgUp,PgDn.  (but how to determine page size?  fixed n?)
                         _ => {
                             escalate_event = Some(event);
                         }
@@ -240,6 +240,7 @@ impl Widget for UtxosScreen {
 
         // chart
         // ?
+        // todo
 
         // table
         let style = Style::default().fg(self.fg).bg(self.bg);


### PR DESCRIPTION
continuation of #701 from a more recent commit

it has a lot of comments to delete when pass the reviews -- I left those to better convey the implementation decisions 

Also given the size of this change it makes sense to split/separate some things which you're OK with to merge earlier. This should ease all the aspects of handling it; I just had some hard time guessing which parts could get a go --- let me listen from you first! :tophat: 

# ~~todos~~
never mind, it was reverted
> I was surprised how many todos the code held. I thought just to invent some other tag for my current todos, but I truly think the system is beyond the point when this was acceptable. Some of them 3 y.o.! My point is they should be converted to the tracker issues and replaced by the reference to the issue. I'll bring them back if I'm wrong on this. But I hope after your first natural rejection reaction you would take less than 2 hours to map the issues to your todos. My first contribution was a small issue from the tracker, not a todo from the code, as an example.
> 
> And ofc I'm converting all the todos I've added around into the issues when the review is passed! :pencil2: 