### PR TITLE
Dont rebuild nops

### DIFF
--- a/neptune-core/src/application/loops/main_loop/proof_upgrader.rs
+++ b/neptune-core/src/application/loops/main_loop/proof_upgrader.rs
@@ -308,7 +308,7 @@ impl UpgradeJob {
         }
     }
 
-    fn upgrade_incentive(&self) -> UpgradeIncentive {
+    pub(crate) fn upgrade_incentive(&self) -> UpgradeIncentive {
         match self {
             UpgradeJob::PrimitiveWitnessToProofCollection(_) => {
                 // If primitive witness is known, transaction must originate


### PR DESCRIPTION
Avoid building multiple nop transactions synced to the same mutator set when composing.