### PR TITLE
build: Avoid use of nightly `assert_matches!`

### DIFF
--- a/neptune-core/src/protocol/consensus/block/block_validation_error.rs
+++ b/neptune-core/src/protocol/consensus/block/block_validation_error.rs
@@ -133,7 +133,6 @@ impl From<RemovalRecordListUnpackError> for BlockValidationError {
 
 #[cfg(test)]
 mod tests {
-    use std::assert_matches;
 
     use num_traits::CheckedSub;
     use proptest::prelude::Just;
@@ -645,10 +644,10 @@ mod tests {
 
         cache_true_claims([BlockProgram::claim(b_new.body(), &b_new.kernel.appendix)]).await;
 
-        assert_matches!(
+        assert!(matches!(
             b_new.validate(&b_prev, ts, network).await.err().unwrap(),
             BlockValidationError::BadLustrationAoclThreshold { .. }
-        );
+        ));
     }
 
     #[proptest(async = "tokio", cases = 1, rng_seed = RngSeed::Fixed(0))]
@@ -673,10 +672,10 @@ mod tests {
 
         cache_true_claims([BlockProgram::claim(b_new.body(), &b_new.kernel.appendix)]).await;
 
-        assert_matches!(
+        assert!(matches!(
             b_new.validate(&b_prev, ts, network).await.err().unwrap(),
             BlockValidationError::BadLustrationCounter { .. }
-        );
+        ));
     }
 
     #[proptest(async = "tokio", cases = 1, rng_seed = RngSeed::Fixed(0))]
@@ -707,10 +706,10 @@ mod tests {
 
         cache_true_claims([BlockProgram::claim(b_new.body(), &b_new.kernel.appendix)]).await;
 
-        assert_matches!(
+        assert!(matches!(
             b_new.validate(&b_prev, ts, network).await.err().unwrap(),
             BlockValidationError::BadLustrationCounter { .. }
-        );
+        ));
     }
 
     #[proptest(async = "tokio", cases = 1, rng_seed = RngSeed::Fixed(0))]
@@ -735,9 +734,9 @@ mod tests {
 
         cache_true_claims([BlockProgram::claim(b_new.body(), &b_new.kernel.appendix)]).await;
 
-        assert_matches!(
+        assert!(matches!(
             b_new.validate(&b_prev, ts, network).await.err().unwrap(),
             BlockValidationError::BadLustrationAoclThreshold { .. }
-        );
+        ));
     }
 }

--- a/neptune-core/src/protocol/consensus/consensus_rule_set.rs
+++ b/neptune-core/src/protocol/consensus/consensus_rule_set.rs
@@ -262,7 +262,6 @@ impl ConsensusRuleSet {
 #[cfg(test)]
 pub(crate) mod tests {
 
-    use std::assert_matches;
     use std::sync::Arc;
 
     use futures::channel::oneshot;
@@ -611,14 +610,14 @@ pub(crate) mod tests {
             dummy_count
         )
         .is_none(),);
-        assert_matches!(
+        assert!(matches!(
             ConsensusRuleSet::lustration_rule(network, first_lustration_block, dummy_count),
             Some(LustrationRule::Initial(_)),
-        );
-        assert_matches!(
+        ));
+        assert!(matches!(
             ConsensusRuleSet::lustration_rule(network, first_lustration_block.next(), dummy_count),
             Some(LustrationRule::Updated { .. }),
-        );
+        ));
     }
 
     #[traced_test]


### PR DESCRIPTION
Re-write in terms of `assert!(matches!(...))`. Also: reduce number of `use` statements.