### PR TITLE
refactor(wallet): Only maintain one MSMP per monitored UTXO

### DIFF
--- a/neptune-core/src/application/config/cli_args.rs
+++ b/neptune-core/src/application/config/cli_args.rs
@@ -386,7 +386,7 @@ pub struct Args {
     pub network: Network,
 
     /// Max number of membership proofs stored per owned UTXO
-    #[structopt(long, default_value = "3")]
+    #[structopt(long, default_value = "1")]
     pub(crate) number_of_mps_per_utxo: usize,
 
     /// Configure how complicated proofs this machine is capable of producing.


### PR DESCRIPTION
Nodes that have an archival mutator set don't need membership proofs for their monitored UTXOs, as all the authentication paths and Bloom filter chunk values can be read from the archival version of the mutator set.

Since archival nodes maintain an archival mutator set and all nodes are currently archival nodes, they don't need *any* membership proofs. This change gets us 2/3 of the way there.

Cf. #813.