### PR TITLE
keep and upgrade unsynced ProofCollection transactions

### DIFF
--- a/neptune-core/src/application/loops/main_loop/proof_upgrader.rs
+++ b/neptune-core/src/application/loops/main_loop/proof_upgrader.rs
@@ -870,42 +870,51 @@ pub(super) async fn get_upgrade_task_from_mempool(
 
     let upgrade_filter = global_state.cli().tx_upgrade_filter;
 
-    // Do we have any `ProofCollection`s?
-    let proof_collection_job = if let Some((kernel, proof, upgrade_priority)) = global_state
+    // Do we have any `ProofCollection`s? These may be raised to a SingleProof
+    // even when they are no longer synced to the current tip: raising a
+    // ProofCollection does not depend on the mutator set, and the resulting
+    // (possibly unsynced) SingleProof can be cheaply updated to the tip
+    // afterwards.
+    //
+    // Decide whether there is a worthwhile ProofCollection to raise while the
+    // mempool is still borrowed, and only clone the (potentially large)
+    // ProofCollection when we are actually going to build the job.
+    let proof_collection_candidate = global_state
         .mempool()
         .preferred_proof_collection(num_proofs_threshold, upgrade_filter)
-    {
-        if kernel.mutator_set_hash != tip_mutator_set.hash() {
-            error!("Deprecated transaction found in mempool. Has ProofCollection in need of updating. Consider clearing mempool.");
-            return None;
-        }
+        .and_then(|(kernel, proof, upgrade_priority)| {
+            let gobbling_potential = kernel.fee.lossy_f64_fraction_mul(gobbling_fraction);
+            let upgrade_incentive =
+                upgrade_priority.incentive_given_gobble_potential(gobbling_potential);
+            upgrade_incentive
+                .upgrade_is_worth_it(min_gobbling_fee)
+                .then(|| (kernel.to_owned(), proof.to_owned(), upgrade_incentive))
+        });
 
-        let (gobble_fee_recipient, gobble_fee_recipient_preimage) =
-            global_state.mining_rewards_address();
-        let gobbling_potential = kernel.fee.lossy_f64_fraction_mul(gobbling_fraction);
-        let upgrade_incentive =
-            upgrade_priority.incentive_given_gobble_potential(gobbling_potential);
-        if upgrade_incentive.upgrade_is_worth_it(min_gobbling_fee) {
-            let upgrade_job =
-                UpgradeJob::ProofCollectionToSingleProof(Box::new(ProofCollectionToSingleProof {
-                    kernel: kernel.to_owned(),
-                    proof: proof.to_owned(),
-                    mutator_set: tip_mutator_set.clone(),
-                    upgrade_incentive,
-                    gobble_fee_recipient,
-                    gobble_fee_recipient_preimage,
-                }));
-            Some(upgrade_job)
-        } else {
-            None
+    let raise_job = if let Some((kernel, proof, upgrade_incentive)) = proof_collection_candidate {
+        // Build the raise job against the transaction's *own* mutator set
+        // (looked up in the archival state), so that any fee-gobbler ends up
+        // on the same mutator set as the raised transaction and the two can
+        // be merged.
+        match global_state
+            .upgrade_proof_collection_job(kernel, proof, upgrade_incentive)
+            .await
+        {
+            Ok(raise_job) => Some(UpgradeJob::ProofCollectionToSingleProof(Box::new(
+                raise_job,
+            ))),
+            Err(error) => {
+                warn!("Could not build ProofCollection upgrade job: {error}");
+                None
+            }
         }
     } else {
         None
     };
 
-    if let Some(upgrade_job) = &proof_collection_job {
+    if let Some(upgrade_job) = &raise_job {
         if let UpgradeIncentive::Critical = upgrade_job.upgrade_incentive() {
-            return proof_collection_job;
+            return raise_job;
         }
     }
 
@@ -959,7 +968,7 @@ pub(super) async fn get_upgrade_task_from_mempool(
     };
 
     // pick the most profitable option
-    let mut jobs = [proof_collection_job, merge_job, update_job]
+    let mut jobs = [raise_job, merge_job, update_job]
         .into_iter()
         .flatten()
         .collect_vec();
@@ -1114,6 +1123,168 @@ mod tests {
                 .upgrade_is_worth_it(bob.min_gobbling_fee()),
             "Update must be worthy after successful raise"
         );
+
+        drop(main_to_peer_rx);
+    }
+
+    #[traced_test]
+    #[apply(shared_tokio_runtime)]
+    async fn upgrades_unsynced_foreign_proof_collection() {
+        // Issue #946: a ProofCollection that has become unsynced because a
+        // new block arrived must still be picked up for raising by the proof
+        // upgrader. The raised (still unsynced) SingleProof can then be cheaply
+        // updated to the tip.
+        let network = Network::RegTest;
+        let cli_args = cli_args::Args {
+            min_gobbling_fee: NativeCurrencyAmount::from_nau(5),
+            network,
+            tx_proving_capability: Some(TxProvingCapability::SingleProof),
+            gobbling_fraction: 1.0,
+            ..Default::default()
+        };
+
+        let alice =
+            mock_genesis_global_state(2, WalletEntropy::devnet_wallet(), cli_args.clone()).await;
+        let pc_fee = NativeCurrencyAmount::coins(1);
+        let pc_tx = transaction_from_state(
+            alice.clone(),
+            512777439428,
+            TxProvingCapability::ProofCollection,
+            pc_fee,
+        )
+        .await;
+
+        let mut bob =
+            mock_genesis_global_state(2, WalletEntropy::new_random(), cli_args.clone()).await;
+        bob.lock_guard_mut()
+            .await
+            .mempool_insert(pc_tx.clone().into(), UpgradePriority::Irrelevant)
+            .await;
+
+        // A new block arrives *before* the raise, making the ProofCollection
+        // unsynced. It must be retained (#946a) rather than kicked out.
+        let genesis = Block::genesis(network);
+        let block1 = invalid_empty_block(&genesis, network);
+        bob.set_new_tip(block1.clone()).await.unwrap();
+
+        let mut bob = bob.lock_guard_mut().await;
+        assert!(
+            bob.mempool().contains(pc_tx.kernel.txid()),
+            "unsynced ProofCollection must be retained across a new block (#946a)"
+        );
+
+        // The upgrader still returns a raise job for the now-unsynced PC.
+        let Some(job @ UpgradeJob::ProofCollectionToSingleProof(_)) =
+            get_upgrade_task_from_mempool(&mut bob).await
+        else {
+            panic!("unsynced foreign ProofCollection must still yield a raise job (#946b)");
+        };
+
+        // The raise job must target the transaction's *own* (older) mutator set
+        // rather than the current tip, so that a fee-gobbler is built on the
+        // same mutator set as the raised transaction and the two can be merged.
+        assert_eq!(
+            pc_tx.kernel.mutator_set_hash,
+            job.mutator_set().hash(),
+            "raise job must use the transaction's own mutator set"
+        );
+        assert_ne!(
+            bob.chain.tip_mutator_set_after().hash(),
+            job.mutator_set().hash(),
+            "sanity: the transaction is genuinely unsynced to the tip"
+        );
+    }
+
+    #[traced_test]
+    #[apply(shared_tokio_runtime)]
+    async fn unsynced_raise_registers_offchain_gobbler_utxos() {
+        // Regression test for #946: raising an *unsynced* ProofCollection with
+        // an off-chain fee-gobbler must still register the gobbler's expected
+        // UTXOs (the upgrader's reward).
+        let network = Network::RegTest;
+        let cli_args = cli_args::Args {
+            min_gobbling_fee: NativeCurrencyAmount::from_nau(5),
+            network,
+            tx_proving_capability: Some(TxProvingCapability::SingleProof),
+            gobbling_fraction: 1.0,
+            // Off-chain fee notification makes the gobbler produce expected
+            // UTXOs that the wallet must record (no mining address is set, so
+            // `mining_rewards_address` yields a preimage the wallet can spend).
+            fee_notification:
+                neptune_wallet::fee_notification_policy::FeeNotificationPolicy::OffChain,
+            ..Default::default()
+        };
+
+        let alice =
+            mock_genesis_global_state(2, WalletEntropy::devnet_wallet(), cli_args.clone()).await;
+        let pc_fee = NativeCurrencyAmount::coins(1);
+        let pc_tx = transaction_from_state(
+            alice.clone(),
+            512777439428,
+            TxProvingCapability::ProofCollection,
+            pc_fee,
+        )
+        .await;
+
+        let mut bob =
+            mock_genesis_global_state(2, WalletEntropy::new_random(), cli_args.clone()).await;
+        bob.lock_guard_mut()
+            .await
+            .mempool_insert(pc_tx.clone().into(), UpgradePriority::Irrelevant)
+            .await;
+
+        // A new block makes the ProofCollection unsynced
+        let genesis = Block::genesis(network);
+        let block1 = invalid_empty_block(&genesis, network);
+        bob.set_new_tip(block1.clone()).await.unwrap();
+
+        let num_expected_before = bob
+            .lock_guard()
+            .await
+            .wallet_state
+            .num_expected_utxos()
+            .await;
+
+        // Fetch and execute the raise job for the now-unsynced ProofCollection.
+        let job = {
+            let mut bob = bob.lock_guard_mut().await;
+            get_upgrade_task_from_mempool(&mut bob).await.unwrap()
+        };
+        assert!(
+            matches!(job, UpgradeJob::ProofCollectionToSingleProof(_)),
+            "expected a ProofCollection -> SingleProof raise job"
+        );
+
+        let (main_to_peer_tx, main_to_peer_rx) =
+            broadcast::channel::<MainToPeerTask>(PEER_CHANNEL_CAPACITY);
+        job.handle_upgrade(
+            TritonVmJobQueue::get_instance(),
+            bob.clone(),
+            main_to_peer_tx,
+        )
+        .await;
+
+        // The gobbler's expected UTXO must be registered even though the raise
+        // was performed against an older (unsynced) mutator set.
+        let num_expected_after = bob
+            .lock_guard()
+            .await
+            .wallet_state
+            .num_expected_utxos()
+            .await;
+        assert!(
+            num_expected_after > num_expected_before,
+            "off-chain gobbler expected UTXO must be registered on the unsynced raise path (#946)"
+        );
+
+        // Once upgraded (raised and updated), the transaction must be ready for
+        // block inclusion.
+        let txs = bob
+            .lock_guard()
+            .await
+            .mempool()
+            .get_transactions_for_block_composition(usize::MAX, None);
+        assert_eq!(1, txs.len());
 
         drop(main_to_peer_rx);
     }

--- a/neptune-core/src/application/loops/main_loop/proof_upgrader.rs
+++ b/neptune-core/src/application/loops/main_loop/proof_upgrader.rs
@@ -448,7 +448,7 @@ impl UpgradeJob {
             // No locks may be held here!
             let fee_notification_medium: UtxoNotificationMedium =
                 global_state_lock.cli().fee_notification.into();
-            let (upgraded, expected_utxos) = match upgrade_job
+            let (upgraded, gobbler_expected_utxo) = match upgrade_job
                 .clone()
                 .upgrade(
                     triton_vm_job_queue.clone(),
@@ -459,12 +459,12 @@ impl UpgradeJob {
                 )
                 .await
             {
-                Ok((upgraded_tx, expected_utxos)) => {
+                Ok((upgraded_tx, expected_utxo)) => {
                     info!(
                         "Successfully upgraded transaction {}",
                         upgraded_tx.kernel.txid()
                     );
-                    (upgraded_tx, expected_utxos)
+                    (upgraded_tx, expected_utxo)
                 }
                 Err(e) => {
                     error!("UpgradeProof job failed. error: {e}");
@@ -481,8 +481,14 @@ impl UpgradeJob {
             /* Check if upgrade resulted in valid transaction */
             upgrade_job = {
                 let mut global_state = global_state_lock.lock_guard_mut().await;
-                let tip_mutator_set = global_state.chain.tip_mutator_set_after();
 
+                // Notify wallet of gobbler UTXO
+                global_state
+                    .wallet_state
+                    .add_expected_utxos(gobbler_expected_utxo)
+                    .await;
+
+                let tip_mutator_set = global_state.chain.tip_mutator_set_after();
                 let transaction_is_up_to_date =
                     upgraded.kernel.mutator_set_hash == tip_mutator_set.hash();
 
@@ -506,11 +512,6 @@ impl UpgradeJob {
                     // sure to have it when they ask.
                     global_state
                         .mempool_insert(upgraded.clone(), upgrade_incentive.into())
-                        .await;
-
-                    global_state
-                        .wallet_state
-                        .add_expected_utxos(expected_utxos)
                         .await;
                     drop(global_state); // sooner is better.
 
@@ -632,6 +633,9 @@ impl UpgradeJob {
 
     /// Build a single-proof backed gobbler transaction that can be used to
     /// charge another transaction for upgrading a proof.
+    ///
+    /// Returns the transaction and the to-be-expected UTXO if node uses
+    /// off-chain fee notificaitons.
     #[expect(clippy::too_many_arguments)]
     async fn build_gobbler(
         gobbling_fee: NativeCurrencyAmount,
@@ -643,7 +647,7 @@ impl UpgradeJob {
         current_block_height: BlockHeight,
         mutator_set: MutatorSetAccumulator,
         old_tx_timestamp: Timestamp,
-    ) -> anyhow::Result<(Transaction, Vec<ExpectedUtxo>)> {
+    ) -> anyhow::Result<(Transaction, Option<ExpectedUtxo>)> {
         info!("Producing gobbler-transaction for a value of {gobbling_fee}");
 
         let receiver_digest = gobbling_recipient.privacy_digest();
@@ -669,13 +673,18 @@ impl UpgradeJob {
 
         let gobbler_witness = gobbler.primitive_witness();
 
-        let expected_utxos = match receiver_preimage {
+        let expected_utxo = match receiver_preimage {
             Some(preimage) if fee_notification_medium == UtxoNotificationMedium::OffChain => {
                 gobbler
                     .tx_outputs
                     .expected_utxos(UtxoNotifier::FeeGobbler, preimage)
             }
             _ => vec![],
+        };
+        let expected_utxo = match expected_utxo.len() {
+            0 => None,
+            1 => Some(expected_utxo[0].clone()),
+            _ => panic!("Fee gobbler can maximum create one known output"),
         };
 
         // ensure that proof-type is SingleProof
@@ -702,17 +711,18 @@ impl UpgradeJob {
             proof,
         };
 
-        Ok((gobbler_tx, expected_utxos))
+        Ok((gobbler_tx, expected_utxo))
     }
 
     /// Execute the proof upgrade.
     ///
     /// Upgrades transactions to a proof of higher quality that is more likely
     /// to be picked up by a miner. Returns the upgraded proof, or an error if
-    /// the prover is already in use and the proof_job_options is set to not wait if
-    /// prover is busy.
+    /// the prover is already in use and the proof_job_options is set to not
+    /// wait if prover is busy.
     ///
-    /// Charges a fee for the upgrade task if this is desirable.
+    /// Charges a fee for the upgrade task if this is desirable, and returns
+    /// the to-be-expected UTXO associated with this fee.
     pub(crate) async fn upgrade(
         self,
         triton_vm_job_queue: Arc<TritonVmJobQueue>,
@@ -720,16 +730,16 @@ impl UpgradeJob {
         own_wallet_entropy: &WalletEntropy,
         current_block_height: BlockHeight,
         fee_notification_medium: UtxoNotificationMedium,
-    ) -> anyhow::Result<(Transaction, Vec<ExpectedUtxo>)> {
+    ) -> anyhow::Result<(Transaction, Option<ExpectedUtxo>)> {
         let gobble_data = self.gobble_data();
         let mutator_set = self.mutator_set();
         let old_tx_timestamp = self.old_tx_timestamp();
         let network = proof_job_options.job_settings.network();
         let consensus_rule_set = ConsensusRuleSet::infer_from(network, current_block_height);
 
-        let (maybe_gobbler, expected_utxos) =
+        let (maybe_gobbler, gobbler_expected_utxo) =
             if let Some((gobble_amt, gobble_receiver, receiver_preimage)) = gobble_data {
-                let (gobbler, eutxos) = Self::build_gobbler(
+                let (gobbler, gobbler_eutxo) = Self::build_gobbler(
                     gobble_amt,
                     gobble_receiver,
                     receiver_preimage,
@@ -742,9 +752,9 @@ impl UpgradeJob {
                 )
                 .await?;
 
-                (Some(gobbler), eutxos)
+                (Some(gobbler), gobbler_eutxo)
             } else {
-                (None, vec![])
+                (None, None)
             };
 
         let mut rng: StdRng =
@@ -788,7 +798,7 @@ impl UpgradeJob {
                     upgraded_tx
                 };
 
-                Ok((tx, expected_utxos))
+                Ok((tx, gobbler_expected_utxo))
             }
             UpgradeJob::Merge {
                 left_kernel,
@@ -818,13 +828,13 @@ impl UpgradeJob {
                 .await?;
                 info!("Proof-upgrader, merge: Done");
 
-                Ok((ret, expected_utxos))
+                Ok((ret, gobbler_expected_utxo))
             }
             UpgradeJob::PrimitiveWitnessToProofCollection(pw_to_pc) => Ok((
                 pw_to_pc
                     .upgrade(triton_vm_job_queue.clone(), &proof_job_options)
                     .await?,
-                expected_utxos,
+                gobbler_expected_utxo,
             )),
             UpgradeJob::PrimitiveWitnessToSingleProof(pw_to_sp) => Ok((
                 pw_to_sp
@@ -834,13 +844,13 @@ impl UpgradeJob {
                         consensus_rule_set,
                     )
                     .await?,
-                expected_utxos,
+                gobbler_expected_utxo,
             )),
             UpgradeJob::UpdateMutatorSetData(update_job) => {
                 let ret = update_job
                     .upgrade(triton_vm_job_queue, proof_job_options)
                     .await?;
-                Ok((ret, expected_utxos))
+                Ok((ret, gobbler_expected_utxo))
             }
         }
     }

--- a/neptune-core/src/state/mempool_tests.rs
+++ b/neptune-core/src/state/mempool_tests.rs
@@ -1483,6 +1483,67 @@ mod tests {
                 "Only one match from mutually exclusive filters"
             );
         }
+
+        /// Issue #946: a `ProofCollection`-backed transaction without a
+        /// primitive witness must be *kept* in the mempool when a new block
+        /// arrives, and must remain selectable for proof-upgrading
+        /// even though it is now unsynced.
+        #[apply(shared_tokio_runtime)]
+        async fn unsynced_proof_collection_is_kept_and_upgradable_after_new_block() {
+            let network = Network::Testnet(42);
+            let fee = NativeCurrencyAmount::coins(1);
+            let pc_tx =
+                genesis_tx_with_proof_type(TxProvingCapability::ProofCollection, network, fee)
+                    .await;
+            let txid = pc_tx.kernel.txid();
+
+            let mut rng = rand::rng();
+            let genesis_block = Block::genesis(network);
+            let mut mempool = Mempool::new(
+                ByteSize::gb(1),
+                TxProvingCapability::SingleProof,
+                &genesis_block,
+            );
+            mempool.insert(pc_tx.into(), UpgradePriority::Irrelevant);
+
+            assert_eq!(1, mempool.len());
+
+            // While synced, the ProofCollection is selectable for a raise.
+            assert!(mempool
+                .preferred_proof_collection(usize::MAX, TxUpgradeFilter::match_all())
+                .is_some());
+
+            // A new, non-conflicting block arrives, making the transaction
+            // unsynced.
+            let block1 = fake_valid_successor_for_tests(
+                &genesis_block,
+                genesis_block.header().timestamp + Timestamp::hours(1),
+                rng.random(),
+                network,
+            )
+            .await;
+            let (_events, update_jobs) = mempool.update_with_block(&block1).unwrap();
+
+            // The transaction is retained rather than kicked out ...
+            assert!(
+                mempool.contains(txid),
+                "Non-conflicting ProofCollection tx must survive a new block (#946a)"
+            );
+
+            // ... and, lacking a primitive witness, produces no block-update job.
+            assert!(
+                update_jobs.is_empty(),
+                "no update job is produced without a primitive witness"
+            );
+
+            // (b) Although now unsynced, it is still returned for proof-upgrading.
+            assert!(
+                mempool
+                    .preferred_proof_collection(usize::MAX, TxUpgradeFilter::match_all())
+                    .is_some(),
+                "unsynced ProofCollection must still be upgradable (#946b)"
+            );
+        }
     }
 
     mod proof_quality_tests {

--- a/neptune-mempool/src/mempool.rs
+++ b/neptune-mempool/src/mempool.rs
@@ -57,7 +57,6 @@ use priority_queue::priority_queue::iterators::IntoSortedIter as SingleEndedIter
 use tasm_lib::prelude::Digest;
 use tracing::debug;
 use tracing::error;
-use tracing::warn;
 
 use crate::mempool_event::MempoolEvent;
 use crate::mempool_update_job::MempoolUpdateJob;
@@ -448,7 +447,10 @@ impl Mempool {
     /// mempool has been deemed to have a financial interest in the transaction,
     /// in which case the filter is ignored.
     ///
-    /// Will only return transactions that are synced to the latest tip.
+    /// May return transactions that are *not* synced to the latest tip. Raising
+    /// a `ProofCollection` to a `SingleProof` does not depend on the mutator
+    /// set, so an unsynced `ProofCollection` can be raised and then cheaply
+    /// updated to the current tip afterwards.
     ///
     /// Also returns the upgrade priority of this transactions, for the node
     /// operator.
@@ -463,9 +465,6 @@ impl Mempool {
             .chain(self.fee_density_iter().map(|(txid, _)| txid))
         {
             let candidate = self.tx_dictionary.get(&candidate_txid).unwrap();
-            if !self.tx_is_synced(&candidate.transaction.kernel) {
-                continue;
-            }
 
             let TransactionProof::ProofCollection(proof_collection) = &candidate.transaction.proof
             else {
@@ -1272,27 +1271,29 @@ impl Mempool {
         let mut update_jobs = vec![];
         let mut kick_outs = Vec::with_capacity(self.tx_dictionary.len());
         for (tx_id, tx) in &self.tx_dictionary {
+            // Transactions without inputs are always kicked out of the mempool,
+            // as they cannot be updated. All other transactions are kept in the
+            // mempool and only removed once they become double-spends (one of
+            // their inputs were mined), or they expire (their age exceeds a
+            // threshold).
             if tx.transaction.kernel.inputs.is_empty() {
                 debug!("Not updating transaction since empty transactions cannot be updated.");
                 kick_outs.push(*tx_id);
                 continue;
             }
 
-            let (update_job, keep_in_mempool) = match &tx.transaction.proof {
+            let update_job = match &tx.transaction.proof {
                 // Proof-collection backed transaction cannot be updated
                 // directly. But if the transaction was initiated locally, the
-                // primitive witness will be known, and it can be updated. Also,
-                // if the proof collection is first upgraded to a SingleProof,
-                // and then update, it could also become synced again that way.
-                // So we could consider keeping PC-backed transactions around
-                // even if we don't have the primitive witness.
+                // primitive witness will be known, and it can be updated to the
+                // new mutator set immediately.
                 TransactionProof::ProofCollection(_) => {
                     if let Some(pw) = &tx.primitive_witness {
                         let pw_update_job = PrimitiveWitnessUpdate::new(pw.to_owned());
                         let pw_update_job = MempoolUpdateJob::ProofCollection(pw_update_job);
-                        (Some(pw_update_job), true)
+                        Some(pw_update_job)
                     } else {
-                        (None, false)
+                        None
                     }
                 }
 
@@ -1300,23 +1301,12 @@ impl Mempool {
                 TransactionProof::Witness(pw) => {
                     let pw_update_job = PrimitiveWitnessUpdate::new(pw.to_owned());
                     let pw_update_job = MempoolUpdateJob::PrimitiveWitness(pw_update_job);
-                    (Some(pw_update_job), true)
+                    Some(pw_update_job)
                 }
 
-                // Single proofs can be updated. So they are kept in the
-                // mempool in the expectation that someone will update them to
-                // be valid under a new mutator set.
-                //
-                // If (the transaction was initiated locally, i.e. deemed
-                // critical), *and* node can produce single-proofs, transaction
+                // If the transaction was initiated locally, i.e. deemed
+                // critical, *and* node can produce single-proofs, transaction
                 // should be updated immediately (and be kept in mempool).
-                //
-                // Note: Do not check for the presence of a primitive witness.
-                // This information is irrelevant for Update tasks and moreover
-                // not always present for critical transactions. For instance:
-                // the edge case in which the transaction was merged (the
-                // primitive witness is dropped) but the merge-sibling was mined
-                // (the current transaction is retrieved from cache).
                 TransactionProof::SingleProof(sp) => {
                     if self.tx_proving_capability == TxProvingCapability::SingleProof
                         && tx.upgrade_priority == UpgradePriority::Critical
@@ -1327,24 +1317,15 @@ impl Mempool {
                             old_single_proof: sp.to_owned(),
                         };
 
-                        (Some(update_sp), true)
+                        Some(update_sp)
                     } else {
-                        (None, true)
+                        None
                     }
                 }
             };
 
             if let Some(update_job) = update_job {
                 update_jobs.push(update_job);
-            }
-
-            if !keep_in_mempool {
-                kick_outs.push(*tx_id);
-                if !tx.upgrade_priority.is_irrelevant() {
-                    warn!(
-                        "Unable to update own transaction to new mutator set. You may need to create this transaction again. Removing {tx_id} from mempool."
-                    );
-                }
             }
         }
 


### PR DESCRIPTION
Changes
1. It makes the transaction flicker in-and-out of the mempool giving a bad user experience
2. The update part is cheap. Anyone performing a "raise" operation (`ProofCollection`->`SingleProof`) can just follow it up by an "update" operation. So the proof upgraders should keep outdated `ProofCollection` transactions in their mempool.
