### PR TITLE
Recover inconsistent archive at init

### DIFF
--- a/neptune-core/src/lib.rs
+++ b/neptune-core/src/lib.rs
@@ -153,6 +153,15 @@ pub async fn initialize(
     let mut global_state_lock =
         GlobalStateLock::from_global_state(global_state, rpc_server_to_main_tx.clone());
 
+    // Ensure archival state is consistent.
+    global_state_lock
+        .lock_guard_mut()
+        .await
+        .chain
+        .archival_state_mut()
+        .recover()
+        .await?;
+
     // Construct the broadcast channel to communicate from the main task to peer tasks
     let (main_to_peer_broadcast_tx, _main_to_peer_broadcast_rx) =
         broadcast::channel::<MainToPeerTask>(PEER_CHANNEL_CAPACITY);

--- a/neptune-core/src/state/archival_state.rs
+++ b/neptune-core/src/state/archival_state.rs
@@ -581,6 +581,27 @@ impl ArchivalState {
         Ok(())
     }
 
+    /// Ensure internal consistency of archival state.
+    ///
+    /// Ensure that the entire archival state is consistent with the tip defined
+    /// by the block index database and the block it points to on disk.
+    ///
+    /// This method is only intended to be run on startup. It is intended to
+    /// be used to recover from a non-graceful shutdown of the node.
+    ///
+    /// It can fix an inconsistent archival state which can be produced for
+    /// example if the node is shut down after the block index database has been
+    /// updated and the block written to disk but before the rest of the
+    /// archival state update is finished.
+    pub(crate) async fn recover(&mut self) -> Result<()> {
+        let tip = self.get_tip().await;
+
+        // Since the sub-parts of the archival state handles reorganizations,
+        // all we have to do is to call the tip updater again. Then all parts
+        // will agree with the block index database.
+        self.set_new_tip(&tip).await
+    }
+
     /// Write a newly found block to database and to disk, without setting it as
     /// tip.
     ///
@@ -2295,6 +2316,7 @@ pub(super) mod tests {
     use rand::Rng;
     use rand::RngCore;
     use rand::SeedableRng;
+    use tracing::error;
     use tracing_test::traced_test;
 
     use super::*;
@@ -2328,6 +2350,85 @@ pub(super) mod tests {
     use crate::tests::shared::globalstate::mock_genesis_global_state;
     use crate::tests::shared::mock_genesis_wallet_state;
     use crate::tests::shared_tokio_runtime;
+
+    impl ArchivalState {
+        async fn is_consistent(&self, expected_tip: &Block) -> bool {
+            let expected_tip_digest = expected_tip.hash();
+
+            if expected_tip_digest != self.get_tip().await.hash() {
+                error!("Archival state must have expected tip");
+                return false;
+            }
+
+            if expected_tip_digest != self.archival_mutator_set.get_sync_label() {
+                error!("Archival state must have expected sync-label");
+                return false;
+            }
+
+            let expected_msa = expected_tip.mutator_set_accumulator_after().unwrap();
+            let msa_from_archive = self.archival_mutator_set.ams().accumulator().await;
+            if expected_msa != msa_from_archive {
+                error!("Archival mutator set must match that in expected tip");
+                return false;
+            }
+
+            if expected_msa.hash() != msa_from_archive.hash() {
+                error!("Archival mutator set hash must match that in expected tip");
+                return false;
+            }
+
+            if expected_tip_digest
+                != self
+                    .get_block(expected_tip_digest)
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .hash()
+            {
+                error!("Expected block must be found in stored state");
+                return false;
+            }
+
+            if expected_tip_digest
+                != self
+                    .archival_block_mmr
+                    .ammr()
+                    .get_latest_leaf()
+                    .await
+                    .unwrap()
+            {
+                error!("Latest leaf in archival block MMR must match expected block");
+                return false;
+            }
+
+            // Verify that archival-block MMR matches that of block
+            {
+                let mut expected_archival_block_mmr_value =
+                    expected_tip.body().block_mmr_accumulator.clone();
+                expected_archival_block_mmr_value.append(expected_tip_digest);
+                if expected_archival_block_mmr_value
+                    != self.archival_block_mmr.ammr().to_accumulator_async().await
+                {
+                    error!("archival block-MMR must match that in tip after adding tip digest");
+                    return false;
+                }
+            }
+
+            // If UTXO index is maintained, check that
+            if let Some(utxo_index) = &self.utxo_index {
+                if !utxo_index.block_was_indexed(expected_tip_digest).await {
+                    error!("UTXO index has not processed tip");
+                    return false;
+                }
+            }
+
+            true
+        }
+
+        pub(crate) async fn assert_consistent(&self, expected_tip: &Block) {
+            assert!(self.is_consistent(expected_tip).await);
+        }
+    }
 
     pub(super) async fn make_test_archival_state(cli: &Args) -> ArchivalState {
         let data_dir: DataDirectory = unit_test_data_directory(cli.network).unwrap();
@@ -5536,6 +5637,130 @@ pub(super) mod tests {
                 .canonical_block_heights_with_puts(HashSet::new(), dummy_tx_output)
                 .await
                 .is_err());
+        }
+    }
+
+    mod recover {
+        use super::*;
+
+        async fn genesis_setup() -> (ArchivalState, Block, Network) {
+            let network = Network::Main;
+            let cli = Args {
+                network,
+                utxo_index: true,
+                ..Default::default()
+            };
+            let archive = make_test_archival_state(&cli).await;
+
+            let genesis = Block::genesis(network);
+
+            (archive, genesis, network)
+        }
+
+        #[apply(shared_tokio_runtime)]
+        async fn recover_happy_case() {
+            let (mut archive, genesis, network) = genesis_setup().await;
+            archive.assert_consistent(&genesis).await;
+            archive.recover().await.unwrap();
+            archive.assert_consistent(&genesis).await;
+
+            let block1 = invalid_empty_block(&genesis, network);
+            archive.set_new_tip(&block1).await.unwrap();
+
+            // consistent before and after recover. From block 1.
+            archive.assert_consistent(&block1).await;
+            archive.recover().await.unwrap();
+            archive.assert_consistent(&block1).await;
+        }
+
+        #[apply(shared_tokio_runtime)]
+        async fn recover_stored_block_one_ahead_rest() {
+            // Block is stored as tip. But no other part of the archival state
+            // has seen this block.
+
+            let (mut archive, genesis, network) = genesis_setup().await;
+            let block1 = invalid_empty_block(&genesis, network);
+            archive.write_block_as_tip(&block1).await.unwrap();
+
+            assert!(!archive.is_consistent(&block1).await);
+            assert!(!archive.is_consistent(&genesis).await);
+
+            // Recover everything but the block storage/block index DB:
+            // archival mutator set, archival block MMR, UTXO index.
+            archive.recover().await.unwrap();
+            assert!(archive.is_consistent(&block1).await);
+            assert!(!archive.is_consistent(&genesis).await);
+        }
+
+        #[apply(shared_tokio_runtime)]
+        async fn recover_stored_block_two_ahead_rest() {
+            // Two blocks stored on disk and in block index DB. But other parts
+            // of the archival state have not seen these two blocks.
+
+            let (mut archive, genesis, network) = genesis_setup().await;
+            let block1 = invalid_empty_block(&genesis, network);
+            let block2 = invalid_empty_block(&block1, network);
+            archive.write_block_as_tip(&block1).await.unwrap();
+            archive.write_block_as_tip(&block2).await.unwrap();
+
+            assert!(!archive.is_consistent(&block2).await);
+            assert!(!archive.is_consistent(&block1).await);
+            assert!(!archive.is_consistent(&genesis).await);
+
+            archive.recover().await.unwrap();
+            assert!(archive.is_consistent(&block2).await);
+            assert!(!archive.is_consistent(&block1).await);
+            assert!(!archive.is_consistent(&genesis).await);
+        }
+
+        #[apply(shared_tokio_runtime)]
+        async fn reorganization_one_deep() {
+            let (mut archive, genesis, network) = genesis_setup().await;
+
+            let block1a = invalid_empty_block_with_proof_size(&genesis, network, 12);
+            let block1b = invalid_empty_block_with_proof_size(&genesis, network, 13);
+
+            archive.set_new_tip(&block1a).await.unwrap();
+            archive.write_block_as_tip(&block1b).await.unwrap();
+
+            assert!(!archive.is_consistent(&block1b).await);
+            archive.recover().await.unwrap();
+            assert!(archive.is_consistent(&block1b).await);
+        }
+
+        #[apply(shared_tokio_runtime)]
+        async fn reorganization_two_deep() {
+            let (mut archive, genesis, network) = genesis_setup().await;
+
+            let block1a = invalid_empty_block_with_proof_size(&genesis, network, 12);
+            let block2a = invalid_empty_block_with_proof_size(&block1a, network, 12);
+            let block1b = invalid_empty_block_with_proof_size(&genesis, network, 13);
+            let block2b = invalid_empty_block_with_proof_size(&block1b, network, 13);
+
+            archive.set_new_tip(&block1a).await.unwrap();
+            archive.set_new_tip(&block2a).await.unwrap();
+            archive.write_block_as_tip(&block1b).await.unwrap();
+            archive.write_block_as_tip(&block2b).await.unwrap();
+
+            assert!(!archive.is_consistent(&block2b).await);
+            archive.recover().await.unwrap();
+            assert!(archive.is_consistent(&block2b).await);
+        }
+
+        #[apply(shared_tokio_runtime)]
+        async fn roll_back_one() {
+            let (mut archive, genesis, network) = genesis_setup().await;
+
+            let block1 = invalid_empty_block_with_proof_size(&genesis, network, 12);
+            let block2 = invalid_empty_block_with_proof_size(&block1, network, 12);
+
+            archive.set_new_tip(&block1).await.unwrap();
+            archive.set_new_tip(&block2).await.unwrap();
+            archive.write_block_as_tip(&block1).await.unwrap();
+
+            assert!(!archive.is_consistent(&block1).await);
+            archive.recover().await.unwrap();
+            assert!(archive.is_consistent(&block1).await);
         }
     }
 

--- a/neptune-core/src/state/archival_state.rs
+++ b/neptune-core/src/state/archival_state.rs
@@ -4116,6 +4116,20 @@ pub(super) mod tests {
         );
         assert_eq!(genesis.hash(), luca_3, "Luca of 1a and 1b is genesis");
 
+        // Test 1a to genesis
+        let (backwards_4, _, forwards_4) = archival_state
+            .find_path(mock_block_1_a.hash(), genesis.hash())
+            .await;
+        assert_eq!(
+            vec![mock_block_1_a.hash()],
+            backwards_4,
+            "Backwards path from 1a to genesis is 1a"
+        );
+        assert!(
+            forwards_4.is_empty(),
+            "Forwards from 1a to genesis is the empty list"
+        );
+
         Ok(())
     }
 

--- a/neptune-core/src/state/mod.rs
+++ b/neptune-core/src/state/mod.rs
@@ -6061,17 +6061,20 @@ mod tests {
                     .get_sync_label(),
                 "Archival state must have expected sync-label",
             );
+
+            let expected_msa = expected_tip.mutator_set_accumulator_after().unwrap();
+            let msa_from_archive = global_state
+                .chain
+                .archival_state()
+                .archival_mutator_set
+                .ams()
+                .accumulator()
+                .await;
             assert_eq!(
-                expected_tip.mutator_set_accumulator_after().unwrap(),
-                global_state
-                    .chain
-                    .archival_state()
-                    .archival_mutator_set
-                    .ams()
-                    .accumulator()
-                    .await,
+                expected_msa, msa_from_archive,
                 "Archival mutator set must match that in expected tip"
             );
+            assert_eq!(expected_msa.hash(), msa_from_archive.hash());
 
             assert_eq!(
                 expected_tip_digest,
@@ -6590,6 +6593,9 @@ mod tests {
                     global_state.set_new_tip(block_1.clone()).await.unwrap();
                     global_state.set_new_tip(block_1.clone()).await.unwrap();
                 }
+
+                // One more time
+                global_state.set_new_tip(block_1.clone()).await.unwrap();
 
                 let expected_num_mutxos = if claim_coinbase { 3 } else { 1 };
                 assert_correct_global_state(

--- a/neptune-core/src/state/mod.rs
+++ b/neptune-core/src/state/mod.rs
@@ -6036,8 +6036,6 @@ mod tests {
     }
 
     mod state_update_on_reorganizations {
-        use tasm_lib::twenty_first::prelude::Mmr;
-
         use super::*;
 
         async fn assert_correct_global_state(
@@ -6051,74 +6049,11 @@ mod tests {
             let expected_tip_digest = expected_tip.hash();
             assert_eq!(expected_tip_digest, global_state.chain.tip().hash());
 
-            // Peeking into archival state
-            assert_eq!(
-                expected_tip_digest,
-                global_state
-                    .chain
-                    .archival_state()
-                    .archival_mutator_set
-                    .get_sync_label(),
-                "Archival state must have expected sync-label",
-            );
-
-            let expected_msa = expected_tip.mutator_set_accumulator_after().unwrap();
-            let msa_from_archive = global_state
+            global_state
                 .chain
                 .archival_state()
-                .archival_mutator_set
-                .ams()
-                .accumulator()
+                .assert_consistent(&expected_tip)
                 .await;
-            assert_eq!(
-                expected_msa, msa_from_archive,
-                "Archival mutator set must match that in expected tip"
-            );
-            assert_eq!(expected_msa.hash(), msa_from_archive.hash());
-
-            assert_eq!(
-                expected_tip_digest,
-                global_state
-                    .chain
-                    .archival_state()
-                    .get_block(expected_tip.hash())
-                    .await
-                    .unwrap()
-                    .unwrap()
-                    .hash(),
-                "Expected block must be returned"
-            );
-
-            assert_eq!(
-                expected_tip_digest,
-                global_state
-                    .chain
-                    .archival_state()
-                    .archival_block_mmr
-                    .ammr()
-                    .get_latest_leaf()
-                    .await
-                    .unwrap(),
-                "Latest leaf in archival block MMR must match expected block"
-            );
-
-            // Verify that archival-block MMR matches that of block
-            {
-                let mut expected_archival_block_mmr_value =
-                    expected_tip.body().block_mmr_accumulator.clone();
-                expected_archival_block_mmr_value.append(expected_tip_digest);
-                assert_eq!(
-                    expected_archival_block_mmr_value,
-                    global_state
-                        .chain
-                        .archival_state()
-                        .archival_block_mmr
-                        .ammr()
-                        .to_accumulator_async()
-                        .await,
-                    "archival block-MMR must match that in tip after adding tip digest"
-                );
-            }
 
             let tip_height = expected_tip.header().height;
             assert_eq!(


### PR DESCRIPTION
A persistent problem for `neptune-core` has been poor data corruption recovery in `ArchivalState`. If the node is shutdown after a new block has stored in the block index database and written to disk but later parts of the `ArchivalState` update fails, for example block MMR or mutator set, the node will refuse to start, and a whole state clearing is required. Since recovering the state usually means that tens of gigabytes need to be downloaded again, this is a significant problem.

The solution is to recover archvial state at startup: Use the already-existing abilities of the sub parts of `ArchivalState` to handle reorganizations. Whatever the block index considers to be the tip is simply re-applied through `set_new_tip` at startup, and the reorganization-handling of the sub parts of `ArchivalState` handle the rest.

This replaces #920.

This closes #810 

