### PR TITLE
feat: Allow for a variable number of consolidation inputs

### DIFF
--- a/neptune-core/src/api/regtest/regtest_impl.rs
+++ b/neptune-core/src/api/regtest/regtest_impl.rs
@@ -168,8 +168,15 @@ impl RegTestPrivate {
             gsl.cli().network,
         );
 
+        let lustration_status = block.header().pow.lustration_status().ok();
+        let version = block.header().version;
         if find_valid_pow {
-            block.satisfy_mock_pow(parent_difficulty, rand::random());
+            block.satisfy_mock_pow(
+                parent_difficulty,
+                rand::random(),
+                lustration_status,
+                version,
+            );
         }
 
         (

--- a/neptune-core/src/api/tx_initiation/builder/input_selector.rs
+++ b/neptune-core/src/api/tx_initiation/builder/input_selector.rs
@@ -301,7 +301,7 @@ impl InputSelector {
             self.policy.accept_lustrations
                 || self
                     .lustration_threshold
-                    .is_none_or(|threshold| threshold >= min_aocl_range)
+                    .is_none_or(|threshold| threshold < min_aocl_range)
         })
     }
 
@@ -428,6 +428,8 @@ fn sort<O: Ord>(order: SortOrder, a: &O, b: &O) -> std::cmp::Ordering {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use strum::IntoEnumIterator;
 
     use super::*;
@@ -467,15 +469,35 @@ mod tests {
     }
 
     #[test]
+    fn filter_on_lustration_requirement_simple() {
+        let early_aocl = dummy_input(0);
+        let early_aocls = vec![early_aocl];
+        let lustration_threshold = u64::from(WINDOW_SIZE) * 3;
+        let reject_lustrations = InputSelector::new(Some(lustration_threshold))
+            .input_candidates(early_aocls.clone())
+            .policy(InputSelectionPolicy {
+                priority: InputSelectionPriority::ByAge(SortOrder::Descending),
+                required_number_of_confirmations: 0,
+                max_num_inputs: None,
+                accept_lustrations: false,
+            });
+        assert!(reject_lustrations
+            .filter_by_lustration_requirement(&early_aocls)
+            .into_iter()
+            .next()
+            .is_none());
+    }
+
+    #[test]
     fn filters_on_lustration_requirement() {
-        let dummy_inputs = (0u64..=u64::from(WINDOW_SIZE) * 40)
+        let dummy_inputs = (0u64..=u64::from(WINDOW_SIZE) * 50)
             .step_by(WINDOW_SIZE as usize)
             .map(dummy_input)
             .collect_vec();
         let num_utxos = dummy_inputs.len();
 
-        let lustration_threshold = Some(u64::from(WINDOW_SIZE) * 2);
-        let reject_lustration = InputSelector::new(lustration_threshold)
+        let lustration_threshold = u64::from(WINDOW_SIZE) * 3;
+        let reject_lustration = InputSelector::new(Some(lustration_threshold))
             .input_candidates(dummy_inputs.clone())
             .policy(InputSelectionPolicy {
                 priority: InputSelectionPriority::ByAge(SortOrder::Descending),
@@ -484,15 +506,30 @@ mod tests {
                 accept_lustrations: false,
             });
 
-        assert!(
-            (reject_lustration
-                .filter_by_lustration_requirement(&dummy_inputs)
-                .into_iter()
-                .count())
-                < num_utxos
-        );
+        let dont_require_lustrations = reject_lustration
+            .filter_by_lustration_requirement(&dummy_inputs)
+            .into_iter()
+            .collect_vec();
+        assert!(dont_require_lustrations
+            .iter()
+            .all(|x| x.index_set().aocl_range().unwrap().0 > lustration_threshold));
+        assert!(dont_require_lustrations.len() < num_utxos);
+        assert!(!dont_require_lustrations.is_empty());
 
-        let accept_lustration = InputSelector::new(lustration_threshold)
+        let dont_require_lustrations: HashSet<_> = dont_require_lustrations
+            .iter()
+            .map(|x| x.index_set())
+            .collect();
+        for input in &dummy_inputs {
+            if dont_require_lustrations.contains(&input.index_set()) {
+                continue;
+            }
+
+            let needs_lustration = input;
+            assert!(needs_lustration.index_set().aocl_range().unwrap().0 <= lustration_threshold);
+        }
+
+        let accept_lustration = InputSelector::new(Some(lustration_threshold))
             .input_candidates(dummy_inputs.clone())
             .policy(InputSelectionPolicy {
                 priority: InputSelectionPriority::ByAge(SortOrder::Descending),

--- a/neptune-core/src/api/tx_initiation/builder/input_selector.rs
+++ b/neptune-core/src/api/tx_initiation/builder/input_selector.rs
@@ -283,6 +283,28 @@ impl InputSelector {
         })
     }
 
+    fn filter_by_lustration_requirement<'a, InputCandidateIter>(
+        &'a self,
+        inputs: InputCandidateIter,
+    ) -> impl IntoIterator<Item = &'a InputCandidate>
+    where
+        InputCandidateIter: IntoIterator<Item = &'a InputCandidate>,
+    {
+        inputs.into_iter().filter(|input_candidate| {
+            let min_aocl_range = match input_candidate.index_set().aocl_range() {
+                Ok((min, _max)) => min,
+                Err(err) => panic!("Failed to get AOCL range for input candidate during lustration filtering: {err}"),
+            };
+
+            // if lustration is not acceptable, exclude inputs with AOCL range
+            // that includes or is less than the lustration threshold.
+            self.policy.accept_lustrations
+                || self
+                    .lustration_threshold
+                    .is_none_or(|threshold| threshold >= min_aocl_range)
+        })
+    }
+
     fn prioritize<'a, InputCandidateIter>(
         &'a self,
         inputs: InputCandidateIter,
@@ -339,6 +361,7 @@ impl InputSelector {
     pub fn take(self, number: usize) -> Vec<InputCandidate> {
         let iter = self.input_candidates_inputs.iter();
         let iter = self.filter_by_confirmation_count(iter);
+        let iter = self.filter_by_lustration_requirement(iter);
         let iter = self.prioritize(iter);
         iter.into_iter().take(number).cloned().collect_vec()
     }
@@ -349,6 +372,8 @@ impl InputSelector {
         // scan sequence until we have enough
         let spend_amount = self.spend_amount;
 
+        // Avoid filtering by lustration requirement here since that's handled
+        // better in the loop below.
         let iter = self.input_candidates_inputs.iter();
         let iter = self.filter_by_confirmation_count(iter);
         let iter = self.prioritize(iter);
@@ -407,6 +432,7 @@ mod tests {
 
     use super::*;
     use crate::state::wallet::wallet_status::SyncedUtxo;
+    use crate::util_types::mutator_set::shared::WINDOW_SIZE;
 
     #[expect(clippy::derivable_impls)]
     impl Default for SortOrder {
@@ -419,10 +445,6 @@ mod tests {
 
     #[test]
     fn no_panic_in_prioritize() {
-        let dummy_input = |aocl_leaf_index: u64| InputCandidate {
-            synced_utxo: SyncedUtxo::empty_dummy(aocl_leaf_index),
-            number_of_confirmations: 14,
-        };
         let dummy_inputs = (0..100).map(dummy_input).collect_vec();
 
         for priority in InputSelectionPriority::iter() {
@@ -441,6 +463,56 @@ mod tests {
 
             // Ensure no panic when calling `prioritize`
             let _inputs = input_selector.prioritize(&dummy_inputs);
+        }
+    }
+
+    #[test]
+    fn filters_on_lustration_requirement() {
+        let dummy_inputs = (0u64..=u64::from(WINDOW_SIZE) * 40)
+            .step_by(WINDOW_SIZE as usize)
+            .map(dummy_input)
+            .collect_vec();
+        let num_utxos = dummy_inputs.len();
+
+        let lustration_threshold = Some(u64::from(WINDOW_SIZE) * 2);
+        let reject_lustration = InputSelector::new(lustration_threshold)
+            .input_candidates(dummy_inputs.clone())
+            .policy(InputSelectionPolicy {
+                priority: InputSelectionPriority::ByAge(SortOrder::Descending),
+                required_number_of_confirmations: 0,
+                max_num_inputs: None,
+                accept_lustrations: false,
+            });
+
+        assert!(
+            (reject_lustration
+                .filter_by_lustration_requirement(&dummy_inputs)
+                .into_iter()
+                .count())
+                < num_utxos
+        );
+
+        let accept_lustration = InputSelector::new(lustration_threshold)
+            .input_candidates(dummy_inputs.clone())
+            .policy(InputSelectionPolicy {
+                priority: InputSelectionPriority::ByAge(SortOrder::Descending),
+                required_number_of_confirmations: 0,
+                max_num_inputs: None,
+                accept_lustrations: true,
+            });
+        assert_eq!(
+            num_utxos,
+            accept_lustration
+                .filter_by_lustration_requirement(&dummy_inputs)
+                .into_iter()
+                .count()
+        );
+    }
+
+    fn dummy_input(aocl_leaf_index: u64) -> InputCandidate {
+        InputCandidate {
+            synced_utxo: SyncedUtxo::empty_dummy(aocl_leaf_index),
+            number_of_confirmations: 14,
         }
     }
 }

--- a/neptune-core/src/api/tx_initiation/consolidate.rs
+++ b/neptune-core/src/api/tx_initiation/consolidate.rs
@@ -34,33 +34,42 @@ impl TransactionInitiator {
     /// wallet, thereby reducing the total number of UTXOs under management.
     pub async fn consolidate(
         &mut self,
-        num_inputs: Option<usize>,
+        max_num_inputs: usize,
         consolidation_address: Option<ReceivingAddress>,
         timestamp: Timestamp,
         accept_lustrations: bool,
     ) -> Result<usize, ConsolidationError> {
-        const MIN_CONSOLIDATION_INPUT_COUNT: usize = 16;
-        let num_inputs = num_inputs.unwrap_or(MIN_CONSOLIDATION_INPUT_COUNT);
+        const MIN_NUM_INPUTS: usize = 2;
 
-        debug!("consolidate: Attempting to consolidate {num_inputs} UTXOs in wallet");
+        debug!("consolidate: Attempting to consolidate {max_num_inputs} UTXOs in wallet");
         let input_candidates = self.input_candidates(timestamp).await;
-        if input_candidates.len() < num_inputs {
-            debug!("Nothing to consolidate as wallet has less than {num_inputs} spendable inputs.");
-            return Err(ConsolidationError::NotEnoughUtxos {
-                requested: num_inputs,
-                present: input_candidates.len(),
-            });
-        }
-
+        let lustration_threshold = self
+            .global_state_lock
+            .lock_guard()
+            .await
+            .chain
+            .lustration_threshold();
         let policy =
             InputSelectionPolicy::from(InputSelectionPriority::ByAge(SortOrder::Descending))
-                .require_confirmations(NUM_CONFIRMATIONS_REQUIRED_FOR_CONSOLIDATION);
-        let selected_inputs = InputSelector::default()
+                .require_confirmations(NUM_CONFIRMATIONS_REQUIRED_FOR_CONSOLIDATION)
+                .set_lustration_acceptance(accept_lustrations);
+        let selected_inputs = InputSelector::new(lustration_threshold)
             .input_candidates(input_candidates)
             .policy(policy)
-            .take(num_inputs)
+            .take(max_num_inputs)
             .into_iter()
             .collect_vec();
+
+        // Ensure we never attempt to consolidate zero or one input
+        if selected_inputs.len() < MIN_NUM_INPUTS {
+            debug!(
+                "Nothing to consolidate as wallet has less than {MIN_NUM_INPUTS} spendable inputs that meet the consolidation criteria."
+            );
+            return Err(ConsolidationError::NotEnoughUtxos {
+                requested: max_num_inputs,
+                present: selected_inputs.len(),
+            });
+        }
 
         let unlocked_inputs = self
             .global_state_lock
@@ -69,10 +78,11 @@ impl TransactionInitiator {
             .unlock_inputs(selected_inputs)
             .await;
 
+        let num_used_inputs = unlocked_inputs.len();
+        let unlocked_amount = unlocked_inputs.total_native_coins();
         debug!(
             "Selected {} inputs for consolidation, in total amount {}.",
-            unlocked_inputs.len(),
-            unlocked_inputs.total_native_coins()
+            num_used_inputs, unlocked_amount
         );
 
         let receiving_address = match consolidation_address {
@@ -93,7 +103,6 @@ impl TransactionInitiator {
             TxProvingCapability::SingleProof => CONSOLIDATION_FEE_SP,
         };
 
-        let unlocked_amount = unlocked_inputs.total_native_coins();
         let Some(output_amount) = unlocked_amount.checked_sub(&fee) else {
             return Err(ConsolidationError::Dust {
                 amount: unlocked_amount,
@@ -152,7 +161,7 @@ impl TransactionInitiator {
 
         tracing::info!("done");
 
-        Ok(num_inputs)
+        Ok(num_used_inputs)
     }
 }
 

--- a/neptune-core/src/api/tx_initiation/consolidate.rs
+++ b/neptune-core/src/api/tx_initiation/consolidate.rs
@@ -39,8 +39,8 @@ impl TransactionInitiator {
         timestamp: Timestamp,
         accept_lustrations: bool,
     ) -> Result<usize, ConsolidationError> {
-        const CONSOLIDATION_INPUT_COUNT: usize = 4;
-        let num_inputs = num_inputs.unwrap_or(CONSOLIDATION_INPUT_COUNT);
+        const MIN_CONSOLIDATION_INPUT_COUNT: usize = 16;
+        let num_inputs = num_inputs.unwrap_or(MIN_CONSOLIDATION_INPUT_COUNT);
 
         debug!("consolidate: Attempting to consolidate {num_inputs} UTXOs in wallet");
         let input_candidates = self.input_candidates(timestamp).await;

--- a/neptune-core/src/api/tx_initiation/consolidate.rs
+++ b/neptune-core/src/api/tx_initiation/consolidate.rs
@@ -38,8 +38,8 @@ impl TransactionInitiator {
         consolidation_address: Option<ReceivingAddress>,
         timestamp: Timestamp,
     ) -> Result<usize, ConsolidationError> {
-        const CONSOLIDATION_INPUT_COUNT: usize = 4;
-        let num_inputs = num_inputs.unwrap_or(CONSOLIDATION_INPUT_COUNT);
+        const MIN_CONSOLIDATION_INPUT_COUNT: usize = 16;
+        let num_inputs = num_inputs.unwrap_or(MIN_CONSOLIDATION_INPUT_COUNT);
 
         debug!("consolidate: Attempting to consolidate {num_inputs} UTXOs in wallet");
         let input_candidates = self.input_candidates(timestamp).await;

--- a/neptune-core/src/application/config/auto_consolidation.rs
+++ b/neptune-core/src/application/config/auto_consolidation.rs
@@ -2,7 +2,13 @@ use crate::api::export::Network;
 use crate::api::export::ReceivingAddress;
 
 #[derive(Debug, Clone, Default)]
-pub enum AutoConsolidationSetting {
+pub struct AutoConsolidationSettings {
+    pub(crate) max_num_inpus: u8,
+    pub(crate) policy: ConsolidationPolicy,
+}
+
+#[derive(Debug, Clone, Default)]
+pub enum ConsolidationPolicy {
     #[default]
     Inactive,
     ActiveDynamic,
@@ -11,24 +17,28 @@ pub enum AutoConsolidationSetting {
     },
 }
 
-impl AutoConsolidationSetting {
+impl AutoConsolidationSettings {
     // OK to suppress this linter rule because we are parsing and the nested
     // type tells clap how to parse.
     #[expect(clippy::option_option)]
     pub(crate) fn parse(
-        cli_argument: &Option<Option<String>>,
+        auto_consolidate_cli: &Option<Option<String>>,
+        num_consolidation_inputs_cli: u8,
         network: Network,
     ) -> Result<Self, String> {
-        let auto_consolidate = match cli_argument {
-            Some(None) => AutoConsolidationSetting::ActiveDynamic,
+        let policy = match auto_consolidate_cli {
+            Some(None) => ConsolidationPolicy::ActiveDynamic,
             Some(Some(address)) => {
                 let address = ReceivingAddress::from_bech32m(address, network)
                     .map_err(|inner_err| inner_err.to_string())?;
-                AutoConsolidationSetting::ActiveFixed { address }
+                ConsolidationPolicy::ActiveFixed { address }
             }
-            None => AutoConsolidationSetting::Inactive,
+            None => ConsolidationPolicy::Inactive,
         };
 
-        Ok(auto_consolidate)
+        Ok(AutoConsolidationSettings {
+            max_num_inpus: num_consolidation_inputs_cli,
+            policy,
+        })
     }
 }

--- a/neptune-core/src/application/config/auto_consolidation.rs
+++ b/neptune-core/src/application/config/auto_consolidation.rs
@@ -2,40 +2,46 @@ use crate::api::export::Network;
 use crate::api::export::ReceivingAddress;
 
 #[derive(Debug, Clone, Default)]
-pub enum AutoConsolidationSetting {
+pub struct AutoConsolidationSettings {
+    pub(crate) max_num_inpus: u8,
+    pub(crate) policy: ConsolidationTarget,
+    pub(crate) accept_lustrations: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+pub enum ConsolidationTarget {
     #[default]
     Inactive,
-    ActiveDynamic {
-        accept_lustrations: bool,
-    },
+    ActiveDynamic,
     ActiveFixed {
-        accept_lustrations: bool,
         address: ReceivingAddress,
     },
 }
 
-impl AutoConsolidationSetting {
+impl AutoConsolidationSettings {
     // OK to suppress this linter rule because we are parsing and the nested
     // type tells clap how to parse.
     #[expect(clippy::option_option)]
     pub(crate) fn parse(
-        cli_argument: &Option<Option<String>>,
+        auto_consolidate_cli: &Option<Option<String>>,
+        num_consolidation_inputs_cli: u8,
         network: Network,
         accept_lustrations: bool,
     ) -> Result<Self, String> {
-        let auto_consolidate = match cli_argument {
-            Some(None) => AutoConsolidationSetting::ActiveDynamic { accept_lustrations },
+        let policy = match auto_consolidate_cli {
+            Some(None) => ConsolidationTarget::ActiveDynamic,
             Some(Some(address)) => {
                 let address = ReceivingAddress::from_bech32m(address, network)
                     .map_err(|inner_err| inner_err.to_string())?;
-                AutoConsolidationSetting::ActiveFixed {
-                    accept_lustrations,
-                    address,
-                }
+                ConsolidationTarget::ActiveFixed { address }
             }
-            None => AutoConsolidationSetting::Inactive,
+            None => ConsolidationTarget::Inactive,
         };
 
-        Ok(auto_consolidate)
+        Ok(AutoConsolidationSettings {
+            max_num_inpus: num_consolidation_inputs_cli,
+            policy,
+            accept_lustrations,
+        })
     }
 }

--- a/neptune-core/src/application/config/cli_args.rs
+++ b/neptune-core/src/application/config/cli_args.rs
@@ -20,7 +20,7 @@ use tracing::error;
 
 use super::fee_notification_policy::FeeNotificationPolicy;
 use super::network::Network;
-use crate::application::config::auto_consolidation::AutoConsolidationSetting;
+use crate::application::config::auto_consolidation::AutoConsolidationSettings;
 use crate::application::config::parser::multiaddr::parse_to_multiaddr;
 use crate::application::config::triton_vm_env_vars::TritonVmEnvVars;
 use crate::application::config::tx_upgrade_filter::TxUpgradeFilter;
@@ -167,7 +167,7 @@ pub struct Args {
     ///
     /// If this flag is set, whenever there are four or more UTXOs managed by
     /// the wallet, the client will initiate and broadcast a transaction that
-    /// spends them to either the next unused symmetric key, or else the given
+    /// sends UTXOs to either the next unused symmetric key, or else the given
     /// address.
     ///
     /// Examples:
@@ -191,7 +191,14 @@ pub struct Args {
     pub(crate) accept_consolidation_lustrations: bool,
 
     #[clap(skip)]
-    pub(crate) auto_consolidate_cache: OnceLock<AutoConsolidationSetting>,
+    pub(crate) auto_consolidate_cache: OnceLock<AutoConsolidationSettings>,
+
+    /// Upper number of inputs per consolidation transaction.
+    ///
+    /// Sets the number of inputs that each consolidation transaction will
+    /// contain.
+    #[clap(long, default_value = "8", value_name = "NUM_INPUTS")]
+    pub(crate) num_consolidation_inputs: u8,
 
     /// Specify environment variables for Triton VM for a given (log2 of) the
     /// padded height. Can be used to control the environment variables
@@ -990,11 +997,12 @@ impl Args {
     /// # Panics
     /// - If cache is not set, and an invalid address is given as consolidation
     ///   address.
-    pub(crate) fn auto_consolidate(&self) -> AutoConsolidationSetting {
+    pub(crate) fn auto_consolidate(&self) -> AutoConsolidationSettings {
         self.auto_consolidate_cache
             .get_or_init(|| {
-                AutoConsolidationSetting::parse(
+                AutoConsolidationSettings::parse(
                     &self.auto_consolidate,
+                    self.num_consolidation_inputs,
                     self.network,
                     self.accept_consolidation_lustrations,
                 )

--- a/neptune-core/src/application/config/cli_args.rs
+++ b/neptune-core/src/application/config/cli_args.rs
@@ -20,7 +20,7 @@ use tracing::error;
 
 use super::fee_notification_policy::FeeNotificationPolicy;
 use super::network::Network;
-use crate::application::config::auto_consolidation::AutoConsolidationSetting;
+use crate::application::config::auto_consolidation::AutoConsolidationSettings;
 use crate::application::config::parser::multiaddr::parse_to_multiaddr;
 use crate::application::config::triton_vm_env_vars::TritonVmEnvVars;
 use crate::application::config::tx_upgrade_filter::TxUpgradeFilter;
@@ -167,7 +167,7 @@ pub struct Args {
     ///
     /// If this flag is set, whenever there are four or more UTXOs managed by
     /// the wallet, the client will initiate and broadcast a transaction that
-    /// spends them to either the next unused symmetric key, or else the given
+    /// sends UTXOs to either the next unused symmetric key, or else the given
     /// address.
     ///
     /// Examples:
@@ -182,7 +182,14 @@ pub struct Args {
     pub(crate) auto_consolidate: Option<Option<String>>,
 
     #[clap(skip)]
-    pub(crate) auto_consolidate_cache: OnceLock<AutoConsolidationSetting>,
+    pub(crate) auto_consolidate_cache: OnceLock<AutoConsolidationSettings>,
+
+    /// Upper number of inputs per consolidation transaction.
+    ///
+    /// Sets the number of inputs that each consolidation transaction will
+    /// contain.
+    #[clap(long, default_value = "8", value_name = "NUM_INPUTS")]
+    pub(crate) num_consolidation_inputs: u8,
 
     /// Specify environment variables for Triton VM for a given (log2 of) the
     /// padded height. Can be used to control the environment variables
@@ -981,11 +988,15 @@ impl Args {
     /// # Panics
     /// - If cache is not set, and an invalid address is given as consolidation
     ///   address.
-    pub(crate) fn auto_consolidate(&self) -> AutoConsolidationSetting {
+    pub(crate) fn auto_consolidate(&self) -> AutoConsolidationSettings {
         self.auto_consolidate_cache
             .get_or_init(|| {
-                AutoConsolidationSetting::parse(&self.auto_consolidate, self.network)
-                    .expect("Must be able to parse auto consolidation setting")
+                AutoConsolidationSettings::parse(
+                    &self.auto_consolidate,
+                    self.num_consolidation_inputs,
+                    self.network,
+                )
+                .expect("Must be able to parse auto consolidation setting")
             })
             .to_owned()
     }

--- a/neptune-core/src/application/config/parser/mod.rs
+++ b/neptune-core/src/application/config/parser/mod.rs
@@ -5,7 +5,7 @@ use sysinfo::System;
 
 use super::cli_args::Args;
 use crate::api::export::TxProvingCapability;
-use crate::application::config::auto_consolidation::AutoConsolidationSetting;
+use crate::application::config::auto_consolidation::AutoConsolidationSettings;
 
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
 pub(crate) enum CliArgsParseError {
@@ -23,9 +23,12 @@ impl Args {
     ///
     /// Sets cache.
     pub(crate) fn second_parse(&mut self) -> Result<(), CliArgsParseError> {
-        let auto_consolidate =
-            AutoConsolidationSetting::parse(&self.auto_consolidate, self.network)
-                .map_err(CliArgsParseError::InvalidConsolidationAddress)?;
+        let auto_consolidate = AutoConsolidationSettings::parse(
+            &self.auto_consolidate,
+            self.num_consolidation_inputs,
+            self.network,
+        )
+        .map_err(CliArgsParseError::InvalidConsolidationAddress)?;
         self.auto_consolidate_cache.set(auto_consolidate).unwrap();
 
         let proving_capability = self.derive_proving_capability()?;

--- a/neptune-core/src/application/config/parser/mod.rs
+++ b/neptune-core/src/application/config/parser/mod.rs
@@ -5,7 +5,7 @@ use sysinfo::System;
 
 use super::cli_args::Args;
 use crate::api::export::TxProvingCapability;
-use crate::application::config::auto_consolidation::AutoConsolidationSetting;
+use crate::application::config::auto_consolidation::AutoConsolidationSettings;
 
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
 pub(crate) enum CliArgsParseError {
@@ -23,8 +23,9 @@ impl Args {
     ///
     /// Sets cache.
     pub(crate) fn second_parse(&mut self) -> Result<(), CliArgsParseError> {
-        let auto_consolidate = AutoConsolidationSetting::parse(
+        let auto_consolidate = AutoConsolidationSettings::parse(
             &self.auto_consolidate,
+            self.num_consolidation_inputs,
             self.network,
             self.accept_consolidation_lustrations,
         )

--- a/neptune-core/src/application/loops/connect_to_peers.rs
+++ b/neptune-core/src/application/loops/connect_to_peers.rs
@@ -769,7 +769,7 @@ mod tests {
             .build();
 
         let (_peer_broadcast_tx, from_main_rx_clone, to_main_tx, _to_main_rx1, _, _, state, _hsd) =
-            get_test_genesis_setup(network, 0, cli_args::Args::default()).await?;
+            get_test_genesis_setup(0, cli_args::Args::default_with_network(network)).await?;
         call_peer_inner(
             mock,
             state.clone(),
@@ -831,7 +831,7 @@ mod tests {
     async fn test_get_connection_status() -> Result<()> {
         let network = Network::Main;
         let (_, _, _, _, _, _, mut state_lock, own_handshake) =
-            get_test_genesis_setup(network, 1, cli_args::Args::default()).await?;
+            get_test_genesis_setup(1, cli_args::Args::default_with_network(network)).await?;
 
         // Get an address for a peer that's not already connected
         let (other_handshake, peer_sa) = get_dummy_peer_connection_data_genesis(network, 1);
@@ -965,7 +965,7 @@ mod tests {
     async fn refuse_connection_bad_timestamp() {
         let network = Network::Main;
         let (_, _, _, _, _, _, state_lock, own_handshake) =
-            get_test_genesis_setup(network, 1, cli_args::Args::default())
+            get_test_genesis_setup(1, cli_args::Args::default_with_network(network))
                 .await
                 .unwrap();
 
@@ -1014,7 +1014,7 @@ mod tests {
         };
 
         let (broadcast_tx, _broadcast_rx, to_main_tx, _to_main_rx, _, _, mut state_lock, handshake) =
-            get_test_genesis_setup(network, 0, args).await?;
+            get_test_genesis_setup(0, args).await?;
 
         // fake a graceful disconnect
         let node_0_address = get_dummy_socket_address(0);
@@ -1114,7 +1114,7 @@ mod tests {
             _,
             state_lock,
             _hsd,
-        ) = get_test_genesis_setup(network, 0, cli_args::Args::default()).await?;
+        ) = get_test_genesis_setup(0, cli_args::Args::default_with_network(network)).await?;
         answer_peer_inner(
             mock,
             state_lock.clone(),
@@ -1149,7 +1149,7 @@ mod tests {
             .build();
 
         let (_peer_broadcast_tx, from_main_rx_clone, to_main_tx, _to_main_rx1, _, _, state, _hsd) =
-            get_test_genesis_setup(network, 0, cli_args::Args::default()).await?;
+            get_test_genesis_setup(0, cli_args::Args::default_with_network(network)).await?;
 
         let answer = answer_peer_inner(
             mock,
@@ -1183,7 +1183,8 @@ mod tests {
             .build();
 
         let (_peer_broadcast_tx, from_main_rx_clone, to_main_tx, _to_main_rx1, _, _, state, _hsd) =
-            get_test_genesis_setup(Network::Testnet(1), 0, cli_args::Args::default()).await?;
+            get_test_genesis_setup(0, cli_args::Args::default_with_network(Network::Testnet(1)))
+                .await?;
 
         let answer = answer_peer_inner(
             mock,
@@ -1213,7 +1214,7 @@ mod tests {
             _,
             state_lock,
             _hsd,
-        ) = get_test_genesis_setup(Network::Main, 0, cli_args::Args::default())
+        ) = get_test_genesis_setup(0, cli_args::Args::default_with_network(Network::Main))
             .await
             .unwrap();
         let state = state_lock.lock_guard().await;
@@ -1308,7 +1309,7 @@ mod tests {
             _,
             mut state_lock,
             _hsd,
-        ) = get_test_genesis_setup(network, 2, cli_args::Args::default()).await?;
+        ) = get_test_genesis_setup(2, cli_args::Args::default_with_network(network)).await?;
 
         // set max_peers to 2 to ensure failure on next connection attempt
         let mut cli = state_lock.cli().clone();
@@ -1332,8 +1333,10 @@ mod tests {
 
     #[apply(shared_tokio_runtime)]
     async fn allow_capping_number_of_peers_per_ip() {
+        let network = Network::Main;
         let allow_5_connections_from_same_ip = cli_args::Args {
             max_connections_per_ip: Some(5),
+            network,
             ..Default::default()
         };
         let (
@@ -1345,7 +1348,7 @@ mod tests {
             _,
             mut state_lock,
             _hsd,
-        ) = get_test_genesis_setup(Network::Main, 0, allow_5_connections_from_same_ip)
+        ) = get_test_genesis_setup(0, allow_5_connections_from_same_ip)
             .await
             .unwrap();
 
@@ -1447,9 +1450,8 @@ mod tests {
             mut state_lock,
             _hsd,
         ) = get_test_genesis_setup(
-            network,
             peer_count_before_incoming_connection_request,
-            cli_args::Args::default(),
+            cli_args::Args::default_with_network(network),
         )
         .await?;
         let bad_standing: PeerStanding = PeerStanding::init(

--- a/neptune-core/src/application/loops/main_loop.rs
+++ b/neptune-core/src/application/loops/main_loop.rs
@@ -874,7 +874,7 @@ impl MainLoopHandler {
                     tokio::task::spawn(async move {
                         let _ = tx_initiator
                             .consolidate(
-                                Some(max_num_inputs as usize),
+                                max_num_inputs as usize,
                                 maybe_consolidation_address,
                                 timestamp,
                                 accept_lustrations,

--- a/neptune-core/src/application/loops/main_loop.rs
+++ b/neptune-core/src/application/loops/main_loop.rs
@@ -2608,6 +2608,7 @@ mod tests {
         main_to_miner_rx: mpsc::Receiver<MainToMiner>,
     }
 
+    /// Return a state synced to the genesis block, with the devnet wallet.
     async fn setup(
         num_init_peers_outgoing: u8,
         num_peers_incoming: u8,
@@ -2615,7 +2616,6 @@ mod tests {
     ) -> TestSetup {
         const CHANNEL_CAPACITY_MINER_TO_MAIN: usize = 10;
 
-        let network = Network::Main;
         let (
             main_to_peer_tx,
             main_to_peer_rx,
@@ -2625,7 +2625,7 @@ mod tests {
             network_event_rx,
             mut state,
             _own_handshake_data,
-        ) = get_test_genesis_setup(network, num_init_peers_outgoing, cli)
+        ) = get_test_genesis_setup(num_init_peers_outgoing, cli)
             .await
             .unwrap();
         assert!(

--- a/neptune-core/src/application/loops/main_loop.rs
+++ b/neptune-core/src/application/loops/main_loop.rs
@@ -762,6 +762,11 @@ impl MainLoopHandler {
 
                 let block_hashes = blocks.iter().map(|x| x.hash()).collect_vec();
                 let last_block = blocks.last().unwrap().to_owned();
+
+                // Track the list of "update" jobs that should be performed
+                // after a new tip is set. Using hashmap deduplicates the jobs
+                // in case multiple incoming blocks trigger the same mempool
+                // transaction to be updated multiple times.
                 let update_jobs = {
                     // Double-check canonicity.
                     // The peer tasks also check this condition. However, there
@@ -780,7 +785,6 @@ impl MainLoopHandler {
                         return Ok(());
                     }
 
-                    // Report.
                     info!(
                         "Block {} from peer is new canonical tip: {:x}",
                         last_block.header().height,
@@ -808,7 +812,7 @@ impl MainLoopHandler {
                     // blocks are sent to the main loop through dedicated
                     // message, NewSyncBlock.
 
-                    let mut update_jobs: Vec<MempoolUpdateJob> = vec![];
+                    let mut update_jobs: HashMap<_, _> = HashMap::new();
                     for new_block in blocks {
                         debug!(
                             "Storing block {:x} in database. Height: {}, Mined: {}",
@@ -817,18 +821,13 @@ impl MainLoopHandler {
                             new_block.kernel.header.timestamp.standard_format()
                         );
 
-                        // Potential race condition here.
-                        // What if last block is new and canonical, but first
-                        // block is already known then we'll store the same block
-                        // twice. That should be OK though, as the appropriate
-                        // database entries are simply overwritten with the new
-                        // block info. See the
-                        // [GlobalState::tests::setting_same_tip_twice_is_allowed]
-                        // test for a test of this phenomenon.
-
                         let update_jobs_ = global_state_mut.set_new_tip(new_block).await?;
 
-                        update_jobs.extend(update_jobs_);
+                        update_jobs.extend(
+                            update_jobs_
+                                .into_iter()
+                                .map(|update_job| (update_job.txid(), update_job)),
+                        );
                     }
 
                     global_state_mut.flush_databases().await?;
@@ -848,8 +847,7 @@ impl MainLoopHandler {
                 }
 
                 // Spawn task to handle mempool tx-updating after new blocks.
-                // TODO: Do clever trick to collapse all jobs relating to the same transaction,
-                //       identified by transaction-ID, into *one* update job.
+                let update_jobs = update_jobs.into_values().collect_vec();
                 self.spawn_mempool_txs_update_job(main_loop_state, update_jobs);
 
                 let (consolidate, maybe_consolidation_address, max_num_inputs, accept_lustrations) = {

--- a/neptune-core/src/application/loops/main_loop.rs
+++ b/neptune-core/src/application/loops/main_loop.rs
@@ -38,7 +38,7 @@ use tracing::trace;
 use tracing::warn;
 
 use crate::api::export::Timestamp;
-use crate::application::config::auto_consolidation::AutoConsolidationSetting;
+use crate::application::config::auto_consolidation::ConsolidationTarget;
 use crate::application::config::parser::multiaddr::multiaddr_to_socketaddr;
 use crate::application::loops::channel::MainToMiner;
 use crate::application::loops::channel::MinerToMain;
@@ -852,17 +852,21 @@ impl MainLoopHandler {
                 //       identified by transaction-ID, into *one* update job.
                 self.spawn_mempool_txs_update_job(main_loop_state, update_jobs);
 
-                let (consolidate, maybe_consolidation_address, accept_lustrations) =
-                    match self.global_state_lock.cli().auto_consolidate() {
-                        AutoConsolidationSetting::Inactive => (false, None, false),
-                        AutoConsolidationSetting::ActiveDynamic { accept_lustrations } => {
-                            (true, None, accept_lustrations)
-                        }
-                        AutoConsolidationSetting::ActiveFixed {
-                            accept_lustrations,
-                            address,
-                        } => (true, Some(address), accept_lustrations),
+                let (consolidate, maybe_consolidation_address, max_num_inputs, accept_lustrations) = {
+                    let settings = self.global_state_lock.cli().auto_consolidate();
+                    let (cons, cons_addr) = match settings.policy {
+                        ConsolidationTarget::Inactive => (false, None),
+                        ConsolidationTarget::ActiveDynamic => (true, None),
+                        ConsolidationTarget::ActiveFixed { address } => (true, Some(address)),
                     };
+
+                    (
+                        cons,
+                        cons_addr,
+                        settings.max_num_inpus,
+                        settings.accept_lustrations,
+                    )
+                };
 
                 if consolidate {
                     let timestamp = Timestamp::now();
@@ -870,7 +874,7 @@ impl MainLoopHandler {
                     tokio::task::spawn(async move {
                         let _ = tx_initiator
                             .consolidate(
-                                Default::default(),
+                                Some(max_num_inputs as usize),
                                 maybe_consolidation_address,
                                 timestamp,
                                 accept_lustrations,

--- a/neptune-core/src/application/loops/main_loop.rs
+++ b/neptune-core/src/application/loops/main_loop.rs
@@ -38,7 +38,7 @@ use tracing::trace;
 use tracing::warn;
 
 use crate::api::export::Timestamp;
-use crate::application::config::auto_consolidation::AutoConsolidationSetting;
+use crate::application::config::auto_consolidation::ConsolidationPolicy;
 use crate::application::config::parser::multiaddr::multiaddr_to_socketaddr;
 use crate::application::loops::channel::MainToMiner;
 use crate::application::loops::channel::MinerToMain;
@@ -852,19 +852,27 @@ impl MainLoopHandler {
                 //       identified by transaction-ID, into *one* update job.
                 self.spawn_mempool_txs_update_job(main_loop_state, update_jobs);
 
-                let (consolidate, maybe_consolidation_address) =
-                    match self.global_state_lock.cli().auto_consolidate() {
-                        AutoConsolidationSetting::Inactive => (false, None),
-                        AutoConsolidationSetting::ActiveDynamic => (true, None),
-                        AutoConsolidationSetting::ActiveFixed { address } => (true, Some(address)),
+                let (consolidate, maybe_consolidation_address, max_num_inputs) = {
+                    let settings = self.global_state_lock.cli().auto_consolidate();
+                    let (cons, cons_addr) = match settings.policy {
+                        ConsolidationPolicy::Inactive => (false, None),
+                        ConsolidationPolicy::ActiveDynamic => (true, None),
+                        ConsolidationPolicy::ActiveFixed { address } => (true, Some(address)),
                     };
+
+                    (cons, cons_addr, settings.max_num_inpus)
+                };
 
                 if consolidate {
                     let timestamp = Timestamp::now();
                     let mut tx_initiator = self.global_state_lock().api_mut().tx_initiator();
                     tokio::task::spawn(async move {
                         let _ = tx_initiator
-                            .consolidate(Default::default(), maybe_consolidation_address, timestamp)
+                            .consolidate(
+                                Some(max_num_inputs as usize),
+                                maybe_consolidation_address,
+                                timestamp,
+                            )
                             .await
                             .inspect_err(|err| warn!("{err}"));
                     });

--- a/neptune-core/src/application/loops/main_loop.rs
+++ b/neptune-core/src/application/loops/main_loop.rs
@@ -2440,7 +2440,7 @@ impl MainLoopHandler {
                 return None;
             }
             SyncToMain::TipSuccessor(block) => {
-                log_slow_scope!(fn_name!() + "::PeerTaskToMain::NewBlocks");
+                log_slow_scope!(fn_name!() + "::PeerTaskToMain::TipSuccessor");
                 let height = block.header().height;
 
                 let mut global_state_mut = self.global_state_lock.lock_guard_mut().await;

--- a/neptune-core/src/application/loops/main_loop/proof_upgrader.rs
+++ b/neptune-core/src/application/loops/main_loop/proof_upgrader.rs
@@ -31,6 +31,7 @@ use crate::protocol::consensus::transaction::TransactionProof;
 use crate::protocol::consensus::type_scripts::native_currency_amount::NativeCurrencyAmount;
 use crate::protocol::proof_abstractions::tasm::program::TritonVmProofJobOptions;
 use crate::protocol::proof_abstractions::timestamp::Timestamp;
+use crate::state::mempool::upgrade_priority::UpgradePriority;
 use crate::state::transaction::transaction_details::TransactionDetails;
 use crate::state::transaction::transaction_kernel_id::TransactionKernelId;
 use crate::state::transaction::tx_proving_capability::TxProvingCapability;
@@ -44,6 +45,8 @@ use crate::state::GlobalStateLock;
 use crate::util_types::mutator_set::mutator_set_accumulator::MutatorSetAccumulator;
 
 pub(crate) const SEARCH_DEPTH_FOR_BLOCKS_FOR_MS_UPDATE: usize = 100;
+const MINIMUM_FEE_FOR_FREE_MERGE: NativeCurrencyAmount =
+    NativeCurrencyAmount::from_nau(NativeCurrencyAmount::coin_as_nau() / 200);
 
 /// Enumerates the types of 'proof upgrades' that can be done.
 ///
@@ -259,6 +262,18 @@ impl UpgradeJob {
         }
     }
 
+    /// Return true if this upgrade job performs the expensive "raise" operation
+    /// which is how a single proof is first created.
+    fn performs_raise(&self) -> bool {
+        match self {
+            UpgradeJob::PrimitiveWitnessToSingleProof(_)
+            | UpgradeJob::ProofCollectionToSingleProof(_) => true,
+            UpgradeJob::PrimitiveWitnessToProofCollection(_)
+            | UpgradeJob::Merge { .. }
+            | UpgradeJob::UpdateMutatorSetData(_) => false,
+        }
+    }
+
     /// The gobbling fee charged for an upgrade job
     ///
     /// Gobbling fees are charged when a transaction is upgraded from
@@ -418,22 +433,17 @@ impl UpgradeJob {
     ) {
         let mut upgrade_job = self;
 
-        let upgrade_incentive = upgrade_job.upgrade_incentive();
-        let priority = match upgrade_incentive {
-            UpgradeIncentive::Critical => TritonVmJobPriority::High,
-            _ => TritonVmJobPriority::Low,
-        };
-
         // process in a loop.  in case a new block comes in while processing
         // the current tx, then we can move on to the next, and so on.
         loop {
             /* Prepare upgrade */
+            let upgrade_incentive = upgrade_job.upgrade_incentive();
+            let priority = match upgrade_incentive {
+                UpgradeIncentive::Critical => TritonVmJobPriority::High,
+                _ => TritonVmJobPriority::Low,
+            };
             let affected_txids = upgrade_job.affected_txids();
             let mutator_set_for_tx = upgrade_job.mutator_set();
-
-            // note: if this task is cancelled, the job will continue
-            // because TritonVmJobOptions::cancel_job_rx is None.
-            // see how compose_task handles cancellation in mine_loop.
             let job_options = global_state_lock.cli().proof_job_options(priority);
 
             // It's a important to *not* hold any locks when proving happens.
@@ -446,7 +456,7 @@ impl UpgradeJob {
                 )
             };
 
-            /* Perform upgrade */
+            /* Perform upgrade by generating a new Triton VM proof */
             // No locks may be held here!
             let offchain_notifications = global_state_lock.cli().fee_notification;
             let (upgraded, expected_utxos) = match upgrade_job
@@ -530,6 +540,43 @@ impl UpgradeJob {
                     }
 
                     info!("Successfully handled proof upgrade.");
+
+                    // Did we just perform a "raise" operation? If so, we see if
+                    // the transaction can be merged with anything favorable to
+                    // us.
+                    if upgrade_job.performs_raise() {
+                        let merge_tx = global_state_lock.lock_guard().await.mempool.merge_partner(
+                            &upgraded.kernel,
+                            consensus_rule_set,
+                            MINIMUM_FEE_FOR_FREE_MERGE,
+                        );
+                        if let Some((right_kernel, single_proof_right, right_priority)) = merge_tx {
+                            info!("Found merge candidate for newly upgraded transaction.");
+
+                            let mut rng: StdRng =
+                                SeedableRng::from_seed(wallet_entropy.shuffle_seed(block_height));
+                            let shuffle_seed: [u8; 32] = rng.random();
+                            let single_proof_left = upgraded.proof.into_single_proof();
+                            let left_priority: UpgradePriority = upgrade_incentive.into();
+                            let new_priority = left_priority + right_priority;
+                            let gobbling_fee = NativeCurrencyAmount::zero();
+                            let merge_job = UpgradeJob::Merge {
+                                left_kernel: upgraded.kernel,
+                                single_proof_left,
+                                right_kernel,
+                                single_proof_right,
+                                shuffle_seed,
+                                mutator_set: upgrade_job.mutator_set(),
+                                upgrade_incentive: new_priority
+                                    .incentive_given_gobble_potential(gobbling_fee),
+                            };
+
+                            upgrade_job = merge_job;
+
+                            continue;
+                        }
+                    }
+
                     return;
                 }
 
@@ -1268,6 +1315,109 @@ mod tests {
                 alice.lock_guard().await.chain.tip_mutator_set_after();
             assert!(mempool_tx.is_confirmable_relative_to(&mutator_set_accumulator_after));
         }
+    }
+
+    #[traced_test]
+    #[apply(shared_tokio_runtime)]
+    async fn merge_after_single_proof_upgrade() {
+        let network = Network::Main;
+
+        let mut rng: StdRng = StdRng::seed_from_u64(512777439429);
+        let cli = cli_args::Args {
+            network,
+            tx_proving_capability: Some(TxProvingCapability::SingleProof),
+            ..Default::default()
+        };
+
+        // Give Bob multiple UTXOs such that at least two transactions can be
+        // created.
+        let mut bob =
+            state_with_premine_and_self_mined_blocks(cli, rng.random::<[Digest; 1]>()).await;
+        let (main_to_peer_tx, main_to_peer_rx) =
+            broadcast::channel::<MainToPeerTask>(PEER_CHANNEL_CAPACITY);
+
+        // Insert a single proof transaction into the mempool, such that the
+        // later primitive witness -> single proof upgrade handler finds a
+        // single proof transaction in the mempool, that it can merge with.
+        let tx_fee = NativeCurrencyAmount::coins(2);
+        let first_tx = transaction_from_state(
+            bob.clone(),
+            rng.random(),
+            TxProvingCapability::SingleProof,
+            tx_fee,
+        )
+        .await;
+        bob.lock_guard_mut()
+            .await
+            .mempool_insert(first_tx.clone().into(), UpgradePriority::Critical)
+            .await;
+
+        let second_tx = transaction_from_state(
+            bob.clone(),
+            rng.random(),
+            TxProvingCapability::PrimitiveWitness,
+            tx_fee,
+        )
+        .await;
+
+        let as_sp_upgrade_job =
+            UpgradeJob::PrimitiveWitnessToSingleProof(PrimitiveWitnessToSingleProof {
+                primitive_witness: second_tx.proof.clone().into_primitive_witness(),
+            });
+        as_sp_upgrade_job
+            .handle_upgrade(
+                TritonVmJobQueue::get_instance(),
+                bob.clone(),
+                main_to_peer_tx,
+            )
+            .await;
+        assert_eq!(
+            1,
+            bob.lock_guard().await.mempool.len(),
+            "Upgraded tx must be merged"
+        );
+
+        assert_eq!(
+            2,
+            main_to_peer_rx.len(),
+            "Must have received info about exactly two new transactions, one raise, and one merge"
+        );
+
+        let mempool_tx = bob
+            .lock_guard()
+            .await
+            .mempool
+            .get_transactions_for_block_composition(usize::MAX, None);
+        assert_eq!(1, mempool_tx.len());
+        let mempool_tx = &mempool_tx[0];
+
+        let consensus_rule_set = ConsensusRuleSet::infer_from(network, BlockHeight::genesis());
+        assert!(mempool_tx.is_valid(network, consensus_rule_set).await);
+
+        // Verify that the two transactions got merged
+        let mempool_inputs: HashSet<_> = mempool_tx
+            .kernel
+            .inputs
+            .iter()
+            .map(|x| x.absolute_indices)
+            .collect();
+        let expected_inputs: HashSet<_> = first_tx
+            .kernel
+            .inputs
+            .iter()
+            .chain(second_tx.kernel.inputs.iter())
+            .map(|x| x.absolute_indices)
+            .collect();
+        assert_eq!(expected_inputs, mempool_inputs);
+
+        let mempool_outputs: HashSet<_> = mempool_tx.kernel.outputs.iter().collect();
+        let expected_outputs: HashSet<_> = first_tx
+            .kernel
+            .outputs
+            .iter()
+            .chain(second_tx.kernel.outputs.iter())
+            .collect();
+        assert_eq!(expected_outputs, mempool_outputs);
     }
 
     #[traced_test]

--- a/neptune-core/src/application/loops/main_loop/proof_upgrader.rs
+++ b/neptune-core/src/application/loops/main_loop/proof_upgrader.rs
@@ -1100,7 +1100,7 @@ mod tests {
             // Alice is premine recipient, so she can make a transaction (after
             // expiry of timelock).
             let (main_to_peer_tx, mut main_to_peer_rx, _bob_peer_to_main_tx, _, _, _, mut alice, _) =
-                get_test_genesis_setup(network, 2, cli).await.unwrap();
+                get_test_genesis_setup(2, cli).await.unwrap();
             let pwtx = transaction_from_state(
                 alice.clone(),
                 512777439428,
@@ -1180,7 +1180,7 @@ mod tests {
             // Alice is premine recipient, so she can make a transaction (after
             // expiry of timelock).
             let (main_to_peer_tx, mut main_to_peer_rx, _, _, _, _, mut alice, _) =
-                get_test_genesis_setup(network, 2, cli).await.unwrap();
+                get_test_genesis_setup(2, cli).await.unwrap();
             let pwtx = transaction_from_state(
                 alice.clone(),
                 512777439429,

--- a/neptune-core/src/application/loops/peer_loop.rs
+++ b/neptune-core/src/application/loops/peer_loop.rs
@@ -2887,7 +2887,16 @@ mod tests {
             assert!(!invalid_pow.has_proof_of_work(network, predecessor.header()));
 
             let mut block_with_valid_mock_pow = block.clone();
-            block_with_valid_mock_pow.satisfy_mock_pow(difficulty, rand::random());
+            block_with_valid_mock_pow.satisfy_mock_pow(
+                difficulty,
+                rand::random(),
+                block_with_valid_mock_pow
+                    .header()
+                    .pow
+                    .lustration_status()
+                    .ok(),
+                block_with_valid_mock_pow.header().version,
+            );
             assert!(block_with_valid_mock_pow.is_valid_mock_pow(difficulty.target()));
             assert!(!block_with_valid_mock_pow.has_proof_of_work(network, predecessor.header()));
 

--- a/neptune-core/src/application/loops/peer_loop.rs
+++ b/neptune-core/src/application/loops/peer_loop.rs
@@ -2408,6 +2408,7 @@ mod tests {
         // software which has new variants of `PeerMessage`. The intended
         // behavior is that a small punishment is applied but that the
         // connection stays open.
+        let network = Network::Main;
         let mock = Mock::new(vec![Action::ReadError, Action::Read(PeerMessage::Bye)]);
 
         let (
@@ -2419,7 +2420,7 @@ mod tests {
             _,
             state_lock,
             hsd,
-        ) = get_test_genesis_setup(Network::Main, 1, cli_args::Args::default())
+        ) = get_test_genesis_setup(1, cli_args::Args::default_with_network(network))
             .await
             .unwrap();
 
@@ -2470,7 +2471,7 @@ mod tests {
             _,
             state_lock,
             hsd,
-        ) = get_test_genesis_setup(Network::Main, 2, cli_args::Args::default()).await?;
+        ) = get_test_genesis_setup(2, cli_args::Args::default()).await?;
 
         let peer_address_sa = get_dummy_socket_address(2);
         let peer_address = socketaddr_to_multiaddr(peer_address_sa);
@@ -2504,7 +2505,7 @@ mod tests {
         let args = cli_args::Args::default();
         let network = args.network;
         let (from_main_tx, from_main_rx, to_main_tx, to_main_rx, _, _, state_lock, _) =
-            get_test_genesis_setup(network, 0, args).await?;
+            get_test_genesis_setup(0, args).await?;
 
         let peer_address_sa = get_dummy_socket_address(0);
         let peer_address = socketaddr_to_multiaddr(peer_address_sa);
@@ -2558,9 +2559,8 @@ mod tests {
                 mut state_lock,
                 hsd,
             ) = get_test_genesis_setup(
-                network,
                 num_already_connected_peers,
-                cli_args::Args::default(),
+                cli_args::Args::default_with_network(network),
             )
             .await
             .unwrap();
@@ -2625,9 +2625,8 @@ mod tests {
                 state_lock,
                 hsd,
             ) = get_test_genesis_setup(
-                network,
                 num_already_connected_peers,
-                cli_args::Args::default(),
+                cli_args::Args::default_with_network(network),
             )
             .await
             .unwrap();
@@ -2697,9 +2696,8 @@ mod tests {
                 state_lock,
                 _hsd,
             ) = get_test_genesis_setup(
-                network,
                 num_already_connected_peers,
-                cli_args::Args::default(),
+                cli_args::Args::default_with_network(network),
             )
             .await
             .unwrap();
@@ -2792,7 +2790,7 @@ mod tests {
                 _,
                 state_lock,
                 hsd,
-            ) = get_test_genesis_setup(network, 0, cli_args::Args::default()).await?;
+            ) = get_test_genesis_setup(0, cli_args::Args::default_with_network(network)).await?;
             assert_eq!(1000, state_lock.cli().peer_tolerance);
             let peer_address_sa = get_dummy_socket_address(0);
 
@@ -2933,7 +2931,7 @@ mod tests {
                 _,
                 state_lock,
                 hsd,
-            ) = get_test_genesis_setup(network, 1, cli_args::Args::default_with_network(network))
+            ) = get_test_genesis_setup(1, cli_args::Args::default_with_network(network))
                 .await
                 .unwrap();
             let (peer_id, peer_info) = state_lock
@@ -3008,7 +3006,7 @@ mod tests {
                 _,
                 state_lock,
                 hsd,
-            ) = get_test_genesis_setup(network, 0, cli_args::Args::default()).await?;
+            ) = get_test_genesis_setup(0, cli_args::Args::default_with_network(network)).await?;
             let peer_address = get_dummy_socket_address(0);
 
             let (no_pow, mock_pow, _, alpha_pow, tvmv1_pow) =
@@ -3097,7 +3095,7 @@ mod tests {
                 _,
                 mut alice,
                 hsd,
-            ) = get_test_genesis_setup(network, 0, cli_args::Args::default()).await?;
+            ) = get_test_genesis_setup(0, cli_args::Args::default_with_network(network)).await?;
             let peer_address = get_dummy_socket_address(0);
             let genesis_block: Block = Block::genesis(network);
 
@@ -3162,7 +3160,7 @@ mod tests {
                 _,
                 mut state_lock,
                 handshake,
-            ) = get_test_genesis_setup(network, 0, cli_args::Args::default())
+            ) = get_test_genesis_setup(0, cli_args::Args::default_with_network(network))
                 .await
                 .unwrap();
             let genesis_block: Block = Block::genesis(network);
@@ -3247,7 +3245,7 @@ mod tests {
                 _,
                 mut state_lock,
                 hsd,
-            ) = get_test_genesis_setup(network, 0, cli_args::Args::default()).await?;
+            ) = get_test_genesis_setup(0, cli_args::Args::default_with_network(network)).await?;
             let genesis_block: Block = Block::genesis(network);
             let peer_address = get_dummy_socket_address(0);
             let [block_1, block_2_a, block_3_a] = fake_valid_sequence_of_blocks_for_tests(
@@ -3375,7 +3373,7 @@ mod tests {
                 _,
                 mut state_lock,
                 hsd,
-            ) = get_test_genesis_setup(network, 0, cli_args::Args::default()).await?;
+            ) = get_test_genesis_setup(0, cli_args::Args::default_with_network(network)).await?;
             let genesis_block = Block::genesis(network);
             let peer_address = get_dummy_socket_address(0);
             let [block_1, block_2_a, block_3_a] = fake_valid_sequence_of_blocks_for_tests(
@@ -3472,7 +3470,7 @@ mod tests {
                 _,
                 state_lock,
                 hsd,
-            ) = get_test_genesis_setup(network, 0, cli_args::Args::default())
+            ) = get_test_genesis_setup(0, cli_args::Args::default_with_network(network))
                 .await
                 .unwrap();
             let peer_address = get_dummy_socket_address(0);
@@ -3527,7 +3525,7 @@ mod tests {
                 _,
                 mut state_lock,
                 hsd,
-            ) = get_test_genesis_setup(network, 0, cli_args::Args::default()).await?;
+            ) = get_test_genesis_setup(0, cli_args::Args::default_with_network(network)).await?;
             let genesis_block = Block::genesis(network);
             let peer_address = get_dummy_socket_address(0);
 
@@ -3599,7 +3597,7 @@ mod tests {
                 _,
                 state_lock,
                 hsd,
-            ) = get_test_genesis_setup(network, 0, cli_args::Args::default())
+            ) = get_test_genesis_setup(0, cli_args::Args::default_with_network(network))
                 .await
                 .unwrap();
             let block_1 = fake_valid_block_for_tests(&state_lock, rng.random()).await;
@@ -3645,7 +3643,7 @@ mod tests {
                 _,
                 mut state_lock,
                 hsd,
-            ) = get_test_genesis_setup(network, 0, cli_args::Args::default())
+            ) = get_test_genesis_setup(0, cli_args::Args::default_with_network(network))
                 .await
                 .unwrap();
             let genesis_block = Block::genesis(network);
@@ -3705,7 +3703,7 @@ mod tests {
                 _,
                 state_lock,
                 hsd,
-            ) = get_test_genesis_setup(network, 0, cli_args::Args::default()).await?;
+            ) = get_test_genesis_setup(0, cli_args::Args::default_with_network(network)).await?;
             let peer_address = get_dummy_socket_address(0);
 
             let block_1 = fake_valid_block_for_tests(&state_lock, rng.random()).await;
@@ -3759,7 +3757,7 @@ mod tests {
                 _,
                 state_lock,
                 hsd,
-            ) = get_test_genesis_setup(network, 0, cli_args::Args::default()).await?;
+            ) = get_test_genesis_setup(0, cli_args::Args::default_with_network(network)).await?;
             let peer_address = get_dummy_socket_address(0);
             let genesis_block: Block = state_lock
                 .lock_guard()
@@ -3838,7 +3836,7 @@ mod tests {
                 _,
                 mut state_lock,
                 _hsd,
-            ) = get_test_genesis_setup(network, 1, cli_args::Args::default()).await?;
+            ) = get_test_genesis_setup(1, cli_args::Args::default_with_network(network)).await?;
             let genesis_block = Block::genesis(network);
 
             // Restrict max number of blocks held in memory to 2.
@@ -3918,7 +3916,7 @@ mod tests {
                 _,
                 mut state_lock,
                 hsd,
-            ) = get_test_genesis_setup(network, 0, cli_args::Args::default())
+            ) = get_test_genesis_setup(0, cli_args::Args::default_with_network(network))
                 .await
                 .unwrap();
             let peer_address: SocketAddr = get_dummy_socket_address(0);
@@ -3991,7 +3989,7 @@ mod tests {
                 _,
                 state_lock,
                 hsd,
-            ) = get_test_genesis_setup(network, 0, cli_args::Args::default()).await?;
+            ) = get_test_genesis_setup(0, cli_args::Args::default_with_network(network)).await?;
             let peer_address = get_dummy_socket_address(0);
             let genesis_block = Block::genesis(network);
 
@@ -4072,7 +4070,7 @@ mod tests {
                 _,
                 mut state_lock,
                 hsd,
-            ) = get_test_genesis_setup(network, 0, cli_args::Args::default()).await?;
+            ) = get_test_genesis_setup(0, cli_args::Args::default_with_network(network)).await?;
             let peer_socket_address: SocketAddr = get_dummy_socket_address(0);
             let genesis_block: Block = state_lock
                 .lock_guard()
@@ -4176,7 +4174,7 @@ mod tests {
                 _,
                 mut state_lock,
                 _hsd,
-            ) = get_test_genesis_setup(network, 1, cli_args::Args::default()).await?;
+            ) = get_test_genesis_setup(1, cli_args::Args::default_with_network(network)).await?;
             let genesis_block = Block::genesis(network);
             let peer_infos: Vec<PeerInfo> = state_lock
                 .lock_guard()
@@ -4320,9 +4318,8 @@ mod tests {
                     state_lock,
                     hsd,
                 ) = test_setup_custom_genesis_block(
-                    network,
                     1,
-                    cli_args::Args::default(),
+                    cli_args::Args::default_with_network(network),
                     hard_fork_minus_2.clone(),
                 )
                 .await
@@ -4451,7 +4448,7 @@ mod tests {
 
             for transaction_is_known in [false, true] {
                 let (_peer_broadcast_tx, from_main_rx, to_main_tx, _, _, _, mut state_lock, _hsd) =
-                    get_test_genesis_setup(network, 1, cli_args::Args::default())
+                    get_test_genesis_setup(1, cli_args::Args::default_with_network(network))
                         .await
                         .unwrap();
                 if transaction_is_known {
@@ -4513,7 +4510,7 @@ mod tests {
                 _,
                 state_lock,
                 _hsd,
-            ) = get_test_genesis_setup(network, 1, cli_args::Args::default())
+            ) = get_test_genesis_setup(1, cli_args::Args::default_with_network(network))
                 .await
                 .unwrap();
 
@@ -4604,7 +4601,7 @@ mod tests {
                 _,
                 mut state_lock,
                 _hsd,
-            ) = get_test_genesis_setup(network, 1, cli_args::Args::default())
+            ) = get_test_genesis_setup(1, cli_args::Args::default_with_network(network))
                 .await
                 .unwrap();
             let spending_key = state_lock
@@ -4726,7 +4723,7 @@ mod tests {
                     _,
                     mut state_lock,
                     _hsd,
-                ) = get_test_genesis_setup(network, 1, cli_args::Args::default())
+                ) = get_test_genesis_setup(1, cli_args::Args::default_with_network(network))
                     .await
                     .unwrap();
                 let consensus_rule_set =
@@ -4816,7 +4813,7 @@ mod tests {
                 _,
                 state_lock,
                 hsd,
-            ) = get_test_genesis_setup(network, 1, cli_args::Args::default())
+            ) = get_test_genesis_setup(1, cli_args::Args::default_with_network(network))
                 .await
                 .unwrap();
             let fee = NativeCurrencyAmount::from_nau(500);
@@ -4865,7 +4862,7 @@ mod tests {
                 _,
                 state_lock,
                 _,
-            ) = get_test_genesis_setup(network, 1, cli_args::Args::default())
+            ) = get_test_genesis_setup(1, cli_args::Args::default_with_network(network))
                 .await
                 .unwrap();
             let fee = NativeCurrencyAmount::from_nau(500);
@@ -4945,9 +4942,7 @@ mod tests {
             let network = cli.network;
             let peer_count = 1;
             let (peer_broadcast_tx, from_main_rx, to_main_tx, to_main_rx, _, _, alice, _hsd) =
-                get_test_genesis_setup(network, peer_count, cli)
-                    .await
-                    .unwrap();
+                get_test_genesis_setup(peer_count, cli).await.unwrap();
             let peer_hsd = get_dummy_handshake_data_for_genesis(network);
             let peer_ma = alice
                 .lock_guard()
@@ -5227,7 +5222,7 @@ mod tests {
                     _,
                     mut alice,
                     handshake,
-                ) = get_test_genesis_setup(network, 1, cli_args::Args::default())
+                ) = get_test_genesis_setup(1, cli_args::Args::default_with_network(network))
                     .await
                     .unwrap();
 
@@ -5329,7 +5324,7 @@ mod tests {
                 _,
                 mut alice,
                 alice_hsd,
-            ) = get_test_genesis_setup(network, 0, cli_args::Args::default())
+            ) = get_test_genesis_setup(0, cli_args::Args::default_with_network(network))
                 .await
                 .unwrap();
             let genesis_block: Block = Block::genesis(network);
@@ -5396,7 +5391,6 @@ mod tests {
             let network = Network::Main;
             let genesis_block: Block = Block::genesis(network);
 
-            let alice_cli = cli_args::Args::default();
             let (
                 _alice_main_to_peer_tx,
                 alice_main_to_peer_rx,
@@ -5406,7 +5400,9 @@ mod tests {
                 _,
                 alice,
                 alice_hsd,
-            ) = get_test_genesis_setup(network, 0, alice_cli).await.unwrap();
+            ) = get_test_genesis_setup(0, cli_args::Args::default_with_network(network))
+                .await
+                .unwrap();
 
             let sync_challenge = SyncChallenge {
                 tip_digest: genesis_block.hash(),
@@ -5465,6 +5461,7 @@ mod tests {
             const ALICE_SYNC_MODE_THRESHOLD: usize = 10;
             let alice_cli = cli_args::Args {
                 sync_mode_threshold: ALICE_SYNC_MODE_THRESHOLD,
+                network,
                 ..Default::default()
             };
             let (
@@ -5476,7 +5473,7 @@ mod tests {
                 _,
                 mut alice,
                 alice_hsd,
-            ) = get_test_genesis_setup(network, 0, alice_cli).await?;
+            ) = get_test_genesis_setup(0, alice_cli).await?;
             let _alice_socket_address = get_dummy_socket_address(0);
 
             let (
@@ -5488,7 +5485,7 @@ mod tests {
                 _,
                 mut bob,
                 _bob_hsd,
-            ) = get_test_genesis_setup(network, 0, cli_args::Args::default()).await?;
+            ) = get_test_genesis_setup(0, cli_args::Args::default_with_network(network)).await?;
             let bob_socket_address = get_dummy_socket_address(0);
 
             let now = genesis_block.header().timestamp + Timestamp::hours(1);

--- a/neptune-core/src/application/rpc/server.rs
+++ b/neptune-core/src/application/rpc/server.rs
@@ -3552,6 +3552,8 @@ impl RPC for NeptuneRPCServer {
         log_slow_scope!(fn_name!());
         token.auth(&self.valid_tokens)?;
 
+        let num_inputs = num_inputs.unwrap_or(7);
+
         Ok(self
             .state
             .api_mut()

--- a/neptune-core/src/protocol/consensus/block/mock_block_generator.rs
+++ b/neptune-core/src/protocol/consensus/block/mock_block_generator.rs
@@ -9,18 +9,15 @@ use crate::application::loops::mine_loop::composer_parameters::ComposerParameter
 use crate::application::loops::mine_loop::prepare_coinbase_transaction_stateless;
 use crate::protocol::consensus::block::block_transaction::BlockTransaction;
 use crate::protocol::consensus::block::validity::block_primitive_witness::BlockPrimitiveWitness;
-use crate::protocol::consensus::block::validity::block_program::BlockProgram;
 use crate::protocol::consensus::block::validity::block_proof_witness::BlockProofWitness;
 use crate::protocol::consensus::block::Block;
 use crate::protocol::consensus::block::BlockProof;
 use crate::protocol::consensus::consensus_rule_set::ConsensusRuleSet;
 use crate::protocol::consensus::transaction::primitive_witness::PrimitiveWitness;
 use crate::protocol::consensus::transaction::validity::neptune_proof::Proof;
-use crate::protocol::consensus::transaction::validity::single_proof::single_proof_claim;
 use crate::protocol::consensus::transaction::validity::tasm::single_proof::merge_branch::MergeWitness;
 use crate::protocol::consensus::transaction::Transaction;
 use crate::protocol::consensus::transaction::TransactionProof;
-use crate::protocol::proof_abstractions::mast_hash::MastHash;
 use crate::protocol::proof_abstractions::timestamp::Timestamp;
 use crate::state::transaction::transaction_details::TransactionDetails;
 use crate::state::wallet::transaction_output::TxOutputList;
@@ -50,8 +47,7 @@ impl MockBlockGenerator {
         let (appendix, proof) = {
             let block_proof_witness = BlockProofWitness::produce(primitive_witness);
             let appendix = block_proof_witness.appendix();
-            let claim = BlockProgram::claim(&body, &appendix);
-            (appendix, BlockProof::SingleProof(Proof::valid_mock(claim)))
+            (appendix, BlockProof::SingleProof(Proof::valid_mock()))
         };
 
         Block::new(header, body, appendix, proof)
@@ -61,17 +57,12 @@ impl MockBlockGenerator {
     /// seems to pass but without the hassle of producing a proof for it. Behind the
     /// scenes, this method updates the true claims cache, such that the call to
     /// `triton_vm::verify` will be by-passed.
-    fn mock_transaction_from_details(
-        transaction_details: &TransactionDetails,
-        consensus_rule_set: ConsensusRuleSet,
-    ) -> Transaction {
+    fn mock_transaction_from_details(transaction_details: &TransactionDetails) -> Transaction {
         let kernel = PrimitiveWitness::from_transaction_details(transaction_details).kernel;
-
-        let claim = single_proof_claim(kernel.mast_hash(), consensus_rule_set);
 
         Transaction {
             kernel,
-            proof: TransactionProof::SingleProof(Proof::valid_mock(claim)),
+            proof: TransactionProof::SingleProof(Proof::valid_mock()),
         }
     }
 
@@ -112,8 +103,6 @@ impl MockBlockGenerator {
         shuffle_seed: [u8; 32],
         mut selected_mempool_txs: Vec<Transaction>,
     ) -> (BlockTransaction, TxOutputList) {
-        let consensus_rule_set =
-            ConsensusRuleSet::infer_from(network, predecessor_block.header().height.next());
         let (composer_txos, transaction_details) = prepare_coinbase_transaction_stateless(
             predecessor_block,
             composer_parameters,
@@ -121,8 +110,7 @@ impl MockBlockGenerator {
             network,
         );
 
-        let coinbase_transaction =
-            Self::mock_transaction_from_details(&transaction_details, consensus_rule_set);
+        let coinbase_transaction = Self::mock_transaction_from_details(&transaction_details);
 
         if selected_mempool_txs.is_empty() {
             // create the nop-tx and merge into the coinbase transaction to set the
@@ -132,12 +120,13 @@ impl MockBlockGenerator {
                 timestamp,
                 network,
             );
-            let nop_transaction =
-                Self::mock_transaction_from_details(&nop_details, consensus_rule_set);
+            let nop_transaction = Self::mock_transaction_from_details(&nop_details);
 
             selected_mempool_txs = vec![nop_transaction];
         }
 
+        let consensus_rule_set =
+            ConsensusRuleSet::infer_from(network, predecessor_block.header().height.next());
         let mut block_transaction = coinbase_transaction.into();
         let mut rng = StdRng::from_seed(shuffle_seed);
         for tx_to_include in selected_mempool_txs {

--- a/neptune-core/src/protocol/consensus/block/mod.rs
+++ b/neptune-core/src/protocol/consensus/block/mod.rs
@@ -1152,13 +1152,25 @@ impl Block {
     /// Satisfy mock-PoW, meaning that only the hash needs to be lower than the
     /// threshold, does not set valid root/authentication paths of the PoW
     /// field.
-    pub fn satisfy_mock_pow(&mut self, difficulty: Difficulty, seed: [u8; 32]) {
+    pub fn satisfy_mock_pow(
+        &mut self,
+        difficulty: Difficulty,
+        seed: [u8; 32],
+        lustration_status: Option<LustrationStatus>,
+        version: BFieldElement,
+    ) {
         let mut rng = StdRng::from_seed(seed);
 
         // Guessing loop.
         let threshold = difficulty.target();
         while !self.is_valid_mock_pow(threshold) {
-            let pow = rng.random();
+            let mut pow: BlockPow = rng.random();
+            if let Some(lustration_status) = lustration_status {
+                pow.set_lustration_status(lustration_status);
+            }
+
+            pow.set_version_in_pow(version);
+
             self.set_header_pow(pow);
         }
     }

--- a/neptune-core/src/protocol/consensus/block/validity/block_primitive_witness.rs
+++ b/neptune-core/src/protocol/consensus/block/validity/block_primitive_witness.rs
@@ -73,6 +73,8 @@ impl BlockPrimitiveWitness {
         &self.transaction
     }
 
+    /// Return the index of the last AOCL element in this block, including
+    /// guesser reward UTXOs.
     fn max_aocl_leaf_index(&self) -> u64 {
         let num_own_outputs =
             self.transaction.kernel.outputs.len() as u64 + NUM_GUESSER_FEE_OUTPUTS;

--- a/neptune-core/src/protocol/consensus/consensus_rule_set.rs
+++ b/neptune-core/src/protocol/consensus/consensus_rule_set.rs
@@ -279,7 +279,6 @@ pub(crate) mod tests {
     use rand::Rng;
     use rand::SeedableRng;
     use tasm_lib::prelude::Digest;
-    use tasm_lib::triton_vm::proof::Claim;
     use tasm_lib::twenty_first::bfe;
     use tasm_lib::twenty_first::prelude::Mmr;
     use tracing_test::traced_test;
@@ -856,9 +855,7 @@ pub(crate) mod tests {
 
             let appendix = BlockAppendix::consensus_claims(block.body(), consensus_rule_set);
             block.set_appendix(BlockAppendix::new(appendix));
-            block.set_proof(BlockProof::SingleProof(NeptuneProof::valid_mock(
-                Claim::new(Digest::default()),
-            )));
+            block.set_proof(BlockProof::SingleProof(NeptuneProof::valid_mock()));
             block.set_lustration_status(parent.header().pow.lustration_status().unwrap());
 
             let now = block.header().timestamp;

--- a/neptune-core/src/protocol/consensus/transaction/announcement.rs
+++ b/neptune-core/src/protocol/consensus/transaction/announcement.rs
@@ -52,7 +52,7 @@ impl Announcement {
     /// method cannot be trusted to correctly identify lustration announcements
     /// which would be meaningless anyway without the context of the whole
     /// transaction kernel.
-    pub(crate) fn looks_like_lustration(&self) -> bool {
+    pub fn looks_like_lustration(&self) -> bool {
         self.message
             .first()
             .is_some_and(|elem0| *elem0 == LUSTRATION_FLAG)

--- a/neptune-core/src/protocol/consensus/transaction/transaction_proof.rs
+++ b/neptune-core/src/protocol/consensus/transaction/transaction_proof.rs
@@ -36,11 +36,7 @@ pub enum TransactionProofType {
 
 impl From<&TransactionProof> for TransactionProofType {
     fn from(proof: &TransactionProof) -> Self {
-        match *proof {
-            TransactionProof::Witness(_) => Self::PrimitiveWitness,
-            TransactionProof::ProofCollection(_) => Self::ProofCollection,
-            TransactionProof::SingleProof(_) => Self::SingleProof,
-        }
+        proof.proof_type()
     }
 }
 
@@ -130,6 +126,14 @@ impl TransactionProof {
             }
             TransactionProof::ProofCollection(_) => Ok(TransactionProofQuality::ProofCollection),
             TransactionProof::SingleProof(_) => Ok(TransactionProofQuality::SingleProof),
+        }
+    }
+
+    pub(crate) fn proof_type(&self) -> TransactionProofType {
+        match self {
+            TransactionProof::Witness(_) => TransactionProofType::PrimitiveWitness,
+            TransactionProof::ProofCollection(_) => TransactionProofType::ProofCollection,
+            TransactionProof::SingleProof(_) => TransactionProofType::SingleProof,
         }
     }
 

--- a/neptune-core/src/protocol/consensus/transaction/validity/neptune_proof.rs
+++ b/neptune-core/src/protocol/consensus/transaction/validity/neptune_proof.rs
@@ -6,7 +6,6 @@ use serde::Deserialize;
 use serde::Serialize;
 use tasm_lib::prelude::Library;
 use tasm_lib::structure::tasm_object::TasmObject;
-use tasm_lib::triton_vm::proof::Claim;
 use tasm_lib::triton_vm::proof::Proof as VmProof;
 
 use crate::protocol::consensus::transaction::BFieldCodec;
@@ -145,14 +144,14 @@ impl NeptuneProof {
     }
 
     /// create a mock proof that will pass validation (if mock proofs are allowed)
-    pub fn valid_mock(_claim: Claim) -> Self {
+    pub fn valid_mock() -> Self {
         Self {
             proof: VmProof(MockProofBehavior::ValidMock.encode()),
         }
     }
 
     /// create a mock proof that will fail validation (if mock proofs are allowed, or not)
-    pub fn invalid_mock(_claim: Claim) -> Self {
+    pub fn invalid_mock() -> Self {
         Self {
             proof: VmProof(MockProofBehavior::InvalidMock.encode()),
         }

--- a/neptune-core/src/protocol/consensus/transaction/validity/proof_collection.rs
+++ b/neptune-core/src/protocol/consensus/transaction/validity/proof_collection.rs
@@ -219,11 +219,10 @@ impl ProofCollection {
         debug!("proving, salted inputs hash: {}", salted_inputs_hash);
         debug!("proving, salted outputs hash: {}", salted_outputs_hash);
 
-        let claim = Claim::new(Digest::default());
         let mock_proof = if valid_mock {
-            Proof::valid_mock(claim)
+            Proof::valid_mock()
         } else {
-            Proof::invalid_mock(claim)
+            Proof::invalid_mock()
         };
 
         let merge_bit_mast_path = primitive_witness

--- a/neptune-core/src/protocol/consensus/transaction/validity/single_proof.rs
+++ b/neptune-core/src/protocol/consensus/transaction/validity/single_proof.rs
@@ -309,11 +309,10 @@ pub(crate) fn single_proof_claim(
 }
 
 pub(crate) fn produce_single_proof_mock(valid_mock: bool) -> Proof {
-    let claim = Claim::new(Digest::default());
     if valid_mock {
-        Proof::valid_mock(claim)
+        Proof::valid_mock()
     } else {
-        Proof::invalid_mock(claim)
+        Proof::invalid_mock()
     }
 }
 

--- a/neptune-core/src/protocol/consensus/transaction/validity/tasm/single_proof/merge_branch.rs
+++ b/neptune-core/src/protocol/consensus/transaction/validity/tasm/single_proof/merge_branch.rs
@@ -148,23 +148,27 @@ impl MergeWitness {
     ) -> Result<Transaction> {
         let new_kernel = self.new_kernel.clone();
 
-        let new_single_proof_witness = SingleProofWitness::from_merge(self);
-        let new_single_proof_claim = new_single_proof_witness.claim();
-        info!("Start: creating new single proof through merge");
-        let new_single_proof = SingleProof
-            .prove(
-                new_single_proof_claim,
-                new_single_proof_witness.nondeterminism(),
-                triton_vm_job_queue,
-                proof_job_options,
-            )
-            .await?;
+        let proof = if proof_job_options.job_settings.network.use_mock_proof() {
+            Proof::valid_mock()
+        } else {
+            let new_single_proof_witness = SingleProofWitness::from_merge(self);
+            let new_single_proof_claim = new_single_proof_witness.claim();
+            info!("Start: creating new single proof through merge");
+            SingleProof
+                .prove(
+                    new_single_proof_claim,
+                    new_single_proof_witness.nondeterminism(),
+                    triton_vm_job_queue,
+                    proof_job_options,
+                )
+                .await?
+        };
 
         info!("Done: creating new single proof through merge");
 
         Ok(Transaction {
             kernel: new_kernel,
-            proof: TransactionProof::SingleProof(new_single_proof),
+            proof: TransactionProof::SingleProof(proof),
         })
     }
 

--- a/neptune-core/src/protocol/consensus/type_scripts/native_currency_amount.rs
+++ b/neptune-core/src/protocol/consensus/type_scripts/native_currency_amount.rs
@@ -83,7 +83,7 @@ impl NativeCurrencyAmount {
         Self(-Self::MAX_NAU)
     }
 
-    pub(crate) const fn coin_as_nau() -> i128 {
+    pub const fn coin_as_nau() -> i128 {
         Self::conversion_factor()
     }
 

--- a/neptune-core/src/protocol/proof_abstractions/tasm/program.rs
+++ b/neptune-core/src/protocol/proof_abstractions/tasm/program.rs
@@ -100,7 +100,7 @@ pub(crate) async fn prove_triton_program(
 ) -> Result<Proof, CreateProofError> {
     // regtest mode: just return a mock (empty) Proof
     if proof_job_options.job_settings.network.use_mock_proof() {
-        return Ok(Proof::valid_mock(claim));
+        return Ok(Proof::valid_mock());
     }
 
     // create a triton-vm-job-queue job for generating this proof.

--- a/neptune-core/src/protocol/proof_abstractions/tasm/prover_job.rs
+++ b/neptune-core/src/protocol/proof_abstractions/tasm/prover_job.rs
@@ -278,7 +278,7 @@ impl ProverJob {
     async fn prove(&self, rx: JobCancelReceiver) -> JobCompletion {
         // produce mock proofs if network so requires. (ie RegTest)
         if self.job_settings.network.use_mock_proof() {
-            let proof = Proof::valid_mock(self.claim.clone());
+            let proof = Proof::valid_mock();
             return ProverProcessCompletion::Finished(proof).into();
         }
 

--- a/neptune-core/src/state/blockchain_state.rs
+++ b/neptune-core/src/state/blockchain_state.rs
@@ -110,7 +110,7 @@ impl BlockchainState {
     }
 
     /// Block height of current tip.
-    pub(crate) fn tip_height(&self) -> BlockHeight {
+    pub fn tip_height(&self) -> BlockHeight {
         self.tip().header().height
     }
 
@@ -127,7 +127,7 @@ impl BlockchainState {
     /// - If lustration rules have been activated, but no lustration status can
     ///   be parsed from the tip. This would mean that the tip is not a valid
     ///   block.
-    pub(crate) fn lustration_status(&self) -> Option<LustrationStatus> {
+    pub fn lustration_status(&self) -> Option<LustrationStatus> {
         // If the lustration status can be read from the header, the lustration
         // status must be set. Otherwise, this function reads
         let height = self.tip_height();

--- a/neptune-core/src/state/mempool.rs
+++ b/neptune-core/src/state/mempool.rs
@@ -52,9 +52,12 @@ use tracing::error;
 use tracing::warn;
 
 use crate::api::export::AdditionRecord;
+use crate::api::export::NativeCurrencyAmount;
 use crate::api::export::NeptuneProof;
+use crate::api::export::TransactionProofType;
 use crate::application::config::tx_upgrade_filter::TxUpgradeFilter;
 use crate::protocol::consensus::block::Block;
+use crate::protocol::consensus::consensus_rule_set::ConsensusRuleSet;
 use crate::protocol::consensus::transaction::primitive_witness::PrimitiveWitness;
 use crate::protocol::consensus::transaction::transaction_kernel::TransactionKernel;
 use crate::protocol::consensus::transaction::validity::neptune_proof::Proof;
@@ -305,6 +308,91 @@ impl Mempool {
                 true
             }
         }
+    }
+
+    /// Return a transaction that can be merged with the specified transaction
+    /// if any is present in the mempool.
+    ///
+    /// The specified transaction should be backed by a single proof. Otherwise
+    /// the returned transaction cannot actually be merged with the input
+    /// transaction.
+    ///
+    /// The returned transaction is guaranteed to:
+    /// 1. Not conflict with the input transaction
+    /// 2. Be synced to the same mutator set
+    /// 3. Pay at least the specified fee
+    /// 4. Not exceed allowed sizes after being merged with the specified
+    ///
+    /// Note that the returned a returned transaction is not guaranteed to be
+    /// synced to the tip. If the input transaction is not synced to the tip,
+    /// neither will any returned transaction be.
+    pub(crate) fn merge_partner(
+        &self,
+        kernel: &TransactionKernel,
+        consensus_rule_set: ConsensusRuleSet,
+        minimum_fee: NativeCurrencyAmount,
+    ) -> Option<(TransactionKernel, Proof, UpgradePriority)> {
+        // Constants to avoid going to the limit of the consensus rules in
+        // terms of outputs and announcements, since the composer probably wants
+        // to set a few outputs and announcement themselves.
+        const NUM_OUTPUTS_BUFFER: usize = 6;
+        const NUM_ANNOUNCEMENTS_BUFFER: usize = 6;
+
+        let max_num_inputs = consensus_rule_set.max_num_inputs();
+        let max_num_outputs = consensus_rule_set.max_num_outputs();
+        let max_num_announcements = consensus_rule_set.max_num_announcements();
+
+        let tx_index_sets: HashSet<_> = kernel.inputs.iter().map(|x| x.absolute_indices).collect();
+
+        for (txid, priority) in self.upgrade_priority_iter().chain(
+            self.fee_density_iter()
+                .map(|(txid, _)| (txid, UpgradePriority::Irrelevant)),
+        ) {
+            let candidate = self
+                .get(txid)
+                .expect("Referenced tx in iterators must exist");
+
+            let TransactionProof::SingleProof(single_proof) = &candidate.proof else {
+                continue;
+            };
+
+            let candidate = &candidate.kernel;
+
+            if candidate.fee < minimum_fee {
+                continue;
+            }
+
+            if candidate.mutator_set_hash != kernel.mutator_set_hash {
+                continue;
+            }
+
+            let conflicts = candidate
+                .inputs
+                .iter()
+                .any(|input| tx_index_sets.contains(&input.absolute_indices));
+            if conflicts {
+                continue;
+            }
+
+            if candidate.inputs.len() + kernel.inputs.len() > max_num_inputs {
+                continue;
+            }
+
+            if candidate.outputs.len() + kernel.outputs.len() + NUM_OUTPUTS_BUFFER > max_num_outputs
+            {
+                continue;
+            }
+
+            if candidate.announcements.len() + kernel.announcements.len() + NUM_ANNOUNCEMENTS_BUFFER
+                > max_num_announcements
+            {
+                continue;
+            }
+
+            return Some((candidate.to_owned(), single_proof.to_owned(), priority));
+        }
+
+        None
     }
 
     /// Return the preferred single-proof backed transaction for the "update"
@@ -866,6 +954,22 @@ impl Mempool {
     /// Computes in O(1)
     pub fn len(&self) -> usize {
         self.tx_dictionary.len()
+    }
+
+    /// Return the number of transactions with the specified proof quality that
+    /// are present in the mempool.
+    pub fn num_with_proof_type(&self, proof_quality: TransactionProofType) -> usize {
+        let mut count = 0;
+        for (txid, _) in self.fee_density_iter() {
+            let tx = self
+                .get(txid)
+                .expect("Transaction referenced in fee density iter must exist in mempool.");
+            if tx.proof.proof_type() == proof_quality {
+                count += 1;
+            }
+        }
+
+        count
     }
 
     /// Return the number of transaction stored in the mempool that are deemed

--- a/neptune-core/src/tests/shared/globalstate.rs
+++ b/neptune-core/src/tests/shared/globalstate.rs
@@ -160,7 +160,6 @@ pub(crate) async fn state_with_premine_and_self_mined_blocks<const NUM_BLOCKS_MI
 /// Returns:
 /// (peer_broadcast_channel, from_main_receiver, to_main_transmitter, to_main_receiver, global state, peer's handshake data)
 pub(crate) async fn get_test_genesis_setup(
-    network: Network,
     peer_count: u8,
     cli: cli_args::Args,
 ) -> anyhow::Result<(
@@ -173,12 +172,12 @@ pub(crate) async fn get_test_genesis_setup(
     GlobalStateLock,
     HandshakeData,
 )> {
+    let network = cli.network;
     let genesis = Block::genesis(network);
-    test_setup_custom_genesis_block(network, peer_count, cli, genesis).await
+    test_setup_custom_genesis_block(peer_count, cli, genesis).await
 }
 
 pub(crate) async fn test_setup_custom_genesis_block(
-    network: Network,
     peer_count: u8,
     cli: cli_args::Args,
     custom_genesis: Block,
@@ -200,6 +199,7 @@ pub(crate) async fn test_setup_custom_genesis_block(
     let (_network_event_tx, network_event_rx) =
         mpsc::channel::<NetworkEvent>(PEER_CHANNEL_CAPACITY);
 
+    let network = cli.network;
     let wallet = WalletEntropy::devnet_wallet();
     let state = mock_genesis_global_state_with_block(peer_count, wallet, cli, custom_genesis).await;
     Ok((

--- a/neptune-core/tests/common/genesis_node.rs
+++ b/neptune-core/tests/common/genesis_node.rs
@@ -11,6 +11,7 @@ use std::str::FromStr;
 use neptune_cash::api::export::GlobalStateLock;
 use neptune_cash::api::export::Network;
 use neptune_cash::api::export::TransactionKernelId;
+use neptune_cash::api::export::TransactionProofType;
 use neptune_cash::application::config::cli_args::Args;
 use neptune_cash::application::config::data_directory::DataDirectory;
 use neptune_cash::protocol::consensus::block::block_height::BlockHeight;
@@ -394,6 +395,36 @@ impl GenesisNode {
             }
             if start.elapsed() > std::time::Duration::from_secs(timeout_secs.into()) {
                 anyhow::bail!("tx not confirmable after {} seconds", timeout_secs);
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        Ok(())
+    }
+
+    /// Wait until the mempool contains exactly n transactions, of the specified
+    /// proof type.
+    pub async fn wait_until_n_txs_in_mempool(
+        &self,
+        n: usize,
+        proof_type: TransactionProofType,
+        timeout_secs: u16,
+    ) -> anyhow::Result<()> {
+        let start = std::time::Instant::now();
+        loop {
+            let num_txs_in_mempool = self
+                .gsl
+                .lock_guard()
+                .await
+                .mempool
+                .num_with_proof_type(proof_type);
+            if num_txs_in_mempool == n {
+                break;
+            }
+
+            if start.elapsed() > std::time::Duration::from_secs(timeout_secs.into()) {
+                anyhow::bail!(
+                    "mempool did not contain {n} transactions after {timeout_secs} seconds. Saw: {num_txs_in_mempool}"
+                );
             }
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         }

--- a/neptune-core/tests/common/genesis_node.rs
+++ b/neptune-core/tests/common/genesis_node.rs
@@ -329,6 +329,8 @@ impl GenesisNode {
         txid: TransactionKernelId,
         timeout_secs: u16,
     ) -> anyhow::Result<()> {
+        // Function may not hold a keep holding a read lock since the node needs
+        // a write lock to update the mempool transaction with a new proof.
         let start = std::time::Instant::now();
         while self.gsl.lock_guard().await.mempool.get(txid).is_none() {
             if start.elapsed() > std::time::Duration::from_secs(timeout_secs.into()) {
@@ -348,6 +350,8 @@ impl GenesisNode {
         txid: TransactionKernelId,
         timeout_secs: u16,
     ) -> anyhow::Result<()> {
+        // Function may not hold a keep holding a read lock since the node needs
+        // a write lock to update the mempool transaction with a new proof.
         let start = std::time::Instant::now();
         loop {
             if let Some(tx) = self.gsl.lock_guard().await.mempool.get(txid) {

--- a/neptune-core/tests/common/genesis_node.rs
+++ b/neptune-core/tests/common/genesis_node.rs
@@ -83,6 +83,24 @@ impl GenesisNode {
                 .expect("Must be able to get socket on local host")
                 .port();
             args.rpc_port = rpc_port;
+
+            let quic_listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+                .await
+                .expect("Must be able to get socket on local host");
+            let quic_port = quic_listener
+                .local_addr()
+                .expect("Must be able to get socket on local host")
+                .port();
+            args.quic_port = quic_port;
+
+            let tcp_listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+                .await
+                .expect("Must be able to get socket on local host");
+            let tcp_port = tcp_listener
+                .local_addr()
+                .expect("Must be able to get socket on local host")
+                .port();
+            args.tcp_port = tcp_port;
         }
 
         // we default proving capability to primitive-witness as lowest common
@@ -147,8 +165,10 @@ impl GenesisNode {
     }
 
     #[track_caller]
-    pub fn cluster_id() -> String {
-        core::panic::Location::caller().to_string()
+    pub fn cluster_id(test_id: Option<u8>) -> String {
+        let test_id = test_id.unwrap_or_default();
+        let location = core::panic::Location::caller().to_string();
+        format!("{location}-{test_id}")
     }
 
     /// provides cli args for each node in a cluster to connect with eachother

--- a/neptune-core/tests/consolidate.rs
+++ b/neptune-core/tests/consolidate.rs
@@ -85,12 +85,13 @@ pub async fn consolidation_basic() {
 
     // Alice consolidates 3 of her UTXOs
     let accept_lustrations = true;
+    let max_num_inputs = 3;
     let num_consolidations = alice
         .gsl
         .api_mut()
         .tx_initiator_mut()
         .consolidate(
-            Some(3),
+            max_num_inputs,
             Some(bob_address),
             Timestamp::now(),
             accept_lustrations,

--- a/neptune-core/tests/consolidate.rs
+++ b/neptune-core/tests/consolidate.rs
@@ -13,16 +13,19 @@ use num_traits::ops::checked::CheckedSub;
 use num_traits::Zero;
 use tracing_test::traced_test;
 
-async fn wallet_with_mining_rewards(num_blocks: u32) -> (GenesisNode, GenesisNode) {
+/// Return a connected cluster where the Alice node has mining rewards.
+///
+/// Must be called with a unique test ID to avoid multiple tests requesting the
+/// same ports from the OS, when tests run in parallel.
+async fn wallet_with_mining_rewards(num_blocks: u32, test_id: u8) -> (GenesisNode, GenesisNode) {
     let timeout_secs = 5;
 
     let mut base_args = GenesisNode::default_args().await;
     base_args.tx_proving_capability =
         Some(neptune_cash::api::export::TxProvingCapability::SingleProof);
 
-    // alice and bob start 2 peer cluster (regtest)
     let [mut alice, bob] = GenesisNode::start_connected_cluster(
-        &GenesisNode::cluster_id(),
+        &GenesisNode::cluster_id(Some(test_id)),
         2,
         Some(base_args),
         timeout_secs,
@@ -67,7 +70,7 @@ pub async fn consolidation_basic() {
     let timeout_secs = 5;
 
     let num_blocks_mined = 3 + NUM_CONFIRMATIONS_REQUIRED_FOR_CONSOLIDATION as u32;
-    let (mut alice, mut bob) = wallet_with_mining_rewards(num_blocks_mined).await;
+    let (mut alice, mut bob) = wallet_with_mining_rewards(num_blocks_mined, 0).await;
 
     let bob_address = bob
         .gsl
@@ -219,7 +222,7 @@ pub async fn consolidation_tx_with_lustration() {
     logging::tracing_logger();
 
     let num_blocks_mined = 20;
-    let (mut alice, bob) = wallet_with_mining_rewards(num_blocks_mined).await;
+    let (mut alice, bob) = wallet_with_mining_rewards(num_blocks_mined, 1).await;
     assert_eq!(
         alice.gsl.lock_guard().await.chain.tip_height(),
         u64::from(num_blocks_mined).into()
@@ -338,7 +341,7 @@ pub async fn merge_consolidation_txs() {
     let timeout_secs = 5;
 
     let num_blocks_mined = 23;
-    let (mut alice, mut bob) = wallet_with_mining_rewards(num_blocks_mined).await;
+    let (mut alice, mut bob) = wallet_with_mining_rewards(num_blocks_mined, 2).await;
 
     assert_eq!(
         alice.gsl.lock_guard().await.chain.tip().header().height,

--- a/neptune-core/tests/consolidate.rs
+++ b/neptune-core/tests/consolidate.rs
@@ -2,14 +2,52 @@ mod common;
 
 use common::genesis_node::GenesisNode;
 use common::logging;
+use itertools::Itertools;
 use neptune_cash::api::export::KeyType;
 use neptune_cash::api::export::NativeCurrencyAmount;
 use neptune_cash::api::export::Timestamp;
+use neptune_cash::api::export::TransactionProofType;
 use neptune_cash::api::tx_initiation::consolidate::CONSOLIDATION_FEE_SP;
 use neptune_cash::api::tx_initiation::consolidate::NUM_CONFIRMATIONS_REQUIRED_FOR_CONSOLIDATION;
 use num_traits::ops::checked::CheckedSub;
 use num_traits::Zero;
 use tracing_test::traced_test;
+
+async fn wallet_with_mining_rewards(num_blocks: u32) -> (GenesisNode, GenesisNode) {
+    let timeout_secs = 5;
+
+    let mut base_args = GenesisNode::default_args().await;
+    base_args.tx_proving_capability =
+        Some(neptune_cash::api::export::TxProvingCapability::SingleProof);
+
+    // alice and bob start 2 peer cluster (regtest)
+    let [mut alice, bob] = GenesisNode::start_connected_cluster(
+        &GenesisNode::cluster_id(),
+        2,
+        Some(base_args),
+        timeout_secs,
+    )
+    .await
+    .unwrap();
+
+    // alice mines a ton of blocks to her wallet
+    alice
+        .gsl
+        .api_mut()
+        .regtest_mut()
+        .mine_blocks_to_wallet(num_blocks, false)
+        .await
+        .unwrap();
+
+    tracing::info!("alice mined a ton of blocks!");
+
+    // wait 5 seconds to allow block to propagate to bob's node.
+    // otherwise bob's node might receive the Tx before accepting the latest block
+    // in which case it will reject it.
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+    (alice, bob)
+}
 
 /// test: basic consolidation
 ///
@@ -28,21 +66,9 @@ pub async fn consolidation_basic() {
     logging::tracing_logger();
     let timeout_secs = 5;
 
-    let mut base_args = GenesisNode::default_args().await;
-    base_args.tx_proving_capability =
-        Some(neptune_cash::api::export::TxProvingCapability::SingleProof);
+    let num_blocks_mined = 3 + NUM_CONFIRMATIONS_REQUIRED_FOR_CONSOLIDATION as u32;
+    let (mut alice, mut bob) = wallet_with_mining_rewards(num_blocks_mined).await;
 
-    // alice and bob start 2 peer cluster (regtest)
-    let [mut alice, mut bob] = GenesisNode::start_connected_cluster(
-        &GenesisNode::cluster_id(),
-        2,
-        Some(base_args),
-        timeout_secs,
-    )
-    .await
-    .unwrap();
-
-    // bob generates receiving address
     let bob_address = bob
         .gsl
         .api_mut()
@@ -50,25 +76,6 @@ pub async fn consolidation_basic() {
         .next_receiving_address(KeyType::Generation)
         .await
         .unwrap();
-
-    // alice mines a ton of blocks to her wallet
-    let num_blocks_mined = 3 + NUM_CONFIRMATIONS_REQUIRED_FOR_CONSOLIDATION as u32;
-    alice
-        .gsl
-        .api_mut()
-        .regtest_mut()
-        .mine_blocks_to_wallet(num_blocks_mined, false)
-        .await
-        .unwrap();
-
-    tracing::info!("alice mined a ton of blocks!");
-
-    // wait 5 seconds to allow block to propagate to bob's node.
-    // otherwise bob's node might receive the Tx before accepting the latest block
-    // in which case it will reject it.  see issue 560
-    // https://github.com/Neptune-Crypto/neptune-core/issues/560
-    // when that is fixed, this line should be removed.
-    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
 
     // alice checks that payment is reflected in her unconfirmed wallet balance
     let alice_balances_before_consolidation =
@@ -201,5 +208,206 @@ pub async fn consolidation_basic() {
     assert_eq!(
         bob_balances.unconfirmed_available.to_string(),
         consolidation_amount.to_string()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[traced_test]
+pub async fn consolidation_tx_with_lustration() {
+    // Verify that consolidation transactions are correctly lustrated, and that
+    // peers accept lustrated transactions into their mempools.
+    logging::tracing_logger();
+
+    let num_blocks_mined = 20;
+    let (mut alice, bob) = wallet_with_mining_rewards(num_blocks_mined).await;
+    assert_eq!(
+        alice.gsl.lock_guard().await.chain.tip_height(),
+        u64::from(num_blocks_mined).into()
+    );
+    assert_eq!(
+        bob.gsl.lock_guard().await.chain.tip_height(),
+        u64::from(num_blocks_mined).into()
+    );
+
+    let lustration_status_before = alice
+        .gsl
+        .lock_guard()
+        .await
+        .chain
+        .lustration_status()
+        .expect("Test assumption: Lustration status is active");
+
+    let accept_lustrations = true;
+    let max_num_inputs = 3;
+    let _ = alice
+        .gsl
+        .api_mut()
+        .tx_initiator_mut()
+        .consolidate(max_num_inputs, None, Timestamp::now(), accept_lustrations)
+        .await
+        .unwrap();
+
+    let mempool_tx = alice
+        .gsl
+        .lock_guard()
+        .await
+        .mempool
+        .fee_density_iter()
+        .map(|(txid, _)| txid)
+        .collect_vec();
+    let mempool_tx = alice
+        .gsl
+        .lock_guard()
+        .await
+        .mempool
+        .get(mempool_tx[0])
+        .unwrap()
+        .to_owned();
+    assert!(mempool_tx
+        .kernel
+        .announcements
+        .iter()
+        .any(|ann| ann.looks_like_lustration()));
+
+    let timeout_secs = 10;
+    alice
+        .wait_until_n_txs_in_mempool(1, TransactionProofType::SingleProof, timeout_secs)
+        .await
+        .unwrap();
+
+    // Ensure that Bob accepts the lustrating tx into his mempool
+    bob.wait_until_n_txs_in_mempool(1, TransactionProofType::SingleProof, timeout_secs)
+        .await
+        .unwrap();
+
+    let new_block_height = 21;
+    let include_mempool_txs = true;
+    alice
+        .gsl
+        .api_mut()
+        .regtest_mut()
+        .mine_blocks_to_wallet(1, include_mempool_txs)
+        .await
+        .unwrap();
+    alice
+        .wait_until_block_height(new_block_height, timeout_secs)
+        .await
+        .unwrap();
+
+    bob.wait_until_block_height(new_block_height, timeout_secs)
+        .await
+        .unwrap();
+
+    let lustration_status_after = alice
+        .gsl
+        .lock_guard()
+        .await
+        .chain
+        .lustration_status()
+        .expect("Test assumption: Lustration status is active");
+
+    // Off by small deviation because of floting point error when dividing
+    // block subsidy between composer and guesser.
+    let expected_input_amount =
+        NativeCurrencyAmount::coins(32).scalar_mul(max_num_inputs.try_into().unwrap());
+    let epsilon = NativeCurrencyAmount::from_nau(NativeCurrencyAmount::coin_as_nau() / 10_000);
+    let upper_limit = lustration_status_before
+        .counter
+        .checked_sub(&expected_input_amount)
+        .unwrap()
+        + epsilon;
+    let lower_limit = lustration_status_before
+        .counter
+        .checked_sub(&expected_input_amount)
+        .unwrap()
+        .checked_sub(&epsilon)
+        .unwrap();
+    assert!(
+        upper_limit > lustration_status_after.counter
+            && lower_limit < lustration_status_after.counter,
+        "New lustration counter match previous minus lustrated amount"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[traced_test]
+pub async fn merge_consolidation_txs() {
+    // check the the proof upgrading automatically merges two consolidation
+    // transactions into one.
+    logging::tracing_logger();
+    let timeout_secs = 5;
+
+    let num_blocks_mined = 23;
+    let (mut alice, mut bob) = wallet_with_mining_rewards(num_blocks_mined).await;
+
+    assert_eq!(
+        alice.gsl.lock_guard().await.chain.tip().header().height,
+        u64::from(num_blocks_mined).into()
+    );
+    assert_eq!(
+        bob.gsl.lock_guard().await.chain.tip().header().height,
+        u64::from(num_blocks_mined).into()
+    );
+
+    let bob_address = bob
+        .gsl
+        .api_mut()
+        .wallet_mut()
+        .next_receiving_address(KeyType::Generation)
+        .await
+        .unwrap();
+
+    // Alice consolidates 3 UTXOs, twice
+    for _ in 0..=1 {
+        let accept_lustrations = true;
+        let max_num_inputs = 3;
+        let _ = alice
+            .gsl
+            .api_mut()
+            .tx_initiator_mut()
+            .consolidate(
+                max_num_inputs,
+                Some(bob_address.clone()),
+                Timestamp::now(),
+                accept_lustrations,
+            )
+            .await
+            .unwrap();
+    }
+
+    // Give Alice time to broadcast single proof transaction
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+    alice
+        .wait_until_n_txs_in_mempool(1, TransactionProofType::SingleProof, timeout_secs)
+        .await
+        .unwrap();
+    bob.wait_until_n_txs_in_mempool(1, TransactionProofType::SingleProof, timeout_secs)
+        .await
+        .unwrap();
+
+    // Mine transaction, that's the merger of two consolidation txs
+    let include_mempool_txs = true;
+    alice
+        .gsl
+        .api_mut()
+        .regtest_mut()
+        .mine_blocks_to_wallet(1, include_mempool_txs)
+        .await
+        .unwrap();
+
+    let num_inputs_observed = alice
+        .gsl
+        .lock_guard()
+        .await
+        .chain
+        .tip()
+        .body()
+        .transaction_kernel()
+        .inputs
+        .len();
+    assert_eq!(
+        6, num_inputs_observed,
+        "The two consolidation transactions must have been merged."
     );
 }

--- a/neptune-core/tests/send_and_receive_basic.rs
+++ b/neptune-core/tests/send_and_receive_basic.rs
@@ -78,7 +78,7 @@ pub async fn alice_sends_to_self() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 pub async fn alice_sends_to_bob_with_primitive_witness_capability() -> anyhow::Result<()> {
     alice_sends_to_bob(
-        &GenesisNode::cluster_id(),
+        &GenesisNode::cluster_id(None),
         TxProvingCapability::PrimitiveWitness,
     )
     .await
@@ -90,7 +90,7 @@ pub async fn alice_sends_to_bob_with_primitive_witness_capability() -> anyhow::R
 #[tokio::test(flavor = "multi_thread")]
 pub async fn alice_sends_to_bob_with_proof_collection_capability() -> anyhow::Result<()> {
     alice_sends_to_bob(
-        &GenesisNode::cluster_id(),
+        &GenesisNode::cluster_id(None),
         TxProvingCapability::PrimitiveWitness,
     )
     .await
@@ -102,7 +102,7 @@ pub async fn alice_sends_to_bob_with_proof_collection_capability() -> anyhow::Re
 #[tokio::test(flavor = "multi_thread")]
 pub async fn alice_sends_to_bob_with_single_proof_capability() -> anyhow::Result<()> {
     alice_sends_to_bob(
-        &GenesisNode::cluster_id(),
+        &GenesisNode::cluster_id(None),
         TxProvingCapability::PrimitiveWitness,
     )
     .await
@@ -272,7 +272,7 @@ pub async fn alice_sends_to_random_key() -> anyhow::Result<()> {
 
     // alice starts a single node cluster
     let [mut alice] =
-        GenesisNode::start_connected_cluster(&GenesisNode::cluster_id(), 1, None, timeout_secs)
+        GenesisNode::start_connected_cluster(&GenesisNode::cluster_id(None), 1, None, timeout_secs)
             .await?;
 
     // alice generates a random symmetric key outside her wallet.
@@ -390,7 +390,7 @@ pub async fn alice_sends_transparent_transaction() -> anyhow::Result<()> {
 
     // alice starts a single node cluster
     let [mut alice] =
-        GenesisNode::start_connected_cluster(&GenesisNode::cluster_id(), 1, None, timeout_secs)
+        GenesisNode::start_connected_cluster(&GenesisNode::cluster_id(None), 1, None, timeout_secs)
             .await?;
 
     // alice generates a random symmetric key outside her wallet.
@@ -536,7 +536,7 @@ pub async fn alice_sends_transparent_transaction() -> anyhow::Result<()> {
 ///     because the time
 #[tokio::test(flavor = "multi_thread")]
 pub async fn alice_sends_time_locked_funds() -> anyhow::Result<()> {
-    let cluster_id = GenesisNode::cluster_id();
+    let cluster_id = GenesisNode::cluster_id(None);
     logging::tracing_logger();
     let timeout_secs = 5;
 

--- a/neptune-core/tests/update_mutator_set_own_tx.rs
+++ b/neptune-core/tests/update_mutator_set_own_tx.rs
@@ -213,7 +213,7 @@ pub async fn update_mutator_set_on_own_transaction_two_new_blocks_from_peer() {
     let mut base_args = GenesisNode::default_args().await;
     base_args.tx_proving_capability = Some(TxProvingCapability::ProofCollection);
     let [alice, bob] = GenesisNode::start_connected_cluster(
-        &GenesisNode::cluster_id(),
+        &GenesisNode::cluster_id(None),
         2,
         Some(base_args),
         timeout_secs,

--- a/neptune-core/tests/update_mutator_set_own_tx.rs
+++ b/neptune-core/tests/update_mutator_set_own_tx.rs
@@ -10,6 +10,161 @@ use neptune_cash::api::export::TxProvingCapability;
 use rand::Rng;
 use tracing_test::traced_test;
 
+enum SourceOfNewBlocks {
+    OwnMiner,
+    Peer {
+        num_new_blocks: u8,
+        peer: Box<GenesisNode>,
+    },
+}
+
+async fn worker(mut alice: GenesisNode, new_block_source: SourceOfNewBlocks) {
+    let tx_proving_capability = alice.gsl.cli().tx_proving_capability.unwrap();
+
+    // Mine two blocks to get a positive balance
+    alice
+        .gsl
+        .api_mut()
+        .regtest_mut()
+        .mine_blocks_to_wallet(2, false)
+        .await
+        .unwrap();
+    assert_eq!(
+        BlockHeight::from(2u64),
+        alice.gsl.lock_guard().await.chain.tip().header().height,
+        "Expected block height: 2"
+    );
+
+    // Generate an address
+    let alice_address = alice
+        .gsl
+        .api_mut()
+        .wallet_mut()
+        .next_receiving_address(KeyType::Generation)
+        .await
+        .unwrap();
+
+    // Create transaction to self
+    let accept_lustrations = true;
+    let tx_artifacts = alice
+        .gsl
+        .api_mut()
+        .tx_sender_mut()
+        .send(
+            vec![(
+                alice_address,
+                NativeCurrencyAmount::coins_from_str("2.45").unwrap(),
+            )],
+            Default::default(),
+            NativeCurrencyAmount::coins(1),
+            Timestamp::now(),
+            accept_lustrations,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(1, alice.gsl.lock_guard().await.mempool.len());
+
+    // Wait until tx has right proof quality
+    let timeout_secs = 10;
+
+    let txid = tx_artifacts.transaction().txid();
+    match tx_proving_capability {
+        TxProvingCapability::LockScript => unreachable!("Not testing this"),
+        TxProvingCapability::PrimitiveWitness => alice
+            .wait_until_tx_in_mempool(txid, timeout_secs)
+            .await
+            .unwrap(),
+        TxProvingCapability::ProofCollection => alice
+            .wait_until_tx_in_mempool_has_proof_collection(txid, timeout_secs)
+            .await
+            .unwrap(),
+        TxProvingCapability::SingleProof => alice
+            .wait_until_tx_in_mempool_has_single_proof(
+                tx_artifacts.transaction().txid(),
+                timeout_secs,
+            )
+            .await
+            .unwrap(),
+    };
+
+    assert_eq!(1, alice.gsl.lock_guard().await.mempool.len());
+
+    let expected_new_height = match new_block_source {
+        SourceOfNewBlocks::OwnMiner => 3,
+        SourceOfNewBlocks::Peer { num_new_blocks, .. } => 2 + u64::from(num_new_blocks),
+    };
+
+    // Add new block(s) that do not include the transaction, and verify that
+    // transaction stays in the mempool, and that it eventually gets updated to
+    // the new mutator set.
+    let mine_mempool_txs = false;
+    match new_block_source {
+        SourceOfNewBlocks::OwnMiner => {
+            alice
+                .gsl
+                .api_mut()
+                .regtest_mut()
+                .mine_blocks_to_wallet(1, mine_mempool_txs)
+                .await
+                .unwrap();
+        }
+        SourceOfNewBlocks::Peer {
+            num_new_blocks,
+            peer: mut bob,
+        } => {
+            bob.gsl
+                .api_mut()
+                .regtest_mut()
+                .mine_blocks_to_wallet(num_new_blocks.into(), mine_mempool_txs)
+                .await
+                .unwrap();
+        }
+    }
+
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+    assert_eq!(1, alice.gsl.lock_guard().await.mempool.len());
+
+    let tip = alice.gsl.lock_guard().await.chain.tip().to_owned();
+
+    assert_eq!(
+        BlockHeight::from(expected_new_height),
+        tip.header().height,
+        "Expected block height: {expected_new_height}",
+    );
+
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    let tip_msa = tip.mutator_set_accumulator_after().unwrap();
+    let tx_upgrade_timeout_secs = 15;
+    alice
+        .wait_until_tx_in_mempool_confirmable(
+            tx_artifacts.transaction().txid(),
+            &tip_msa,
+            tx_upgrade_timeout_secs,
+        )
+        .await
+        .unwrap();
+
+    // Sleep to give application time to send all messages before receivers
+    // are dropped. When the application shuts down after it goes out of
+    // scope all messages must have been sent, otherwise there might be a
+    // sender without a receiver and that causes a panic.
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+    // Verify that transaction is confirmable against tip.
+    let txid = tx_artifacts.transaction().txid();
+    let tx = alice
+        .gsl
+        .lock_guard()
+        .await
+        .mempool
+        .get(txid)
+        .unwrap()
+        .to_owned();
+    assert!(tx.is_confirmable_relative_to(&tip_msa));
+}
+
 /// Test: Alice creates a proof-collection backed transaction.
 ///
 /// this is a test that proof collection backed transactions are updated on the
@@ -25,15 +180,16 @@ use tracing_test::traced_test;
 ///    after the processing of the new block.
 #[traced_test]
 #[tokio::test(flavor = "multi_thread")]
-pub async fn alice_updates_mutator_set_data_on_own_transaction() {
-    logging::tracing_logger();
-
-    let mut rng = rand::rng();
+pub async fn update_mutator_set_on_own_transaction_one_new_block_self_mined() {
     for tx_proving_capability in [
         TxProvingCapability::PrimitiveWitness,
         TxProvingCapability::ProofCollection,
         TxProvingCapability::SingleProof,
     ] {
+        logging::tracing_logger();
+
+        let mut rng = rand::rng();
+
         let mut cli_args = GenesisNode::default_args().await;
         cli_args.tx_proving_capability = Some(tx_proving_capability);
 
@@ -41,127 +197,36 @@ pub async fn alice_updates_mutator_set_data_on_own_transaction() {
         // socket.
         cli_args.peer_port = rng.random_range((1 << 10)..=u16::MAX);
         cli_args.rpc_port = rng.random_range((1 << 10)..=u16::MAX);
-        let mut alice = GenesisNode::start_node(cli_args).await.unwrap();
-
-        // Mine two blocks to get a positive balance
-        alice
-            .gsl
-            .api_mut()
-            .regtest_mut()
-            .mine_blocks_to_wallet(2, false)
-            .await
-            .unwrap();
-        assert_eq!(
-            BlockHeight::from(2u64),
-            alice.gsl.lock_guard().await.chain.tip().header().height,
-            "Expected block height: 2"
-        );
-
-        // Generate an address
-        let alice_address = alice
-            .gsl
-            .api_mut()
-            .wallet_mut()
-            .next_receiving_address(KeyType::Generation)
-            .await
-            .unwrap();
-
-        // Create transaction to self
-        let accept_lustrations = true;
-        let tx_artifacts = alice
-            .gsl
-            .api_mut()
-            .tx_sender_mut()
-            .send(
-                vec![(
-                    alice_address,
-                    NativeCurrencyAmount::coins_from_str("2.45").unwrap(),
-                )],
-                Default::default(),
-                NativeCurrencyAmount::coins(1),
-                Timestamp::now(),
-                accept_lustrations,
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(1, alice.gsl.lock_guard().await.mempool.len());
-
-        // Wait until tx has right proof quality
-        let timeout_secs = 10;
-
-        let txid = tx_artifacts.transaction().txid();
-        match tx_proving_capability {
-            TxProvingCapability::LockScript => unreachable!("Not testing this"),
-            TxProvingCapability::PrimitiveWitness => alice
-                .wait_until_tx_in_mempool(txid, timeout_secs)
-                .await
-                .unwrap(),
-            TxProvingCapability::ProofCollection => alice
-                .wait_until_tx_in_mempool_has_proof_collection(txid, timeout_secs)
-                .await
-                .unwrap(),
-            TxProvingCapability::SingleProof => alice
-                .wait_until_tx_in_mempool_has_single_proof(
-                    tx_artifacts.transaction().txid(),
-                    timeout_secs,
-                )
-                .await
-                .unwrap(),
-        };
-
-        assert_eq!(1, alice.gsl.lock_guard().await.mempool.len());
-
-        // Mine one block that does *not* include the transaction, and verify
-        // that transaction stays in the mempool, and that it eventually gets
-        // updated to the new mutator set.
-        let mine_mempool_txs = false;
-        alice
-            .gsl
-            .api_mut()
-            .regtest_mut()
-            .mine_blocks_to_wallet(1, mine_mempool_txs)
-            .await
-            .unwrap();
-        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-
-        assert_eq!(1, alice.gsl.lock_guard().await.mempool.len());
-
-        let tip = alice.gsl.lock_guard().await.chain.tip().to_owned();
-        assert_eq!(
-            BlockHeight::from(3u64),
-            tip.header().height,
-            "Expected block height: 3"
-        );
-
-        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-        let tip_msa = tip.mutator_set_accumulator_after().unwrap();
-        let tx_upgrade_timeout_secs = 15;
-        alice
-            .wait_until_tx_in_mempool_confirmable(
-                tx_artifacts.transaction().txid(),
-                &tip_msa,
-                tx_upgrade_timeout_secs,
-            )
-            .await
-            .unwrap();
-
-        // Sleep to give application time to send all messages before receivers
-        // are dropped. When the application shuts down after it goes out of
-        // scope all messages must have been sent, otherwise there might be a
-        // sender without a receiver and that causes a panic.
-        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-
-        // Verify that transaction is confirmable against tip.
-        let txid = tx_artifacts.transaction().txid();
-        let tx = alice
-            .gsl
-            .lock_guard()
-            .await
-            .mempool
-            .get(txid)
-            .unwrap()
-            .to_owned();
-        assert!(tx.is_confirmable_relative_to(&tip_msa));
+        let alice = GenesisNode::start_node(cli_args).await.unwrap();
+        worker(alice, SourceOfNewBlocks::OwnMiner).await;
     }
+}
+
+#[traced_test]
+#[tokio::test(flavor = "multi_thread")]
+pub async fn update_mutator_set_on_own_transaction_two_new_blocks_from_peer() {
+    // alice and bob start 2 peer cluster (regtest)
+    logging::tracing_logger();
+
+    let timeout_secs = 5;
+
+    let mut base_args = GenesisNode::default_args().await;
+    base_args.tx_proving_capability = Some(TxProvingCapability::ProofCollection);
+    let [alice, bob] = GenesisNode::start_connected_cluster(
+        &GenesisNode::cluster_id(),
+        2,
+        Some(base_args),
+        timeout_secs,
+    )
+    .await
+    .unwrap();
+
+    worker(
+        alice,
+        SourceOfNewBlocks::Peer {
+            num_new_blocks: 2,
+            peer: Box::new(bob),
+        },
+    )
+    .await;
 }


### PR DESCRIPTION
- Allow custom number of transaction inputs per transaction when activating auto consolidation
- Check if a "merge" makes sense after performing a successful "raise" operation
- Big test-related diff