### PR TITLE
feat(json_rpc): add archival batch_are_bloom_indices_set endpoint

### DIFF
--- a/neptune-core/src/application/json_rpc/core/api/ops.rs
+++ b/neptune-core/src/application/json_rpc/core/api/ops.rs
@@ -127,6 +127,9 @@ pub enum RpcMethods {
     AreBloomIndicesSet,
 
     #[namespace(Namespace::Archival)]
+    BatchAreBloomIndicesSet,
+
+    #[namespace(Namespace::Archival)]
     CirculatingSupply,
 
     #[namespace(Namespace::Archival)]

--- a/neptune-core/src/application/json_rpc/core/api/rpc.rs
+++ b/neptune-core/src/application/json_rpc/core/api/rpc.rs
@@ -89,6 +89,9 @@ pub enum RpcError {
     #[error("Filtering conditions may not be empty")]
     EmptyFilteringConditions,
 
+    #[error("Too many absolute index sets requested: maximum is {max}, got {got}")]
+    TooManyAbsoluteIndexSets { max: usize, got: usize },
+
     // Common case errors
     #[error("Invalid address provided in arguments")]
     InvalidAddress,
@@ -125,6 +128,8 @@ pub enum RpcError {
 }
 
 pub type RpcResult<T> = Result<T, RpcError>;
+
+pub const MAX_BATCH_ARE_BLOOM_INDICES_SET_INDEX_SETS: usize = 1000;
 
 #[async_trait]
 pub trait RpcApi: Sync + Send {
@@ -336,6 +341,29 @@ pub trait RpcApi: Sync + Send {
         &self,
         request: AreBloomIndicesSetRequest,
     ) -> RpcResult<AreBloomIndicesSetResponse>;
+
+    /// Batched form of [`Self::are_bloom_indices_set`]: for each absolute index
+    /// set, check whether all of its indices are set in the node's archival
+    /// mutator set, in a single request instead of one request per index set.
+    ///
+    /// The returned `are_set` vector corresponds element-by-element, and in the
+    /// same order, to the `absolute_index_sets` argument (duplicate inputs are
+    /// preserved). An empty input yields an empty response. At most 1000
+    /// absolute index sets may be requested at once.
+    async fn batch_are_bloom_indices_set(
+        &self,
+        absolute_index_sets: Vec<RpcAbsoluteIndexSet>,
+    ) -> RpcResult<BatchAreBloomIndicesSetResponse> {
+        self.batch_are_bloom_indices_set_call(BatchAreBloomIndicesSetRequest {
+            absolute_index_sets,
+        })
+        .await
+    }
+
+    async fn batch_are_bloom_indices_set_call(
+        &self,
+        request: BatchAreBloomIndicesSetRequest,
+    ) -> RpcResult<BatchAreBloomIndicesSetResponse>;
 
     async fn circulating_supply(&self) -> RpcResult<CirculatingSupplyResponse> {
         self.circulating_supply_call(CirculatingSupplyRequest {})

--- a/neptune-core/src/application/json_rpc/core/model/message.rs
+++ b/neptune-core/src/application/json_rpc/core/model/message.rs
@@ -284,6 +284,20 @@ pub struct AreBloomIndicesSetResponse {
     pub are_set: bool,
 }
 
+#[derive(Clone, Debug, Serialize_tuple, Deserialize_tuple)]
+#[serde(rename_all = "camelCase")]
+pub struct BatchAreBloomIndicesSetRequest {
+    pub absolute_index_sets: Vec<RpcAbsoluteIndexSet>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BatchAreBloomIndicesSetResponse {
+    /// One entry per input set, in the same order as the request. `are_set[i]`
+    /// is `true` iff all indices of the `i`-th input set are set.
+    pub are_set: Vec<bool>,
+}
+
 #[derive(Clone, Copy, Debug, Serialize_tuple, Deserialize_tuple)]
 #[serde(rename_all = "camelCase")]
 pub struct CirculatingSupplyRequest {}

--- a/neptune-core/src/application/json_rpc/server/service.rs
+++ b/neptune-core/src/application/json_rpc/server/service.rs
@@ -404,6 +404,32 @@ impl RpcApi for RpcServer {
         })
     }
 
+    async fn batch_are_bloom_indices_set_call(
+        &self,
+        request: BatchAreBloomIndicesSetRequest,
+    ) -> RpcResult<BatchAreBloomIndicesSetResponse> {
+        let got = request.absolute_index_sets.len();
+        if got > MAX_BATCH_ARE_BLOOM_INDICES_SET_INDEX_SETS {
+            return Err(RpcError::TooManyAbsoluteIndexSets {
+                max: MAX_BATCH_ARE_BLOOM_INDICES_SET_INDEX_SETS,
+                got,
+            });
+        }
+
+        // Acquire the state lock once for the whole batch — instead of once per
+        // index set, as repeated single-set requests would — and evaluate every
+        // index set against the same archival mutator set snapshot.
+        let state = self.state.lock_guard().await;
+        let ams = state.chain.archival_state().archival_mutator_set.ams();
+
+        let mut are_set = Vec::with_capacity(request.absolute_index_sets.len());
+        for absolute_index_set in request.absolute_index_sets {
+            are_set.push(ams.absolute_index_set_was_applied(absolute_index_set).await);
+        }
+
+        Ok(BatchAreBloomIndicesSetResponse { are_set })
+    }
+
     async fn circulating_supply_call(
         &self,
         _request: CirculatingSupplyRequest,
@@ -1764,6 +1790,7 @@ pub mod tests {
     use crate::application::json_rpc::core::api::ops::Namespace;
     use crate::application::json_rpc::core::api::rpc::RpcApi;
     use crate::application::json_rpc::core::api::rpc::RpcError;
+    use crate::application::json_rpc::core::api::rpc::MAX_BATCH_ARE_BLOOM_INDICES_SET_INDEX_SETS;
     use crate::application::json_rpc::core::model::common::RpcBlockSelector;
     use crate::application::json_rpc::core::model::message::BlockHeightsByFlagsRequest;
     use crate::application::json_rpc::core::model::mining::template::RpcBlockTemplate;
@@ -1790,6 +1817,7 @@ pub mod tests {
     use crate::tests::shared::strategies::txkernel;
     use crate::tests::shared_tokio_runtime;
     use crate::util_types::mutator_set::removal_record::absolute_index_set::AbsoluteIndexSet;
+    use crate::util_types::mutator_set::shared::NUM_TRIALS;
     use crate::BFieldElement;
     use crate::Block;
 
@@ -1824,6 +1852,141 @@ pub mod tests {
         assert_eq!(
             BlockHeight::genesis(),
             rpc_server.height().await.unwrap().height
+        );
+    }
+
+    /// Test for the `archival::batchAreBloomIndicesSet` endpoint: a batch query
+    /// returns one result per input set, in the same order (duplicates
+    /// preserved), and agrees with the single-set `are_bloom_indices_set`
+    /// endpoint element-by-element.
+    #[apply(shared_tokio_runtime)]
+    async fn batch_are_bloom_indices_set_matches_single_set() {
+        let mut rpc_server = test_rpc_server().await;
+        let network = rpc_server.state.cli().network;
+
+        // Have the devnet wallet spend the premine into the rpc_server's wallet.
+        // Once the resulting block is applied, the spent premine input's absolute
+        // index set is "set", while the freshly received output's set is not.
+        let mut cli = cli_args::Args::default_with_network(Network::Main);
+        cli.tx_proving_capability = Some(TxProvingCapability::ProofCollection);
+        let mut devnet_node =
+            mock_genesis_global_state(0, WalletEntropy::devnet_wallet(), cli).await;
+
+        let rpc_address = rpc_server
+            .state
+            .api()
+            .wallet()
+            .next_receiving_address(KeyType::Generation)
+            .await
+            .unwrap();
+        let mock_amount = NativeCurrencyAmount::coins_from_str("1").unwrap();
+        let devnet_artifacts = devnet_node
+            .api_mut()
+            .tx_sender_mut()
+            .send(
+                vec![OutputFormat::AddressAndAmount(rpc_address, mock_amount)],
+                Default::default(),
+                mock_amount,
+                network.launch_date() + Timestamp::months(3),
+                true,
+            )
+            .await
+            .unwrap();
+
+        let block_1 = invalid_block_with_transaction(
+            &Block::genesis(network),
+            devnet_artifacts.transaction().clone(),
+        );
+        rpc_server.state.set_new_tip(block_1.clone()).await.unwrap();
+
+        // An absolute index set that *is* applied: the spent premine input.
+        let applied_set = block_1.kernel.body.transaction_kernel.inputs[0].absolute_indices;
+
+        // An absolute index set that is *not* applied: the unspent UTXO our
+        // wallet just received (its indices are only set once it is spent).
+        let wallet_status = rpc_server
+            .state
+            .lock_guard()
+            .await
+            .get_wallet_status_for_tip()
+            .await;
+        let SyncedUtxo {
+            aocl_leaf_index,
+            utxo,
+            sender_randomness,
+            receiver_preimage,
+            ..
+        } = &wallet_status.synced_unspent(None).next().unwrap();
+        let not_applied_set = AbsoluteIndexSet::compute(
+            Tip5::hash(utxo),
+            *sender_randomness,
+            *receiver_preimage,
+            *aocl_leaf_index,
+        );
+
+        // Sanity-check the single-set endpoint.
+        assert!(
+            rpc_server
+                .are_bloom_indices_set(applied_set)
+                .await
+                .unwrap()
+                .are_set
+        );
+        assert!(
+            !rpc_server
+                .are_bloom_indices_set(not_applied_set)
+                .await
+                .unwrap()
+                .are_set
+        );
+
+        // Empty input -> empty output.
+        assert!(rpc_server
+            .batch_are_bloom_indices_set(vec![])
+            .await
+            .unwrap()
+            .are_set
+            .is_empty());
+
+        // The batch endpoint preserves input order and duplicates.
+        let inputs = vec![applied_set, not_applied_set, applied_set];
+        let are_set = rpc_server
+            .batch_are_bloom_indices_set(inputs.clone())
+            .await
+            .unwrap()
+            .are_set;
+        assert_eq!(vec![true, false, true], are_set);
+        assert_eq!(inputs.len(), are_set.len());
+
+        // The batch endpoint agrees with the single-set endpoint element-wise.
+        for set in inputs {
+            let single = rpc_server.are_bloom_indices_set(set).await.unwrap().are_set;
+            let batched = rpc_server
+                .batch_are_bloom_indices_set(vec![set])
+                .await
+                .unwrap()
+                .are_set;
+            assert_eq!(vec![single], batched);
+        }
+    }
+
+    #[apply(shared_tokio_runtime)]
+    async fn batch_are_bloom_indices_set_rejects_too_many_index_sets() {
+        let rpc_server = test_rpc_server().await;
+        let got = MAX_BATCH_ARE_BLOOM_INDICES_SET_INDEX_SETS + 1;
+        let absolute_index_set = AbsoluteIndexSet::new([0_u128; NUM_TRIALS as usize]);
+
+        let err = rpc_server
+            .batch_are_bloom_indices_set(vec![absolute_index_set; got])
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            RpcError::TooManyAbsoluteIndexSets {
+                max: MAX_BATCH_ARE_BLOOM_INDICES_SET_INDEX_SETS,
+                got
+            },
+            err
         );
     }
 


### PR DESCRIPTION
## Add RPC endpoint: `archival::batch_are_bloom_indices_set`

Closes #929.

Batched version of `are_bloom_indices_set`: checks many absolute index sets in one request instead of one request per set.

- **In:** `Vec<AbsoluteIndexSet>` → **Out:** `Vec<bool>` (one per input, in order)
- Locks state once for the whole batch
- Empty input → empty response

Includes a test covering ordering, duplicates, empty input, and parity with the single-set endpoint.
