### PR TITLE
fix(ams): make update_mutator_set idempotent

### DIFF
--- a/neptune-core/src/state/archival_state.rs
+++ b/neptune-core/src/state/archival_state.rs
@@ -1869,6 +1869,11 @@ impl ArchivalState {
             // Get the block digest that the mutator set was most recently synced to
             let ms_block_sync_digest = self.archival_mutator_set.get_sync_label();
 
+            // AMS is already synced to this block; skip to avoid double-application.
+            if ms_block_sync_digest == new_block.hash() {
+                return Ok(());
+            }
+
             // Find path from mutator set sync digest to new block. Optimize for the common case,
             // where the new block is the child block of block that the mutator set is synced to.
             let (backwards, _luca, forwards) =


### PR DESCRIPTION
## Problem

`update_mutator_set` panics with an AMS commitment mismatch when called for a block that has already been processed. This can happen when `set_new_tip` is invoked twice for the same block — for example during sync fast-forward, where a canonical block arrives via `NewSyncBlock` and the main loop calls `set_new_tip` on an already-stored block.

The sequence of events that triggers the panic:

1. Block B is already stored and the AMS is correctly synced to B (`sync_label == B.hash()`)
2. `set_new_tip(B)` is called again (e.g. from the fast-forward path, or on restart after a crash mid-application)
3. `find_path(sync_label, B.prev_digest)` returns an empty backwards path and `[]` as the forward path, but the code then appends `B.hash()` to get `forwards = [B.hash()]`
4. All of B's additions and removals are re-applied to the AMS
5. The assertion `ams.hash() == B.mutator_set_accumulator_after().hash()` fires — the AMS is now *two* applications ahead of where it should be

The panic message is:
```
assertion `left == right` failed: Calculated archival mutator set commitment must match that from newly added block.
```

This manifested reliably during mainnet sync when the sync loop's fast-forward mechanism replayed blocks already present in the archival chain.

## Fix

Add a three-line early return at the start of the path-finding block: if `ms_block_sync_digest == new_block.hash()` the accumulator is already in the correct post-block state, so there is nothing to do.

```rust
// AMS is already synced to this block; skip to avoid double-application.
if ms_block_sync_digest == new_block.hash() {
    return Ok(());
}
```

This is safe because:
- `get_sync_label()` returns the hash of the block that was last committed to the AMS
- If that equals `new_block.hash()`, the AMS already reflects all of that block's additions and removals
- The function is now idempotent for the same input, which is the correct semantic

🤖 Generated with [Claude Code](https://claude.com/claude-code)