### PR TITLE
ci: Faster CI failures & runs

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,17 @@
+name: Cleanup Caches
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Cleanup PR Caches
+        run: |
+          gh cache delete --ref "refs/pull/${{ github.event.pull_request.number }}/merge" --all
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -20,11 +20,11 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        benchmark: [ wallet_state ]
-        mode: [ simulation ]
+        benchmark: [wallet_state]
+        mode: [simulation]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -33,6 +33,14 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-codspeed
+
+      # CodSpeed-specific caching
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          # We use a distinct key because CodSpeed builds
+          # are instrumented differently than standard builds
+          prefix-key: "v1-codspeed"
 
       - name: Build benchmarks
         run: cargo codspeed build --bench ${{ matrix.benchmark }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,37 +47,39 @@ jobs:
       - name: Install stable Toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "v1-test-${{ matrix.os }}"
+          prefix-key: "v2-test-${{ matrix.os }}"
 
-      - name: Build Benches
-        run: cargo build --benches
+      - name: Check Benches
+        run: cargo check --benches
 
+      # Nextest uses a filter expression (-E) for skipping tests.
       - name: Run tests without benches
         run: >
-          cargo test
-          --lib --bins --tests --examples
-          --
-          --skip mine_20_blocks_in_40_seconds
-          --skip hash_rate_independent_of_tx_size
-          --skip blocks_with_0_to_10_inputs_and_successors_are_valid
-          --skip can_cancel_preprocess_within_one_second
-          --skip can_cancel_merkle_tree_construction_within_two_seconds
-          --skip alice_updates_mutator_set_data_on_own_transaction
-          --skip can_sync_from
-          --skip can_sync_with_moving
-          --skip verify_all_proof_servers_work
+          cargo nextest run
+          -E 'not (
+            test(mine_20_blocks_in_40_seconds) |
+            test(hash_rate_independent_of_tx_size) |
+            test(blocks_with_0_to_10_inputs_and_successors_are_valid) |
+            test(can_cancel_preprocess_within_one_second) |
+            test(can_cancel_merkle_tree_construction_within_two_seconds) |
+            test(alice_updates_mutator_set_data_on_own_transaction) |
+            test(can_sync_from) |
+            test(can_sync_with_moving) |
+            test(verify_all_proof_servers_work)
+          )'
 
-      - name: Run non-parallel test "resume block download from saved state"
+      - name: Run Ignored Tests (Nextest)
         run: >
-          cargo test can_resume_block_download_from_saved_state -- --ignored
+          cargo nextest run
+          --run-ignored all
+          -E 'test(can_resume_block_download_from_saved_state) or test(can_resume_sync_from_saved_state)'
 
-      - name: Run non-parallel test "resume sync from saved state"
-        run: >
-          cargo test can_resume_sync_from_saved_state -- --ignored
-
-        # `--doc` cannot be mixed with other target option
+      # `--doc` cannot be mixed with other target option
       - name: Run documentation tests
         run: cargo test --doc

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,34 +9,50 @@ on:
 name: Rust
 
 jobs:
-  runner-matrix:
-    name: format, lint, test
+  # Job 1: Lint & Format (Fast, Linux only)
+  fmt-clippy-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check Formatting
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Build Docs
+        run: cargo doc --no-deps --workspace --document-private-items
+        env:
+          RUSTDOCFLAGS: -D warnings
+
+  # Job 2: Multi-OS Tests & Builds
+  tests:
+    needs: fmt-clippy-docs # don't waste OS minutes if linting fails
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - name: Install stable toolchain
+      - name: Install stable Toolchain
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
         with:
-          components: rustfmt, clippy
+          prefix-key: "v1-test-${{ matrix.os }}"
 
-      - name: Run cargo fmt
-        run: cargo fmt --all -- --check
-
-      - name: Build documentation
-        run: cargo doc --no-deps --workspace --document-private-items
-        env:
-          RUSTDOCFLAGS: -D warnings
-
-      - name: Run clippy
-        run: cargo clippy --all-targets -- -D warnings
-
-      - name: Build benches
+      - name: Build Benches
         run: cargo build --benches
 
       - name: Run tests without benches

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,7 @@ jobs:
             test(verify_all_proof_servers_work)
           )'
 
-      - name: Run Ignored Tests (Nextest)
+      - name: Run Ignored Tests
         run: >
           cargo nextest run
           --run-ignored all

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,9 @@ jobs:
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
+        with:
+          # This key is the "Common Ground" for all jobs in this file
+          shared-key: "workflow-cache"
 
       - name: Check Formatting
         run: cargo fmt --all -- --check
@@ -53,6 +56,7 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         with:
+          shared-key: "workflow-cache"
           prefix-key: "v2-test-${{ matrix.os }}"
 
       - name: Check Benches

--- a/.github/workflows/no_lock_build.yml
+++ b/.github/workflows/no_lock_build.yml
@@ -13,17 +13,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Remove Cargo.lock
-        run: rm Cargo.lock
+      # Run cargo update to ensure this works with latest dependencies, without
+      # specific dependencies listed in `Cargo.lock`.
+      - name: Update dependencies to latest
+        run: cargo update
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          # A unique prefix for the "no-lock" build to avoid
+          # conflicting with other caches.
+          prefix-key: "v1-no-lock-${{ matrix.os }}"
 
       - name: Show available compilers (debug)
         if: matrix.os != 'windows-latest'
@@ -46,8 +55,8 @@ jobs:
         env:
           CC: clang
           CXX: clang++
-        run: cargo build --all --release
+        run: cargo check --all --release
 
       - name: Build (windows)
         if: matrix.os == 'windows-latest'
-        run: cargo build --all --release
+        run: cargo check --all --release

--- a/.github/workflows/no_lock_build.yml
+++ b/.github/workflows/no_lock_build.yml
@@ -32,23 +32,7 @@ jobs:
         with:
           # A unique prefix for the "no-lock" build to avoid
           # conflicting with other caches.
-          prefix-key: "v1-no-lock-${{ matrix.os }}"
-
-      - name: Show available compilers (debug)
-        if: matrix.os != 'windows-latest'
-        run: |
-          echo "c++ -> $(which c++ 2>/dev/null || true)"
-          c++ --version || true
-          echo "clang++ -> $(which clang++ 2>/dev/null || true)"
-          clang++ --version || true
-        shell: bash
-
-      - name: Install clang (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y clang
-        shell: bash
+          prefix-key: "v2-no-lock-${{ matrix.os }}"
 
       - name: Build (linux & macos)
         if: matrix.os != 'windows-latest'


### PR DESCRIPTION
Use caching for faster CI builds. And only run certain CI steps (formating and linting) on Ubuntu.