### PR TITLE
build: Remove obsolete workaround

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,9 +4,6 @@
 rustflags = ["--cfg", "tokio_unstable"]
 
 [env]
-# workaround for rustc 1.80 running out of stack space when building triton-vm
-RUST_MIN_STACK = "33554432"
-
 # so that anyhow errors automatically display stack trace
 RUST_BACKTRACE = "1"
 


### PR DESCRIPTION
For rustc version 1.80 (only), the dependency Triton VM required an increased stack size to build successfully. The current version of rustc is 1.91 and as such, the workaround is no longer needed.
