### PR TITLE
Lowered default sync mode threshold from 1000 to 100

### DIFF
--- a/neptune-core/src/application/config/cli_args.rs
+++ b/neptune-core/src/application/config/cli_args.rs
@@ -444,7 +444,7 @@ pub struct Args {
     /// Maximum number of blocks that the client can catch up to without going
     /// into sync mode.
     ///
-    /// Default: 1000.
+    /// Default: 100.
     ///
     /// The process running this program should have access to enough RAM: at
     /// least the number of blocks set by this argument multiplied with the max
@@ -453,7 +453,7 @@ pub struct Args {
     // Notice that the minimum value here may not be less than
     // [SYNC_CHALLENGE_POW_WITNESS_LENGTH](crate::models::peer::SYNC_CHALLENGE_POW_WITNESS_LENGTH)
     // as that would prevent going into sync mode.
-    #[clap(long, default_value = "1000", value_parser(RangedI64ValueParser::<usize>::new().range(10..100000)))]
+    #[clap(long, default_value = "100", value_parser(RangedI64ValueParser::<usize>::new().range(10..100000)))]
     pub(crate) sync_mode_threshold: usize,
 
     /// By default the node will attempt to resume a previously aborted sync


### PR DESCRIPTION
**Background for this PR:**

After the hard fork beta had occurred at block height 38,000, I started node v0.10.2 at block height 37,888. The tip was at 38,159, so I was 271 blocks behind. The node waited 20 minutes before it started to receive blocks from peers:

> [2m2026-05-13T19:00:56.5537403Z[0m [31mERROR[0m ThreadId(09) [2mtarpc::server::in_flight_requests[0m[2m:[0m DeadlineExceeded
> [2m2026-05-13T19:01:06.5559908Z[0m [31mERROR[0m ThreadId(03) [2mtarpc::server::in_flight_requests[0m[2m:[0m DeadlineExceeded
> [2m2026-05-13T19:01:14.4837565Z[0m [32m INFO[0m ThreadId(01) [2mneptune_cash::state[0m[2m:[0m Blockchain rules changed! From TvmProofVersion1 to HardforkBeta. Clearing mempool.
> [2m2026-05-13T19:01:25.2979158Z[0m [33m WARN[0m ThreadId(06) [2mneptune_cash::application::network::handshake[0m[2m:[0m Handshake failed: local network (main) =/= remote network testnet-0.
> [2m2026-05-13T19:01:38.6392289Z[0m [32m INFO[0m ThreadId(01) [2mneptune_cash::application::loops::main_loop[0m[2m:[0m Block 38158 from peer is new canonical tip: 009417d307ea0885a7a111dd4df5807226885fceb2720142eeccfce57304b6832290060000000000
> [2m2026-05-13T19:01:43.1910549Z[0m [33m WARN[0m ThreadId(12) [2mneptune_cash::application::loops::peer_loop[0m[2m:[0m Received 39 blocks from peer but incoming blocks are less canonical than current tip.


I mentioned this matter in the TG channel, and Thorkil recommended to lower the sync mode threshold limit (currently 1000) to 100. This would have put my node straight into the sync mode.

For context, attached is the full log from the above scenario.
[log_long_sync_wait_after_hardfork.txt](https://github.com/user-attachments/files/27732843/log_long_sync_wait_after_hardfork.txt)



**TG discussion on 2026-05-13:**

Me:

> Hmm.. Just tested this, I was originally synched to blockheight 37888 (so just before the hardfork point, i.e. 38k). Using node v. 0.10.2, but did not find any peers that would provide blocks for a long time. Finally after 20 mins I get two errors in the node console: "DeadLineExceeded", followed by info msg "Blockchain ruled changed. Then the node started to receive blocks from peers


Thorkil:

> If you're less than, say, 500 blocks behind, you'll download the blocks at startup, without any info messages, only debug log messages (which are hidden by default). I actually thought we had lowered this limit to 100 recently, exactly because of this invisible syncing problem...
> 
> Culprit:
> https://github.com/Neptune-Crypto/neptune-core/blob/8a730f3bf93fd5f9a54740ca7844c2ba435f274c/neptune-core/src/application/config/cli_args.rs#L457
> 
> I'd happily accept a PR that lowers the default value to 100 :)