### PR TITLE
Stop using the archival mutator set as a scratch pad

### DIFF
--- a/neptune-archive/src/archival_state.rs
+++ b/neptune-archive/src/archival_state.rs
@@ -29,7 +29,6 @@ use neptune_database::NeptuneLevelDb;
 use neptune_database::WriteBatchAsync;
 use neptune_database::create_db_if_missing;
 use neptune_database::storage::storage_schema::traits::*;
-use neptune_database::storage::storage_vec::traits::StorageVecBase;
 use neptune_mutator_set::addition_record::AdditionRecord;
 use neptune_mutator_set::commit;
 use neptune_mutator_set::mutator_set_accumulator::MutatorSetAccumulator;
@@ -1798,7 +1797,7 @@ impl ArchivalState {
     /// max search depth, as it loads all the blocks in the search path into
     /// memory. A max search depth of 0 means that only the tip is checked.
     async fn mutator_set_to_tip_internal(
-        &mut self,
+        &self,
         old_ms_digest: Digest,
         old_aocl_num_leafs: Option<u64>,
         max_search_depth: usize,
@@ -1830,13 +1829,15 @@ impl ArchivalState {
                 return None;
             }
 
-            let MutatorSetUpdate {
-                removals,
-                additions,
-            } = haystack
+            let mutator_set_update = haystack
                 .mutator_set_update()
                 .expect("Block from state must have mutator set update");
-            block_mutations.push((additions, removals));
+            let predecessor_msa = parent
+                .as_ref()
+                .unwrap()
+                .mutator_set_accumulator_after()
+                .expect("Block from state must have mutator set after");
+            block_mutations.push((predecessor_msa, mutator_set_update));
 
             haystack = parent.unwrap();
             parent = self
@@ -1845,67 +1846,20 @@ impl ArchivalState {
                 .expect("Must succeed in reading block");
         };
 
-        // The removal records collected above were valid for each block but
-        // are in the general case not valid for the `mutator_set` which was
-        // given as input to this function. In order to find the right removal
-        // records, we, temporarily, roll back the state of the archival mutator
-        // set. This allows us to read out MMR-authentication paths from a
-        // previous state of the mutator set. It's crucial that these changes
-        // are not persisted, as that would leave the archival mutator set in a
-        // state incompatible with the tip.
-        self.archival_mutator_set.persist().await;
-        for (additions, removals) in &block_mutations {
-            for rr in removals.iter().rev() {
-                self.archival_mutator_set.ams_mut().revert_remove(rr).await;
-            }
-
-            for ar in additions.iter().rev() {
-                self.archival_mutator_set.ams_mut().revert_add(ar).await;
-            }
+        let timer = std::time::Instant::now();
+        let mutator_set_update = MutatorSetUpdate::compose(&block_mutations);
+        if block_mutations.len() > 1 {
+            info!(
+                "Composed mutator-set update to tip spanning {} blocks, with {} removals \
+                 and {} additions, in {:?}",
+                block_mutations.len(),
+                mutator_set_update.removals.len(),
+                mutator_set_update.additions.len(),
+                timer.elapsed(),
+            );
         }
 
-        let (mut addition_records, mut removal_records): (
-            Vec<Vec<AdditionRecord>>,
-            Vec<Vec<RemovalRecord>>,
-        ) = block_mutations.clone().into_iter().unzip();
-
-        addition_records.reverse();
-        removal_records.reverse();
-
-        let addition_records = addition_records.concat();
-        let mut removal_records = removal_records.concat();
-
-        let swbf_length = self.archival_mutator_set.ams().chunks.len().await;
-        for rr in &mut removal_records {
-            let mut removals = vec![];
-            for (chkidx, (mp, chunk)) in rr
-                .target_chunks
-                .chunk_indices_and_membership_proofs_and_leafs_iter_mut()
-            {
-                if swbf_length <= *chkidx {
-                    removals.push(*chkidx);
-                } else {
-                    *mp = self
-                        .archival_mutator_set
-                        .ams()
-                        .swbf_inactive
-                        .prove_membership_async(*chkidx)
-                        .await;
-                    *chunk = self.archival_mutator_set.ams().chunks.get(*chkidx).await;
-                }
-            }
-
-            for remove in removals {
-                rr.target_chunks.retain(|(x, _)| *x != remove);
-            }
-        }
-
-        self.archival_mutator_set.drop_unpersisted().await;
-
-        Some((
-            old_msa,
-            MutatorSetUpdate::new(removal_records, addition_records),
-        ))
+        Some((old_msa, mutator_set_update))
     }
 
     /// Returns the old mutator set matching the provided digest as well as the
@@ -1917,7 +1871,7 @@ impl ArchivalState {
     /// max search depth, as it loads all the blocks in the search path into
     /// memory. A max search depth of 0 means that only the tip is checked.
     pub async fn old_mutator_set_and_mutator_set_update_to_tip(
-        &mut self,
+        &self,
         old_mutator_set_digest: Digest,
         max_search_depth: usize,
     ) -> Option<(MutatorSetAccumulator, MutatorSetUpdate)> {
@@ -1934,7 +1888,7 @@ impl ArchivalState {
     /// max search depth, as it loads all the blocks in the search path into
     /// memory. A max search depth of 0 means that only the tip is checked.
     pub async fn get_mutator_set_update_to_tip(
-        &mut self,
+        &self,
         mutator_set: &MutatorSetAccumulator,
         max_search_depth: usize,
     ) -> Option<MutatorSetUpdate> {
@@ -2700,7 +2654,7 @@ mod tests {
     #[apply(shared_tokio_runtime)]
     async fn ms_update_to_tip_genesis() {
         let network = Network::Main;
-        let mut archival_state = make_test_archival_state(network, false).await;
+        let archival_state = make_test_archival_state(network, false).await;
         let current_msa = archival_state
             .archival_mutator_set
             .ams()
@@ -3461,7 +3415,7 @@ mod tests {
         }
 
         // Walking the opposite way returns None, and does not crash.
-        let mut genesis_archival_state = make_test_archival_state(network, false).await;
+        let genesis_archival_state = make_test_archival_state(network, false).await;
         for i in 0..10 {
             assert!(
                 genesis_archival_state
@@ -3469,6 +3423,31 @@ mod tests {
                     .await
                     .is_none()
             );
+        }
+    }
+
+    #[traced_test]
+    #[apply(shared_tokio_runtime)]
+    async fn ms_update_to_tip_across_removal_records() {
+        let network = Network::Main;
+        let mut archival_state = make_test_archival_state(network, false).await;
+
+        let genesis = Block::genesis(network);
+        let mut msas = vec![genesis.mutator_set_accumulator_after().unwrap()];
+        let mut current_block = genesis;
+
+        // The first block only adds, but enough to slide the mutator-set
+        // window; the following blocks remove UTXOs too.
+        for (num_inputs, num_outputs) in [(0, 32), (5, 33), (7, 58), (3, 0), (5, 104)] {
+            let next_block = block_with_num_puts(network, &current_block, num_inputs, num_outputs);
+            archival_state.set_new_tip(&next_block).await.unwrap();
+            msas.push(next_block.mutator_set_accumulator_after().unwrap());
+            current_block = next_block;
+        }
+
+        let search_depth = 10;
+        for past_msa in &msas {
+            positive_prop_ms_update_to_tip(past_msa, &mut archival_state, search_depth).await;
         }
     }
 

--- a/neptune-consensus/src/block/mutator_set_update.rs
+++ b/neptune-consensus/src/block/mutator_set_update.rs
@@ -186,43 +186,35 @@ impl MutatorSetUpdate {
         authenticated_items: &mut [&mut AuthenticatedItem],
     ) -> bool {
         let mut cloned_removals = self.removals.clone();
-        let mut remaining_removal_records = cloned_removals.iter_mut().rev().collect::<Vec<_>>();
-        for addition_record in &self.additions {
-            RemovalRecord::batch_update_from_addition(
-                &mut remaining_removal_records,
-                ms_accumulator,
-            );
+        {
+            let mut own_removal_records = cloned_removals.iter_mut().collect::<Vec<_>>();
+            for addition_record in &self.additions {
+                RemovalRecord::batch_update_from_addition(&mut own_removal_records, ms_accumulator);
 
-            RemovalRecord::batch_update_from_addition(removal_records, ms_accumulator);
+                RemovalRecord::batch_update_from_addition(removal_records, ms_accumulator);
 
-            AuthenticatedItem::batch_update_from_addition(
-                authenticated_items,
-                ms_accumulator,
-                *addition_record,
-            );
+                AuthenticatedItem::batch_update_from_addition(
+                    authenticated_items,
+                    ms_accumulator,
+                    *addition_record,
+                );
 
-            ms_accumulator.add(addition_record);
-        }
-
-        let mut removal_records_are_valid = true;
-        while let Some(applied_removal_record) = remaining_removal_records.pop() {
-            RemovalRecord::batch_update_from_remove(
-                &mut remaining_removal_records,
-                applied_removal_record,
-            );
-
-            RemovalRecord::batch_update_from_remove(removal_records, applied_removal_record);
-
-            AuthenticatedItem::batch_update_from_remove(
-                authenticated_items,
-                applied_removal_record,
-            );
-
-            if !ms_accumulator.can_remove(applied_removal_record) {
-                removal_records_are_valid = false;
+                ms_accumulator.add(addition_record);
             }
-            ms_accumulator.remove(applied_removal_record);
         }
+
+        let removal_records_are_valid = ms_accumulator.can_remove_all(&cloned_removals);
+
+        // Apply all removal records in one batch. The batch application
+        // produces the same accumulator, removal records and authenticated
+        // items as applying the records one at a time: the Bloom filter
+        // insertions commute.
+        RemovalRecord::batch_update_from_removals(removal_records, &cloned_removals);
+        let mut preserved_membership_proofs = authenticated_items
+            .iter_mut()
+            .map(|authenticated_item| &mut authenticated_item.ms_membership_proof)
+            .collect::<Vec<_>>();
+        ms_accumulator.batch_remove(cloned_removals, &mut preserved_membership_proofs);
 
         removal_records_are_valid
     }
@@ -283,6 +275,309 @@ mod tests {
         msa_and_records: MsaAndRecords,
     ) {
         prop_assert!(prop(msa_and_records).is_ok())
+    }
+
+    mod batch_apply {
+        use itertools::Itertools;
+        use neptune_mutator_set::authenticated_item::AuthenticatedItem;
+        use neptune_mutator_set::commit;
+        use neptune_mutator_set::msa_and_records::MsaAndRecords;
+        use neptune_mutator_set::mutator_set_accumulator::MutatorSetAccumulator;
+        use neptune_mutator_set::removal_record::absolute_index_set::AbsoluteIndexSet;
+        use neptune_mutator_set::removal_record::chunk_dictionary::ChunkDictionary;
+        use neptune_mutator_set::removal_record::RemovalRecord;
+        use neptune_mutator_set::shared::NUM_TRIALS;
+        use proptest::collection::vec;
+        use proptest::prelude::TestCaseError;
+        use proptest::prop_assert;
+        use proptest::prop_assert_eq;
+        use proptest_arbitrary_interop::arb;
+        use tasm_lib::prelude::Digest;
+        use test_strategy::proptest;
+
+        use super::MutatorSetUpdate;
+
+        /// The sequential implementation that
+        /// `apply_to_accumulator_and_records_inner` used before batch
+        /// application, kept as a reference for differential testing.
+        ///
+        /// Practially like the production code but without using the fastest
+        /// possible batch method for removal record maintanence. Weaker than
+        /// the production code since the `can_remove` check is applied in-order
+        /// here, and in an order-independent way in the production code. This
+        /// weakness can, in the consensus path, only be hit with negligible
+        /// (read: ~2^(-160)) probability. So switching to the batching-version
+        /// in the production code is technically a softfork, just one that can
+        /// only be hit with negligible probability.
+        fn sequential_apply_reference(
+            update: &MutatorSetUpdate,
+            ms_accumulator: &mut MutatorSetAccumulator,
+            removal_records: &mut [&mut RemovalRecord],
+            authenticated_items: &mut [&mut AuthenticatedItem],
+        ) -> bool {
+            let mut cloned_removals = update.removals.clone();
+            let mut remaining_removal_records =
+                cloned_removals.iter_mut().rev().collect::<Vec<_>>();
+            for addition_record in &update.additions {
+                RemovalRecord::batch_update_from_addition(
+                    &mut remaining_removal_records,
+                    ms_accumulator,
+                );
+                RemovalRecord::batch_update_from_addition(removal_records, ms_accumulator);
+                AuthenticatedItem::batch_update_from_addition(
+                    authenticated_items,
+                    ms_accumulator,
+                    *addition_record,
+                );
+                ms_accumulator.add(addition_record);
+            }
+
+            let mut removal_records_are_valid = true;
+            while let Some(applied_removal_record) = remaining_removal_records.pop() {
+                RemovalRecord::batch_update_from_remove(
+                    &mut remaining_removal_records,
+                    applied_removal_record,
+                );
+                RemovalRecord::batch_update_from_remove(removal_records, applied_removal_record);
+                AuthenticatedItem::batch_update_from_remove(
+                    authenticated_items,
+                    applied_removal_record,
+                );
+                if !ms_accumulator.can_remove(applied_removal_record) {
+                    removal_records_are_valid = false;
+                }
+                ms_accumulator.remove(applied_removal_record);
+            }
+
+            removal_records_are_valid
+        }
+
+        fn batch_and_sequential_apply_agree(
+            msa_and_records: MsaAndRecords,
+            removables: Vec<(Digest, Digest, Digest)>,
+            num_removals: usize,
+            addition_preimages: Vec<(Digest, Digest, Digest)>,
+        ) -> std::result::Result<(), TestCaseError> {
+            let all_records = msa_and_records.unpacked_removal_records();
+            let all_mps = &msa_and_records.membership_proofs;
+            let msa = &msa_and_records.mutator_set_accumulator;
+
+            let additions = addition_preimages
+                .iter()
+                .map(|(item, sender_randomness, receiver_preimage)| {
+                    commit(*item, *sender_randomness, receiver_preimage.hash())
+                })
+                .collect_vec();
+            let update = MutatorSetUpdate::new(all_records[..num_removals].to_vec(), additions);
+
+            // The records and authenticated items to be maintained through
+            // the application.
+            let preserved_records = all_records[num_removals..].to_vec();
+            let preserved_items = removables[num_removals..]
+                .iter()
+                .zip(&all_mps[num_removals..])
+                .map(|((item, _, _), ms_membership_proof)| AuthenticatedItem {
+                    item: *item,
+                    ms_membership_proof: ms_membership_proof.clone(),
+                })
+                .collect_vec();
+
+            let mut msa_batch = msa.clone();
+            let mut records_batch = preserved_records.clone();
+            let mut items_batch = preserved_items.clone();
+            let batch_result = update.apply_to_accumulator_and_records(
+                &mut msa_batch,
+                &mut records_batch.iter_mut().collect_vec(),
+                &mut items_batch.iter_mut().collect_vec(),
+            );
+
+            let mut msa_sequential = msa.clone();
+            let mut records_sequential = preserved_records.clone();
+            let mut items_sequential = preserved_items.clone();
+            let sequential_is_valid = sequential_apply_reference(
+                &update,
+                &mut msa_sequential,
+                &mut records_sequential.iter_mut().collect_vec(),
+                &mut items_sequential.iter_mut().collect_vec(),
+            );
+
+            prop_assert!(batch_result.is_ok());
+            prop_assert!(sequential_is_valid);
+            prop_assert_eq!(msa_sequential, msa_batch);
+            prop_assert_eq!(records_sequential, records_batch);
+            for (sequential, batch) in items_sequential.iter().zip(&items_batch) {
+                prop_assert_eq!(sequential.item, batch.item);
+                prop_assert_eq!(&sequential.ms_membership_proof, &batch.ms_membership_proof);
+            }
+
+            Ok(())
+        }
+
+        #[proptest(cases = 12)]
+        fn batch_apply_agrees_with_sequential_apply_u8(
+            #[strategy(1usize..10)] num_removals: usize,
+            #[strategy(1usize..6)] _num_preserved: usize,
+            #[strategy((((#num_removals + #_num_preserved) as u64))..=(u64::from(u8::MAX)))]
+            _num_leafs_aocl: u64,
+            #[strategy(vec((arb::<Digest>(), arb::<Digest>(), arb::<Digest>()), #num_removals + #_num_preserved))]
+            removables: Vec<(Digest, Digest, Digest)>,
+            #[strategy(MsaAndRecords::arbitrary_with((#removables, #_num_leafs_aocl)))]
+            msa_and_records: MsaAndRecords,
+            #[strategy(vec((arb::<Digest>(), arb::<Digest>(), arb::<Digest>()), 0usize..8))]
+            addition_preimages: Vec<(Digest, Digest, Digest)>,
+        ) {
+            prop_assert!(batch_and_sequential_apply_agree(
+                msa_and_records,
+                removables,
+                num_removals,
+                addition_preimages
+            )
+            .is_ok())
+        }
+
+        #[proptest(cases = 6)]
+        fn batch_apply_agrees_with_sequential_apply_u16(
+            #[strategy(1usize..10)] num_removals: usize,
+            #[strategy(1usize..6)] _num_preserved: usize,
+            #[strategy((((#num_removals + #_num_preserved) as u64))..=(u64::from(u16::MAX)))]
+            _num_leafs_aocl: u64,
+            #[strategy(vec((arb::<Digest>(), arb::<Digest>(), arb::<Digest>()), #num_removals + #_num_preserved))]
+            removables: Vec<(Digest, Digest, Digest)>,
+            #[strategy(MsaAndRecords::arbitrary_with((#removables, #_num_leafs_aocl)))]
+            msa_and_records: MsaAndRecords,
+            #[strategy(vec((arb::<Digest>(), arb::<Digest>(), arb::<Digest>()), 0usize..8))]
+            addition_preimages: Vec<(Digest, Digest, Digest)>,
+        ) {
+            prop_assert!(batch_and_sequential_apply_agree(
+                msa_and_records,
+                removables,
+                num_removals,
+                addition_preimages
+            )
+            .is_ok())
+        }
+
+        #[proptest(cases = 3)]
+        fn batch_apply_agrees_with_sequential_apply_u32(
+            #[strategy(1usize..10)] num_removals: usize,
+            #[strategy(1usize..6)] _num_preserved: usize,
+            #[strategy((((#num_removals + #_num_preserved) as u64))..=(u64::from(u32::MAX)))]
+            _num_leafs_aocl: u64,
+            #[strategy(vec((arb::<Digest>(), arb::<Digest>(), arb::<Digest>()), #num_removals + #_num_preserved))]
+            removables: Vec<(Digest, Digest, Digest)>,
+            #[strategy(MsaAndRecords::arbitrary_with((#removables, #_num_leafs_aocl)))]
+            msa_and_records: MsaAndRecords,
+            #[strategy(vec((arb::<Digest>(), arb::<Digest>(), arb::<Digest>()), 0usize..8))]
+            addition_preimages: Vec<(Digest, Digest, Digest)>,
+        ) {
+            prop_assert!(batch_and_sequential_apply_agree(
+                msa_and_records,
+                removables,
+                num_removals,
+                addition_preimages
+            )
+            .is_ok())
+        }
+
+        #[proptest(cases = 3)]
+        fn batch_apply_agrees_with_sequential_apply_u63(
+            #[strategy(1usize..10)] num_removals: usize,
+            #[strategy(1usize..6)] _num_preserved: usize,
+            #[strategy((((#num_removals + #_num_preserved) as u64))..=(u64::MAX / 2))]
+            _num_leafs_aocl: u64,
+            #[strategy(vec((arb::<Digest>(), arb::<Digest>(), arb::<Digest>()), #num_removals + #_num_preserved))]
+            removables: Vec<(Digest, Digest, Digest)>,
+            #[strategy(MsaAndRecords::arbitrary_with((#removables, #_num_leafs_aocl)))]
+            msa_and_records: MsaAndRecords,
+            #[strategy(vec((arb::<Digest>(), arb::<Digest>(), arb::<Digest>()), 0usize..8))]
+            addition_preimages: Vec<(Digest, Digest, Digest)>,
+        ) {
+            prop_assert!(batch_and_sequential_apply_agree(
+                msa_and_records,
+                removables,
+                num_removals,
+                addition_preimages
+            )
+            .is_ok())
+        }
+
+        #[proptest(cases = 10)]
+        fn duplicated_removal_record_invalidates_update(
+            #[strategy(1u64..=(u64::from(u8::MAX)))] _num_leafs_aocl: u64,
+            #[strategy(vec((arb::<Digest>(), arb::<Digest>(), arb::<Digest>()), 1))]
+            _removables: Vec<(Digest, Digest, Digest)>,
+            #[strategy(MsaAndRecords::arbitrary_with((#_removables, #_num_leafs_aocl)))]
+            msa_and_records: MsaAndRecords,
+        ) {
+            let removal_record = msa_and_records.unpacked_removal_records()[0].clone();
+            let update =
+                MutatorSetUpdate::new(vec![removal_record.clone(), removal_record], vec![]);
+
+            let mut msa_batch = msa_and_records.mutator_set_accumulator.clone();
+            prop_assert!(update.apply_to_accumulator(&mut msa_batch).is_err());
+
+            let mut msa_sequential = msa_and_records.mutator_set_accumulator.clone();
+            let sequential_is_valid =
+                sequential_apply_reference(&update, &mut msa_sequential, &mut [], &mut []);
+            prop_assert!(!sequential_is_valid);
+
+            prop_assert_eq!(msa_sequential, msa_batch);
+        }
+
+        /// The batch check is stricter than sequential application in one
+        /// corner: a removal record whose indices are covered by the Bloom
+        /// filter and the *other* records of the update combined, without
+        /// being covered by the Bloom filter and earlier records alone.
+        /// passes sequentially but fails the batch check. For honestly
+        /// generated removal records this corner has negligible probability.
+        #[test]
+        fn batch_check_rejects_fully_covered_record_where_sequential_accepts() {
+            // All indices lie in the initial active window, so removal
+            // records with empty chunk dictionaries are valid.
+            fn removal_record(indices: [u128; NUM_TRIALS as usize]) -> RemovalRecord {
+                RemovalRecord {
+                    absolute_indices: AbsoluteIndexSet::new(indices),
+                    target_chunks: ChunkDictionary::default(),
+                }
+            }
+
+            // The pre-state has indices 0..45 set.
+            let pre_set = core::array::from_fn(|i| i as u128);
+            let mut msa = MutatorSetAccumulator::default();
+            MutatorSetUpdate::new(vec![removal_record(pre_set)], vec![])
+                .apply_to_accumulator(&mut msa)
+                .unwrap();
+
+            // The first record's indices are covered by the pre-state
+            // (0..20) and the second record (100..125) combined; the second
+            // record has twenty uncovered indices (200..220).
+            let first = core::array::from_fn(|i| {
+                if i < 20 {
+                    i as u128
+                } else {
+                    100 + (i as u128 - 20)
+                }
+            });
+            let second = core::array::from_fn(|i| {
+                if i < 25 {
+                    100 + i as u128
+                } else {
+                    200 + (i as u128 - 25)
+                }
+            });
+            let update =
+                MutatorSetUpdate::new(vec![removal_record(first), removal_record(second)], vec![]);
+
+            let mut msa_sequential = msa.clone();
+            let sequential_is_valid =
+                sequential_apply_reference(&update, &mut msa_sequential, &mut [], &mut []);
+            assert!(sequential_is_valid);
+
+            let mut msa_batch = msa.clone();
+            assert!(update.apply_to_accumulator(&mut msa_batch).is_err());
+
+            assert_eq!(msa_sequential, msa_batch);
+        }
     }
 
     mod compose {

--- a/neptune-consensus/src/block/mutator_set_update.rs
+++ b/neptune-consensus/src/block/mutator_set_update.rs
@@ -5,6 +5,7 @@ use neptune_mutator_set::mutator_set_accumulator::MutatorSetAccumulator;
 use neptune_mutator_set::removal_record::RemovalRecord;
 use serde::Deserialize;
 use serde::Serialize;
+use tasm_lib::twenty_first::util_types::mmr::mmr_trait::Mmr;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct MutatorSetUpdate {
@@ -31,6 +32,81 @@ impl MutatorSetUpdate {
 
     pub fn is_empty(&self) -> bool {
         self.removals.is_empty() && self.additions.is_empty()
+    }
+
+    /// Compose a chain of mutator-set updates into a single update.
+    ///
+    /// Mutator-set updates compose like arrows between mutator-set states:
+    /// given `A -> B` and `B -> C`, this returns `A -> C`. Concatenating the
+    /// addition and removal records is only a part of that. Each removal
+    /// record carries MMR-authentication paths and chunks derived against the
+    /// state it was made for, and an arrow out of `A` is only well-formed once
+    /// those are re-derived against `A`. To that end, the removal records
+    /// collected from later updates are reverted over each earlier update, one
+    /// update at a time, until they reach `A`.
+    ///
+    /// `chain` is ordered from the most recent update going backwards, e.g.
+    /// from a chain tip towards older blocks. Each element holds the mutator
+    /// set accumulator that an update applies to, along with the update
+    /// itself. The records in the returned update are ordered forwards, ready
+    /// for sequential application to `A`.
+    pub fn compose(chain: &[(MutatorSetAccumulator, MutatorSetUpdate)]) -> MutatorSetUpdate {
+        // All removal records collected so far, valid at the state that the
+        // most recently processed update applies to, in forward application
+        // order.
+        let mut composed_removals: Vec<RemovalRecord> = vec![];
+        let mut addition_batches_reversed: Vec<&Vec<AdditionRecord>> = vec![];
+
+        for (predecessor_msa, update) in chain {
+            if !composed_removals.is_empty() {
+                // Reverting the collected records over this update requires
+                // the update's own removal records synced to the update's
+                // resulting state, as sources of authentication data. Replay
+                // the additions on the predecessor accumulator, then bring
+                // the records through the application of all the update's
+                // removals — including themselves — in one combined pass.
+                let mut replay_msa = predecessor_msa.clone();
+                let mut applied_removals = update.removals.clone();
+                for addition_record in &update.additions {
+                    RemovalRecord::batch_update_from_addition(
+                        &mut applied_removals.iter_mut().collect::<Vec<_>>(),
+                        &replay_msa,
+                    );
+                    replay_msa.add(addition_record);
+                }
+                let pre_removal_forms = applied_removals.clone();
+                RemovalRecord::batch_update_from_removals(
+                    &mut applied_removals.iter_mut().collect::<Vec<_>>(),
+                    &pre_removal_forms,
+                );
+
+                // Walk the collected records back to the state that this
+                // update applies to: undo all the removals in one pass, then
+                // the additions.
+                RemovalRecord::batch_revert_update_from_removals(
+                    &mut composed_removals.iter_mut().collect::<Vec<_>>(),
+                    &applied_removals,
+                );
+                RemovalRecord::batch_revert_update_from_addition(
+                    &mut composed_removals.iter_mut().collect::<Vec<_>>(),
+                    predecessor_msa.swbf_inactive.num_leafs(),
+                );
+            }
+
+            // This update's own removal records, as stored, are already valid
+            // at the state that the update applies to. They apply before
+            // everything collected so far.
+            composed_removals.splice(0..0, update.removals.iter().cloned());
+            addition_batches_reversed.push(&update.additions);
+        }
+
+        let composed_additions = addition_batches_reversed
+            .into_iter()
+            .rev()
+            .flatten()
+            .copied()
+            .collect();
+        MutatorSetUpdate::new(composed_removals, composed_additions)
     }
 
     /// Like `apply_to_accumulator` but does not verify that the removal records
@@ -207,5 +283,215 @@ mod tests {
         msa_and_records: MsaAndRecords,
     ) {
         prop_assert!(prop(msa_and_records).is_ok())
+    }
+
+    mod compose {
+        use itertools::Itertools;
+        use neptune_mutator_set::addition_record::AdditionRecord;
+        use neptune_mutator_set::authenticated_item::AuthenticatedItem;
+        use neptune_mutator_set::commit;
+        use neptune_mutator_set::mutator_set_accumulator::MutatorSetAccumulator;
+        use neptune_mutator_set::removal_record::RemovalRecord;
+        use neptune_mutator_set::shared::BATCH_SIZE;
+        use neptune_mutator_set::test_shared::mock_item_and_randomnesses;
+        use rand::Rng;
+
+        use super::MutatorSetUpdate;
+
+        #[test]
+        fn compose_three_updates_into_one() {
+            // Construct three valid updates, and compose them into one. Verify the
+            // correctness of the composed update.
+            let mut accumulator = MutatorSetAccumulator::default();
+
+            let (initial_ars, (items, (srs, rps))): (Vec<_>, (Vec<_>, (Vec<_>, Vec<_>))) = (0..100)
+                .map(|_| {
+                    let (item, sender_randomness, receiver_preimage) = mock_item_and_randomnesses();
+                    (
+                        commit(item, sender_randomness, receiver_preimage.hash()),
+                        (item, (sender_randomness, receiver_preimage)),
+                    )
+                })
+                .collect_vec()
+                .into_iter()
+                .unzip();
+
+            // List of consistent pairs of (mutator set acc, update) where the
+            // update's removal records are valid under the mutator set acc.
+            let mut states = vec![(
+                accumulator.clone(),
+                MutatorSetUpdate::new(vec![], initial_ars.clone()),
+            )];
+
+            let mut auth_items = vec![];
+            for j in 0..100 {
+                AuthenticatedItem::batch_update_from_addition(
+                    &mut auth_items.iter_mut().collect_vec(),
+                    &accumulator,
+                    initial_ars[j],
+                );
+                auth_items.push(AuthenticatedItem {
+                    item: items[j],
+                    ms_membership_proof: accumulator.prove(items[j], srs[j], rps[j]),
+                });
+                accumulator.add(&initial_ars[j]);
+            }
+
+            // Construct and apply the next two consistent updates
+            for j in 0..=1 {
+                // Construct all addition records/removal records before applying
+                // anything, as all cryptographic data must only be valid against
+                // the snapshotted accumulator.
+                let mut addition_records = vec![];
+                for _ in 0..100 {
+                    let (item, sender_randomness, receiver_preimage) = mock_item_and_randomnesses();
+                    let addition_record = commit(item, sender_randomness, receiver_preimage.hash());
+                    addition_records.push(addition_record);
+                }
+
+                let rrs = auth_items
+                    .iter()
+                    .enumerate()
+                    .filter(|(i, _)| i % 3 == j)
+                    .map(|(_, auth_item)| {
+                        accumulator.drop(auth_item.item, &auth_item.ms_membership_proof)
+                    })
+                    .collect_vec();
+
+                let update = MutatorSetUpdate::new(rrs, addition_records);
+                states.push((accumulator.clone(), update.clone()));
+
+                update
+                    .apply_to_accumulator_and_records(
+                        &mut accumulator,
+                        &mut [],
+                        &mut auth_items.iter_mut().collect_vec(),
+                    )
+                    .unwrap();
+            }
+
+            states.reverse();
+
+            let composed = MutatorSetUpdate::compose(&states);
+
+            let mut rebuilt_from_composition = MutatorSetAccumulator::default();
+            composed
+                .apply_to_accumulator(&mut rebuilt_from_composition)
+                .unwrap();
+
+            assert_eq!(accumulator, rebuilt_from_composition)
+        }
+
+        #[test]
+        fn compose_block_mutations_equals_sequential_application() {
+            let mut rng = rand::rng();
+            let mut accumulator = MutatorSetAccumulator::default();
+
+            // A pool of live removal records, kept synced to the accumulator, for
+            // the updates to draw their removals from. `pool_tags` records, per
+            // pool entry, whether the removed item predates the chain of updates.
+            let mut pool: Vec<RemovalRecord> = vec![];
+            let mut pool_tags: Vec<bool> = vec![];
+            let add_item = |accumulator: &mut MutatorSetAccumulator,
+                            pool: &mut Vec<RemovalRecord>|
+             -> AdditionRecord {
+                let (item, sender_randomness, receiver_preimage) = mock_item_and_randomnesses();
+                let addition_record = commit(item, sender_randomness, receiver_preimage.hash());
+                let mp = accumulator.prove(item, sender_randomness, receiver_preimage);
+                RemovalRecord::batch_update_from_addition(
+                    &mut pool.iter_mut().collect::<Vec<_>>(),
+                    accumulator,
+                );
+                accumulator.add(&addition_record);
+                pool.push(accumulator.drop(item, &mp));
+                addition_record
+            };
+
+            // Seed the accumulator so the first update has something to remove.
+            for _ in 0..(2 * BATCH_SIZE) {
+                add_item(&mut accumulator, &mut pool);
+            }
+            pool_tags.extend(std::iter::repeat_n(true, pool.len()));
+
+            // Build a chain of updates, each with additions and removals, applied
+            // to the accumulator as it goes.
+            let old_msa = accumulator.clone();
+            let num_updates = 6;
+            let mut chain = vec![];
+            let mut chain_tags = vec![];
+            for _ in 0..num_updates {
+                let predecessor_msa = accumulator.clone();
+
+                // Draw this update's removals from the pool. Their pre-update
+                // form goes into the chain; the working copies follow the
+                // update's application.
+                let mut working_removals = vec![];
+                let mut update_tags = vec![];
+                for _ in 0..2 {
+                    let draw = rng.random_range(0..pool.len());
+                    working_removals.push(pool.remove(draw));
+                    update_tags.push(pool_tags.remove(draw));
+                }
+                let stored_removals = working_removals.clone();
+
+                // Create and apply the additions one at a time, keeping the pool
+                // and the pending removals in sync.
+                let mut additions = vec![];
+                for _ in 0..4 {
+                    let (item, sender_randomness, receiver_preimage) = mock_item_and_randomnesses();
+                    let addition_record = commit(item, sender_randomness, receiver_preimage.hash());
+                    let mp = accumulator.prove(item, sender_randomness, receiver_preimage);
+                    RemovalRecord::batch_update_from_addition(
+                        &mut pool
+                            .iter_mut()
+                            .chain(working_removals.iter_mut())
+                            .collect::<Vec<_>>(),
+                        &accumulator,
+                    );
+                    accumulator.add(&addition_record);
+                    pool.push(accumulator.drop(item, &mp));
+                    pool_tags.push(false);
+                    additions.push(addition_record);
+                }
+
+                // Apply the removals, keeping the pool in sync.
+                MutatorSetUpdate::new(working_removals, vec![])
+                    .apply_to_accumulator_and_records(
+                        &mut accumulator,
+                        &mut pool.iter_mut().collect::<Vec<_>>(),
+                        &mut [],
+                    )
+                    .unwrap();
+
+                chain.push((
+                    predecessor_msa,
+                    MutatorSetUpdate::new(stored_removals, additions),
+                ));
+                chain_tags.push(update_tags);
+            }
+            let tip_hash = accumulator.hash();
+
+            // Compose the chain, most recent update first.
+            chain.reverse();
+            chain_tags.reverse();
+            let composed = MutatorSetUpdate::compose(&chain);
+
+            // Composed removal records for items that predate the chain must be
+            // valid at the old state. Records for items added within the chain
+            // itself cannot be: those become valid only as the replay of the
+            // additions progresses, which the application below checks.
+            let composed_tags = chain_tags.iter().rev().flatten().collect::<Vec<_>>();
+            assert_eq!(composed_tags.len(), composed.removals.len());
+            for (born_before_chain, removal_record) in composed_tags.iter().zip(&composed.removals)
+            {
+                if **born_before_chain {
+                    assert!(removal_record.validate(&old_msa));
+                    assert!(old_msa.can_remove(removal_record));
+                }
+            }
+            let mut replay_msa = old_msa;
+            composed.apply_to_accumulator(&mut replay_msa).unwrap();
+            assert_eq!(tip_hash, replay_msa.hash());
+        }
     }
 }

--- a/neptune-core/src/application/loops/main_loop.rs
+++ b/neptune-core/src/application/loops/main_loop.rs
@@ -404,7 +404,7 @@ impl MainLoopHandler {
     ///
     /// Sends the result back through the provided channel.
     async fn update_mempool_jobs(
-        mut global_state_lock: GlobalStateLock,
+        global_state_lock: GlobalStateLock,
         update_jobs: Vec<MempoolUpdateJob>,
         job_queue: Arc<TritonVmJobQueue>,
         transaction_update_sender: mpsc::Sender<Vec<MempoolUpdateJobResult>>,
@@ -424,10 +424,10 @@ impl MainLoopHandler {
 
                     // Acquire lock, and drop it immediately.
                     let msa_update = global_state_lock
-                        .lock_guard_mut()
+                        .lock_guard()
                         .await
                         .chain
-                        .archival_state_mut()
+                        .archival_state()
                         .get_mutator_set_update_to_tip(
                             old_msa,
                             SEARCH_DEPTH_FOR_BLOCKS_FOR_MS_UPDATE,
@@ -476,7 +476,7 @@ impl MainLoopHandler {
                 } => {
                     let upgrade_incentive = UpgradeIncentive::Critical;
                     let Ok(update_job) = global_state_lock
-                        .lock_guard_mut()
+                        .lock_guard()
                         .await
                         .update_single_proof_job(
                             old_kernel.to_owned(),
@@ -1455,7 +1455,7 @@ impl MainLoopHandler {
         // Check if it's time to run the proof-upgrader, and if we're capable
         // of upgrading a transaction proof.
         let upgrade_candidate = {
-            let mut global_state = self.global_state_lock.lock_guard_mut().await;
+            let global_state = self.global_state_lock.lock_guard().await;
             if !attempt_upgrade(&global_state, main_loop_state) {
                 trace!("Not attempting upgrade.");
                 return Ok(());
@@ -1464,8 +1464,7 @@ impl MainLoopHandler {
             debug!("Attempting to run transaction-proof-upgrade");
 
             // Find a candidate for proof upgrade
-            let Some(upgrade_candidate) = get_upgrade_task_from_mempool(&mut global_state).await
-            else {
+            let Some(upgrade_candidate) = get_upgrade_task_from_mempool(&global_state).await else {
                 debug!("Found no transaction-proof to upgrade");
                 return Ok(());
             };

--- a/neptune-core/src/application/loops/main_loop/proof_upgrader.rs
+++ b/neptune-core/src/application/loops/main_loop/proof_upgrader.rs
@@ -580,7 +580,7 @@ impl UpgradeJob {
 
                 let Some(ms_update) = global_state
                     .chain
-                    .archival_state_mut()
+                    .archival_state()
                     .get_mutator_set_update_to_tip(
                         &mutator_set_for_tx,
                         SEARCH_DEPTH_FOR_BLOCKS_FOR_MS_UPDATE,
@@ -861,7 +861,7 @@ impl UpgradeJob {
 /// of this job to the wallet of this node. The value reported will be zero for
 /// all 3rd party transactions.
 pub(super) async fn get_upgrade_task_from_mempool(
-    global_state: &mut GlobalState,
+    global_state: &GlobalState,
 ) -> Option<UpgradeJob> {
     let tip_mutator_set = global_state.chain.tip_mutator_set_after();
     let gobbling_fraction = global_state.gobbling_fraction();
@@ -1084,7 +1084,7 @@ mod tests {
             bob.mempool_insert(px_tx_for_raise.clone().into(), UpgradePriority::Irrelevant)
                 .await;
 
-            get_upgrade_task_from_mempool(&mut bob).await.unwrap()
+            get_upgrade_task_from_mempool(&bob).await.unwrap()
         };
 
         assert!(
@@ -1105,8 +1105,8 @@ mod tests {
         let block1 = invalid_empty_block(&genesis, network);
         bob.set_new_tip(block1.clone()).await.unwrap();
 
-        let mut bob = bob.lock_guard_mut().await;
-        let new_job = get_upgrade_task_from_mempool(&mut bob).await.unwrap();
+        let bob = bob.lock_guard().await;
+        let new_job = get_upgrade_task_from_mempool(&bob).await.unwrap();
 
         let UpgradeJob::UpdateMutatorSetData(new_job) = new_job else {
             panic!("Expected ms-update job");
@@ -1167,7 +1167,7 @@ mod tests {
         let block1 = invalid_empty_block(&genesis, network);
         bob.set_new_tip(block1.clone()).await.unwrap();
 
-        let mut bob = bob.lock_guard_mut().await;
+        let bob = bob.lock_guard().await;
         assert!(
             bob.mempool().contains(pc_tx.kernel.txid()),
             "unsynced ProofCollection must be retained across a new block (#946a)"
@@ -1175,7 +1175,7 @@ mod tests {
 
         // The upgrader still returns a raise job for the now-unsynced PC.
         let Some(job @ UpgradeJob::ProofCollectionToSingleProof(_)) =
-            get_upgrade_task_from_mempool(&mut bob).await
+            get_upgrade_task_from_mempool(&bob).await
         else {
             panic!("unsynced foreign ProofCollection must still yield a raise job (#946b)");
         };
@@ -1247,8 +1247,8 @@ mod tests {
 
         // Fetch and execute the raise job for the now-unsynced ProofCollection.
         let job = {
-            let mut bob = bob.lock_guard_mut().await;
-            get_upgrade_task_from_mempool(&mut bob).await.unwrap()
+            let bob = bob.lock_guard().await;
+            get_upgrade_task_from_mempool(&bob).await.unwrap()
         };
         assert!(
             matches!(job, UpgradeJob::ProofCollectionToSingleProof(_)),
@@ -1320,9 +1320,9 @@ mod tests {
                 .await;
             assert!(
                 !upgrade_priority.is_irrelevant()
-                    && get_upgrade_task_from_mempool(&mut rando).await.is_some()
+                    && get_upgrade_task_from_mempool(&rando).await.is_some()
                     || upgrade_priority.is_irrelevant()
-                        && get_upgrade_task_from_mempool(&mut rando).await.is_none()
+                        && get_upgrade_task_from_mempool(&rando).await.is_none()
             );
 
             // A high-fee paying transaction must be returned for upgrading
@@ -1337,7 +1337,7 @@ mod tests {
             rando
                 .mempool_insert(pc_tx_high_fee.clone().into(), UpgradePriority::Irrelevant)
                 .await;
-            let job = get_upgrade_task_from_mempool(&mut rando).await.unwrap();
+            let job = get_upgrade_task_from_mempool(&rando).await.unwrap();
             let UpgradeJob::ProofCollectionToSingleProof(pc2sp) = job else {
                 panic!("Expected proof-collection to single-proof job");
             };
@@ -1672,7 +1672,7 @@ mod tests {
         rando
             .mempool_insert(pc_tx.clone().into(), UpgradePriority::Irrelevant)
             .await;
-        let job = get_upgrade_task_from_mempool(&mut rando).await.unwrap();
+        let job = get_upgrade_task_from_mempool(&rando).await.unwrap();
 
         let UpgradeJob::ProofCollectionToSingleProof(pc2sp) = job else {
             panic!("Expected PC to SP job");
@@ -1733,8 +1733,8 @@ mod tests {
         }
 
         let merge_upgrade_job = {
-            let mut alice = alice.lock_guard_mut().await;
-            get_upgrade_task_from_mempool(&mut alice).await.unwrap()
+            let alice = alice.lock_guard().await;
+            get_upgrade_task_from_mempool(&alice).await.unwrap()
         };
         assert!(
             matches!(merge_upgrade_job, UpgradeJob::Merge { .. }),

--- a/neptune-core/src/application/loops/mine_loop.rs
+++ b/neptune-core/src/application/loops/mine_loop.rs
@@ -571,7 +571,7 @@ pub(crate) async fn create_block_transaction_from(
         info!("No synced single-proof tx found for merge. Looking for one to update.");
         let min_gobbling_fee = NativeCurrencyAmount::zero();
         let update_job = global_state_lock
-            .lock_guard_mut()
+            .lock_guard()
             .await
             .preferred_update_job_from_mempool(min_gobbling_fee, TxUpgradeFilter::match_all())
             .await;

--- a/neptune-core/src/application/rpc/server.rs
+++ b/neptune-core/src/application/rpc/server.rs
@@ -3553,7 +3553,7 @@ impl RPC for NeptuneRPCServer {
     }
 
     async fn upgrade(
-        mut self,
+        self,
         _ctx: context::Context,
         token: auth::Token,
         tx_kernel_id: TransactionKernelId,
@@ -3582,7 +3582,7 @@ impl RPC for NeptuneRPCServer {
                 let gobbling_potential = NativeCurrencyAmount::zero();
                 let update_job = self
                     .state
-                    .lock_guard_mut()
+                    .lock_guard()
                     .await
                     .update_single_proof_job(
                         tx.kernel,
@@ -3599,7 +3599,7 @@ impl RPC for NeptuneRPCServer {
                 let gobbling_potential = NativeCurrencyAmount::zero();
                 let raise_job = self
                     .state
-                    .lock_guard_mut()
+                    .lock_guard()
                     .await
                     .upgrade_proof_collection_job(
                         tx.kernel,

--- a/neptune-core/src/state/mod.rs
+++ b/neptune-core/src/state/mod.rs
@@ -3227,14 +3227,11 @@ impl GlobalState {
     /// Favors transactions based on upgrade priority first, fee density
     /// second.
     ///
-    /// Needs mutable state access because of how the mutator set update value
-    /// is calculated. Does not actually mutate any state.
-    ///
     /// Returns none if no transaction in the mempool is in need of upgrading
     /// or if transaction in need of upgrading does not provide enough
     /// incentive.
     pub(crate) async fn preferred_update_job_from_mempool(
-        &mut self,
+        &self,
         min_gobbling_fee: NativeCurrencyAmount,
         tx_upgrade_filter: TxUpgradeFilter,
     ) -> Option<UpdateMutatorSetDataJob> {
@@ -3306,14 +3303,14 @@ impl GlobalState {
     }
 
     pub(crate) async fn upgrade_proof_collection_job(
-        &mut self,
+        &self,
         kernel: TransactionKernel,
         proof: ProofCollection,
         upgrade_incentive: UpgradeIncentive,
     ) -> Result<ProofCollectionToSingleProof> {
         let msa_lookup_result = self
             .chain
-            .archival_state_mut()
+            .archival_state()
             .old_mutator_set_and_mutator_set_update_to_tip(
                 kernel.mutator_set_hash,
                 SEARCH_DEPTH_FOR_BLOCKS_FOR_MS_UPDATE,
@@ -3342,14 +3339,14 @@ impl GlobalState {
     /// Does not perform any proof upgrading, only returns the witness data
     /// required to construct a synced single proof.
     pub(crate) async fn update_single_proof_job(
-        &mut self,
+        &self,
         old_kernel: TransactionKernel,
         old_proof: NeptuneProof,
         upgrade_incentive: UpgradeIncentive,
     ) -> Result<UpdateMutatorSetDataJob> {
         let msa_lookup_result = self
             .chain
-            .archival_state_mut()
+            .archival_state()
             .old_mutator_set_and_mutator_set_update_to_tip(
                 old_kernel.mutator_set_hash,
                 SEARCH_DEPTH_FOR_BLOCKS_FOR_MS_UPDATE,

--- a/neptune-database/src/storage/storage_schema/simple_rusty_storage.rs
+++ b/neptune-database/src/storage/storage_schema/simple_rusty_storage.rs
@@ -24,23 +24,26 @@ pub struct SimpleRustyStorage {
 impl StorageWriter for SimpleRustyStorage {
     #[inline]
     async fn persist(&mut self) {
-        let mut write_ops = WriteBatchAsync::new();
+        // Hold the lock across the entire operation, so that no interleaved
+        // write can land between building the batch and clearing the queue.
+        let mut pending_writes = self.schema.pending_writes.lock_guard_mut().await;
 
-        // note: we read all pending ops and perform mutations
-        // in a single atomic operation.
-        {
-            let mut pending_writes = self.schema.pending_writes.lock_guard_mut().await;
-            for op in &pending_writes.write_ops {
-                match op.clone() {
-                    WriteOperation::Write(key, value) => write_ops.op_write(key, value),
-                    WriteOperation::Delete(key) => write_ops.op_delete(key),
-                }
+        let mut write_ops = WriteBatchAsync::new();
+        for op in &pending_writes.write_ops {
+            match op.clone() {
+                WriteOperation::Write(key, value) => write_ops.op_write(key, value),
+                WriteOperation::Delete(key) => write_ops.op_delete(key),
             }
-            pending_writes.write_ops.clear();
-            pending_writes.persist_count += 1;
         }
 
-        self.db.batch_write(write_ops).await
+        self.db.batch_write(write_ops).await;
+
+        // Only clear the queue once the batch write has completed. If this
+        // future is dropped mid-write, the operations stay queued and the next
+        // persist retries them. Redoing an operation is harmless: writes and
+        // deletes are both idempotent.
+        pending_writes.write_ops.clear();
+        pending_writes.persist_count += 1;
     }
 
     async fn drop_unpersisted(&mut self) {

--- a/neptune-mutator-set/src/mutator_set_accumulator.rs
+++ b/neptune-mutator-set/src/mutator_set_accumulator.rs
@@ -186,40 +186,75 @@ impl MutatorSetAccumulator {
     /// if either the MMR membership proofs are unsynced, or if all its indices
     /// are already set, or if the chunk dictionary is missing entries.
     pub fn can_remove(&self, removal_record: &RemovalRecord) -> bool {
-        let mut have_absent_index = false;
+        self.can_remove_all(std::slice::from_ref(removal_record))
+    }
 
-        // Validate verifies that the all required chunk/MMR membership proof
-        // pairs are present, and that all MMR membership proofs are valid
-        // against the mutator set accumulator.
-        if !removal_record.validate(self) {
-            return false;
-        }
-
-        let swbfi_num_leafs = self.get_batch_index();
-        let active_window_start = u128::from(swbfi_num_leafs) * u128::from(CHUNK_SIZE);
-        for inserted_index in removal_record.absolute_indices.to_vec() {
-            // determine if inserted index lives in active window
-            if inserted_index < active_window_start {
-                let inserted_index_chunkidx = (inserted_index / u128::from(CHUNK_SIZE)) as u64;
-                let (_mmr_mp, chunk) = removal_record
-                    .target_chunks
-                    .get(&inserted_index_chunkidx)
-                    .expect("Presence of required MMR MPs should have already been established.");
-                let relative_index = (inserted_index % u128::from(CHUNK_SIZE)) as u32;
-                if !chunk.contains(relative_index) {
-                    have_absent_index = true;
-                    break;
-                }
-            } else {
-                let relative_index = (inserted_index - active_window_start) as u32;
-                if !self.swbf_active.contains(relative_index) {
-                    have_absent_index = true;
-                    break;
-                }
+    /// Check if a batch of removal records can be applied to a mutator set.
+    ///
+    /// Returns false if some removal record's MMR membership proofs are
+    /// unsynced or its chunk dictionary is missing entries, or if some
+    /// removal record contributes nothing: every removal record must have at
+    /// least one index that is neither set in the Bloom filter already nor
+    /// contributed by any other removal record in the batch.
+    ///
+    /// For a single removal record this coincides with [`Self::can_remove`].
+    /// For larger batches it is slightly stricter than checking
+    /// [`Self::can_remove`] for each record under sequential application:
+    /// sequential application accepts a record whose indices are covered by
+    /// the Bloom filter and *later* records combined. Unlike the sequential
+    /// check, this predicate is independent of the records' order.
+    pub fn can_remove_all(&self, removal_records: &[RemovalRecord]) -> bool {
+        // index -> multiplicity, over the entire batch
+        let mut combined_counts: HashMap<u128, u32> = HashMap::new();
+        for removal_record in removal_records {
+            for index in removal_record.absolute_indices.iter() {
+                *combined_counts.entry(index).or_default() += 1;
             }
         }
 
-        have_absent_index
+        let active_window_start = u128::from(self.get_batch_index()) * u128::from(CHUNK_SIZE);
+        removal_records.iter().all(|removal_record| {
+            // Validate verifies that the all required chunk/MMR membership
+            // proof pairs are present, and that all MMR membership proofs are
+            // valid against the mutator set accumulator.
+            if !removal_record.validate(self) {
+                return false;
+            }
+
+            let mut own_counts: HashMap<u128, u32> = HashMap::new();
+            for index in removal_record.absolute_indices.iter() {
+                *own_counts.entry(index).or_default() += 1;
+            }
+
+            own_counts.into_iter().any(|(inserted_index, own_count)| {
+                // An index contributed by another removal record in the batch
+                // counts as set.
+                // This checks compatibility with all other removal records in
+                // the list.
+                if combined_counts[&inserted_index] > own_count {
+                    return false;
+                }
+
+                // Determine if index was set prior to the application of these
+                // removal records.
+                if inserted_index < active_window_start {
+                    // Index lives in a chunk
+                    let inserted_index_chunkidx = (inserted_index / u128::from(CHUNK_SIZE)) as u64;
+                    let (_mmr_mp, chunk) = removal_record
+                        .target_chunks
+                        .get(&inserted_index_chunkidx)
+                        .expect(
+                            "Presence of required MMR MPs should have already been established.",
+                        );
+                    let relative_index = (inserted_index % u128::from(CHUNK_SIZE)) as u32;
+                    !chunk.contains(relative_index)
+                } else {
+                    // Index lives in the active window
+                    let relative_index = (inserted_index - active_window_start) as u32;
+                    !self.swbf_active.contains(relative_index)
+                }
+            })
+        })
     }
 }
 
@@ -582,6 +617,66 @@ mod tests {
 
         use super::*;
         use crate::msa_and_records::MsaAndRecords;
+
+        #[test]
+        fn can_remove_all_requires_a_unique_unset_index_per_record() {
+            // All indices lie in the initial active window, so removal records
+            // with empty chunk dictionaries are valid.
+            fn removal_record(indices: [u128; NUM_TRIALS as usize]) -> RemovalRecord {
+                RemovalRecord {
+                    absolute_indices: AbsoluteIndexSet::new(indices),
+                    target_chunks: ChunkDictionary::default(),
+                }
+            }
+            fn indices_from(start: u128) -> [u128; NUM_TRIALS as usize] {
+                core::array::from_fn(|i| start + i as u128)
+            }
+
+            let mut msa = MutatorSetAccumulator::default();
+            let first = removal_record(indices_from(0));
+            let second = removal_record(indices_from(1000));
+
+            // Every record in a batch of disjoint records has unique indices.
+            assert!(msa.can_remove_all(&[]));
+            assert!(msa.can_remove_all(std::slice::from_ref(&first)));
+            assert!(msa.can_remove_all(&[first.clone(), second.clone()]));
+
+            // In a batch of two identical records, neither record has an
+            // index that the other does not also contribute.
+            assert!(!msa.can_remove_all(&[first.clone(), first.clone()]));
+
+            // A record's index multiplicity does not count against itself.
+            let self_repeating = removal_record([9000; NUM_TRIALS as usize]);
+            assert!(msa.can_remove_all(std::slice::from_ref(&self_repeating)));
+
+            // Indices set in the Bloom filter count as covered.
+            msa.remove(&first);
+            assert!(!msa.can_remove_all(std::slice::from_ref(&first)));
+            assert!(!msa.can_remove_all(&[first, second.clone()]));
+            assert!(msa.can_remove_all(std::slice::from_ref(&second)));
+
+            // A record whose indices are covered by the Bloom filter and
+            // another record *combined* invalidates the batch, even though
+            // each record passes the single-record check.
+            let covered = removal_record(core::array::from_fn(|i| {
+                if i < 20 {
+                    i as u128
+                } else {
+                    100 + (i as u128 - 20)
+                }
+            }));
+            let covering = removal_record(core::array::from_fn(|i| {
+                if i < 25 {
+                    100 + i as u128
+                } else {
+                    200 + (i as u128 - 25)
+                }
+            }));
+            assert!(msa.can_remove(&covered));
+            assert!(msa.can_remove(&covering));
+            assert!(!msa.can_remove_all(&[covered.clone(), covering.clone()]));
+            assert!(!msa.can_remove_all(&[covering, covered]));
+        }
 
         #[proptest]
         fn missing_chunk_dictionary_entry_small(

--- a/neptune-mutator-set/src/removal_record.rs
+++ b/neptune-mutator-set/src/removal_record.rs
@@ -30,7 +30,10 @@ use twenty_first::util_types::mmr::mmr_trait::Mmr;
 use super::mutator_set_accumulator::MutatorSetAccumulator;
 use super::removal_record::chunk_dictionary::ChunkDictionary;
 use super::shared::get_batch_mutation_argument_for_removal_record;
+use super::shared::get_batch_mutation_argument_for_removal_records;
 use super::shared::indices_to_hash_map;
+use super::shared::prepare_authenticated_batch_modification_for_removal_record_reversion;
+use super::shared::prepare_authenticated_batch_modification_for_removal_records_reversion;
 use super::shared::BATCH_SIZE;
 use super::shared::CHUNK_SIZE;
 use super::MutatorSetError;
@@ -197,6 +200,189 @@ impl RemovalRecord {
                 .map(|(i, p, l)| LeafMutation::new(*i, *l, p.clone()))
                 .collect_vec(),
         );
+    }
+
+    /// Update a batch of removal records that are synced to a given mutator
+    /// set, in anticipation of the application of any number of removal
+    /// records.
+    ///
+    /// Equivalent to applying [`Self::batch_update_from_remove`] for each
+    /// applied removal record in turn — with the applied records themselves
+    /// kept in sync between applications — but performs only a single batch
+    /// mutation of the underlying MMR membership proofs. The combined
+    /// mutation is well-defined because the chunk modifications of the
+    /// individual applications commute.
+    ///
+    /// The applied removal records must be synced to the same mutator-set
+    /// state as the removal records being updated. The batch being updated
+    /// may contain copies of the applied records; such copies end up synced
+    /// to the state after the application of the entire batch, including
+    /// themselves.
+    pub fn batch_update_from_removals(
+        removal_records: &mut [&mut Self],
+        applied_removal_records: &[RemovalRecord],
+    ) {
+        // Set all chunk values to the new values and calculate the mutation argument
+        // for the batch updating of the MMR membership proofs.
+        let mut chunk_dictionaries: Vec<&mut ChunkDictionary> = removal_records
+            .iter_mut()
+            .map(|rr| &mut rr.target_chunks)
+            .collect();
+        let (_mutated_chunks_by_rr_indices, mutation_argument) =
+            get_batch_mutation_argument_for_removal_records(
+                applied_removal_records,
+                &mut chunk_dictionaries,
+            );
+
+        // Collect all the MMR membership proofs from the chunk dictionaries.
+        let mut own_mmr_mps: Vec<&mut mmr::mmr_membership_proof::MmrMembershipProof> = vec![];
+        let mut leaf_indices = vec![];
+        for chunk_dict in &mut chunk_dictionaries {
+            for (chunk_index, (mp, _)) in chunk_dict.iter_mut() {
+                own_mmr_mps.push(mp);
+                leaf_indices.push(*chunk_index);
+            }
+        }
+
+        // Perform the batch mutation of the MMR membership proofs
+        mmr::mmr_membership_proof::MmrMembershipProof::batch_update_from_batch_leaf_mutation(
+            &mut own_mmr_mps,
+            &leaf_indices,
+            mutation_argument
+                .iter()
+                .map(|(i, p, l)| LeafMutation::new(*i, *l, p.clone()))
+                .collect_vec(),
+        );
+    }
+
+    /// Revert a batch of removal records to their state prior to the
+    /// application of any number of removal records.
+    ///
+    /// Reverse of [`Self::batch_update_from_removals`]: applying that
+    /// function and then this one, with the same batch of applied removal
+    /// records, is the identity. Unlike
+    /// [`Self::batch_revert_update_from_remove`], which takes the reverted
+    /// record in its as-applied form, the reverted removal records here must
+    /// be synced to the same mutator-set state as the records being reverted
+    /// — the state after the application of the entire batch, including
+    /// themselves.
+    pub fn batch_revert_update_from_removals(
+        removal_records: &mut [&mut Self],
+        reverted_removal_records: &[RemovalRecord],
+    ) {
+        // Set all chunk values back to the old values and calculate the
+        // mutation argument for the batch updating of the MMR membership
+        // proofs.
+        let mut chunk_dictionaries: Vec<&mut ChunkDictionary> = removal_records
+            .iter_mut()
+            .map(|rr| &mut rr.target_chunks)
+            .collect();
+        let (_mutated_chunks_by_rr_indices, mutation_argument) =
+            prepare_authenticated_batch_modification_for_removal_records_reversion(
+                reverted_removal_records,
+                &mut chunk_dictionaries,
+            );
+
+        // Collect all the MMR membership proofs from the chunk dictionaries.
+        let mut own_mmr_mps: Vec<&mut mmr::mmr_membership_proof::MmrMembershipProof> = vec![];
+        let mut leaf_indices = vec![];
+        for chunk_dict in &mut chunk_dictionaries {
+            for (chunk_index, (mp, _)) in chunk_dict.iter_mut() {
+                own_mmr_mps.push(mp);
+                leaf_indices.push(*chunk_index);
+            }
+        }
+
+        // Perform the batch mutation of the MMR membership proofs
+        mmr::mmr_membership_proof::MmrMembershipProof::batch_update_from_batch_leaf_mutation(
+            &mut own_mmr_mps,
+            &leaf_indices,
+            mutation_argument
+                .iter()
+                .map(|(i, p, l)| LeafMutation::new(*i, *l, p.clone()))
+                .collect_vec(),
+        );
+    }
+
+    /// Revert a batch of removal records to their state prior to being
+    /// updated with the application of another removal record.
+    ///
+    /// Reverse of [`Self::batch_update_from_remove`]: applying that function
+    /// and then this one, with the same `reverted_removal_record`, is the
+    /// identity.
+    pub fn batch_revert_update_from_remove(
+        removal_records: &mut [&mut Self],
+        reverted_removal_record: &RemovalRecord,
+    ) {
+        // Set all chunk values back to the old values and calculate the
+        // mutation argument for the batch updating of the MMR membership
+        // proofs.
+        let mut chunk_dictionaries: Vec<&mut ChunkDictionary> = removal_records
+            .iter_mut()
+            .map(|rr| &mut rr.target_chunks)
+            .collect();
+        let (_mutated_chunks_by_rr_indices, mutation_argument) =
+            prepare_authenticated_batch_modification_for_removal_record_reversion(
+                reverted_removal_record,
+                &mut chunk_dictionaries,
+            );
+
+        // Collect all the MMR membership proofs from the chunk dictionaries.
+        let mut own_mmr_mps: Vec<&mut mmr::mmr_membership_proof::MmrMembershipProof> = vec![];
+        let mut leaf_indices = vec![];
+        for chunk_dict in &mut chunk_dictionaries {
+            for (chunk_index, (mp, _)) in chunk_dict.iter_mut() {
+                own_mmr_mps.push(mp);
+                leaf_indices.push(*chunk_index);
+            }
+        }
+
+        // Perform the batch mutation of the MMR membership proofs
+        mmr::mmr_membership_proof::MmrMembershipProof::batch_update_from_batch_leaf_mutation(
+            &mut own_mmr_mps,
+            &leaf_indices,
+            mutation_argument
+                .iter()
+                .map(|(i, p, l)| LeafMutation::new(*i, *l, p.clone()))
+                .collect_vec(),
+        );
+    }
+
+    /// Revert a batch of removal records to their state at a previous mutator
+    /// set accumulator, prior to being updated with one or more additions.
+    ///
+    /// The previous accumulator is identified by the number of leafs in its
+    /// inactive sliding-window Bloom filter, i.e. its batch index; nothing
+    /// else about it is needed.
+    ///
+    /// Reverse of [`Self::batch_update_from_addition`], but can revert any
+    /// number of additions in one call. Only additions may separate the
+    /// records' current state from the previous accumulator; removals in
+    /// between must be reverted with [`Self::batch_revert_update_from_remove`]
+    /// first.
+    pub fn batch_revert_update_from_addition(
+        removal_records: &mut [&mut Self],
+        previous_swbfi_leaf_count: u64,
+    ) {
+        for removal_record in removal_records.iter_mut() {
+            // Chunks that the reverted additions slid out of the active window
+            // have their dictionary entries removed.
+            removal_record
+                .target_chunks
+                .retain(|(chunk_index, _)| *chunk_index < previous_swbfi_leaf_count);
+
+            // Appending to an MMR only ever extends the authentication path of
+            // an existing leaf, so the appends are reverted by truncating each
+            // path back to the height of its leaf's Merkle tree in the
+            // previous MMR.
+            for (chunk_index, (mp, _chunk)) in removal_record.target_chunks.iter_mut() {
+                let chunk_discrepancies = previous_swbfi_leaf_count ^ *chunk_index;
+                let chunk_mt_height = u128::from(chunk_discrepancies).ilog2();
+                while mp.authentication_path.len() > chunk_mt_height as usize {
+                    mp.authentication_path.pop();
+                }
+            }
+        }
     }
 
     fn has_required_authenticated_chunks(
@@ -720,6 +906,188 @@ mod tests {
                     .unwrap()
             );
         }
+    }
+
+    #[test]
+    fn batch_revert_update_from_addition_round_trip() {
+        let num_additions = 4 * BATCH_SIZE + 4;
+        let mut accumulator = MutatorSetAccumulator::default();
+        let mut removal_records: Vec<RemovalRecord> = vec![];
+
+        // The (accumulator, removal records) state before each addition.
+        let mut snapshots: Vec<(MutatorSetAccumulator, Vec<RemovalRecord>)> = vec![];
+
+        for _ in 0..num_additions {
+            let (item, sender_randomness, receiver_preimage) = mock_item_and_randomnesses();
+            let addition_record = commit(item, sender_randomness, receiver_preimage.hash());
+            let mp = accumulator.prove(item, sender_randomness, receiver_preimage);
+
+            snapshots.push((accumulator.clone(), removal_records.clone()));
+
+            RemovalRecord::batch_update_from_addition(
+                &mut removal_records.iter_mut().collect::<Vec<_>>(),
+                &accumulator,
+            );
+            accumulator.add(&addition_record);
+
+            let removal_record = accumulator.drop(item, &mp);
+            removal_records.push(removal_record);
+        }
+
+        let final_records = removal_records.clone();
+
+        // Revert one addition at a time, all the way back to the empty
+        // mutator set, and verify that each step reproduces the recorded
+        // state exactly.
+        for (previous_accumulator, previous_removal_records) in snapshots.iter().rev() {
+            // The removal record born of this addition does not exist in the
+            // previous state.
+            removal_records.pop();
+
+            RemovalRecord::batch_revert_update_from_addition(
+                &mut removal_records.iter_mut().collect::<Vec<_>>(),
+                previous_accumulator.swbf_inactive.num_leafs(),
+            );
+
+            assert_eq!(*previous_removal_records, removal_records);
+            for removal_record in &removal_records {
+                assert!(removal_record.validate(previous_accumulator));
+                assert!(previous_accumulator.can_remove(removal_record));
+            }
+        }
+
+        // Also revert many additions in one call: take the oldest removal
+        // record at the final state directly back to its birth state.
+        let (birth_accumulator, _) = &snapshots[1];
+        let mut oldest = final_records[0].clone();
+        RemovalRecord::batch_revert_update_from_addition(
+            &mut [&mut oldest],
+            birth_accumulator.swbf_inactive.num_leafs(),
+        );
+        assert_eq!(snapshots[1].1[0], oldest);
+        assert!(oldest.validate(birth_accumulator));
+    }
+
+    #[test]
+    fn batch_revert_update_from_remove_round_trip() {
+        let num_additions = 16 * BATCH_SIZE + 4;
+        let mut accumulator = MutatorSetAccumulator::default();
+        let mut removal_records: Vec<RemovalRecord> = vec![];
+
+        // Add all items, keeping all removal records in sync.
+        for _ in 0..num_additions {
+            let (item, sender_randomness, receiver_preimage) = mock_item_and_randomnesses();
+            let addition_record = commit(item, sender_randomness, receiver_preimage.hash());
+            let mp = accumulator.prove(item, sender_randomness, receiver_preimage);
+
+            RemovalRecord::batch_update_from_addition(
+                &mut removal_records.iter_mut().collect::<Vec<_>>(),
+                &accumulator,
+            );
+            accumulator.add(&addition_record);
+
+            let removal_record = accumulator.drop(item, &mp);
+            removal_records.push(removal_record);
+        }
+
+        // Apply half the removal records one at a time, keeping the rest in
+        // sync and recording the state before each removal.
+        let num_removals = num_additions as usize / 2;
+        let mut history = vec![];
+        for _ in 0..num_removals {
+            let remove_idx = rand::rng().random_range(0..removal_records.len());
+            let snapshot = (accumulator.clone(), removal_records.clone());
+            let applied = removal_records.remove(remove_idx);
+            RemovalRecord::batch_update_from_remove(
+                &mut removal_records.iter_mut().collect::<Vec<_>>(),
+                &applied,
+            );
+            accumulator.remove(&applied);
+            history.push((remove_idx, applied, snapshot));
+        }
+
+        // Revert one removal at a time and verify that each step reproduces
+        // the recorded state exactly. The applied record itself was not
+        // updated past its application, so re-inserting it restores the full
+        // record list.
+        for (remove_idx, applied, (snapshot_accumulator, snapshot_records)) in
+            history.into_iter().rev()
+        {
+            RemovalRecord::batch_revert_update_from_remove(
+                &mut removal_records.iter_mut().collect::<Vec<_>>(),
+                &applied,
+            );
+            removal_records.insert(remove_idx, applied);
+
+            assert_eq!(snapshot_records, removal_records);
+            for removal_record in &removal_records {
+                assert!(removal_record.validate(&snapshot_accumulator));
+                assert!(snapshot_accumulator.can_remove(removal_record));
+            }
+        }
+    }
+
+    #[test]
+    fn batch_removals_agree_with_sequential_application() {
+        let num_additions = 16 * BATCH_SIZE + 4;
+        let mut accumulator = MutatorSetAccumulator::default();
+        let mut all_records: Vec<RemovalRecord> = vec![];
+
+        // Add all items, keeping all removal records in sync.
+        for _ in 0..num_additions {
+            let (item, sender_randomness, receiver_preimage) = mock_item_and_randomnesses();
+            let addition_record = commit(item, sender_randomness, receiver_preimage.hash());
+            let mp = accumulator.prove(item, sender_randomness, receiver_preimage);
+
+            RemovalRecord::batch_update_from_addition(
+                &mut all_records.iter_mut().collect::<Vec<_>>(),
+                &accumulator,
+            );
+            accumulator.add(&addition_record);
+
+            all_records.push(accumulator.drop(item, &mp));
+        }
+
+        // The first `num_removals` records are applied; the rest are
+        // bystanders. `all_records` also keeps copies of the applied records
+        // themselves in sync, through their own application and past it.
+        let num_removals = 20;
+        let applied_records: Vec<RemovalRecord> = all_records[..num_removals].to_vec();
+        let pre_removal_records = all_records.clone();
+
+        // Sequential ground truth, applying one removal record at a time.
+        let mut seq_records = all_records.clone();
+        for i in 0..num_removals {
+            let applied = seq_records[i].clone();
+            RemovalRecord::batch_update_from_remove(
+                &mut seq_records.iter_mut().collect::<Vec<_>>(),
+                &applied,
+            );
+            assert!(accumulator.can_remove(&applied));
+            accumulator.remove(&applied);
+        }
+        for removal_record in &seq_records[num_removals..] {
+            assert!(removal_record.validate(&accumulator));
+            assert!(accumulator.can_remove(removal_record));
+        }
+
+        // The combined application must reproduce the sequential result
+        // exactly.
+        let mut batch_records = pre_removal_records.clone();
+        RemovalRecord::batch_update_from_removals(
+            &mut batch_records.iter_mut().collect::<Vec<_>>(),
+            &applied_records,
+        );
+        assert_eq!(seq_records, batch_records);
+
+        // The combined reversion, fed the applied records in their
+        // post-application form, must restore the pre-removal state exactly.
+        let post_removal_applied_forms = batch_records[..num_removals].to_vec();
+        RemovalRecord::batch_revert_update_from_removals(
+            &mut batch_records.iter_mut().collect::<Vec<_>>(),
+            &post_removal_applied_forms,
+        );
+        assert_eq!(pre_removal_records, batch_records);
     }
 
     proptest::proptest! {

--- a/neptune-mutator-set/src/removal_record/chunk.rs
+++ b/neptune-mutator-set/src/removal_record/chunk.rs
@@ -63,6 +63,21 @@ impl Chunk {
         self.relative_indices.sort();
     }
 
+    /// Insert a batch of indices. Equivalent to calling [`Self::insert`] for
+    /// each of them, but sorts only once.
+    pub fn insert_many(&mut self, indices: &[u32]) {
+        for index in indices {
+            assert!(
+                *index < CHUNK_SIZE,
+                "index cannot exceed chunk size in `insert`. CHUNK_SIZE = {}, got index = {}",
+                CHUNK_SIZE,
+                index
+            );
+        }
+        self.relative_indices.extend_from_slice(indices);
+        self.relative_indices.sort();
+    }
+
     pub fn remove_once(&mut self, index: u32) {
         assert!(
             index < CHUNK_SIZE,

--- a/neptune-mutator-set/src/shared.rs
+++ b/neptune-mutator-set/src/shared.rs
@@ -6,6 +6,7 @@ use tasm_lib::prelude::Digest;
 use tasm_lib::prelude::Tip5;
 use tasm_lib::twenty_first::util_types::mmr::mmr_membership_proof::MmrMembershipProof;
 
+use super::removal_record::chunk::Chunk;
 use super::removal_record::chunk_dictionary::ChunkDictionary;
 use super::removal_record::RemovalRecord;
 
@@ -127,9 +128,158 @@ pub fn get_batch_mutation_argument_for_removal_record(
     )
 }
 
+/// Given a batch of removal records, return a hashmap of
+/// {chunk_index => absolute_indices} with the indices of the entire batch
+/// put in the correct chunk buckets. Multiplicities are preserved.
+fn combined_chunkidx_to_indices_dict(removal_records: &[RemovalRecord]) -> HashMap<u64, Vec<u128>> {
+    let mut chunkidx_to_indices: HashMap<u64, Vec<u128>> = HashMap::new();
+    for removal_record in removal_records {
+        for (chunk_index, indices) in removal_record.get_chunkidx_to_indices_dict() {
+            chunkidx_to_indices
+                .entry(chunk_index)
+                .or_default()
+                .extend(indices);
+        }
+    }
+
+    chunkidx_to_indices
+}
+
+/// Shared implementation of
+/// [`get_batch_mutation_argument_for_removal_records`] and
+/// [`prepare_authenticated_batch_modification_for_removal_records_reversion`],
+/// parameterized over the chunk mutation: inserting the batch's indices
+/// (application) or removing them (reversion).
+///
+/// Iterates each chunk dictionary once and looks its entries up in the
+/// combined index map, rather than scanning all dictionaries per mutated
+/// chunk; the batches can be large in both dimensions.
+fn batch_mutation_argument_for_removal_records<F: Fn(&mut Chunk, &[u128])>(
+    removal_records: &[RemovalRecord],
+    chunk_dictionaries: &mut [&mut ChunkDictionary],
+    mutate_chunk: F,
+) -> (HashSet<usize>, Vec<(u64, MmrMembershipProof, Digest)>) {
+    let chunkidx_to_indices = combined_chunkidx_to_indices_dict(removal_records);
+
+    // chunk index -> (mmr mp, chunk hash)
+    let mut batch_modification_hash_map: HashMap<u64, (MmrMembershipProof, Digest)> =
+        HashMap::new();
+    // `mutated_chunk_dictionaries` records the indices into the
+    // input `chunk_dictionaries` slice that shows which elements
+    // contain modified chunks.
+    let mut mutated_chunk_dictionaries: HashSet<usize> = HashSet::new();
+    for (i, chunk_dictionary) in chunk_dictionaries.iter_mut().enumerate() {
+        for (chunk_index, (mmr_mp, chunk)) in chunk_dictionary.iter_mut() {
+            let Some(indices) = chunkidx_to_indices.get(chunk_index) else {
+                continue;
+            };
+            mutated_chunk_dictionaries.insert(i);
+            mutate_chunk(chunk, indices);
+
+            // Since all of the batch's indices have been applied to the
+            // chunk, the hash of the fully mutated chunk can be calculated
+            // now. Inserted into the mutation argument is the mutated chunk
+            // and its *old* (non-mutated) MMR membership proof.
+            if !batch_modification_hash_map.contains_key(chunk_index) {
+                batch_modification_hash_map
+                    .insert(*chunk_index, (mmr_mp.to_owned(), Tip5::hash(chunk)));
+            }
+        }
+    }
+
+    // For leafs that exist in no chunk dictionary, the authentication data is
+    // read from the removal records instead. Their chunk values are synced to
+    // the same state as the chunk dictionaries, so the mutation applies to
+    // the sourced chunks too. Indices whose chunk the removal records don't
+    // have either should be in the active part of the SWBF, where no leaf
+    // needs mutating.
+    if batch_modification_hash_map.len() < chunkidx_to_indices.len() {
+        let record_chunks: HashMap<u64, &(MmrMembershipProof, Chunk)> = removal_records
+            .iter()
+            .flat_map(|removal_record| removal_record.target_chunks.iter())
+            .map(|(chunk_index, authenticated_chunk)| (*chunk_index, authenticated_chunk))
+            .collect();
+        for (chunk_index, indices) in &chunkidx_to_indices {
+            if batch_modification_hash_map.contains_key(chunk_index) {
+                continue;
+            }
+            let Some((mp, chunk)) = record_chunks.get(chunk_index) else {
+                continue;
+            };
+            let mut target_chunk = chunk.to_owned();
+            mutate_chunk(&mut target_chunk, indices);
+
+            batch_modification_hash_map
+                .insert(*chunk_index, (mp.to_owned(), Tip5::hash(&target_chunk)));
+        }
+    }
+
+    (
+        mutated_chunk_dictionaries,
+        batch_modification_hash_map
+            .into_iter()
+            .map(|(i, (p, l))| (i, p, l))
+            .collect(),
+    )
+}
+
 /// Prepare a batch-modification with necessary authentication data
 /// to update the chunk dictionaries of mutator set membership proofs
-/// under *reversion* of a removal record.
+/// or removal records under application of a batch of removal records.
+///
+/// Like [`get_batch_mutation_argument_for_removal_record`], but handles the
+/// application of any number of removal records with a single mutation
+/// argument, i.e. a single batch-mutation of the MMR membership proofs. The
+/// combined mutation is well-defined because the chunk modifications of the
+/// individual applications commute: each only inserts indices into chunks.
+///
+/// The applied removal records must be synced to the same mutator-set state
+/// as the chunk dictionaries.
+pub fn get_batch_mutation_argument_for_removal_records(
+    removal_records: &[RemovalRecord],
+    chunk_dictionaries: &mut [&mut ChunkDictionary],
+) -> (HashSet<usize>, Vec<(u64, MmrMembershipProof, Digest)>) {
+    batch_mutation_argument_for_removal_records(removal_records, chunk_dictionaries, {
+        |chunk, indices| {
+            let relative_indices = indices
+                .iter()
+                .map(|index| (index % u128::from(CHUNK_SIZE)) as u32)
+                .collect_vec();
+            chunk.insert_many(&relative_indices);
+        }
+    })
+}
+
+/// Prepare a batch-modification with necessary authentication data
+/// to update the chunk dictionaries of mutator set membership proofs
+/// or removal records under *reversion* of a batch of removal records.
+///
+/// Like
+/// [`prepare_authenticated_batch_modification_for_removal_record_reversion`],
+/// but handles the reversion of any number of removal records with a single
+/// mutation argument, i.e. a single batch-mutation of the MMR membership
+/// proofs.
+///
+/// Unlike the one-record version, which takes the reverted record in its
+/// as-applied form, the reverted removal records here must be synced to the
+/// same mutator-set state as the chunk dictionaries — the state *after* the
+/// application of the entire batch, including themselves.
+pub fn prepare_authenticated_batch_modification_for_removal_records_reversion(
+    removal_records: &[RemovalRecord],
+    chunk_dictionaries: &mut [&mut ChunkDictionary],
+) -> (HashSet<usize>, Vec<(u64, MmrMembershipProof, Digest)>) {
+    batch_mutation_argument_for_removal_records(removal_records, chunk_dictionaries, {
+        |chunk, indices| {
+            for index in indices {
+                chunk.remove_once((index % u128::from(CHUNK_SIZE)) as u32);
+            }
+        }
+    })
+}
+
+/// Prepare a batch-modification with necessary authentication data
+/// to update the chunk dictionaries of mutator set membership proofs
+/// or removal records under *reversion* of a removal record.
 ///
 /// Parameters:
 ///  - `removal_record`: a reference to the removal record that is


### PR DESCRIPTION
Compose a single `MutatorSetUpdate` from a chain of (`MutatorSetUpdate`, `MutatorSetAccumulator`) pairs, without relying on the archival mutator set.

Bonus: Much faster application of mutator set updates since an inner algorithm for maintaining removal records across the application of removal records goes form (O(N^2)) to (O(N).

Logically this optimization softforks the chain but an actual softfork would occur with negligible probability ~2^(-160). So this is considered OK.

I verified that no historical blocks fail to validate under these new, (theoretically stricter) rules.
<img width="875" height="137" alt="image" src="https://github.com/user-attachments/assets/2bb69c5f-7ee6-4255-a1f8-277683ba12f4" />

<img width="588" height="101" alt="image" src="https://github.com/user-attachments/assets/49d6e45e-1327-43fc-87af-7c00d8997d10" />

