### PR TITLE
devops: Faster release and bench builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,8 +104,17 @@ opt-level = 2                # Set to make execution of tests in this crate fast
 [profile.release]
 build-override.opt-level = 3
 
+opt-level = 3
+lto = "fat"
+codegen-units = 1
+panic = "abort"
+strip = "symbols"
+
 [profile.bench]
-build-override.opt-level = 3
+# bench inherits from "release" so we don't need to repeat, cf.
+# https://doc.rust-lang.org/cargo/reference/profiles.html#bench
+# Only override what must differ
+# Exception is "panic" values which are always "unwind" in benches.
 
 [profile.dev]
 build-override.opt-level = 2
@@ -120,4 +129,4 @@ panic = "abort"
 # The profile that 'dist' will build with
 [profile.dist]
 inherits = "release"
-lto = "thin"
+


### PR DESCRIPTION
All below changes will lead to slower builds but should lead to faster binaries:

lto = "fat": Link time optimization: More inlining
codegen-units = 1: Forces compiler to look at entire program
panic = "abort": Removes unwinding logic for smaller binaries
strip = symbols: Shrinks binary sizes