### PR TITLE
Out-of-Process Tests and Feature Flag "spec"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3366,6 +3366,7 @@ dependencies = [
  "libp2p",
  "macro_rules_attr",
  "memmap2",
+ "neptune-cash",
  "neptune-rpc-macros",
  "num-bigint",
  "num-rational",

--- a/neptune-core/Cargo.toml
+++ b/neptune-core/Cargo.toml
@@ -165,6 +165,10 @@ libp2p = { version = "0.56.0", features = [
 whoami = "2.0.0"
 
 [dev-dependencies]
+# Integration test `can_prove_out_of_process_kernel_to_outputs` needs both
+# arbitrary implementations and specfications. The next line says, for
+# integration tests we want to rely on whatever is public in crate neptune cash
+# *when feature flags "arbitrary-impls" and "spec" are enabled*.
 neptune-cash = { path = "../neptune-core", features = ["arbitrary-impls", "spec"] }
 
 # note: arbitrary, proptest, proptest-arbitrary-interop are duplicated in [dev-dependencies]

--- a/neptune-core/Cargo.toml
+++ b/neptune-core/Cargo.toml
@@ -62,6 +62,9 @@ tokio-console = ["dep:console-subscriber"]
 # the client side.
 mock-rpc = []
 
+# defines and implements TritonProgramSpecification for various programs
+spec = []
+
 [dependencies]
 
 # note: arbitrary, proptest, proptest-arbitrary-interop are duplicated in [dev-dependencies]
@@ -162,6 +165,7 @@ libp2p = { version = "0.56.0", features = [
 whoami = "2.0.0"
 
 [dev-dependencies]
+neptune-cash = { path = "../neptune-core", features = ["arbitrary-impls", "spec"] }
 
 # note: arbitrary, proptest, proptest-arbitrary-interop are duplicated in [dev-dependencies]
 # because they are optional deps but required for unit tests.

--- a/neptune-core/src/protocol/consensus/block/validity.rs
+++ b/neptune-core/src/protocol/consensus/block/validity.rs
@@ -91,7 +91,7 @@ impl TritonProgram for PrincipalBlockValidationLogic {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
-    use crate::protocol::proof_abstractions::tasm::program::tests::TritonProgramSpecification;
+    use crate::protocol::proof_abstractions::tasm::program::spec::TritonProgramSpecification;
 
     impl TritonProgramSpecification for PrincipalBlockValidationLogic {
         fn source(&self) {

--- a/neptune-core/src/protocol/consensus/block/validity/block_program.rs
+++ b/neptune-core/src/protocol/consensus/block/validity/block_program.rs
@@ -355,8 +355,8 @@ pub(crate) mod tests {
     use crate::protocol::consensus::transaction::Transaction;
     use crate::protocol::proof_abstractions::tasm::builtins as tasm;
     use crate::protocol::proof_abstractions::tasm::builtins::verify_stark;
+    use crate::protocol::proof_abstractions::tasm::program::spec::TritonProgramSpecification;
     use crate::protocol::proof_abstractions::tasm::program::tests::test_program_snapshot;
-    use crate::protocol::proof_abstractions::tasm::program::tests::TritonProgramSpecification;
     use crate::protocol::proof_abstractions::timestamp::Timestamp;
     use crate::protocol::proof_abstractions::SecretWitness;
     use crate::state::transaction::tx_creation_config::TxCreationConfig;

--- a/neptune-core/src/protocol/consensus/block/validity/coinbase_is_valid.rs
+++ b/neptune-core/src/protocol/consensus/block/validity/coinbase_is_valid.rs
@@ -52,7 +52,7 @@ impl TritonProgram for CoinbaseIsValid {
 #[cfg_attr(coverage_nightly, coverage(off))]
 pub mod tests {
     use super::*;
-    use crate::protocol::proof_abstractions::tasm::program::tests::TritonProgramSpecification;
+    use crate::protocol::proof_abstractions::tasm::program::spec::TritonProgramSpecification;
 
     impl TritonProgramSpecification for CoinbaseIsValid {
         fn source(&self) {

--- a/neptune-core/src/protocol/consensus/block/validity/correct_control_parameter_update.rs
+++ b/neptune-core/src/protocol/consensus/block/validity/correct_control_parameter_update.rs
@@ -51,7 +51,7 @@ impl TritonProgram for CorrectControlParameterUpdate {
 #[cfg_attr(coverage_nightly, coverage(off))]
 pub mod tests {
     use super::*;
-    use crate::protocol::proof_abstractions::tasm::program::tests::TritonProgramSpecification;
+    use crate::protocol::proof_abstractions::tasm::program::spec::TritonProgramSpecification;
 
     impl TritonProgramSpecification for CorrectControlParameterUpdate {
         fn source(&self) {

--- a/neptune-core/src/protocol/consensus/block/validity/correct_mmr_update.rs
+++ b/neptune-core/src/protocol/consensus/block/validity/correct_mmr_update.rs
@@ -51,7 +51,7 @@ impl TritonProgram for CorrectMmrUpdate {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
-    use crate::protocol::proof_abstractions::tasm::program::tests::TritonProgramSpecification;
+    use crate::protocol::proof_abstractions::tasm::program::spec::TritonProgramSpecification;
 
     impl TritonProgramSpecification for CorrectMmrUpdate {
         fn source(&self) {

--- a/neptune-core/src/protocol/consensus/block/validity/correct_mutator_set_update.rs
+++ b/neptune-core/src/protocol/consensus/block/validity/correct_mutator_set_update.rs
@@ -51,7 +51,7 @@ impl TritonProgram for CorrectMutatorSetUpdate {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
-    use crate::protocol::proof_abstractions::tasm::program::tests::TritonProgramSpecification;
+    use crate::protocol::proof_abstractions::tasm::program::spec::TritonProgramSpecification;
 
     impl TritonProgramSpecification for CorrectMutatorSetUpdate {
         fn source(&self) {

--- a/neptune-core/src/protocol/consensus/block/validity/mmr_membership.rs
+++ b/neptune-core/src/protocol/consensus/block/validity/mmr_membership.rs
@@ -51,7 +51,7 @@ impl TritonProgram for MmrMembership {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
-    use crate::protocol::proof_abstractions::tasm::program::tests::TritonProgramSpecification;
+    use crate::protocol::proof_abstractions::tasm::program::spec::TritonProgramSpecification;
 
     impl TritonProgramSpecification for MmrMembership {
         fn source(&self) {

--- a/neptune-core/src/protocol/consensus/block/validity/predecessor_is_valid.rs
+++ b/neptune-core/src/protocol/consensus/block/validity/predecessor_is_valid.rs
@@ -51,7 +51,7 @@ impl TritonProgram for PredecessorIsValid {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
-    use crate::protocol::proof_abstractions::tasm::program::tests::TritonProgramSpecification;
+    use crate::protocol::proof_abstractions::tasm::program::spec::TritonProgramSpecification;
 
     impl TritonProgramSpecification for PredecessorIsValid {
         fn source(&self) {

--- a/neptune-core/src/protocol/consensus/transaction/validity/collect_lock_scripts.rs
+++ b/neptune-core/src/protocol/consensus/transaction/validity/collect_lock_scripts.rs
@@ -207,8 +207,8 @@ mod tests {
 
     use super::*;
     use crate::protocol::proof_abstractions::tasm::builtins as tasm;
+    use crate::protocol::proof_abstractions::tasm::program::spec::TritonProgramSpecification;
     use crate::protocol::proof_abstractions::tasm::program::tests::test_program_snapshot;
-    use crate::protocol::proof_abstractions::tasm::program::tests::TritonProgramSpecification;
 
     impl TritonProgramSpecification for CollectLockScripts {
         fn source(&self) {

--- a/neptune-core/src/protocol/consensus/transaction/validity/collect_type_scripts.rs
+++ b/neptune-core/src/protocol/consensus/transaction/validity/collect_type_scripts.rs
@@ -441,8 +441,8 @@ mod tests {
     use crate::protocol::consensus::type_scripts::native_currency::NativeCurrency;
     use crate::protocol::consensus::type_scripts::time_lock::neptune_arbitrary::arbitrary_primitive_witness_with_active_timelocks;
     use crate::protocol::proof_abstractions::tasm::builtins as tasm;
+    use crate::protocol::proof_abstractions::tasm::program::spec::TritonProgramSpecification;
     use crate::protocol::proof_abstractions::tasm::program::tests::test_program_snapshot;
-    use crate::protocol::proof_abstractions::tasm::program::tests::TritonProgramSpecification;
     use crate::protocol::proof_abstractions::timestamp::Timestamp;
 
     impl TritonProgramSpecification for CollectTypeScripts {

--- a/neptune-core/src/protocol/consensus/transaction/validity/kernel_to_outputs.rs
+++ b/neptune-core/src/protocol/consensus/transaction/validity/kernel_to_outputs.rs
@@ -358,24 +358,14 @@ impl TritonProgram for KernelToOutputs {
     }
 }
 
-#[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
-mod tests {
-    use proptest::prop_assert_eq;
-    use proptest::strategy::Strategy;
-    use proptest::test_runner::TestRunner;
-    use rand::random;
-    use tasm_lib::triton_vm;
-    use test_strategy::proptest;
-
+#[cfg(any(test, feature = "spec"))]
+mod spec {
     use super::*;
-    use crate::protocol::consensus::transaction::utxo::Utxo;
+
+    use crate::api::export::AdditionRecord;
+    use crate::api::export::Utxo;
     use crate::protocol::proof_abstractions::tasm::builtins as tasm;
-    use crate::protocol::proof_abstractions::tasm::program::tests::test_program_snapshot;
-    use crate::protocol::proof_abstractions::tasm::program::tests::TritonProgramSpecification;
-    use crate::triton_vm::proof::Claim;
-    use crate::triton_vm::stark::Stark;
-    use crate::util_types::mutator_set::addition_record::AdditionRecord;
+    use crate::protocol::proof_abstractions::tasm::program::spec::TritonProgramSpecification;
     use crate::util_types::mutator_set::commit;
 
     impl TritonProgramSpecification for KernelToOutputs {
@@ -423,6 +413,23 @@ mod tests {
             tasm::tasmlib_io_write_to_stdout___digest(salted_output_utxos_hash);
         }
     }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use proptest::prop_assert_eq;
+    use proptest::strategy::Strategy;
+    use proptest::test_runner::TestRunner;
+    use rand::random;
+    use tasm_lib::triton_vm;
+    use test_strategy::proptest;
+
+    use super::*;
+    use crate::protocol::proof_abstractions::tasm::program::spec::TritonProgramSpecification;
+    use crate::protocol::proof_abstractions::tasm::program::tests::test_program_snapshot;
+    use crate::triton_vm::proof::Claim;
+    use crate::triton_vm::stark::Stark;
 
     #[proptest(cases = 30)]
     fn kernel_to_outputs_proptest(

--- a/neptune-core/src/protocol/consensus/transaction/validity/proof_collection.rs
+++ b/neptune-core/src/protocol/consensus/transaction/validity/proof_collection.rs
@@ -307,7 +307,7 @@ impl ProofCollection {
                 [self.salted_inputs_hash, self.salted_outputs_hash]
                     .into_iter()
                     .flat_map(|d| d.reversed().values())
-                    .collect_vec(),
+                    .collect::<Vec<BFieldElement>>(),
             )
             .with_output(
                 self.type_script_hashes
@@ -333,7 +333,7 @@ impl ProofCollection {
                     ]
                     .into_iter()
                     .flat_map(|d| d.reversed().values())
-                    .collect_vec(),
+                    .collect::<Vec<BFieldElement>>(),
                 )
             })
             .collect_vec();
@@ -486,7 +486,7 @@ pub mod tests {
     use crate::api::export::NativeCurrencyAmount;
     use crate::api::export::NeptuneProof;
     use crate::application::triton_vm_job_queue::vm_job_queue;
-    use crate::protocol::proof_abstractions::tasm::program::tests::TritonProgramSpecification;
+    use crate::protocol::proof_abstractions::tasm::program::spec::TritonProgramSpecification;
     use crate::tests::shared_tokio_runtime;
 
     impl ProofCollection {

--- a/neptune-core/src/protocol/consensus/transaction/validity/proof_collection.rs
+++ b/neptune-core/src/protocol/consensus/transaction/validity/proof_collection.rs
@@ -307,7 +307,7 @@ impl ProofCollection {
                 [self.salted_inputs_hash, self.salted_outputs_hash]
                     .into_iter()
                     .flat_map(|d| d.reversed().values())
-                    .collect::<Vec<BFieldElement>>(),
+                    .collect::<Vec<_>>(),
             )
             .with_output(
                 self.type_script_hashes
@@ -333,7 +333,7 @@ impl ProofCollection {
                     ]
                     .into_iter()
                     .flat_map(|d| d.reversed().values())
-                    .collect::<Vec<BFieldElement>>(),
+                    .collect::<Vec<_>>(),
                 )
             })
             .collect_vec();

--- a/neptune-core/src/protocol/consensus/transaction/validity/removal_records_integrity.rs
+++ b/neptune-core/src/protocol/consensus/transaction/validity/removal_records_integrity.rs
@@ -1056,8 +1056,8 @@ mod tests {
     use crate::protocol::consensus::transaction::utxo::Utxo;
     use crate::protocol::consensus::transaction::TransactionKernelModifier;
     use crate::protocol::proof_abstractions::tasm::builtins as tasm;
+    use crate::protocol::proof_abstractions::tasm::program::spec::TritonProgramSpecification;
     use crate::protocol::proof_abstractions::tasm::program::tests::test_program_snapshot;
-    use crate::protocol::proof_abstractions::tasm::program::tests::TritonProgramSpecification;
     use crate::util_types::mutator_set::addition_record::AdditionRecord;
     use crate::util_types::mutator_set::commit;
     use crate::util_types::mutator_set::removal_record::absolute_index_set::AbsoluteIndexSet;

--- a/neptune-core/src/protocol/consensus/transaction/validity/single_proof.rs
+++ b/neptune-core/src/protocol/consensus/transaction/validity/single_proof.rs
@@ -780,7 +780,7 @@ pub(crate) mod tests {
     use crate::protocol::consensus::type_scripts::time_lock::neptune_arbitrary::arbitrary_primitive_witness_with_expired_timelocks;
     use crate::protocol::proof_abstractions::tasm::builtins as tasm;
     use crate::protocol::proof_abstractions::tasm::program::tests::test_program_snapshot;
-    use crate::protocol::proof_abstractions::tasm::program::tests::TritonProgramSpecification;
+    use crate::protocol::proof_abstractions::tasm::program::spec::TritonProgramSpecification;
     use crate::protocol::proof_abstractions::tasm::program::TritonError;
     use crate::protocol::proof_abstractions::timestamp::Timestamp;
     use crate::tests::shared_tokio_runtime;

--- a/neptune-core/src/protocol/consensus/type_scripts/native_currency.rs
+++ b/neptune-core/src/protocol/consensus/type_scripts/native_currency.rs
@@ -768,8 +768,8 @@ pub mod tests {
     use crate::protocol::consensus::type_scripts::time_lock::neptune_arbitrary::arbitrary_primitive_witness_with_active_timelocks;
     use crate::protocol::consensus::type_scripts::time_lock::TimeLock;
     use crate::protocol::proof_abstractions::tasm::builtins as tasm;
+    use crate::protocol::proof_abstractions::tasm::program::spec::TritonProgramSpecification;
     use crate::protocol::proof_abstractions::tasm::program::tests::test_program_snapshot;
-    use crate::protocol::proof_abstractions::tasm::program::tests::TritonProgramSpecification;
     use crate::protocol::proof_abstractions::tasm::program::TritonError;
     use crate::protocol::proof_abstractions::timestamp::Timestamp;
     use crate::protocol::proof_abstractions::verifier::verify;

--- a/neptune-core/src/protocol/consensus/type_scripts/time_lock.rs
+++ b/neptune-core/src/protocol/consensus/type_scripts/time_lock.rs
@@ -1012,8 +1012,8 @@ mod tests {
     use super::neptune_arbitrary::arbitrary_primitive_witness_with_expired_timelocks;
     use super::*;
     use crate::protocol::proof_abstractions::tasm::builtins as tasm;
+    use crate::protocol::proof_abstractions::tasm::program::spec::TritonProgramSpecification;
     use crate::protocol::proof_abstractions::tasm::program::tests::test_program_snapshot;
-    use crate::protocol::proof_abstractions::tasm::program::tests::TritonProgramSpecification;
 
     impl TritonProgramSpecification for TimeLock {
         #[expect(clippy::needless_return)]

--- a/neptune-core/src/protocol/proof_abstractions/tasm/environment.rs
+++ b/neptune-core/src/protocol/proof_abstractions/tasm/environment.rs
@@ -25,14 +25,14 @@ thread_local! {
     pub(super) static PROGRAM_DIGEST: RefCell<Digest> = RefCell::new(Digest::default());
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "spec"))]
 pub(crate) fn audit_end_state() {
     assert!(ND_DIGESTS.with_borrow(|f| f.is_empty()));
     assert!(PUB_INPUT.with_borrow(|f| f.is_empty()));
     assert!(ND_INDIVIDUAL_TOKEN.with_borrow(|f| f.is_empty()));
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "spec"))]
 pub(crate) fn init(
     program_digest: Digest,
     input: &[BFieldElement],

--- a/neptune-core/src/protocol/proof_abstractions/tasm/program.rs
+++ b/neptune-core/src/protocol/proof_abstractions/tasm/program.rs
@@ -167,82 +167,16 @@ pub struct TritonVmProofJobOptions {
     pub cancel_job_rx: Option<tokio::sync::watch::Receiver<()>>,
 }
 
-#[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
-pub mod tests {
-    use std::fs::create_dir_all;
-    use std::fs::File;
-    use std::io::stdout;
-    use std::io::Write;
+#[cfg(any(test, feature = "spec"))]
+pub mod spec {
+    use super::*;
+
     use std::panic::catch_unwind;
-    use std::path::Path;
-    use std::path::PathBuf;
-    use std::time::SystemTime;
 
     use itertools::Itertools;
-    use macro_rules_attr::apply;
-    use tasm_lib::triton_vm;
     use tracing::debug;
 
-    use super::*;
-    use crate::api::export::Network;
-    use crate::application::config::triton_vm_env_vars::TritonVmEnvVars;
-    use crate::protocol::consensus::transaction::transaction_proof::TransactionProofType;
     use crate::protocol::proof_abstractions::tasm::environment;
-    use crate::state::transaction::tx_proving_capability::TxProvingCapability;
-    use crate::tests::shared::files::headers_for_proof_server_request;
-    use crate::tests::shared::files::load_test_proof_servers;
-    use crate::tests::shared::files::test_helper_data_dir;
-    use crate::tests::shared::files::try_fetch_file;
-    use crate::tests::shared::files::try_fetch_from_server;
-    use crate::tests::shared::files::try_load_file_from_disk;
-    use crate::tests::shared_tokio_runtime;
-    use crate::triton_vm::stark::Stark;
-
-    impl From<TritonVmJobPriority> for TritonVmProofJobOptions {
-        fn from(job_priority: TritonVmJobPriority) -> Self {
-            let job_settings = ProverJobSettings {
-                tx_proving_capability: TxProvingCapability::SingleProof,
-                proof_type: TransactionProofType::SingleProof,
-                ..Default::default()
-            };
-            Self {
-                job_priority,
-                job_settings,
-                cancel_job_rx: None,
-            }
-        }
-    }
-
-    impl TritonVmProofJobOptions {
-        pub(crate) fn default_with_network(network: Network) -> Self {
-            let job_settings = ProverJobSettings {
-                network,
-                ..Default::default()
-            };
-            Self {
-                job_settings,
-                ..Default::default()
-            }
-        }
-    }
-
-    impl From<(TritonVmJobPriority, Option<u8>)> for TritonVmProofJobOptions {
-        fn from(v: (TritonVmJobPriority, Option<u8>)) -> Self {
-            let (job_priority, max_log2_padded_height_for_proofs) = v;
-            Self {
-                job_priority,
-                job_settings: ProverJobSettings {
-                    max_log2_padded_height_for_proofs,
-                    network: Default::default(),
-                    tx_proving_capability: TxProvingCapability::SingleProof,
-                    proof_type: TransactionProofType::SingleProof,
-                    triton_vm_env_vars: TritonVmEnvVars::default(),
-                },
-                cancel_job_rx: None,
-            }
-        }
-    }
 
     pub trait TritonProgramSpecification: TritonProgram {
         /// The canonical reference source code for the Triton program, written
@@ -352,6 +286,82 @@ pub mod tests {
             };
 
             Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+pub mod tests {
+    use std::fs::create_dir_all;
+    use std::fs::File;
+    use std::io::stdout;
+    use std::io::Write;
+    use std::path::Path;
+    use std::path::PathBuf;
+    use std::time::SystemTime;
+
+    use itertools::Itertools;
+    use macro_rules_attr::apply;
+    use tasm_lib::triton_vm;
+    use tracing::debug;
+
+    use super::*;
+    use crate::api::export::Network;
+    use crate::application::config::triton_vm_env_vars::TritonVmEnvVars;
+    use crate::protocol::consensus::transaction::transaction_proof::TransactionProofType;
+    use crate::state::transaction::tx_proving_capability::TxProvingCapability;
+    use crate::tests::shared::files::headers_for_proof_server_request;
+    use crate::tests::shared::files::load_test_proof_servers;
+    use crate::tests::shared::files::test_helper_data_dir;
+    use crate::tests::shared::files::try_fetch_file;
+    use crate::tests::shared::files::try_fetch_from_server;
+    use crate::tests::shared::files::try_load_file_from_disk;
+    use crate::tests::shared_tokio_runtime;
+    use crate::triton_vm::stark::Stark;
+
+    impl From<TritonVmJobPriority> for TritonVmProofJobOptions {
+        fn from(job_priority: TritonVmJobPriority) -> Self {
+            let job_settings = ProverJobSettings {
+                tx_proving_capability: TxProvingCapability::SingleProof,
+                proof_type: TransactionProofType::SingleProof,
+                ..Default::default()
+            };
+            Self {
+                job_priority,
+                job_settings,
+                cancel_job_rx: None,
+            }
+        }
+    }
+
+    impl TritonVmProofJobOptions {
+        pub(crate) fn default_with_network(network: Network) -> Self {
+            let job_settings = ProverJobSettings {
+                network,
+                ..Default::default()
+            };
+            Self {
+                job_settings,
+                ..Default::default()
+            }
+        }
+    }
+
+    impl From<(TritonVmJobPriority, Option<u8>)> for TritonVmProofJobOptions {
+        fn from(v: (TritonVmJobPriority, Option<u8>)) -> Self {
+            let (job_priority, max_log2_padded_height_for_proofs) = v;
+            Self {
+                job_priority,
+                job_settings: ProverJobSettings {
+                    max_log2_padded_height_for_proofs,
+                    network: Default::default(),
+                    tx_proving_capability: TxProvingCapability::SingleProof,
+                    proof_type: TransactionProofType::SingleProof,
+                    triton_vm_env_vars: TritonVmEnvVars::default(),
+                },
+                cancel_job_rx: None,
+            }
         }
     }
 
@@ -474,7 +484,7 @@ pub mod tests {
         let proof = decode_proof_from_server(file_contents, &server)?;
         println!("got proof.");
 
-        Some((proof, server))
+        Some((proof, server.to_string()))
     }
 
     #[apply(shared_tokio_runtime)]

--- a/neptune-core/tests/external_proving_process.rs
+++ b/neptune-core/tests/external_proving_process.rs
@@ -1,20 +1,29 @@
+#![recursion_limit = "256"]
+
+use std::collections::HashMap;
 use std::time::SystemTime;
 
+use itertools::Itertools;
 use neptune_cash::api::export::Claim;
 use neptune_cash::api::export::Program;
 use neptune_cash::protocol::proof_abstractions::tasm::prover_job::ProverJob;
 use neptune_cash::protocol::proof_abstractions::tasm::prover_job::ProverJobSettings;
 use neptune_cash::protocol::proof_abstractions::tasm::prover_job::ProverProcessCompletion;
+use tasm_lib::prelude::Digest;
+use tasm_lib::prelude::Tip5;
+use tasm_lib::triton_vm::isa::triton_instr;
 use tasm_lib::triton_vm::prelude::triton_asm;
 use tasm_lib::triton_vm::stark::Stark;
 use tasm_lib::triton_vm::vm::NonDeterminism;
 use tasm_lib::triton_vm::vm::VMState;
+use tasm_lib::twenty_first::bfe;
+use tasm_lib::twenty_first::bfe_array;
 use tasm_lib::twenty_first::bfe_vec;
 use tasm_lib::twenty_first::prelude::BFieldElement;
 use tokio::sync::watch;
 
 #[tokio::test(flavor = "multi_thread")]
-async fn can_prove_out_of_process() {
+async fn can_prove_out_of_process_2in() {
     // Initialize a global subscriber that definitely writes to stdout.
     let _ = tracing_subscriber::fmt()
         .with_env_filter("debug")
@@ -22,10 +31,87 @@ async fn can_prove_out_of_process() {
         .try_init();
 
     // Compile claim.
+    let code = triton_asm! {
+        // _
+
+        read_io 2
+
+        halt
+
+    };
+    let program = Program::new(&code);
+    let input = bfe_vec![499, 501];
+    let nondeterminism = NonDeterminism::default();
+    let mut vm_state = VMState::new(
+        program.clone(),
+        input.clone().into(),
+        nondeterminism.clone(),
+    );
+    vm_state.run().unwrap();
+    let output = vm_state.public_output;
+    let claim = Claim::about_program(&program)
+        .with_input(input)
+        .with_output(output);
+
+    // Compile job.
+    let job = ProverJob::new(
+        program,
+        claim.clone(),
+        nondeterminism.clone(),
+        ProverJobSettings::default(),
+    );
+
+    // Execute job.
+    let tick = SystemTime::now();
+    let (_cancel_tx, cancel_rx) = watch::channel::<()>(());
+    let prover_result = match job.prove_out_of_process(cancel_rx).await {
+        Ok(r) => r,
+        Err(e) => {
+            panic!("Out of process job, launched according to happy path, errored: {e:?}")
+        }
+    };
+    let ProverProcessCompletion::Finished(proof) = prover_result else {
+        panic!("out-of-process prover was canceled unexpectedly");
+    };
+    let tock = tick.elapsed().unwrap();
+    println!("Out-of-process proof took {tock:?}");
+
+    // Verify.
+    let stark = Stark::default();
+    let verdict = stark.verify(&claim, &proof);
+    assert!(verdict.is_ok());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn can_prove_out_of_process_fibonacci() {
+    // Initialize a global subscriber that definitely writes to stdout.
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("debug")
+        .with_test_writer()
+        .try_init();
+
+    // Merkle nodes
+    let sibling1: Digest = Digest::new(bfe_array![101, 102, 103, 104, 105]);
+    let sibling2: Digest = Digest::new(bfe_array![205, 204, 203, 202, 201]);
+    let leaf: Digest = Digest::new(bfe_array![35, 34, 33, 32, 31]);
+    let root: Digest = Tip5::hash_pair(Tip5::hash_pair(sibling1, leaf), sibling2);
+
+    // Macro
+    let push_digest = |d: Digest| {
+        d.reversed()
+            .values()
+            .into_iter()
+            .map(|b| triton_instr!(push b))
+            .collect_vec()
+    };
+
+    // Compile claim.
     let fibonacci_code = triton_asm! {
         // _
 
-        read_io 1
+        // test fibonacci loop
+        read_io 2
+        add
         push 0
         push 1
 
@@ -36,6 +122,46 @@ async fn can_prove_out_of_process() {
 
         write_io 1
         pop 2
+
+        // test nondeterministic tokens
+        divine 5
+        push 1
+        push 2
+        push 3
+        push 4
+        push 5
+        assert_vector error_id 1
+
+        // test nondeterministic digests
+        push 1
+        {&push_digest(leaf)}
+        // _ 1 [leaf]
+
+        merkle_step
+        merkle_step
+        // _ 0 [root]
+
+        {&push_digest(root)}
+        // _ 0 [root] [root]
+
+        assert_vector error_id 2
+        pop 5
+        // _ 0
+
+        push 0 eq assert error_id 3
+        // _
+
+        // test nondeterministic memory
+        push 13
+        read_mem 1
+        pop 1
+        push 37 eq assert error_id 4
+        pop 1
+
+        // add extra output
+        push 5005
+        write_io 1
+
         halt
 
         fib_loop:
@@ -58,11 +184,18 @@ async fn can_prove_out_of_process() {
 
     };
     let fibonacci_program = Program::new(&fibonacci_code);
-    let input = bfe_vec![1000];
+    let input = bfe_vec![499, 501];
+    let nondeterminism = NonDeterminism::new(bfe_vec![1, 2, 3, 4, 5])
+        .with_digests(vec![sibling1, sibling2])
+        .with_ram(
+            [(bfe!(13), bfe!(37))]
+                .into_iter()
+                .collect::<HashMap<_, _>>(),
+        );
     let mut vm_state = VMState::new(
         fibonacci_program.clone(),
         input.clone().into(),
-        NonDeterminism::default(),
+        nondeterminism.clone(),
     );
     vm_state.run().unwrap();
     let output = vm_state.public_output;
@@ -74,7 +207,7 @@ async fn can_prove_out_of_process() {
     let job = ProverJob::new(
         fibonacci_program,
         claim.clone(),
-        NonDeterminism::default(),
+        nondeterminism.clone(),
         ProverJobSettings::default(),
     );
 
@@ -97,4 +230,85 @@ async fn can_prove_out_of_process() {
     let stark = Stark::default();
     let verdict = tasm_lib::triton_vm::verify(stark, &claim, &proof);
     assert!(verdict);
+}
+
+// Some tests require functions that are hidden behind the #[cfg(test)]
+// decoration. This test module activates that guard.
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use neptune_cash::protocol::consensus::transaction::primitive_witness::PrimitiveWitness;
+    use neptune_cash::protocol::consensus::transaction::validity::kernel_to_outputs::KernelToOutputs;
+    use neptune_cash::protocol::consensus::transaction::validity::kernel_to_outputs::KernelToOutputsWitness;
+    use neptune_cash::protocol::proof_abstractions::tasm::program::spec::TritonProgramSpecification;
+    use neptune_cash::protocol::proof_abstractions::tasm::program::TritonProgram;
+    use neptune_cash::protocol::proof_abstractions::SecretWitness;
+    use proptest::strategy::Strategy;
+    use proptest::test_runner::TestRunner;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn can_prove_out_of_process_kernel_to_outputs() {
+        // Initialize a global subscriber that definitely writes to stdout.
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter("debug")
+            .with_test_writer()
+            .try_init();
+
+        // Get test setup.
+        let num_inputs = 2;
+        let num_outputs = 2;
+        let mut test_runner = TestRunner::deterministic();
+        let primitive_witness =
+            PrimitiveWitness::arbitrary_with_size_numbers(Some(num_inputs), num_outputs, 2)
+                .new_tree(&mut test_runner)
+                .unwrap()
+                .current();
+        let kernel_to_outputs_witness = KernelToOutputsWitness::from(&primitive_witness);
+        let std_input = kernel_to_outputs_witness.standard_input();
+        let non_determinism = kernel_to_outputs_witness.nondeterminism();
+        let tasm_result = KernelToOutputs
+            .run_tasm(&std_input, non_determinism.clone())
+            .unwrap();
+        assert_eq!(kernel_to_outputs_witness.output(), tasm_result);
+
+        let rust_result = KernelToOutputs
+            .run_rust(&std_input, non_determinism.clone())
+            .unwrap();
+        assert_eq!(rust_result, tasm_result);
+
+        // Compile program and claim.
+        let program = KernelToOutputs.program();
+        let output = rust_result;
+        let claim = Claim::about_program(&program)
+            .with_input(std_input)
+            .with_output(output);
+
+        // Compile job.
+        let job = ProverJob::new(
+            program,
+            claim.clone(),
+            non_determinism.clone(),
+            ProverJobSettings::default(),
+        );
+
+        // Execute job.
+        let tick = SystemTime::now();
+        let (_cancel_tx, cancel_rx) = watch::channel::<()>(());
+        let prover_result = match job.prove_out_of_process(cancel_rx).await {
+            Ok(r) => r,
+            Err(e) => {
+                panic!("Out of process job, launched according to happy path, errored: {e:?}")
+            }
+        };
+        let ProverProcessCompletion::Finished(proof) = prover_result else {
+            panic!("out-of-process prover was canceled unexpectedly");
+        };
+        let tock = tick.elapsed().unwrap();
+        println!("Out-of-process proof took {tock:?}");
+
+        // Verify.
+        let stark = Stark::default();
+        let verdict = tasm_lib::triton_vm::verify(stark, &claim, &proof);
+        assert!(verdict);
+    }
 }


### PR DESCRIPTION
This PR expands the coverage of the test (now tests, plural) in `external_proving_process.rs`. The test that previously merely computed a Fibonacci number now reads from all three sources of non-determinism first. A new test reads two input symbols from standard input. Another new test invokes the out-of-process prover on an actual `KernelToOutputs` computation. In all cases the correct verification of the resulting proof is asserted.

The last case, the `KernelToOutputs` test is a simple but adequate excerpt from the transaction initiation pipeline. Not too complicated but indicative of which things the out-of-process prover ought to support. In order to invoke and test this Triton program, the `TritonProgramSpecification` must be exposed to the integration test, which means that it cannot live behind a test flag alone as it did up until now. To get around this obstacle, this PR introduces a new feature flag "spec". Now, `TritonProgramSpecification` is declared if either the test flag is on, or if compilation happens with feature flag `spec`.