### PR TITLE
feat(`prove_membership_relative_to_smaller_mmr`): add `spawn_blocking`

### DIFF
--- a/neptune-core/src/application/loops/peer_loop.rs
+++ b/neptune-core/src/application/loops/peer_loop.rs
@@ -273,7 +273,8 @@ impl PeerLoopHandler {
                     block.header().height.into(),
                     anchor.num_leafs(),
                 )
-                .await;
+                .await
+                .ok()?;
             let block: TransferBlock = block.try_into().unwrap();
             ret.push((block, mmr_mp));
         }

--- a/neptune-core/src/state/mod.rs
+++ b/neptune-core/src/state/mod.rs
@@ -3128,7 +3128,7 @@ impl GlobalState {
                         child_height.into(),
                         tip_height.next().into(),
                     )
-                    .await,
+                    .await?,
             );
             block_pairs.push((
                 p.try_into()

--- a/neptune-core/src/util_types/archival_mmr.rs
+++ b/neptune-core/src/util_types/archival_mmr.rs
@@ -244,7 +244,7 @@ impl<Storage: StorageVec<Digest>> ArchivalMmr<Storage> {
         &self,
         leaf_index: u64,
         num_leafs: u64,
-    ) -> MmrMembershipProof {
+    ) -> Result<MmrMembershipProof, tokio::task::JoinError> {
         // TODO: Replace this local function with the one in `twenty_first` once
         // available through never version.
         fn auth_path_node_indices(num_leafs: u64, leaf_index: u64) -> Vec<u64> {
@@ -285,12 +285,14 @@ impl<Storage: StorageVec<Digest>> ArchivalMmr<Storage> {
             "Cannot find membership proofs relative to bigger MMR"
         );
 
-        let node_indices = auth_path_node_indices(num_leafs, leaf_index);
+        let node_indices =
+            tokio::task::spawn_blocking(move || auth_path_node_indices(num_leafs, leaf_index))
+                .await?;
         let ap_elements = self.digests.get_many(&node_indices).await;
 
-        MmrMembershipProof {
+        Ok(MmrMembershipProof {
             authentication_path: ap_elements,
-        }
+        })
     }
 
     /// Return membership proof
@@ -758,7 +760,7 @@ pub(crate) mod tests {
         let mp = ammr
             .prove_membership_relative_to_smaller_mmr(leaf_index, reduced_num_leafs)
             .await;
-        prop_assert!(mp.verify(
+        prop_assert!(mp.unwrap().verify(
             leaf_index,
             leaf,
             &smaller_mmr.peaks(),
@@ -784,7 +786,8 @@ pub(crate) mod tests {
                     mp,
                     archival
                         .prove_membership_relative_to_smaller_mmr(i, size)
-                        .await,
+                        .await
+                        .unwrap(),
                     "Two ways of getting MMRMPs must agree"
                 );
 


### PR DESCRIPTION
less starving the caller thread plus parallelizing `PeerLoopHandler::batch_response`