### PR TITLE
Fix missing Release Notes on Releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,10 @@
 - Reduce noise ([d59dac78](https://github.com/Neptune-Crypto/neptune-core/commit/d59dac78), [743403cc](https://github.com/Neptune-Crypto/neptune-core/commit/743403cc), [08f3b46c](https://github.com/Neptune-Crypto/neptune-core/commit/08f3b46c), [ad588094](https://github.com/Neptune-Crypto/neptune-core/commit/ad588094), [41752652](https://github.com/Neptune-Crypto/neptune-core/commit/41752652))
 - Report on number of own txs confirmed by block proposal ([65064aac](https://github.com/Neptune-Crypto/neptune-core/commit/65064aac))
 
+### 🪢 Merge
+
+- Merge([#779](https://github.com/Neptune-Crypto/neptune-core/issues/779)): Scrollable Tables ([3a4d18d4](https://github.com/Neptune-Crypto/neptune-core/commit/3a4d18d4))
+
 ## [0.6.0](https://github.com/Neptune-Crypto/neptune-core/compare/v0.5.0..v0.6.0) - 2026-02-03
 
 ### 🔱 Fork


### PR DESCRIPTION
- [x] deleting double-entry for v0.6.1 in changelog

This is what caused the lack of the auto-generation of the release notes on `dist plan`, which are based on the changelog file.
Explanation: `dist plan` generates the Notes based on the cli tool [parse-changelog](https://github.com/taiki-e/parse-changelog), which produced the following output on v0.7.0:
```bash
> parse-changelog ./CHANGELOG.md
error: multiple release notes for '0.6.1' in ./CHANGELOG.md
```

In the future, if there's a double entry, this will prevent future Release Notes to be added to the release

P.S Yay! first PR to neptune!!