### PR TITLE
network-security: Prevent infinite sync challenges

### DIFF
--- a/neptune-core/src/application/loops/peer_loop.rs
+++ b/neptune-core/src/application/loops/peer_loop.rs
@@ -734,6 +734,12 @@ impl PeerLoopHandler {
 
                     info!("Got sync challenge from {}", self.peer_address.ip());
 
+                    // Sync challenges are *always* punished to prevent a
+                    // malicious peer from spamming these, as they are expensive
+                    // to respond to.
+                    self.punish(NegativePeerSanction::ReceivedSyncChallenge)
+                        .await?;
+
                     let response = self
                         .global_state_lock
                         .lock_guard()

--- a/neptune-core/src/protocol/peer.rs
+++ b/neptune-core/src/protocol/peer.rs
@@ -100,6 +100,11 @@ pub enum NegativePeerSanction {
     UnwantedMessage,
 
     NoStandingFoundMaybeCrash,
+
+    /// A sync challenge was received. Is punished to prevent many challenges
+    /// from same peer, as they're expensive (in disk I/O and networking
+    /// bandwidth) to respond to.
+    ReceivedSyncChallenge,
 }
 
 /// The reason for improving a peer's standing
@@ -171,6 +176,7 @@ impl Display for NegativePeerSanction {
             }
             NegativePeerSanction::FishyPowEvolutionChallengeResponse => "fishy pow evolution",
             NegativePeerSanction::FishyDifficultiesChallengeResponse => "fishy difficulties",
+            NegativePeerSanction::ReceivedSyncChallenge => "received sync challenge",
         };
         write!(f, "{string}")
     }
@@ -246,6 +252,7 @@ impl Sanction for NegativePeerSanction {
             NegativePeerSanction::BatchBlocksRequestTooManyDigests => -50,
             NegativePeerSanction::FishyPowEvolutionChallengeResponse => -51,
             NegativePeerSanction::FishyDifficultiesChallengeResponse => -51,
+            NegativePeerSanction::ReceivedSyncChallenge => -50,
         }
     }
 }


### PR DESCRIPTION
An attack I spotted through the logs of a node: peer connects, peer sends a sync challenge which requires 20 blocks to be read from disk and sent over the network, and then disconnects. Continues this forever.

To mitigate this attack, each sync challenge is now punished at 50 points reputation. So after 20 such sync challenges from the same IP address, this IP address will be banned.