### PR TITLE
Recover guesser rewards to all spending keys

### DIFF
--- a/neptune-consensus/src/block/guesser_receiver_data.rs
+++ b/neptune-consensus/src/block/guesser_receiver_data.rs
@@ -5,8 +5,19 @@ use tasm_lib::prelude::Digest;
 use tasm_lib::prelude::TasmObject;
 use tasm_lib::twenty_first::math::bfield_codec::BFieldCodec;
 
+/// Public data in a block header, dictating where the guesser reward goes
 #[derive(
-    Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, BFieldCodec, TasmObject, GetSize,
+    Copy,
+    Clone,
+    Debug,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    Hash,
+    BFieldCodec,
+    TasmObject,
+    GetSize,
 )]
 #[cfg_attr(
     any(test, feature = "arbitrary-impls"),

--- a/neptune-core/benchmark/benches/wallet_state.rs
+++ b/neptune-core/benchmark/benches/wallet_state.rs
@@ -7,6 +7,7 @@ use neptune_primitives::network::Network;
 use neptune_primitives::timestamp::Timestamp;
 use neptune_wallet::address::KeyType;
 use neptune_wallet::utxo_notification::UtxoNotificationMedium;
+use strum::IntoEnumIterator;
 
 fn main() {
     divan::main();
@@ -133,6 +134,48 @@ mod wallet_state {
     #[divan::bench(sample_count = 10)]
     fn set_new_tip_1000_4(bencher: Bencher) {
         set_new_tip::<1000, 4>(bencher);
+    }
+
+    /// Like [`set_new_tip`], but first fills the wallet with many keys of every
+    /// type. This exercises the per-key scanning in
+    /// `update_wallet_state_with_new_block` (the guesser-fee and announced-UTXO
+    /// scans), guarding against O(num_keys) regressions there — e.g. deriving
+    ///  an address per key per block.
+    fn set_new_tip_many_keys<
+        const NUM_OUTPUTS_PER_TX: usize,
+        const NUM_BLOCKS: usize,
+        const NUM_KEYS_PER_TYPE: u64,
+    >(
+        bencher: Bencher,
+    ) {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let (mut global_state, _) = rt.block_on(setup::<NUM_OUTPUTS_PER_TX, NUM_BLOCKS>());
+        let mut global_state = rt.block_on(global_state.lock_guard_mut());
+
+        // Populate the wallet with NUM_KEYS_PER_TYPE keys of every type.
+        rt.block_on(async {
+            for key_type in KeyType::iter() {
+                global_state
+                    .wallet_state
+                    .bump_derivation_index(key_type, NUM_KEYS_PER_TYPE - 1)
+                    .await;
+            }
+        });
+
+        let next_block = rt.block_on(next_block(&mut global_state, NUM_OUTPUTS_PER_TX));
+
+        bencher.bench_local(|| {
+            rt.block_on(global_state.set_new_tip(next_block.clone()))
+                .unwrap();
+        });
+    }
+
+    #[divan::bench(sample_count = 10)]
+    fn set_new_tip_100_2_1000keys(bencher: Bencher) {
+        // 1000 keys of each of the 4 types = 4000 keys. Sized so a reintroduced
+        // per-key address derivation (lattice keygen ~14us) in the block-update
+        // scans is a clear (~+30%) slowdown here, not lost in the fixed cost.
+        set_new_tip_many_keys::<100, 2, 1000>(bencher);
     }
 
     #[divan::bench(sample_count = 10)]

--- a/neptune-core/src/application/loops/main_loop.rs
+++ b/neptune-core/src/application/loops/main_loop.rs
@@ -2189,7 +2189,7 @@ impl MainLoopHandler {
                         .await
                         .wallet_state
                         .get_all_known_spending_keys()
-                        .map(|key| (key.to_address().into(), key.privacy_preimage()))
+                        .map(|key| (key.guesser_receiver_data(), key.privacy_preimage()))
                         .collect();
                     let mut state = global_state_lock.lock_guard_mut().await;
                     let _ = state

--- a/neptune-core/src/application/loops/main_loop.rs
+++ b/neptune-core/src/application/loops/main_loop.rs
@@ -15,6 +15,7 @@ use anyhow::Result;
 use itertools::Either;
 use itertools::Itertools;
 use libp2p::PeerId;
+use neptune_consensus::block::guesser_receiver_data::GuesserReceiverData;
 use neptune_consensus::block::Block;
 use neptune_consensus::proof_abstractions::tasm::program::TritonVmProofJobOptions;
 use neptune_consensus::proof_abstractions::triton_vm_job_queue::vm_job_queue;
@@ -2180,8 +2181,20 @@ impl MainLoopHandler {
 
                 let mut global_state_lock = self.global_state_lock.clone();
                 tokio::task::spawn(async move {
+                    // Derive each known key's guesser data and unlocking preimage
+                    // while holding only a read lock, so the write lock below
+                    // covers just the database rescan.
+                    let known_guessers: HashMap<GuesserReceiverData, Digest> = global_state_lock
+                        .lock_guard()
+                        .await
+                        .wallet_state
+                        .get_all_known_spending_keys()
+                        .map(|key| (key.to_address().into(), key.privacy_preimage()))
+                        .collect();
                     let mut state = global_state_lock.lock_guard_mut().await;
-                    let _ = state.rescan_guesser_rewards(first, last).await;
+                    let _ = state
+                        .rescan_guesser_rewards(first, last, &known_guessers)
+                        .await;
 
                     // Scan for expenditures to ensure wallet doesn't
                     // erroneously count some new UTXOs as unspent.

--- a/neptune-core/src/state/mod.rs
+++ b/neptune-core/src/state/mod.rs
@@ -1091,7 +1091,12 @@ impl GlobalState {
     ///
     /// # Panics
     /// - If start block height is greater than end block height
-    pub(crate) async fn rescan_guesser_rewards(&mut self, first: BlockHeight, last: BlockHeight) {
+    pub(crate) async fn rescan_guesser_rewards(
+        &mut self,
+        first: BlockHeight,
+        last: BlockHeight,
+        known_guessers: &HashMap<GuesserReceiverData, Digest>,
+    ) {
         let first: u64 = first.into();
         let last: u64 = last.into();
         assert!(
@@ -1099,10 +1104,6 @@ impl GlobalState {
             "Must call function with a non-empty range. Got range: {first}..={last}."
         );
 
-        let own_guesser_key: SpendingKey =
-            self.wallet_state.wallet_entropy.guesser_fee_key().into();
-        let own_guesser_data: GuesserReceiverData = own_guesser_key.to_address().into();
-        let receiver_preimage = own_guesser_key.privacy_preimage();
         let num_mps_per_mutxo = self.cli().number_of_mps_per_utxo;
 
         let mut recovery_list = vec![];
@@ -1126,10 +1127,11 @@ impl GlobalState {
                 .await
                 .expect("Must have block header for canonical block");
 
-            if !block_header.was_guessed_by(&own_guesser_data) {
+            let Some(&receiver_preimage) = known_guessers.get(&block_header.guesser_receiver_data)
+            else {
                 trace!("block {block_height} not guessed by us.");
                 continue;
-            }
+            };
 
             // Check if the two guesser rewards have already been added to the
             // wallet.
@@ -3609,19 +3611,22 @@ mod tests {
 
             // All incoming UTXOs must be registered before handling the spending of
             // UTXOs, otherwise spends will not be registered.
-            self.rescan_guesser_rewards(first, last).await;
+            let known_keys: Vec<SpendingKey> =
+                self.wallet_state.get_all_known_spending_keys().collect();
+            let known_guessers: HashMap<GuesserReceiverData, Digest> = known_keys
+                .iter()
+                .map(|key| (key.to_address().into(), key.privacy_preimage()))
+                .collect();
+            self.rescan_guesser_rewards(first, last, &known_guessers)
+                .await;
 
-            let all_keys = self
-                .wallet_state
-                .get_all_known_spending_keys()
-                .collect_vec();
             match announcement_scan_mode {
                 AnnouncementScanMode::Range => {
-                    self.rescan_announced_incoming(all_keys, first, last)
+                    self.rescan_announced_incoming(known_keys, first, last)
                         .await?
                 }
                 AnnouncementScanMode::FlagIndex => {
-                    self.rescan_announced_incoming_from_flag_index(all_keys, first, last)
+                    self.rescan_announced_incoming_from_flag_index(known_keys, first, last)
                         .await?
                 }
             }
@@ -4474,6 +4479,8 @@ mod tests {
     }
 
     mod rescan_wallet {
+        use strum::IntoEnumIterator;
+
         use super::*;
         use crate::tests::shared::blocks::block_with_outputs;
         use crate::tests::shared::blocks::invalid_empty_block1_with_guesser_fraction;
@@ -4659,8 +4666,14 @@ mod tests {
                     .confirmed_available_balance(block1.header().height, balance_timestamp),
                 "Must have zero balance after clearing monitored UTXOs"
             );
+
+            let known_guessers: HashMap<GuesserReceiverData, Digest> = alice
+                .wallet_state
+                .get_all_known_spending_keys()
+                .map(|key| (key.to_address().into(), key.privacy_preimage()))
+                .collect();
             alice
-                .rescan_guesser_rewards(0u64.into(), 15u64.into())
+                .rescan_guesser_rewards(0u64.into(), 15u64.into(), &known_guessers)
                 .await;
             alice
                 .restore_monitored_utxos_from_archival_mutator_set()
@@ -4673,6 +4686,64 @@ mod tests {
                     .confirmed_available_balance(block1.header().height, balance_timestamp),
                 "Must have liquid balance of 64 after rescan of guesser rewards"
             );
+        }
+
+        #[traced_test]
+        #[apply(shared_tokio_runtime)]
+        async fn rescan_guesser_rewards_recovers_reward_locked_to_any_wallet_key() {
+            let network = Network::Main;
+            let cli_args = cli_args::Args {
+                network,
+                ..Default::default()
+            };
+            let mut alice =
+                mock_genesis_global_state(0, WalletEntropy::new_random(), cli_args.clone()).await;
+            let mut alice = alice.lock_guard_mut().await;
+
+            // Guess the block with one of the wallet's keys that is *not* the
+            // dedicated guesser-fee key, as happens with a custom mining address.
+            for key_type in KeyType::iter() {
+                let other_key = alice.wallet_state.next_unused_spending_key(key_type).await;
+
+                let guesser_fraction = 1f64;
+                let mut block1 =
+                    invalid_empty_block1_with_guesser_fraction(network, guesser_fraction).await;
+                block1.set_header_guesser_data(other_key.to_address().into());
+                alice.set_new_tip(block1.clone()).await.unwrap();
+
+                let balance_timestamp = alice.chain.tip().header().timestamp;
+                let expected_balance = NativeCurrencyAmount::coins(64);
+
+                alice.wallet_state.wallet_db.clear_mutxos().await;
+                assert_eq!(
+                    NativeCurrencyAmount::zero(),
+                    alice
+                        .get_wallet_status_for_tip()
+                        .await
+                        .confirmed_available_balance(block1.header().height, balance_timestamp),
+                    "Must have zero balance after clearing monitored UTXOs"
+                );
+
+                let known_guessers: HashMap<GuesserReceiverData, Digest> = alice
+                    .wallet_state
+                    .get_all_known_spending_keys()
+                    .map(|key| (key.to_address().into(), key.privacy_preimage()))
+                    .collect();
+                alice
+                    .rescan_guesser_rewards(0u64.into(), 15u64.into(), &known_guessers)
+                    .await;
+                alice
+                    .restore_monitored_utxos_from_archival_mutator_set()
+                    .await;
+                assert_eq!(
+                    expected_balance,
+                    alice
+                        .get_wallet_status_for_tip()
+                        .await
+                        .confirmed_available_balance(block1.header().height, balance_timestamp),
+                    "Rescan must recover a guesser reward locked to any wallet key"
+                );
+            }
         }
 
         #[traced_test]

--- a/neptune-core/src/state/mod.rs
+++ b/neptune-core/src/state/mod.rs
@@ -3615,7 +3615,7 @@ mod tests {
                 self.wallet_state.get_all_known_spending_keys().collect();
             let known_guessers: HashMap<GuesserReceiverData, Digest> = known_keys
                 .iter()
-                .map(|key| (key.to_address().into(), key.privacy_preimage()))
+                .map(|key| (key.guesser_receiver_data(), key.privacy_preimage()))
                 .collect();
             self.rescan_guesser_rewards(first, last, &known_guessers)
                 .await;
@@ -4670,7 +4670,7 @@ mod tests {
             let known_guessers: HashMap<GuesserReceiverData, Digest> = alice
                 .wallet_state
                 .get_all_known_spending_keys()
-                .map(|key| (key.to_address().into(), key.privacy_preimage()))
+                .map(|key| (key.guesser_receiver_data(), key.privacy_preimage()))
                 .collect();
             alice
                 .rescan_guesser_rewards(0u64.into(), 15u64.into(), &known_guessers)
@@ -4727,7 +4727,7 @@ mod tests {
                 let known_guessers: HashMap<GuesserReceiverData, Digest> = alice
                     .wallet_state
                     .get_all_known_spending_keys()
-                    .map(|key| (key.to_address().into(), key.privacy_preimage()))
+                    .map(|key| (key.guesser_receiver_data(), key.privacy_preimage()))
                     .collect();
                 alice
                     .rescan_guesser_rewards(0u64.into(), 15u64.into(), &known_guessers)

--- a/neptune-core/src/state/wallet/wallet_state.rs
+++ b/neptune-core/src/state/wallet/wallet_state.rs
@@ -748,21 +748,26 @@ impl WalletState {
         &'a self,
         tx_kernel: &'a TransactionKernel,
     ) -> impl Iterator<Item = IncomingUtxo> + 'a {
-        // scan for announced utxos for every known key of every key type.
-        self.get_all_known_spending_keys()
-            .flat_map(|key| key.scan_for_announced_utxos(tx_kernel))
-            .filter(|au| {
-                let transaction_contains_addition_record =
-                    tx_kernel.outputs.contains(&au.addition_record());
-                if !transaction_contains_addition_record {
-                    warn!(
-                        "Transaction does not contain announced UTXO encrypted \
+        // Match every announcement against every known key in
+        // O(keys + announcements), rather than scanning all announcements once
+        // per key.
+        SpendingKey::scan_announcements_for_keys(
+            &tx_kernel.announcements,
+            self.get_all_known_spending_keys(),
+        )
+        .into_iter()
+        .filter(|au| {
+            let transaction_contains_addition_record =
+                tx_kernel.outputs.contains(&au.addition_record());
+            if !transaction_contains_addition_record {
+                warn!(
+                    "Transaction does not contain announced UTXO encrypted \
                         to own receiving address. Announced UTXO was: {:#?}",
-                        au.utxo
-                    );
-                }
-                transaction_contains_addition_record
-            })
+                    au.utxo
+                );
+            }
+            transaction_contains_addition_record
+        })
     }
 
     /// Scan the given transaction for announced UTXOs as recognized by *future*

--- a/neptune-core/src/state/wallet/wallet_state.rs
+++ b/neptune-core/src/state/wallet/wallet_state.rs
@@ -875,7 +875,7 @@ impl WalletState {
     ) -> impl Iterator<Item = IncomingUtxo> + 'a {
         let guessing_key = self
             .get_all_known_spending_keys()
-            .find(|key| block.header().was_guessed_by(&key.to_address().into()));
+            .find(|key| block.header().was_guessed_by(&key.guesser_receiver_data()));
 
         let incoming_utxos = if let Some(key) = guessing_key {
             let sender_randomness = block.hash();

--- a/neptune-core/src/state/wallet/wallet_state.rs
+++ b/neptune-core/src/state/wallet/wallet_state.rs
@@ -861,18 +861,25 @@ impl WalletState {
 
     /// Scan the block for guesser fee UTXOs that this wallet can unlock.
     ///
-    /// Return an iterator over them, which is empty if the block was guessed by
-    /// some other wallet.
-    pub(crate) fn scan_for_guesser_fee_utxos<'a>(
+    /// A block's guesser reward is locked to the miner's chosen address. That is
+    /// the dedicated guesser-fee key by default, but it can be any address —
+    /// including any of this wallet's other keys — when a custom mining address
+    /// is configured. So all known spending keys are checked, not just the
+    /// guesser-fee key.
+    ///
+    /// Return an iterator over the unlockable UTXOs, which is empty if the
+    /// block was guessed by an address none of this wallet's keys can unlock.
+    fn scan_for_guesser_fee_utxos<'a>(
         &'a self,
         block: &Block,
     ) -> impl Iterator<Item = IncomingUtxo> + 'a {
-        let own_guesser_key = self.wallet_entropy.guesser_fee_key();
-        let was_guessed_by_us = block
-            .header()
-            .was_guessed_by(&own_guesser_key.to_address().into());
-        let incoming_utxos = if was_guessed_by_us {
+        let guessing_key = self
+            .get_all_known_spending_keys()
+            .find(|key| block.header().was_guessed_by(&key.to_address().into()));
+
+        let incoming_utxos = if let Some(key) = guessing_key {
             let sender_randomness = block.hash();
+            let receiver_preimage = key.privacy_preimage();
             block
                 .kernel
                 .guesser_fee_utxos()
@@ -881,7 +888,7 @@ impl WalletState {
                 .map(|utxo| IncomingUtxo {
                     utxo,
                     sender_randomness,
-                    receiver_preimage: own_guesser_key.receiver_preimage(),
+                    receiver_preimage,
                     is_guesser_fee: true,
                 })
                 .collect_vec()
@@ -3478,7 +3485,7 @@ pub(crate) mod tests {
             let network = Network::Main;
             let mut rng = rng();
             let cli_args = cli_args::Args::default_with_network(network);
-            let wallet_state =
+            let mut wallet_state =
                 mock_genesis_wallet_state(WalletEntropy::new_random(), &cli_args).await;
             let composer_key = wallet_state.wallet_entropy.nth_generation_spending_key(0);
             let genesis_block = Block::genesis(network);
@@ -3495,7 +3502,7 @@ pub(crate) mod tests {
                     .count()
             );
 
-            // our lucky guess -> guesser fees detected
+            // our lucky guess with the dedicated guesser-fee key -> detected
             let own = wallet_state.wallet_entropy.guesser_fee_key().to_address();
             incoming_block.set_header_guesser_data(own.into());
             assert_eq!(
@@ -3504,6 +3511,19 @@ pub(crate) mod tests {
                     .scan_for_guesser_fee_utxos(&incoming_block)
                     .count()
             );
+
+            // guessed with a *different* one of our keys (as happens with a
+            // custom mining address) -> still detected
+            for key_type in KeyType::iter() {
+                let other_key = wallet_state.next_unused_spending_key(key_type).await;
+                incoming_block.set_header_guesser_data(other_key.to_address().into());
+                assert_eq!(
+                    2,
+                    wallet_state
+                        .scan_for_guesser_fee_utxos(&incoming_block)
+                        .count()
+                );
+            }
         }
     }
 

--- a/neptune-wallet/src/address/addressable_key.rs
+++ b/neptune-wallet/src/address/addressable_key.rs
@@ -243,7 +243,12 @@ impl SpendingKey {
     }
 
     pub fn lock_script_hash(&self) -> Digest {
-        self.lock_script().hash()
+        match self {
+            SpendingKey::Generation(k) => k.lock_script_hash(),
+            SpendingKey::Symmetric(k) => k.lock_script_hash(),
+            SpendingKey::EcHybrid(k) => k.lock_script_hash(),
+            SpendingKey::ViewingAddressKey(k) => k.lock_script_hash(),
+        }
     }
 
     /// The [`GuesserReceiverData`] that locks a block's guesser-fee reward to
@@ -471,6 +476,43 @@ mod tests {
                 KeyType::ViewingAddress => {
                     viewing_address::ViewingAddressKey::from_seed(seed).into()
                 }
+            }
+        }
+    }
+
+    #[test]
+    fn cached_lock_script_hash_matches_freshly_built() {
+        for seed in [Digest::default(), Digest::default().hash()] {
+            for key_type in KeyType::iter() {
+                let key = SpendingKey::from_seed(seed, key_type);
+                assert_eq!(
+                    key.lock_script().hash(),
+                    key.lock_script_hash(),
+                    "cached lock_script_hash must match freshly built hash for {key_type}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn key_serialization_is_seed_only() {
+        // Guards wallet-database compatibility: the cached fields are derived
+        // from the seed and must never appear in the serialized form.
+        // Each key must serialize to exactly its seed, so on-disk
+        // representations are unchanged by the caching.
+        for seed in [Digest::default(), Digest::default().hash()] {
+            let seed_bytes = bincode::serialize(&seed).unwrap();
+            for key_type in KeyType::iter() {
+                let key_bytes = match SpendingKey::from_seed(seed, key_type) {
+                    SpendingKey::Generation(k) => bincode::serialize(&k).unwrap(),
+                    SpendingKey::Symmetric(k) => bincode::serialize(&k).unwrap(),
+                    SpendingKey::EcHybrid(k) => bincode::serialize(&k).unwrap(),
+                    SpendingKey::ViewingAddressKey(k) => bincode::serialize(&k).unwrap(),
+                };
+                assert_eq!(
+                    seed_bytes, key_bytes,
+                    "{key_type} key must serialize to exactly its seed"
+                );
             }
         }
     }

--- a/neptune-wallet/src/address/addressable_key.rs
+++ b/neptune-wallet/src/address/addressable_key.rs
@@ -1,5 +1,6 @@
 use anyhow::bail;
 use anyhow::Result;
+use neptune_consensus::block::guesser_receiver_data::GuesserReceiverData;
 use neptune_consensus::transaction::announcement::Announcement;
 use neptune_consensus::transaction::lock_script::LockScript;
 use neptune_consensus::transaction::lock_script::LockScriptAndWitness;
@@ -243,6 +244,20 @@ impl SpendingKey {
         self.lock_script().hash()
     }
 
+    /// The [`GuesserReceiverData`] that locks a block's guesser-fee reward to
+    /// this key.
+    ///
+    /// Equivalent to `GuesserReceiverData::from(self.to_address())`, but derived
+    /// straight from the key's hash-based lock and receiver preimage — avoiding
+    /// the expensive lattice-KEM key derivation performed by
+    /// [`Self::to_address`], for generation keys.
+    pub fn guesser_receiver_data(&self) -> GuesserReceiverData {
+        GuesserReceiverData {
+            receiver_digest: self.privacy_preimage().hash(),
+            lock_script_hash: self.lock_script_hash(),
+        }
+    }
+
     /// Return the privacy preimage if this spending key has a corresponding
     /// receiving address.
     ///
@@ -416,6 +431,20 @@ mod tests {
             let as_str = v.to_string();
             println!("as_str: {as_str}");
             assert_eq!(v, KeyType::from_str(&as_str).unwrap());
+        }
+    }
+
+    #[test]
+    fn guesser_receiver_data_matches_address_derivation() {
+        for seed in [Digest::default(), Digest::default().hash()] {
+            for key_type in KeyType::iter() {
+                let key = SpendingKey::from_seed(seed, key_type);
+                assert_eq!(
+                    GuesserReceiverData::from(key.to_address()),
+                    key.guesser_receiver_data(),
+                    "guesser_receiver_data mismatch for {key_type:?}",
+                );
+            }
         }
     }
 

--- a/neptune-wallet/src/address/addressable_key.rs
+++ b/neptune-wallet/src/address/addressable_key.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use anyhow::bail;
 use anyhow::Result;
 use neptune_consensus::block::guesser_receiver_data::GuesserReceiverData;
@@ -363,6 +365,74 @@ impl SpendingKey {
                     is_guesser_fee: false,
                 }
             }).collect()
+    }
+
+    /// Scan a transaction's announcements for UTXOs decryptable by any of the
+    /// given keys.
+    ///
+    /// Equivalent to calling [`Self::scan_for_announced_utxos`] for each key and
+    /// concatenating the results, but runs in `O(keys + announcements)` rather
+    /// than `O(keys × announcements)`: an announcement names exactly one key via
+    /// its receiver identifier, so the keys are indexed by that identifier and
+    /// each announcement is matched with a single lookup.
+    ///
+    /// Does not verify that the announced UTXOs are actually outputs of the
+    /// transaction; that is the caller's responsibility.
+    pub fn scan_announcements_for_keys(
+        announcements: &[Announcement],
+        keys: impl IntoIterator<Item = SpendingKey>,
+    ) -> Vec<IncomingUtxo> {
+        // Index the keys by receiver identifier. A single identifier mapping to
+        // more than one key is astronomically unlikely but handled for
+        // correctness.
+        let mut keys_by_receiver_id: HashMap<BFieldElement, Vec<SpendingKey>> = HashMap::new();
+        for key in keys {
+            keys_by_receiver_id
+                .entry(key.receiver_identifier())
+                .or_default()
+                .push(key);
+        }
+
+        let mut incoming_utxos = vec![];
+        for announcement in announcements {
+            let Ok(receiver_identifier) =
+                common::receiver_identifier_from_announcement(announcement)
+            else {
+                continue;
+            };
+            let Some(candidate_keys) = keys_by_receiver_id.get(&receiver_identifier) else {
+                continue;
+            };
+            for key in candidate_keys {
+                if let Some(incoming_utxo) = key.incoming_utxo_from_announcement(announcement) {
+                    incoming_utxos.push(incoming_utxo);
+                    // An announcement encrypts a UTXO to a single key.
+                    break;
+                }
+            }
+        }
+
+        incoming_utxos
+    }
+
+    /// Decrypt a single announcement with this key, if it is of this key's type
+    /// and decryptable.
+    ///
+    /// The caller is responsible for having matched the announcement's receiver
+    /// identifier to this key (see [`Self::scan_announcements_for_keys`]); this
+    /// method only checks the key-type flag and attempts decryption.
+    fn incoming_utxo_from_announcement(&self, announcement: &Announcement) -> Option<IncomingUtxo> {
+        if !self.matches_announcement_key_type(announcement) {
+            return None;
+        }
+        let ciphertext = self.ok_warn(common::ciphertext_from_announcement(announcement))?;
+        let (utxo, sender_randomness) = self.ok_warn(self.decrypt(&ciphertext))?;
+        Some(IncomingUtxo {
+            utxo,
+            sender_randomness,
+            receiver_preimage: self.privacy_preimage(),
+            is_guesser_fee: false,
+        })
     }
 
     /// converts a result into an Option and logs a warning on any error

--- a/neptune-wallet/src/address/elliptic_curve_hybrid.rs
+++ b/neptune-wallet/src/address/elliptic_curve_hybrid.rs
@@ -94,6 +94,8 @@ pub struct EcHybridKey {
     receiver_preimage: Digest,
 
     unlock_key_preimage: Digest,
+
+    lock_script_hash: Digest,
 }
 
 impl EcHybridKey {
@@ -125,14 +127,23 @@ impl EcHybridKey {
         let ec_public_key = ec_secret_key.public_key();
         let receiver_identifier = receiver_id(&ec_public_key);
 
-        Self {
+        let mut key = Self {
             seed,
             receiver_identifier,
             ec_secret_key,
             ec_public_key,
             receiver_preimage,
             unlock_key_preimage,
-        }
+            lock_script_hash: Digest::default(),
+        };
+        key.lock_script_hash = key.lock_script_and_witness().program.hash();
+        key
+    }
+
+    /// The hash of this key's lock script. Cached; see the `lock_script_hash`
+    /// field.
+    pub fn lock_script_hash(&self) -> Digest {
+        self.lock_script_hash
     }
 
     pub fn viewing_key(&self) -> EcHybridViewingKey {

--- a/neptune-wallet/src/address/generation_address.rs
+++ b/neptune-wallet/src/address/generation_address.rs
@@ -66,6 +66,12 @@ pub struct GenerationSpendingKey {
 
     #[serde(skip)]
     unlock_key_preimage: Digest,
+
+    /// Cached hash of the lock script. Derived from `unlock_key_preimage`;
+    /// cached because building and hashing the lock-script program is
+    /// expensive.
+    #[serde(skip)]
+    lock_script_hash: Digest,
 }
 
 // manually impl Deserialize so we can derive all other fields from the seed.
@@ -169,6 +175,12 @@ impl GenerationSpendingKey {
         LockScriptAndWitness::standard_hash_lock_from_preimage(self.unlock_key_preimage)
     }
 
+    /// The hash of this key's lock script. Cached; see the `lock_script_hash`
+    /// field.
+    pub fn lock_script_hash(&self) -> Digest {
+        self.lock_script_hash
+    }
+
     pub fn derive_from_seed(seed: Digest) -> Self {
         let privacy_preimage =
             Tip5::hash_varlen(&[seed.values().to_vec(), vec![BFieldElement::new(0)]].concat());
@@ -178,13 +190,15 @@ impl GenerationSpendingKey {
         let (sk, _pk) = lattice::kem::keygen(randomness);
         let receiver_identifier = common::derive_receiver_id(seed);
 
-        let spending_key = Self {
+        let mut spending_key = Self {
             receiver_identifier,
             decryption_key: sk,
             receiver_preimage: privacy_preimage,
             unlock_key_preimage: unlock_key,
             seed: seed.to_owned(),
+            lock_script_hash: Digest::default(),
         };
+        spending_key.lock_script_hash = spending_key.lock_script_and_witness().program.hash();
 
         // Sanity check that spending key's receiver address can be encoded to
         // bech32m without loss of information.

--- a/neptune-wallet/src/address/symmetric_key.rs
+++ b/neptune-wallet/src/address/symmetric_key.rs
@@ -85,9 +85,40 @@ const HRP_PREFIX: &str = "nsymk";
 /// The implementation can be easily changed later if needed as the type is
 /// opaque.
 #[derive(Clone, Debug, Copy, Serialize, Deserialize, PartialEq, Eq)]
-#[cfg_attr(any(test, feature = "arbitrary-impls"), derive(Arbitrary))]
+#[serde(from = "SymmetricKeyDto", into = "SymmetricKeyDto")]
 pub struct SymmetricKey {
     seed: Digest,
+
+    // Cached hash of the lock script; building and hashing the lock-script
+    // program is expensive and done for every known key on every new block.
+    // Derived from the seed, so not serialized (see `SymmetricKeyDto`).
+    lock_script_hash: Digest,
+}
+
+/// Serialization helper for [`SymmetricKey`]: only the seed is stored, all
+/// other fields are re-derived on deserialization.
+#[derive(Serialize, Deserialize)]
+struct SymmetricKeyDto {
+    seed: Digest,
+}
+
+impl From<SymmetricKeyDto> for SymmetricKey {
+    fn from(dto: SymmetricKeyDto) -> Self {
+        Self::from_seed(dto.seed)
+    }
+}
+
+impl From<SymmetricKey> for SymmetricKeyDto {
+    fn from(key: SymmetricKey) -> Self {
+        Self { seed: key.seed }
+    }
+}
+
+#[cfg(any(test, feature = "arbitrary-impls"))]
+impl<'a> Arbitrary<'a> for SymmetricKey {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self::from_seed(Digest::arbitrary(u)?))
+    }
 }
 
 // future improvements: a strong argument can be made that this type should not
@@ -104,7 +135,18 @@ pub struct SymmetricKey {
 impl SymmetricKey {
     /// instantiate `SymmetricKey` from a random seed
     pub fn from_seed(seed: Digest) -> Self {
-        Self { seed }
+        let mut key = Self {
+            seed,
+            lock_script_hash: Digest::default(),
+        };
+        key.lock_script_hash = key.lock_script_and_witness().program.hash();
+        key
+    }
+
+    /// The hash of this key's lock script. Cached; see the `lock_script_hash`
+    /// field.
+    pub fn lock_script_hash(&self) -> Digest {
+        self.lock_script_hash
     }
 
     /// returns the secret key

--- a/neptune-wallet/src/address/viewing_address.rs
+++ b/neptune-wallet/src/address/viewing_address.rs
@@ -78,6 +78,10 @@ pub struct ViewingAddressKey {
     receiver_preimage: Digest,
 
     unlock_key_preimage: Digest,
+
+    // Cached hash of the lock script; building and hashing the lock-script
+    // program is expensive.
+    lock_script_hash: Digest,
 }
 
 impl ViewingAddressKey {
@@ -95,12 +99,21 @@ impl ViewingAddressKey {
         let lockscript_postimage = lock_postimage(unlock_key_preimage);
         let receiver_identifier = receiver_id(lockscript_postimage, receiver_preimage.hash());
 
-        Self {
+        let mut key = Self {
             seed,
             receiver_identifier,
             receiver_preimage,
             unlock_key_preimage,
-        }
+            lock_script_hash: Digest::default(),
+        };
+        key.lock_script_hash = key.lock_script_and_witness().program.hash();
+        key
+    }
+
+    /// The hash of this key's lock script. Cached; see the `lock_script_hash`
+    /// field.
+    pub fn lock_script_hash(&self) -> Digest {
+        self.lock_script_hash
     }
 
     pub fn to_address(&self) -> ViewingAddress {


### PR DESCRIPTION
- Fix: Check *all* spending keys for guesser rewards
- bench: Add benchmark for tracking `set_new_tip` when wallet has many keys
- perf: Various performace improvements in wallet. Most notably: cache the lock_script_hash for each key type to avoid having to reconstruct and then hash the Triton VM lock script program.