### PR TITLE
fix(dashboard): Mock RPC call `latest-address`

### DIFF
--- a/neptune-dashboard/src/dashboard_rpc_client.rs
+++ b/neptune-dashboard/src/dashboard_rpc_client.rs
@@ -178,6 +178,23 @@ impl DashboardRpcClient {
         }
     }
 
+    pub async fn latest_address(
+        &self,
+        ctx: ::tarpc::context::Context,
+        token: auth::Token,
+        address_type: KeyType,
+    ) -> ::core::result::Result<RpcResult<ReceivingAddress>, ::tarpc::client::RpcError> {
+        match self {
+            DashboardRpcClient::Authentic(rpcclient) => {
+                rpcclient.latest_address(ctx, token, address_type).await
+            }
+            #[cfg(feature = "mock")]
+            DashboardRpcClient::Mock(mock_client) => {
+                mock_client.latest_address(ctx, token, address_type).await
+            }
+        }
+    }
+
     pub async fn next_receiving_address(
         &self,
         ctx: ::tarpc::context::Context,


### PR DESCRIPTION
Commits 489853b and 9c35136 add a RPC end-point for getting the most recent address and displaying it by default in the dashboard. However, the mock RPC server, which is used when running the dashboard in mock mode, does not know this method and consequently when it is called control is passed to the real RPC server, leading to a crash.

This commit mocks the endpoint, fixing the cash.