### PR TITLE
Small Dashboard Features

### DIFF
--- a/neptune-dashboard/src/mock_rpc_client.rs
+++ b/neptune-dashboard/src/mock_rpc_client.rs
@@ -57,7 +57,7 @@ impl MockRpcClient {
     fn init_mock_data() -> MockState {
         let mut rng = StdRng::from_seed(rng().random());
 
-        let num_peers = 100 + rng.random_range(1..10);
+        let num_peers = 100;
         let peers: Vec<PeerInfo> = (0..num_peers).map(|_| rng.random()).collect();
 
         let num_utxos = rng.random_range(1..20);

--- a/neptune-dashboard/src/peers_screen.rs
+++ b/neptune-dashboard/src/peers_screen.rs
@@ -624,6 +624,8 @@ impl Events {
     }
 
     /// Jump the selector down by a page.
+    ///
+    /// By convention, one page is half the number of visible rows.
     pub fn next_page(&mut self) {
         let offset = Self::TABLE_HEADER_ROWS;
         let num_rows = Self::terminal_height() as usize
@@ -641,6 +643,8 @@ impl Events {
     }
 
     // Jump the selector up by a page.
+    ///
+    /// By convention, one page is half the number of visible rows.
     pub fn previous_page(&mut self) {
         let offset = Self::TABLE_HEADER_ROWS;
         let num_rows = Self::terminal_height() as usize


### PR DESCRIPTION
 1. Escape focus in Peers screen by pressing `q`.
 2. Jump up/down by one page using PgUp/PgDn.