### PR TITLE
fix(sync_loop): Increase sync channel capacity to 100

### DIFF
--- a/neptune-core/src/application/loops/sync_loop.rs
+++ b/neptune-core/src/application/loops/sync_loop.rs
@@ -32,7 +32,7 @@ pub(crate) mod rapid_block_download;
 pub mod sync_progress;
 pub(crate) mod synchronization_bit_mask;
 
-pub(crate) const SYNC_LOOP_CHANNEL_CAPACITY: usize = 10;
+pub(crate) const SYNC_LOOP_CHANNEL_CAPACITY: usize = 100;
 
 /// After this long without a response from a given peer, that peer will be sent
 /// another block request.


### PR DESCRIPTION
The individual message types used in this channel do not exceed 1 block in size, so they will not be more than the consensus size-limit for blocks which is 8MB. So this change allows for 800MB to be used by the sync loop. For archival nodes, I consider that acceptable.

This fixes the problem of a very slow test
`can_sync_with_moving_target_from_dynamic_set_of_flaky_syncing_peers` which is slow because the channel capacity to the main loop is exhausted. It should also improve production-code behavior as the sync loop's channel to send to main loop will be less likely to be exhausted.