### PR TITLE
test: harden flaky update_mutator_set integration tests

### DIFF
--- a/neptune-core/src/api/regtest/regtest_impl.rs
+++ b/neptune-core/src/api/regtest/regtest_impl.rs
@@ -256,7 +256,7 @@ impl RegTestPrivate {
         state.net.freeze = false;
     }
 
-    // waits (polls) until block is found in canonical chain or 5 second timeout occurs.
+    // waits (polls) until block is found in canonical chain or a timeout occurs.
     //
     // note: temporary until listener approach is implemented.
     async fn wait_until_block_in_chain(
@@ -278,9 +278,9 @@ impl RegTestPrivate {
                 {
                     return Ok(());
                 }
-                return Err(RegTestError::Failed(
-                    "block not in blockchain after {timeout_in_secs} seconds".into(),
-                ));
+                return Err(RegTestError::Failed(format!(
+                    "block not in blockchain after {timeout_in_secs} seconds"
+                )));
             }
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         }

--- a/neptune-core/tests/update_mutator_set_own_tx.rs
+++ b/neptune-core/tests/update_mutator_set_own_tx.rs
@@ -113,6 +113,11 @@ async fn worker(mut alice: GenesisNode, new_block_source: SourceOfNewBlocks) {
             num_new_blocks,
             peer: mut bob,
         } => {
+            // Bob must have synced Alice's two blocks before he starts mining,
+            // so that he composes on top of the shared tip.
+            bob.wait_until_block_height(2u64, timeout_secs)
+                .await
+                .unwrap();
             bob.gsl
                 .api_mut()
                 .regtest_mut()


### PR DESCRIPTION
Reduces flakiness of the two tests tracked in #928 by removing their deterministic and test-infrastructure failure modes:
fix #928 
- Fix the "block not in blockchain" error string, which used a non-interpolated `{timeout_in_secs}` literal.
- `wait_until_tx_in_mempool_confirmable` no longer panics when the tx is evicted by a failed mutator-set update; it reports a clear error on timeout instead.
- Cluster nodes now get random base ports instead of ports derived deterministically from the call site, which collided across repeated/concurrent runs.
- Add a regression test for the cluster port invariants.

`cargo fmt`, `cargo clippy -- -D warnings`, and both tests (serial and parallel) pass locally.