### PR TITLE
Fix Windows block-notification test script

### DIFF
--- a/neptune-core/src/application/loops/main_loop.rs
+++ b/neptune-core/src/application/loops/main_loop.rs
@@ -3132,7 +3132,6 @@ mod tests {
     }
 
     mod peer_messages {
-
         use super::*;
 
         #[traced_test]
@@ -3144,7 +3143,10 @@ mod tests {
             use crate::tests::shared::files::unit_test_data_directory;
             use crate::tests::shared::files::wait_for_file_to_exist;
 
+            #[cfg(not(windows))]
             const BLOCK_NOTIFY_SHELL_SCRIPT_NAME: &str = "block_notify_dummy.py";
+            #[cfg(windows)]
+            const BLOCK_NOTIFY_SHELL_SCRIPT_NAME: &str = "block_notify_dummy.bat";
 
             let network = Network::Main;
             let dummy_block = invalid_empty_block(&Block::genesis(network), network);

--- a/neptune-core/test_data/block_notify_dummy.bat
+++ b/neptune-core/test_data/block_notify_dummy.bat
@@ -1,0 +1,4 @@
+@echo off
+
+REM thin wrapper since she-bang shenanigans don't work on windows
+py %~dp0\block_notify_dummy.py %*


### PR DESCRIPTION
Because Windows doesn't have she-bang (`#!`) execution, the python script that is used to test the block notification CLI parameter causes errors.

Add a batch (`.bat`) script that is a thin wrapper around the original script.