### PR TITLE
fix(Mempool): Cover edge case for initiating Update

### DIFF
--- a/neptune-core/src/state/mempool.rs
+++ b/neptune-core/src/state/mempool.rs
@@ -1038,12 +1038,19 @@ impl Mempool {
                 // mempool in the expectation that someone will update them to
                 // be valid under a new mutator set.
                 //
-                // If the transaction was initiated locally, *and* node can
-                // produce single-proofs, transaction should be updated
-                // immediately (and be kept in mempool).
+                // If (the transaction was initiated locally or deemed
+                // critical), *and* node can produce single-proofs, transaction
+                // should be updated immediately (and be kept in mempool).
+                //
+                // Note: Do not check for the presence of a primitive witness.
+                // This information is irrelevant for Update tasks and moreover
+                // not always present for critical transactions. For instance:
+                // the edge case in which the transaction was merged (the
+                // primitive witness is dropped) but the merge-sibling was mined
+                // (the current transaction is retrieved from cache).
                 TransactionProof::SingleProof(sp) => {
                     if self.tx_proving_capability == TxProvingCapability::SingleProof
-                        && tx.primitive_witness.is_some()
+                        && tx.upgrade_priority == UpgradePriority::Critical
                     {
                         // Node initiated transaction and can update.
                         let update_sp = MempoolUpdateJob::SingleProof {

--- a/neptune-core/src/state/mempool/upgrade_priority.rs
+++ b/neptune-core/src/state/mempool/upgrade_priority.rs
@@ -17,7 +17,8 @@ pub enum UpgradePriority {
     /// There's a certain amount of interest.
     ///
     /// For example, wallets can use the sum of the outputs the transaction
-    /// sends to them.
+    /// sends to them. Should also be used when this node has upgraded the
+    /// transaction.
     Interested(NativeCurrencyAmount),
 
     /// The transaction in question is of the highest possible priority. Wallets


### PR DESCRIPTION
This commit fixes an edge case in the mempool logic that results in transactions initiated by ourselves to be ignored for Updates as new blocks are found, even when we were the ones to produce a SingleProof for them.

The edge case comes about as follows:
 - We initiate the transaction and produce a SingleProof for it.
 - We broadcast the transaction.
 - Someone else merges the transaction with some other transaction and broadcasts that.
 - That merge-result is inserted into our mempool and this insertion moves the original transaction into the cache (without primitive witness).
 - The other operand of the merger is mined. So our transaction is fetched from the cache and inserted back into the mempool (without primitive witness).
 - A new block is mined.
 - We do not Update our transaction because
 - it does not have an associated primitive witness <-- error is here.

The correct criterion for deciding whether a transaction should be updated is whether it is critical; not whether it has a primitive witness. Critical means "initiated by us". Transactions cannot have a primitive witness without being critical; but they obviously can be critical without having a primitive witness. More to the point, the primitive witness is not relevant data for performing an Update job.