### PR TITLE
Mmr authenticate sync received blocks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,6 +79,7 @@ jobs:
             test(verify_all_proof_servers_work) |
             test(basic_sync) |
             test(sync_with_validated_blocks) |
+            test(syncing_peers_complete_sync_from_each_other) |
             test(alice_sends_to_bob_with_proof_collection_capability)
           )'
 
@@ -96,6 +97,7 @@ jobs:
               test(validate_donation_address) |
               test(basic_sync) |
               test(sync_with_validated_blocks) |
+              test(syncing_peers_complete_sync_from_each_other) |
               test(alice_sends_to_bob_with_proof_collection_capability)
               '
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,8 @@ jobs:
             test(can_sync_from) |
             test(can_sync_with_moving) |
             test(verify_all_proof_servers_work) |
-            test(bob_catches_up_to_alices_new_blocks_with_sync_state) |
+            test(basic_sync) |
+            test(sync_with_validated_blocks) |
             test(alice_sends_to_bob_with_proof_collection_capability)
           )'
 
@@ -93,7 +94,8 @@ jobs:
               test(update_mutator_set_on_own_transaction_one_new_block_self_mined) |
               test(update_mutator_set_on_own_transaction_two_new_blocks_from_peer) |
               test(validate_donation_address) |
-              test(bob_catches_up_to_alices_new_blocks_with_sync_state) |
+              test(basic_sync) |
+              test(sync_with_validated_blocks) |
               test(alice_sends_to_bob_with_proof_collection_capability)
               '
 

--- a/neptune-archival-mmr/src/lib.rs
+++ b/neptune-archival-mmr/src/lib.rs
@@ -37,6 +37,7 @@ mod test_utils {
     pub(crate) use shared_tokio_runtime;
 }
 
+use std::collections::HashMap;
 use std::ops::RangeInclusive;
 
 use itertools::Itertools;
@@ -278,56 +279,117 @@ impl<Storage: StorageVec<Digest>> ArchivalMmr<Storage> {
     /// Return membership proof, as it looks relative to a smaller version of
     /// the MMR which only has `num_leafs` leafs. `num_leafs` may not exceed
     /// the actual number of leafs.
+    ///
+    /// # Panics
+    /// - If the `num_leafs` that the membership proof is served relative to is
+    ///   greater than this MMR's num leafs.
     pub async fn prove_membership_relative_to_smaller_mmr(
         &self,
         leaf_index: u64,
         num_leafs: u64,
     ) -> MmrMembershipProof {
-        // TODO: Replace this local function with the one in `twenty_first` once
-        // available through never version.
-        fn auth_path_node_indices(num_leafs: u64, leaf_index: u64) -> Vec<u64> {
-            assert!(
-                leaf_index < num_leafs,
-                "Leaf index out-of-bounds: {leaf_index}/{num_leafs}"
-            );
-
-            let (mut merkle_tree_index, _) =
-                leaf_index_to_mt_index_and_peak_index(leaf_index, num_leafs);
-            let mut node_index = leaf_index_to_node_index(leaf_index);
-            let mut height = 0;
-            let tree_height = u64::BITS - merkle_tree_index.leading_zeros() - 1;
-            let mut ret = Vec::with_capacity(tree_height as usize);
-            while merkle_tree_index > 1 {
-                let is_left_sibling = merkle_tree_index & 1 == 0;
-                let height_pow = 1u64 << (height + 1);
-                let as_1_or_minus_1: u64 = (2 * i64::from(is_left_sibling) - 1) as u64;
-                let signed_height_pow = height_pow.wrapping_mul(as_1_or_minus_1);
-                let sibling = node_index
-                    .wrapping_add(signed_height_pow)
-                    .wrapping_sub(as_1_or_minus_1);
-
-                node_index += 1 << ((height + 1) * u32::from(is_left_sibling));
-
-                ret.push(sibling);
-                merkle_tree_index >>= 1;
-                height += 1;
-            }
-
-            debug_assert_eq!(tree_height, ret.len() as u32, "Allocation must be optimal");
-
-            ret
-        }
-
         assert!(
             num_leafs <= self.num_leafs().await,
             "Cannot find membership proofs relative to bigger MMR"
         );
 
-        let node_indices = auth_path_node_indices(num_leafs, leaf_index);
+        let node_indices = shared_advanced::auth_path_node_indices(num_leafs, leaf_index);
         let ap_elements = self.digests.get_many(&node_indices).await;
 
         MmrMembershipProof {
             authentication_path: ap_elements,
+        }
+    }
+
+    /// Return membership proof, as it looks relative to a larger version of
+    /// the MMR, one that extends this MMR with additional leafs, and whose
+    /// nodes are known only through the authentication path of a later leaf of
+    /// this MMR.
+    ///
+    /// Every entry of the returned path is one of three kinds: a node known to
+    /// this MMR; the node at which the leaf's path joins the later leaf's path,
+    /// or an entry of `later_leaf_path` above that join.
+    ///
+    /// If the `later_leaf_path` is correct, and the path of a leaf after this
+    /// node's tip, then the result will be correct.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the MMR is empty, if `leaf_index` is out-of-bounds, if
+    /// `larger_num_leafs` is smaller than this MMR's number of leafs, or if
+    /// `later_leaf_path` does not have the length that `larger_num_leafs`
+    /// prescribes for this MMR's last leaf.
+    pub async fn prove_membership_relative_to_larger_mmr(
+        &self,
+        leaf_index: u64,
+        later_leaf_path: &MmrMembershipProof,
+        larger_num_leafs: u64,
+    ) -> MmrMembershipProof {
+        let num_leafs = self.num_leafs().await;
+        assert!(num_leafs > 0, "Cannot prove membership in an empty MMR");
+        assert!(
+            leaf_index < num_leafs,
+            "Leaf index out-of-bounds: {leaf_index}/{num_leafs}"
+        );
+        assert!(
+            num_leafs <= larger_num_leafs,
+            "Cannot find membership proofs relative to smaller MMR"
+        );
+
+        let last_leaf_index = num_leafs - 1;
+        let later_leaf_path_node_indices =
+            shared_advanced::auth_path_node_indices(larger_num_leafs, last_leaf_index);
+        assert_eq!(
+            later_leaf_path_node_indices.len(),
+            later_leaf_path.authentication_path.len(),
+            "Last leaf's authentication path must be relative to the larger MMR"
+        );
+
+        // Calculate all MMR nodes that can be known.
+        let mut node_index = leaf_index_to_node_index(last_leaf_index);
+        let mut acc_hash = self.get_leaf_async(last_leaf_index).await;
+        let mut beyond_own_nodes: HashMap<u64, Digest> = HashMap::new();
+        for (&sibling_index, &sibling) in later_leaf_path_node_indices
+            .iter()
+            .zip(&later_leaf_path.authentication_path)
+        {
+            beyond_own_nodes.insert(sibling_index, sibling);
+            let is_right_child =
+                shared_advanced::right_lineage_length_and_own_height(node_index).0 != 0;
+            acc_hash = if is_right_child {
+                Tip5::hash_pair(sibling, acc_hash)
+            } else {
+                Tip5::hash_pair(acc_hash, sibling)
+            };
+            node_index = shared_advanced::parent(node_index);
+            beyond_own_nodes.insert(node_index, acc_hash);
+        }
+
+        // Find the required MMR nodes for this membership proof, among the ones
+        // we could calculate.
+        let num_own_nodes = self.digests.len().await - 1;
+        let path_node_indices =
+            shared_advanced::auth_path_node_indices(larger_num_leafs, leaf_index);
+        let own_node_indices = path_node_indices
+            .iter()
+            .copied()
+            .filter(|node_index| *node_index <= num_own_nodes)
+            .collect_vec();
+        let mut own_digests = self.digests.get_many(&own_node_indices).await.into_iter();
+
+        let authentication_path = path_node_indices
+            .into_iter()
+            .map(|node_index| {
+                if node_index <= num_own_nodes {
+                    own_digests.next().unwrap()
+                } else {
+                    beyond_own_nodes[&node_index]
+                }
+            })
+            .collect();
+
+        MmrMembershipProof {
+            authentication_path,
         }
     }
 
@@ -809,6 +871,33 @@ pub(crate) mod tests {
             &smaller_mmr.peaks(),
             smaller_mmr.num_leafs()
         ));
+    }
+
+    #[proptest(cases = 20, async = "tokio")]
+    async fn prove_membership_relative_to_larger_mmr(
+        #[strategy(1u64..500)] num_leafs: u64,
+        #[strategy(vec(arb(), #num_leafs as usize))] digests: Vec<Digest>,
+        #[strategy(1u64..=#num_leafs)] reduced_num_leafs: u64,
+        #[strategy(0u64..#reduced_num_leafs)] leaf_index: u64,
+    ) {
+        let last_leaf_index = reduced_num_leafs - 1;
+        let full_ammr = mock::get_ammr_from_digests(digests.clone()).await;
+        let later_leaf_path = full_ammr.prove_membership_async(last_leaf_index).await;
+
+        let reduced_ammr =
+            mock::get_ammr_from_digests(digests[0..reduced_num_leafs as usize].to_vec()).await;
+        let mp = reduced_ammr
+            .prove_membership_relative_to_larger_mmr(leaf_index, &later_leaf_path, num_leafs)
+            .await;
+
+        let larger_mmr = MmrAccumulator::new_from_leafs(digests.clone());
+        prop_assert!(mp.verify(
+            leaf_index,
+            digests[leaf_index as usize],
+            &larger_mmr.peaks(),
+            larger_mmr.num_leafs()
+        ));
+        prop_assert_eq!(full_ammr.prove_membership_async(leaf_index).await, mp);
     }
 
     #[apply(shared_tokio_runtime)]

--- a/neptune-core/src/application/config/cli_args.rs
+++ b/neptune-core/src/application/config/cli_args.rs
@@ -472,6 +472,12 @@ pub struct Args {
     #[clap(long, value_name = "DIR")]
     pub sync_dir: Option<PathBuf>,
 
+    /// Override the version advertised in the peer handshake. Not settable
+    /// from the command line. Tests use it to exercise behavior that is gated
+    /// on peer versions.
+    #[clap(skip)]
+    pub advertised_version: Option<String>,
+
     /// Multiaddrs (or IPs) of nodes to connect to, e.g.:
     /// ```text
     /// --peer /ip4/8.8.8.8 \

--- a/neptune-core/src/application/loops/main_loop.rs
+++ b/neptune-core/src/application/loops/main_loop.rs
@@ -2473,7 +2473,7 @@ impl MainLoopHandler {
                 // files. Just drop the handle.
                 return None;
             }
-            SyncToMain::TipSuccessor(block) => {
+            SyncToMain::TipSuccessor { block, auth_path } => {
                 log_slow_scope!(fn_name!() + "::PeerTaskToMain::TipSuccessor");
                 let height = block.header().height;
 
@@ -2485,8 +2485,18 @@ impl MainLoopHandler {
                     if let Err(e) = global_state_mut.store_block_not_tip(*block).await {
                         panic!("Could not store sync block {}: {e}.", height);
                     }
-                } else if let Err(e) = global_state_mut.set_new_tip(*block).await {
-                    panic!("Could not store sync block {} as new tip: {e}.", height);
+                } else {
+                    if let Err(e) = global_state_mut.set_new_tip(*block).await {
+                        panic!("Could not store sync block {} as new tip: {e}.", height);
+                    }
+
+                    // The block is now the tip, and the sync loop deletes its
+                    // copy of the block's authentication path. Retain the path
+                    // for the tip as it's needed to serve other syncing peers
+                    // with authentication paths.
+                    if let Some(sync_anchor) = &mut global_state_mut.net.sync_anchor {
+                        sync_anchor.tip_auth_path = auth_path.map(|auth_path| (height, auth_path));
+                    }
                 }
 
                 // Flush.

--- a/neptune-core/src/application/loops/main_loop.rs
+++ b/neptune-core/src/application/loops/main_loop.rs
@@ -1147,7 +1147,7 @@ impl MainLoopHandler {
                     }
                 }
             }
-            PeerTaskToMain::NewSyncBlock(block, peer) => {
+            PeerTaskToMain::NewSyncBlock(block, peer, auth_path) => {
                 if let Some(sync_loop) = &main_loop_state.maybe_sync_loop {
                     // If we already know this block and it is on the canonical
                     // chain, then we can fast-forward the sync; we are only
@@ -1173,7 +1173,7 @@ impl MainLoopHandler {
                         info!("Fast-forwarding sync to block {}.", block.header().height);
                         sync_loop.send_fast_forward_block(block).await;
                     } else {
-                        sync_loop.send_block(block, peer);
+                        sync_loop.send_block(block, peer, auth_path);
                     }
                 }
             }
@@ -1182,9 +1182,9 @@ impl MainLoopHandler {
                     sync_loop.send_sync_coverage(socket_addr, synchronization_bit_mask);
                 }
             }
-            PeerTaskToMain::PeerWantsSyncBlock(peer, height) => {
+            PeerTaskToMain::PeerWantsSyncBlock(peer, height, requester_anchor) => {
                 if let Some(sync_loop) = &main_loop_state.maybe_sync_loop {
-                    sync_loop.send_try_fetch_block(peer, height);
+                    sync_loop.send_try_fetch_block(peer, height, requester_anchor);
                 }
             }
             PeerTaskToMain::Ban(malicious_peer_id) => {
@@ -2533,8 +2533,21 @@ impl MainLoopHandler {
                     peer_handle,
                 });
             }
-            SyncToMain::SyncBlock { block, peer_handle } => {
-                self.main_to_peer_broadcast(MainToPeerTask::SyncBlock { block, peer_handle });
+            SyncToMain::UnableToServeValidatedBlock { peer_handle } => {
+                self.main_to_peer_broadcast(MainToPeerTask::UnableToServeValidatedBlock {
+                    peer_handle,
+                });
+            }
+            SyncToMain::SyncBlock {
+                block,
+                peer_handle,
+                auth_path,
+            } => {
+                self.main_to_peer_broadcast(MainToPeerTask::SyncBlock {
+                    block,
+                    peer_handle,
+                    auth_path,
+                });
             }
         }
 

--- a/neptune-core/src/application/loops/peer_loop.rs
+++ b/neptune-core/src/application/loops/peer_loop.rs
@@ -67,6 +67,7 @@ use crate::application::loops::main_loop::MAX_NUM_DIGESTS_IN_BATCH_REQUEST;
 use crate::application::loops::peer_loop::channel::MainToPeerTask;
 use crate::application::loops::peer_loop::channel::PeerTaskToMain;
 use crate::application::loops::peer_loop::channel::PeerTaskToMainTransaction;
+use crate::application::loops::sync_loop::rapid_block_download::truncate_auth_path;
 use crate::application::loops::sync_loop::synchronization_bit_mask::SynchronizationBitMask;
 use crate::macros::fn_name;
 use crate::macros::log_slow_scope;
@@ -242,8 +243,15 @@ impl PeerLoopHandler {
     /// Construct an anchor-authenticated block response, with blocks and their
     /// MMR membership proofs relative to a specified anchor.
     ///
-    /// Returns `None` if the anchor has a lower leaf count than the blocks, or
-    /// a block height of the response exceeds own tip height.
+    /// The proofs are derived from the own archival block MMR, whose paths
+    /// are, by append-invariance, prefixes of the anchor-relative ones. So
+    /// the anchor may even lie beyond the own chain, as long as it does not
+    /// require longer paths than the own chain provides. Each derived path is
+    /// verified against the anchor before it is included, which also
+    /// establishes that the anchor lies on the own chain at all.
+    ///
+    /// Returns `None` if any block cannot be authenticated relative to the
+    /// anchor, or a block height of the response exceeds own tip height.
     async fn anchor_authenticated_block_response(
         state: &GlobalState,
         blocks: Vec<Block>,
@@ -270,16 +278,19 @@ impl PeerLoopHandler {
 
         let mut ret = vec![];
         for block in blocks {
-            let mmr_mp = state
+            let height: u64 = block.header().height.into();
+            let own_auth_path = state
                 .chain
                 .archival_state()
                 .archival_block_mmr
                 .ammr()
-                .prove_membership_relative_to_smaller_mmr(
-                    block.header().height.into(),
-                    anchor.num_leafs(),
-                )
+                .prove_membership_async(height)
                 .await;
+            let mmr_mp = truncate_auth_path(&own_auth_path, height, anchor.num_leafs()).filter(
+                |auth_path| {
+                    auth_path.verify(height, block.hash(), &anchor.peaks(), anchor.num_leafs())
+                },
+            )?;
             let block: TransferBlock = block.try_into().unwrap();
             ret.push((block, mmr_mp));
         }
@@ -1613,23 +1624,34 @@ impl PeerLoopHandler {
                     .await?
                     .expect("block should live in archival state because fetching the block digest from height worked");
 
-                let response =
-                    Self::anchor_authenticated_block_response(&state, vec![block], &anchor).await;
+                let authenticated_response =
+                    Self::anchor_authenticated_block_response(&state, vec![block.clone()], &anchor)
+                        .await;
 
                 // issue 457. do not hold lock across a peer.send(), nor self.punish()
                 drop(state);
 
-                let Some(mut response) = response else {
-                    warn!("Unable to satisfy validated block request");
-                    self.punish(NegativePeerSanction::BatchBlocksUnknownRequest)
-                        .await?;
-                    return Ok(KEEP_CONNECTION_ALIVE);
-                };
-
-                let authenticated_block = response.pop().expect("response has exactly one block");
-                peer.send(PeerMessage::ValidatedBlock(Box::new(authenticated_block)))
-                    .await?;
-                debug!("Sent validated block of height {block_height}");
+                match authenticated_response {
+                    Some(mut response) => {
+                        let authenticated_block =
+                            response.pop().expect("response has exactly one block");
+                        peer.send(PeerMessage::ValidatedBlock(Box::new(authenticated_block)))
+                            .await?;
+                        debug!("Sent validated block of height {block_height}");
+                    }
+                    None => {
+                        // No authentication path relative to the requester's
+                        // anchor can be produced, e.g. because this node is
+                        // itself syncing and its archival chain is shorter
+                        // than the requester's anchor. The requester accepts
+                        // plain blocks while syncing.
+                        let transfer_block = TransferBlock::try_from(block)
+                            .expect("block fetched from archival state should be valid");
+                        peer.send(PeerMessage::Block(Box::new(transfer_block)))
+                            .await?;
+                        debug!("Sent plain block of height {block_height}");
+                    }
+                }
 
                 Ok(KEEP_CONNECTION_ALIVE)
             }
@@ -3505,6 +3527,130 @@ mod tests {
                     .await
                     .unwrap();
             }
+        }
+
+        #[traced_test]
+        #[apply(shared_tokio_runtime)]
+        async fn validated_block_request_by_height_with_future_anchor() -> Result<()> {
+            // Scenario: The requester's sync anchor lies beyond this node's
+            // own chain, e.g. because this node is itself syncing and has
+            // already processed the requested block. The block is served with
+            // a valid authentication path whenever the requester's anchor
+            // does not require a longer path than the own chain provides;
+            // otherwise it is served as a plain block, without punishment.
+            let network = Network::Testnet(42);
+            let (
+                _peer_broadcast_tx,
+                from_main_rx_clone,
+                to_main_tx,
+                _to_main_rx1,
+                _,
+                _,
+                mut state_lock,
+                handshake,
+            ) = get_test_genesis_setup(0, cli_args::Args::default_with_network(network)).await?;
+            let genesis_block: Block = Block::genesis(network);
+            let peer_address = get_dummy_socket_address(0);
+            let mut rng = StdRng::seed_from_u64(5550005);
+            let [block_1, block_2, block_3, block_4, block_5] =
+                fake_valid_sequence_of_blocks_for_tests(
+                    &genesis_block,
+                    Timestamp::hours(1),
+                    rng.random(),
+                    network,
+                )
+                .await;
+            let blocks = [genesis_block, block_1, block_2, block_3, block_4, block_5];
+            for block in blocks.iter().skip(1) {
+                state_lock.set_new_tip(block.to_owned()).await.unwrap();
+            }
+
+            let own_leafs = blocks.iter().map(|block| block.hash()).collect_vec();
+            let own_num_leafs = own_leafs.len() as u64;
+            let mut anchor_leafs = own_leafs;
+            anchor_leafs.push(rng.random());
+            let future_anchor = MmrAccumulator::new_from_leafs(anchor_leafs.clone());
+            anchor_leafs.push(rng.random());
+            let far_future_anchor = MmrAccumulator::new_from_leafs(anchor_leafs);
+
+            let requested_height = BlockHeight::from(3u64);
+            let requested_block = &blocks[3];
+            let transfer_block = TransferBlock::try_from(requested_block.clone()).unwrap();
+
+            let own_auth_path = state_lock
+                .lock_guard()
+                .await
+                .chain
+                .archival_state()
+                .archival_block_mmr
+                .ammr()
+                .prove_membership_async(requested_height.into())
+                .await;
+
+            // The one-block-future anchor does not grow the requested block's
+            // local subtree, so the own path serves as-is.
+            let expected_path = truncate_auth_path(
+                &own_auth_path,
+                requested_height.into(),
+                future_anchor.num_leafs(),
+            )
+            .unwrap();
+            assert!(expected_path.verify(
+                requested_height.into(),
+                requested_block.hash(),
+                &future_anchor.peaks(),
+                future_anchor.num_leafs(),
+            ));
+
+            // The two-block-future anchor completes a larger subtree
+            // (2^3 leafs) and requires a longer path than the own chain can
+            // provide.
+            assert!(truncate_auth_path(
+                &own_auth_path,
+                requested_height.into(),
+                far_future_anchor.num_leafs(),
+            )
+            .is_none());
+            assert_eq!(8, far_future_anchor.num_leafs());
+            assert_eq!(6, own_num_leafs);
+
+            let cases = [
+                (
+                    future_anchor,
+                    PeerMessage::ValidatedBlock(Box::new((transfer_block.clone(), expected_path))),
+                ),
+                (
+                    far_future_anchor,
+                    PeerMessage::Block(Box::new(transfer_block)),
+                ),
+            ];
+            for (anchor, expected_message) in cases {
+                let mock = Mock::new(vec![
+                    Action::Read(PeerMessage::ValidatedBlockRequestByHeight(
+                        ValidatedBlockRequestByHeight {
+                            height: requested_height,
+                            anchor,
+                        },
+                    )),
+                    Action::Write(expected_message),
+                    Action::Read(PeerMessage::Bye),
+                ]);
+                let mut peer_loop_handler = PeerLoopHandler::new(
+                    to_main_tx.clone(),
+                    state_lock.clone(),
+                    pseudorandom_peer_id(&peer_address),
+                    socketaddr_to_multiaddr(peer_address),
+                    handshake,
+                    false,
+                    1,
+                );
+
+                peer_loop_handler
+                    .run_wrapper(mock, from_main_rx_clone.resubscribe())
+                    .await?;
+            }
+
+            Ok(())
         }
 
         #[traced_test]

--- a/neptune-core/src/application/loops/peer_loop.rs
+++ b/neptune-core/src/application/loops/peer_loop.rs
@@ -243,12 +243,8 @@ impl PeerLoopHandler {
     /// Construct an anchor-authenticated block response, with blocks and their
     /// MMR membership proofs relative to a specified anchor.
     ///
-    /// The proofs are derived from the own archival block MMR, whose paths
-    /// are, by append-invariance, prefixes of the anchor-relative ones. So
-    /// the anchor may even lie beyond the own chain, as long as it does not
-    /// require longer paths than the own chain provides. Each derived path is
-    /// verified against the anchor before it is included, which also
-    /// establishes that the anchor lies on the own chain at all.
+    /// Membership proofs are guaranteed to be valid against the provided
+    /// anchor.
     ///
     /// Returns `None` if any block cannot be authenticated relative to the
     /// anchor, or a block height of the response exceeds own tip height.
@@ -276,21 +272,46 @@ impl PeerLoopHandler {
             return None;
         }
 
+        let ammr = state.chain.archival_state().archival_block_mmr.ammr();
+        let own_num_leafs = ammr.num_leafs().await;
+
+        // are we syncing, and do we have an authentication path for our
+        // current tip relative to a bigger MMR? If so, use to append to
+        // authentication paths if needed.
+        let tip_auth_path = state.net.sync_anchor.as_ref().and_then(|sync_anchor| {
+            sync_anchor
+                .tip_auth_path
+                .as_ref()
+                .filter(|(tip_height, _)| tip_height.next().value() == own_num_leafs)
+                .filter(|_| own_num_leafs <= sync_anchor.block_mmr.num_leafs())
+                .map(|(_, auth_path)| (auth_path, sync_anchor.block_mmr.num_leafs()))
+        });
+
         let mut ret = vec![];
         for block in blocks {
             let height: u64 = block.header().height.into();
-            let own_auth_path = state
-                .chain
-                .archival_state()
-                .archival_block_mmr
-                .ammr()
-                .prove_membership_async(height)
-                .await;
-            let mmr_mp = truncate_auth_path(&own_auth_path, height, anchor.num_leafs()).filter(
-                |auth_path| {
-                    auth_path.verify(height, block.hash(), &anchor.peaks(), anchor.num_leafs())
-                },
-            )?;
+            let own_auth_path = ammr.prove_membership_async(height).await;
+            let mut mmr_mp = truncate_auth_path(&own_auth_path, height, anchor.num_leafs());
+
+            // The anchor requires longer paths than the own block MMR
+            // provides. Append the own path to one relative to the sync
+            // anchor, which the requester's anchor may lie within.
+            if mmr_mp.is_none() {
+                if let Some((tip_auth_path, sync_anchor_num_leafs)) = tip_auth_path {
+                    let stretched = ammr
+                        .prove_membership_relative_to_larger_mmr(
+                            height,
+                            tip_auth_path,
+                            sync_anchor_num_leafs,
+                        )
+                        .await;
+                    mmr_mp = truncate_auth_path(&stretched, height, anchor.num_leafs());
+                }
+            }
+
+            let mmr_mp = mmr_mp.filter(|auth_path| {
+                auth_path.verify(height, block.hash(), &anchor.peaks(), anchor.num_leafs())
+            })?;
             let block: TransferBlock = block.try_into().unwrap();
             ret.push((block, mmr_mp));
         }
@@ -1479,14 +1500,14 @@ impl PeerLoopHandler {
                     returned_blocks.push(block);
                 }
 
-                let response =
+                let authenticated_response =
                     Self::anchor_authenticated_block_response(&state, returned_blocks, &anchor)
                         .await;
 
                 // issue 457. do not hold lock across a peer.send(), nor self.punish()
                 drop(state);
 
-                let Some(response) = response else {
+                let Some(response) = authenticated_response else {
                     warn!("Unable to satisfy batch-block request");
                     self.punish(NegativePeerSanction::BatchBlocksUnknownRequest)
                         .await?;
@@ -3707,6 +3728,216 @@ mod tests {
 
         #[traced_test]
         #[apply(shared_tokio_runtime)]
+        async fn validated_block_request_by_height_with_retained_tip_path() -> Result<()> {
+            // Scenario: This node is syncing and has already processed blocks
+            // beyond what its own block MMR can authenticate against foreign
+            // anchors. The sync process has retained the archival tip's
+            // authentication path relative to the sync anchor. Requests whose
+            // anchors lie within the sync anchor are served by stretching the
+            // own path through the retained one; anchors that fork from the
+            // sync chain or require even longer paths are declined. So is
+            // everything when the retained path pertains to a stale tip.
+
+            /// Build an MMR over the given leafs while tracking the
+            /// authentication path of one of the leafs.
+            fn tracked_path(leafs: &[Digest], tracked_index: u64) -> MmrMembershipProof {
+                let mut mmra = MmrAccumulator::new_from_leafs(vec![]);
+                let mut tracked: Option<MmrMembershipProof> = None;
+                for (i, leaf) in leafs.iter().enumerate() {
+                    if let Some(mp) = &mut tracked {
+                        MmrMembershipProof::batch_update_from_append(
+                            &mut [mp],
+                            &[tracked_index],
+                            mmra.num_leafs(),
+                            *leaf,
+                            &mmra.peaks(),
+                        );
+                    }
+                    let mp = mmra.append(*leaf);
+                    if i as u64 == tracked_index {
+                        tracked = Some(mp);
+                    }
+                }
+
+                tracked.unwrap()
+            }
+
+            let network = Network::Testnet(42);
+            let (
+                _peer_broadcast_tx,
+                from_main_rx_clone,
+                to_main_tx,
+                _to_main_rx1,
+                _,
+                _,
+                mut state_lock,
+                handshake,
+            ) = get_test_genesis_setup(0, cli_args::Args::default_with_network(network)).await?;
+            let genesis_block: Block = Block::genesis(network);
+            let peer_address = get_dummy_socket_address(0);
+            let mut rng = StdRng::seed_from_u64(5550006);
+            let [block_1, block_2, block_3, block_4, block_5] =
+                fake_valid_sequence_of_blocks_for_tests(
+                    &genesis_block,
+                    Timestamp::hours(1),
+                    rng.random(),
+                    network,
+                )
+                .await;
+            let blocks = [genesis_block, block_1, block_2, block_3, block_4, block_5];
+            for block in blocks.iter().skip(1) {
+                state_lock.set_new_tip(block.to_owned()).await.unwrap();
+            }
+
+            // The sync anchor covers the own chain of six blocks plus four
+            // blocks yet to be downloaded. The claimed blocks themselves
+            // never enter the picture.
+            let mut anchor_leafs = blocks.iter().map(|block| block.hash()).collect_vec();
+            anchor_leafs.extend((0..4).map(|_| rng.random::<Digest>()));
+            let sync_anchor_mmra = MmrAccumulator::new_from_leafs(anchor_leafs.clone());
+            let tip_auth_path = tracked_path(&anchor_leafs, 5);
+            {
+                let mut state = state_lock.lock_guard_mut().await;
+                let claimed_pow = state.chain.tip().header().cumulative_proof_of_work;
+                let mut sync_anchor = crate::state::networking_state::SyncAnchor::new(
+                    claimed_pow,
+                    sync_anchor_mmra.clone(),
+                    BlockHeight::from(9u64),
+                    *anchor_leafs.last().unwrap(),
+                );
+                sync_anchor.tip_auth_path =
+                    Some((blocks[5].header().height, tip_auth_path.clone()));
+                state.net.sync_anchor = Some(sync_anchor);
+            }
+
+            let requested_height = BlockHeight::from(3u64);
+            let requested_block = &blocks[3];
+            let transfer_block = TransferBlock::try_from(requested_block.clone()).unwrap();
+
+            // The expected authentication paths, derived independently of the
+            // code under test. The own block MMR of six leafs provides paths
+            // of length 2 for leaf 3; all these anchors require length 3.
+            let full_path = tracked_path(&anchor_leafs, 3);
+            let path_for = |anchor: &MmrAccumulator| {
+                let path = truncate_auth_path(&full_path, 3, anchor.num_leafs()).unwrap();
+                assert!(path.verify(
+                    3,
+                    requested_block.hash(),
+                    &anchor.peaks(),
+                    anchor.num_leafs(),
+                ));
+                path
+            };
+
+            // A prefix of the sync anchor, the sync anchor itself, and an
+            // extension of it that requires no longer paths are all served.
+            let prefix_anchor = MmrAccumulator::new_from_leafs(anchor_leafs[..8].to_vec());
+            let mut extended_leafs = anchor_leafs.clone();
+            extended_leafs.push(rng.random());
+            let extension_anchor = MmrAccumulator::new_from_leafs(extended_leafs);
+
+            // An anchor whose chain forks off beyond the own tip fails path
+            // verification; an anchor that completes a larger subtree
+            // requires paths that even the sync anchor cannot provide. Both
+            // are declined.
+            let mut forked_leafs = anchor_leafs[..6].to_vec();
+            forked_leafs.extend((0..2).map(|_| rng.random::<Digest>()));
+            let forked_anchor = MmrAccumulator::new_from_leafs(forked_leafs);
+            let mut far_leafs = anchor_leafs.clone();
+            far_leafs.extend((0..6).map(|_| rng.random::<Digest>()));
+            let far_anchor = MmrAccumulator::new_from_leafs(far_leafs);
+            assert_eq!(16, far_anchor.num_leafs());
+
+            let cases = [
+                (
+                    prefix_anchor.clone(),
+                    PeerMessage::ValidatedBlock(Box::new((
+                        transfer_block.clone(),
+                        path_for(&prefix_anchor),
+                    ))),
+                ),
+                (
+                    sync_anchor_mmra.clone(),
+                    PeerMessage::ValidatedBlock(Box::new((
+                        transfer_block.clone(),
+                        path_for(&sync_anchor_mmra),
+                    ))),
+                ),
+                (
+                    extension_anchor.clone(),
+                    PeerMessage::ValidatedBlock(Box::new((
+                        transfer_block,
+                        path_for(&extension_anchor),
+                    ))),
+                ),
+                (forked_anchor, PeerMessage::UnableToSatisfyBatchRequest),
+                (far_anchor, PeerMessage::UnableToSatisfyBatchRequest),
+            ];
+            for (anchor, expected_message) in cases {
+                let mock = Mock::new(vec![
+                    Action::Read(PeerMessage::ValidatedBlockRequestByHeight(
+                        ValidatedBlockRequestByHeight {
+                            height: requested_height,
+                            anchor,
+                        },
+                    )),
+                    Action::Write(expected_message),
+                    Action::Read(PeerMessage::Bye),
+                ]);
+                let mut peer_loop_handler = PeerLoopHandler::new(
+                    to_main_tx.clone(),
+                    state_lock.clone(),
+                    pseudorandom_peer_id(&peer_address),
+                    socketaddr_to_multiaddr(peer_address),
+                    handshake,
+                    false,
+                    1,
+                );
+
+                peer_loop_handler
+                    .run_wrapper(mock, from_main_rx_clone.resubscribe())
+                    .await?;
+            }
+
+            // A retained path that no longer pertains to the tip is not used
+            // for stretching.
+            state_lock
+                .lock_guard_mut()
+                .await
+                .net
+                .sync_anchor
+                .as_mut()
+                .unwrap()
+                .tip_auth_path = Some((blocks[4].header().height, tip_auth_path));
+            let mock = Mock::new(vec![
+                Action::Read(PeerMessage::ValidatedBlockRequestByHeight(
+                    ValidatedBlockRequestByHeight {
+                        height: requested_height,
+                        anchor: prefix_anchor,
+                    },
+                )),
+                Action::Write(PeerMessage::UnableToSatisfyBatchRequest),
+                Action::Read(PeerMessage::Bye),
+            ]);
+            let mut peer_loop_handler = PeerLoopHandler::new(
+                to_main_tx.clone(),
+                state_lock.clone(),
+                pseudorandom_peer_id(&peer_address),
+                socketaddr_to_multiaddr(peer_address),
+                handshake,
+                false,
+                1,
+            );
+
+            peer_loop_handler
+                .run_wrapper(mock, from_main_rx_clone.resubscribe())
+                .await?;
+
+            Ok(())
+        }
+
+        #[traced_test]
+        #[apply(shared_tokio_runtime)]
         async fn validated_block_request_by_height_forwards_to_sync_loop_when_syncing() -> Result<()>
         {
             // Scenario: This node is itself syncing and receives a validated
@@ -3804,10 +4035,8 @@ mod tests {
             // plain block. If the block extends the sync champion it is
             // accepted, since successors lie beyond the sync anchor and
             // cannot be authenticated against it. Any other plain block from
-            // such a peer is ignored — without punishment, since it might be
-            // the honest answer to a request sent before sync mode became
-            // active. Plain blocks from peers on older versions are still
-            // accepted.
+            // such a peer is ignored, without punishment. Plain blocks from
+            // peers on older versions are still accepted.
             use neptune_p2p::peer::handshake_data::VersionString;
 
             let network = Network::Testnet(42);

--- a/neptune-core/src/application/loops/peer_loop.rs
+++ b/neptune-core/src/application/loops/peer_loop.rs
@@ -42,6 +42,7 @@ use neptune_p2p::peer::PeerSanction;
 use neptune_p2p::peer::PeerStanding;
 use neptune_p2p::peer::PositivePeerSanction;
 use neptune_p2p::peer::SyncChallenge;
+use neptune_p2p::peer::ValidatedBlockRequestByHeight;
 use neptune_primitives::block_height::BlockHeight;
 use neptune_primitives::mast_hash::MastHash;
 use neptune_primitives::timestamp::Timestamp;
@@ -238,12 +239,12 @@ impl PeerLoopHandler {
         sanction_result.map_err(|err| anyhow::anyhow!("Cannot reward banned peer: {err}"))
     }
 
-    /// Construct a batch response, with blocks and their MMR membership proofs
-    /// relative to a specified anchor.
+    /// Construct an anchor-authenticated block response, with blocks and their
+    /// MMR membership proofs relative to a specified anchor.
     ///
     /// Returns `None` if the anchor has a lower leaf count than the blocks, or
     /// a block height of the response exceeds own tip height.
-    async fn batch_response(
+    async fn anchor_authenticated_block_response(
         state: &GlobalState,
         blocks: Vec<Block>,
         anchor: &MmrAccumulator,
@@ -284,6 +285,107 @@ impl PeerLoopHandler {
         }
 
         Some(ret)
+    }
+
+    /// Handle a block received while sync mode is active: establish everything
+    /// about the block that can be established without its predecessor, then
+    /// hand it to the sync loop through the main loop.
+    ///
+    /// The caller must have established that sync mode is active; `champion`
+    /// is the sync anchor's champion as read by the caller.
+    async fn receive_sync_block(
+        &mut self,
+        block: Box<Block>,
+        champion: (BlockHeight, Digest),
+    ) -> Result<()> {
+        let network = self.global_state_lock.cli().network;
+        let (champion_height, champion_digest) = champion;
+        let height = block.header().height;
+        let digest = block.hash();
+
+        // A block above the champion that does not extend it is
+        // ignored below, so don't pay for verifying its proof.
+        // Verification is the expensive part of handling a block,
+        // and an unauthenticated peer decides when we do it.
+        let extends_champion = block.header().prev_block_digest == champion_digest;
+        if champion_height < height && !extends_champion {
+            warn!(
+                "Block {} / {:x} from peer {} is above the sync champion without \
+                 extending it; ignoring without verifying its proof.",
+                height, digest, self.peer_id
+            );
+            return Ok(());
+        }
+
+        // Establish everything about the block that can be
+        // established without its predecessor, before storing it.
+        // Otherwise this path is open to a DOS attack. Validation
+        // relative to the predecessor happens in the sync loop,
+        // which is where the predecessor becomes known.
+        //
+        // Note that this leaves the block's place in the chain
+        // unchecked: its `prev_block_digest` names a block we may
+        // not have, and nothing here ties the block to the fork
+        // being synced.
+        //
+        // No locks may be held here, since proof validation takes
+        // milliseconds.
+        let is_valid = block.solo_validate(self.now(), network).await.is_ok();
+        if !is_valid {
+            self.punish(NegativePeerSanction::InvalidBlock((height, digest)))
+                .await?;
+            return Ok(());
+        }
+
+        // Hold lock as state mutation must be atomic
+        let mut state_lock = self.global_state_lock.lock_guard_mut().await;
+        let Some(sync_anchor) = &mut state_lock.net.sync_anchor else {
+            // Handle race condition
+            warn!("Sync status dropped while processing block. Discarding latest block received from peer");
+            return Ok(());
+        };
+
+        let is_successor = block.header().prev_block_digest == sync_anchor.champion.1;
+        let is_new_champion = sync_anchor.incoming_block_is_new_champion(height);
+        if is_successor && is_new_champion {
+            // Inform main loop about a new tip-successor.
+            self.to_main_tx
+                .send(PeerTaskToMain::NewSyncTarget(block))
+                .await?;
+
+            // Keep sync anchor up to date.
+            sync_anchor.catch_up(height, digest);
+        } else if is_new_champion {
+            // The incoming block is the new champion but is not the
+            // successor of the current tip. This happens when
+            //  a) the peer sends new blocks out of order, or one of
+            //     the intermediate blocks was dropped in transit;
+            //     or
+            //  b) the peer reorg'ed.
+            // In either case, we can deal with the problem once
+            // sync mode is done. So ignore for now.
+            tracing::warn!(
+                "Block {} / {:x} from peer {} is new champion but not successor to tip; ignoring.",
+                height,
+                digest,
+                self.peer_id
+            );
+        } else if is_successor {
+            // Cannot happen.
+            tracing::error!(
+                "Block {} / {:x} from peer {} is successor to tip but not new champion; ignoring. Cannot happen.",
+                height,
+                digest,
+                self.peer_id
+            );
+        } else {
+            // Inform main loop about a new middle block.
+            self.to_main_tx
+                .send(PeerTaskToMain::NewSyncBlock(block, self.peer_id))
+                .await?;
+        }
+
+        Ok(())
     }
 
     /// Log why a transaction cannot be confirmed, and pick the sanction that
@@ -1181,7 +1283,6 @@ impl PeerLoopHandler {
 
                 // If sync mode is active, incoming blocks are destined for the
                 // sync loop.
-                let network = self.global_state_lock.cli().network;
                 let champion = self
                     .global_state_lock
                     .lock_guard()
@@ -1190,91 +1291,8 @@ impl PeerLoopHandler {
                     .sync_anchor
                     .as_ref()
                     .map(|sync_anchor| sync_anchor.champion);
-                if let Some((champion_height, champion_digest)) = champion {
-                    let height = block.header().height;
-                    let digest = block.hash();
-
-                    // A block above the champion that does not extend it is
-                    // ignored below, so don't pay for verifying its proof.
-                    // Verification is the expensive part of handling a block,
-                    // and an unauthenticated peer decides when we do it.
-                    let extends_champion = block.header().prev_block_digest == champion_digest;
-                    if champion_height < height && !extends_champion {
-                        warn!(
-                            "Block {} / {:x} from peer {} is above the sync champion without \
-                             extending it; ignoring without verifying its proof.",
-                            height, digest, self.peer_id
-                        );
-                        return Ok(KEEP_CONNECTION_ALIVE);
-                    }
-
-                    // Establish everything about the block that can be
-                    // established without its predecessor, before storing it.
-                    // Otherwise this path is open to a DOS attack. Validation
-                    // relative to the predecessor happens in the sync loop,
-                    // which is where the predecessor becomes known.
-                    //
-                    // Note that this leaves the block's place in the chain
-                    // unchecked: its `prev_block_digest` names a block we may
-                    // not have, and nothing here ties the block to the fork
-                    // being synced.
-                    //
-                    // No locks may be held here, since proof validation takes
-                    // milliseconds.
-                    let is_valid = block.solo_validate(self.now(), network).await.is_ok();
-                    if !is_valid {
-                        self.punish(NegativePeerSanction::InvalidBlock((height, digest)))
-                            .await?;
-                        return Ok(KEEP_CONNECTION_ALIVE);
-                    }
-
-                    // Hold lock as state mutation must be atomic
-                    let mut state_lock = self.global_state_lock.lock_guard_mut().await;
-                    let Some(sync_anchor) = &mut state_lock.net.sync_anchor else {
-                        // Handle race condition
-                        warn!("Sync status dropped while processing block. Discarding latest block received from peer");
-                        return Ok(KEEP_CONNECTION_ALIVE);
-                    };
-
-                    let is_successor = block.header().prev_block_digest == sync_anchor.champion.1;
-                    let is_new_champion = sync_anchor.incoming_block_is_new_champion(height);
-                    if is_successor && is_new_champion {
-                        // Inform main loop about a new tip-successor.
-                        self.to_main_tx
-                            .send(PeerTaskToMain::NewSyncTarget(block))
-                            .await?;
-
-                        // Keep sync anchor up to date.
-                        sync_anchor.catch_up(height, digest);
-                    } else if is_new_champion {
-                        // The incoming block is the new champion but is not the
-                        // successor of the current tip. This happens when
-                        //  a) the peer sends new blocks out of order, or one of
-                        //     the intermediate blocks was dropped in transit;
-                        //     or
-                        //  b) the peer reorg'ed.
-                        // In either case, we can deal with the problem once
-                        // sync mode is done. So ignore for now.
-                        tracing::warn!(
-                            "Block {} / {:x} from peer {} is new champion but not successor to tip; ignoring.",
-                            height,
-                            digest,
-                            self.peer_id
-                        );
-                    } else if is_successor {
-                        // Cannot happen.
-                        tracing::error!(
-                            "Block {} / {:x} from peer {} is successor to tip but not new champion; ignoring. Cannot happen.",
-                            height,
-                            digest,
-                            self.peer_id
-                        );
-                    } else {
-                        // Inform main loop about a new middle block.
-                        self.to_main_tx
-                            .send(PeerTaskToMain::NewSyncBlock(block, self.peer_id))
-                            .await?;
-                    }
+                if let Some(champion) = champion {
+                    self.receive_sync_block(block, champion).await?;
                     return Ok(KEEP_CONNECTION_ALIVE);
                 }
 
@@ -1419,7 +1437,9 @@ impl PeerLoopHandler {
                     returned_blocks.push(block);
                 }
 
-                let response = Self::batch_response(&state, returned_blocks, &anchor).await;
+                let response =
+                    Self::anchor_authenticated_block_response(&state, returned_blocks, &anchor)
+                        .await;
 
                 // issue 457. do not hold lock across a peer.send(), nor self.punish()
                 drop(state);
@@ -1529,6 +1549,144 @@ impl PeerLoopHandler {
                     .await?;
 
                 // Reward happens as part of `handle_blocks`.
+
+                Ok(KEEP_CONNECTION_ALIVE)
+            }
+            PeerMessage::ValidatedBlockRequestByHeight(request) => {
+                log_slow_scope!(fn_name!() + "::PeerMessage::ValidatedBlockRequestByHeight");
+
+                let ValidatedBlockRequestByHeight {
+                    height: block_height,
+                    anchor,
+                } = request;
+                debug!("Got ValidatedBlockRequestByHeight of height {block_height}");
+
+                if block_height.is_genesis() {
+                    self.punish(NegativePeerSanction::RequestForGenesisBlock)
+                        .await?;
+                    return Ok(KEEP_CONNECTION_ALIVE);
+                }
+
+                let state = self.global_state_lock.lock_guard().await;
+                let canonical_block_digest = state
+                    .chain
+                    .archival_state()
+                    .archival_block_mmr
+                    .ammr()
+                    .try_get_leaf(block_height.into())
+                    .await;
+                let Some(block_digest) = canonical_block_digest else {
+                    let sync_mode_active = state.net.sync_anchor.is_some();
+                    drop(state);
+
+                    // If this node is itself syncing, the requested block
+                    // might be managed by the sync loop, which serves it as a
+                    // plain, unauthenticated `Block`: an authentication path
+                    // can only be produced from the archival block MMR. The
+                    // requester accepts plain blocks during sync, so this
+                    // degrades gracefully.
+                    if sync_mode_active {
+                        let _ = self
+                            .to_main_tx
+                            .send(PeerTaskToMain::PeerWantsSyncBlock(
+                                self.peer_id,
+                                block_height,
+                            ))
+                            .await;
+
+                        return Ok(KEEP_CONNECTION_ALIVE);
+                    }
+
+                    warn!(
+                        "Got validated block request by height ({block_height}) for unknown block."
+                    );
+                    self.punish(NegativePeerSanction::BlockRequestUnknownHeight)
+                        .await?;
+
+                    return Ok(KEEP_CONNECTION_ALIVE);
+                };
+
+                let block = state
+                    .chain
+                    .archival_state()
+                    .get_block(block_digest)
+                    .await?
+                    .expect("block should live in archival state because fetching the block digest from height worked");
+
+                let response =
+                    Self::anchor_authenticated_block_response(&state, vec![block], &anchor).await;
+
+                // issue 457. do not hold lock across a peer.send(), nor self.punish()
+                drop(state);
+
+                let Some(mut response) = response else {
+                    warn!("Unable to satisfy validated block request");
+                    self.punish(NegativePeerSanction::BatchBlocksUnknownRequest)
+                        .await?;
+                    return Ok(KEEP_CONNECTION_ALIVE);
+                };
+
+                let authenticated_block = response.pop().expect("response has exactly one block");
+                peer.send(PeerMessage::ValidatedBlock(Box::new(authenticated_block)))
+                    .await?;
+                debug!("Sent validated block of height {block_height}");
+
+                Ok(KEEP_CONNECTION_ALIVE)
+            }
+            PeerMessage::ValidatedBlock(authenticated_block) => {
+                log_slow_scope!(fn_name!() + "::PeerMessage::ValidatedBlock");
+
+                let (t_block, membership_proof) = *authenticated_block;
+
+                debug!(
+                    "Got validated block from peer {}, height {}",
+                    self.peer_id, t_block.header.height,
+                );
+
+                // Verify that we are in fact in syncing mode. The
+                // authentication path is relative to the sync anchor, so the
+                // message is meaningless outside of sync mode.
+                let Some(sync_anchor) = self
+                    .global_state_lock
+                    .lock_guard()
+                    .await
+                    .net
+                    .sync_anchor
+                    .clone()
+                else {
+                    warn!("Received a validated block without being in syncing mode");
+                    self.punish(NegativePeerSanction::ReceivedBatchBlocksOutsideOfSync)
+                        .await?;
+                    return Ok(KEEP_CONNECTION_ALIVE);
+                };
+
+                let Ok(block) = Block::try_from(t_block) else {
+                    warn!("Received invalid transfer block from peer");
+                    self.punish(NegativePeerSanction::InvalidTransferBlock)
+                        .await?;
+                    return Ok(KEEP_CONNECTION_ALIVE);
+                };
+
+                // The authentication path establishes, without access to the
+                // block's parent, that the block is an ancestor of the tip
+                // that is being synced towards.
+                if !membership_proof.verify(
+                    block.header().height.into(),
+                    block.hash(),
+                    &sync_anchor.block_mmr.peaks(),
+                    sync_anchor.block_mmr.num_leafs(),
+                ) {
+                    warn!("Authentication of received block fails relative to anchor");
+                    self.punish(NegativePeerSanction::InvalidBlockMmrAuthentication)
+                        .await?;
+                    return Ok(KEEP_CONNECTION_ALIVE);
+                }
+
+                // The authentication path ties the block to the chain being
+                // synced, but says nothing about the block's intrinsic
+                // validity; `receive_sync_block` solo-validates.
+                self.receive_sync_block(Box::new(block), sync_anchor.champion)
+                    .await?;
 
                 Ok(KEEP_CONNECTION_ALIVE)
             }
@@ -2042,9 +2200,41 @@ impl PeerLoopHandler {
                     std::process::exit(255);
                 }
 
-                peer.send(PeerMessage::BlockRequestByHeight(height)).await?;
+                // Prefer the validated block request, whose response can be
+                // authenticated against the sync anchor without access to the
+                // block's parent. Older peers do not understand it, and
+                // outside of sync mode there is no anchor to validate
+                // against; fall back to the plain block request there.
+                let anchor = if self
+                    .peer_handshake_data
+                    .version
+                    .supports_validated_block_request()
+                {
+                    self.global_state_lock
+                        .lock_guard()
+                        .await
+                        .net
+                        .sync_anchor
+                        .as_ref()
+                        .map(|sync_anchor| sync_anchor.block_mmr.clone())
+                } else {
+                    None
+                };
 
-                debug!("sent block-request-by-height ({height}) to peer {target_peer}");
+                if let Some(anchor) = anchor {
+                    peer.send(PeerMessage::ValidatedBlockRequestByHeight(
+                        ValidatedBlockRequestByHeight { height, anchor },
+                    ))
+                    .await?;
+
+                    debug!(
+                        "sent validated-block-request-by-height ({height}) to peer {target_peer}"
+                    );
+                } else {
+                    peer.send(PeerMessage::BlockRequestByHeight(height)).await?;
+
+                    debug!("sent block-request-by-height ({height}) to peer {target_peer}");
+                }
 
                 Ok(KEEP_CONNECTION_ALIVE)
             }
@@ -3187,9 +3377,13 @@ mod tests {
                 let expected_response = {
                     let state = state_lock.lock_guard().await;
                     let blocks_for_response = blocks.iter().skip(i + 1).cloned().collect_vec();
-                    PeerLoopHandler::batch_response(&state, blocks_for_response, &mmra)
-                        .await
-                        .unwrap()
+                    PeerLoopHandler::anchor_authenticated_block_response(
+                        &state,
+                        blocks_for_response,
+                        &mmra,
+                    )
+                    .await
+                    .unwrap()
                 };
                 let mock = Mock::new(vec![
                     Action::Read(PeerMessage::BlockRequestBatch(BlockRequestBatch {
@@ -3215,6 +3409,187 @@ mod tests {
                     .await
                     .unwrap();
             }
+        }
+
+        #[traced_test]
+        #[apply(shared_tokio_runtime)]
+        async fn validated_block_request_by_height() {
+            // Scenario: Six blocks (including genesis) are known. Peer
+            // requests anchor-authenticated versions of each non-genesis block
+            // by height, and the client responds with the block along with an
+            // MMR authentication path that is valid relative to the request's
+            // anchor.
+            let network = Network::Testnet(42);
+            let (
+                _peer_broadcast_tx,
+                from_main_rx_clone,
+                to_main_tx,
+                _to_main_rx1,
+                _,
+                _,
+                mut state_lock,
+                handshake,
+            ) = get_test_genesis_setup(0, cli_args::Args::default_with_network(network))
+                .await
+                .unwrap();
+            let genesis_block: Block = Block::genesis(network);
+            let peer_address = get_dummy_socket_address(0);
+            let [block_1, block_2, block_3, block_4, block_5] =
+                fake_valid_sequence_of_blocks_for_tests(
+                    &genesis_block,
+                    Timestamp::hours(1),
+                    StdRng::seed_from_u64(5550002).random(),
+                    network,
+                )
+                .await;
+            let blocks = [genesis_block, block_1, block_2, block_3, block_4, block_5];
+            for block in blocks.iter().skip(1) {
+                state_lock.set_new_tip(block.to_owned()).await.unwrap();
+            }
+
+            let mut peer_loop_handler = PeerLoopHandler::new(
+                to_main_tx.clone(),
+                state_lock.clone(),
+                pseudorandom_peer_id(&peer_address),
+                socketaddr_to_multiaddr(peer_address),
+                handshake,
+                false,
+                1,
+            );
+            let mmra = state_lock
+                .lock_guard()
+                .await
+                .chain
+                .archival_state()
+                .archival_block_mmr
+                .ammr()
+                .to_accumulator_async()
+                .await;
+            for block in blocks.iter().skip(1) {
+                let expected_response = {
+                    let state = state_lock.lock_guard().await;
+                    PeerLoopHandler::anchor_authenticated_block_response(
+                        &state,
+                        vec![block.clone()],
+                        &mmra,
+                    )
+                    .await
+                    .unwrap()
+                    .pop()
+                    .unwrap()
+                };
+
+                // The response's authentication path establishes ancestry
+                // relative to the anchor, without access to the parent.
+                let (transfer_block, membership_proof) = &expected_response;
+                assert!(membership_proof.verify(
+                    transfer_block.header.height.into(),
+                    block.hash(),
+                    &mmra.peaks(),
+                    mmra.num_leafs(),
+                ));
+
+                let mock = Mock::new(vec![
+                    Action::Read(PeerMessage::ValidatedBlockRequestByHeight(
+                        ValidatedBlockRequestByHeight {
+                            height: block.header().height,
+                            anchor: mmra.clone(),
+                        },
+                    )),
+                    Action::Write(PeerMessage::ValidatedBlock(Box::new(expected_response))),
+                    Action::Read(PeerMessage::Bye),
+                ]);
+
+                peer_loop_handler
+                    .run_wrapper(mock, from_main_rx_clone.resubscribe())
+                    .await
+                    .unwrap();
+            }
+        }
+
+        #[traced_test]
+        #[apply(shared_tokio_runtime)]
+        async fn validated_block_request_by_height_forwards_to_sync_loop_when_syncing() -> Result<()>
+        {
+            // Scenario: This node is itself syncing and receives a validated
+            // block request for a height it does not have in its archival
+            // state. The request is forwarded to the sync loop rather than
+            // punished: the sync loop may manage the block and can serve it
+            // as a plain, unauthenticated `Block`.
+            let network = Network::Testnet(42);
+            let (
+                _peer_broadcast_tx,
+                from_main_rx_clone,
+                to_main_tx,
+                mut to_main_rx1,
+                _,
+                _,
+                mut state_lock,
+                handshake,
+            ) = get_test_genesis_setup(0, cli_args::Args::default_with_network(network)).await?;
+            let peer_address = get_dummy_socket_address(0);
+
+            // Enter sync mode, towards a claimed chain of eleven blocks. The
+            // claimed blocks themselves never enter the picture; the anchor
+            // and champion just have to be coherent with each other.
+            let mut rng = StdRng::seed_from_u64(5550003);
+            let claimed_height = BlockHeight::from(10u64);
+            let claimed_block_digests: Vec<Digest> = (0..=u64::from(claimed_height))
+                .map(|_| rng.random())
+                .collect_vec();
+            let anchor = MmrAccumulator::new_from_leafs(claimed_block_digests.clone());
+            {
+                let mut state = state_lock.lock_guard_mut().await;
+                let claimed_pow = state.chain.tip().header().cumulative_proof_of_work;
+                state.net.sync_anchor = Some(crate::state::networking_state::SyncAnchor::new(
+                    claimed_pow,
+                    anchor.clone(),
+                    claimed_height,
+                    *claimed_block_digests.last().unwrap(),
+                ));
+            }
+
+            // The requested height lies within the anchor, but is not in this
+            // node's archival state.
+            let requested_height = BlockHeight::from(5u64);
+
+            let mock = Mock::new(vec![
+                Action::Read(PeerMessage::ValidatedBlockRequestByHeight(
+                    ValidatedBlockRequestByHeight {
+                        height: requested_height,
+                        anchor,
+                    },
+                )),
+                Action::Read(PeerMessage::Bye),
+            ]);
+            let peer_id = pseudorandom_peer_id(&peer_address);
+            let mut peer_loop_handler = PeerLoopHandler::new(
+                to_main_tx.clone(),
+                state_lock.clone(),
+                peer_id,
+                socketaddr_to_multiaddr(peer_address),
+                handshake,
+                false,
+                1,
+            );
+
+            peer_loop_handler
+                .run_wrapper(mock, from_main_rx_clone.resubscribe())
+                .await?;
+
+            loop {
+                match to_main_rx1.try_recv() {
+                    Ok(PeerTaskToMain::PeerWantsSyncBlock(sender, height)) => {
+                        assert_eq!(peer_id, sender);
+                        assert_eq!(requested_height, height);
+                        break;
+                    }
+                    Ok(_) => (),
+                    Err(_) => bail!("Expected request to be forwarded to the sync loop"),
+                }
+            }
+
+            Ok(())
         }
 
         #[traced_test]
@@ -3270,7 +3645,7 @@ mod tests {
                 .await;
             let response_1 = {
                 let state_lock = state_lock.lock_guard().await;
-                PeerLoopHandler::batch_response(
+                PeerLoopHandler::anchor_authenticated_block_response(
                     &state_lock,
                     vec![block_1.clone(), block_2_a.clone(), block_3_a.clone()],
                     &anchor,
@@ -3307,7 +3682,7 @@ mod tests {
             // Peer knows block 2_b, verify that canonical chain with 2_a is returned
             let response_2 = {
                 let state_lock = state_lock.lock_guard().await;
-                PeerLoopHandler::batch_response(
+                PeerLoopHandler::anchor_authenticated_block_response(
                     &state_lock,
                     vec![block_2_a, block_3_a.clone()],
                     &anchor,
@@ -3406,7 +3781,7 @@ mod tests {
 
             let response = {
                 let state_lock = state_lock.lock_guard().await;
-                PeerLoopHandler::batch_response(
+                PeerLoopHandler::anchor_authenticated_block_response(
                     &state_lock,
                     vec![block_1.clone(), block_2_a, block_3_a.clone()],
                     &expected_anchor,

--- a/neptune-core/src/application/loops/peer_loop.rs
+++ b/neptune-core/src/application/loops/peer_loop.rs
@@ -302,12 +302,16 @@ impl PeerLoopHandler {
     /// about the block that can be established without its predecessor, then
     /// hand it to the sync loop through the main loop.
     ///
+    /// If the authentication path is set, the caller *must* have ensured that
+    /// it is valid against the node's syncing anchor.
+    ///
     /// The caller must have established that sync mode is active; `champion`
     /// is the sync anchor's champion as read by the caller.
     async fn receive_sync_block(
         &mut self,
         block: Box<Block>,
         champion: (BlockHeight, Digest),
+        auth_path: Option<MmrMembershipProof>,
     ) -> Result<()> {
         let network = self.global_state_lock.cli().network;
         let (champion_height, champion_digest) = champion;
@@ -348,7 +352,8 @@ impl PeerLoopHandler {
             return Ok(());
         }
 
-        // Hold lock as state mutation must be atomic
+        // Hold lock as state mutation must be atomic. Lock must be until
+        // processing is done.
         let mut state_lock = self.global_state_lock.lock_guard_mut().await;
         let Some(sync_anchor) = &mut state_lock.net.sync_anchor else {
             // Handle race condition
@@ -356,6 +361,7 @@ impl PeerLoopHandler {
             return Ok(());
         };
 
+        // Recalculate under write lock. To avoid race conditions.
         let is_successor = block.header().prev_block_digest == sync_anchor.champion.1;
         let is_new_champion = sync_anchor.incoming_block_is_new_champion(height);
         if is_successor && is_new_champion {
@@ -392,7 +398,7 @@ impl PeerLoopHandler {
         } else {
             // Inform main loop about a new middle block.
             self.to_main_tx
-                .send(PeerTaskToMain::NewSyncBlock(block, self.peer_id))
+                .send(PeerTaskToMain::NewSyncBlock(block, self.peer_id, auth_path))
                 .await?;
         }
 
@@ -1266,6 +1272,7 @@ impl PeerLoopHandler {
                     .send(PeerTaskToMain::PeerWantsSyncBlock(
                         self.peer_id,
                         block_height,
+                        None,
                     ))
                     .await;
 
@@ -1303,7 +1310,31 @@ impl PeerLoopHandler {
                     .as_ref()
                     .map(|sync_anchor| sync_anchor.champion);
                 if let Some(champion) = champion {
-                    self.receive_sync_block(block, champion).await?;
+                    // A peer on a version that understands
+                    // ValidatedBlockRequestByHeight serves middle blocks
+                    // authenticated whenever it can, and declines otherwise.
+                    //
+                    // TODO: Once the minimum supported peer version exceeds
+                    // 0.15.1, every peer serves authenticated blocks, and the
+                    // acceptance of plain middle blocks below can be dropped.
+                    let extends_champion = block.header().prev_block_digest == champion.1;
+                    let peer_serves_validated_blocks = self
+                        .peer_handshake_data
+                        .version
+                        .supports_validated_block_request();
+                    if peer_serves_validated_blocks && !extends_champion {
+                        warn!(
+                            "Ignoring unauthenticated block {} / {:x} from peer {}: the peer \
+                             can serve authenticated blocks, and the block does not extend \
+                             the sync champion.",
+                            block.header().height,
+                            block.hash(),
+                            self.peer_id
+                        );
+                        return Ok(KEEP_CONNECTION_ALIVE);
+                    }
+
+                    self.receive_sync_block(block, champion, None).await?;
                     return Ok(KEEP_CONNECTION_ALIVE);
                 }
 
@@ -1591,17 +1622,17 @@ impl PeerLoopHandler {
                     drop(state);
 
                     // If this node is itself syncing, the requested block
-                    // might be managed by the sync loop, which serves it as a
-                    // plain, unauthenticated `Block`: an authentication path
-                    // can only be produced from the archival block MMR. The
-                    // requester accepts plain blocks during sync, so this
-                    // degrades gracefully.
+                    // might be managed by the sync loop. The requester's
+                    // anchor travels along, so that the sync loop can serve
+                    // the block with its stored authentication path where
+                    // that path suits the anchor, and decline otherwise.
                     if sync_mode_active {
                         let _ = self
                             .to_main_tx
                             .send(PeerTaskToMain::PeerWantsSyncBlock(
                                 self.peer_id,
                                 block_height,
+                                Some(anchor),
                             ))
                             .await;
 
@@ -1641,15 +1672,10 @@ impl PeerLoopHandler {
                     }
                     None => {
                         // No authentication path relative to the requester's
-                        // anchor can be produced, e.g. because this node is
-                        // itself syncing and its archival chain is shorter
-                        // than the requester's anchor. The requester accepts
-                        // plain blocks while syncing.
-                        let transfer_block = TransferBlock::try_from(block)
-                            .expect("block fetched from archival state should be valid");
-                        peer.send(PeerMessage::Block(Box::new(transfer_block)))
-                            .await?;
-                        debug!("Sent plain block of height {block_height}");
+                        // anchor can be produced, so decline. How to proceed
+                        // is the caller's decision.
+                        peer.send(PeerMessage::UnableToSatisfyBatchRequest).await?;
+                        debug!("Declined validated block request of height {block_height}");
                     }
                 }
 
@@ -1707,8 +1733,12 @@ impl PeerLoopHandler {
                 // The authentication path ties the block to the chain being
                 // synced, but says nothing about the block's intrinsic
                 // validity; `receive_sync_block` solo-validates.
-                self.receive_sync_block(Box::new(block), sync_anchor.champion)
-                    .await?;
+                self.receive_sync_block(
+                    Box::new(block),
+                    sync_anchor.champion,
+                    Some(membership_proof),
+                )
+                .await?;
 
                 Ok(KEEP_CONNECTION_ALIVE)
             }
@@ -2341,12 +2371,37 @@ impl PeerLoopHandler {
                 }
                 Ok(KEEP_CONNECTION_ALIVE)
             }
-            MainToPeerTask::SyncBlock { block, peer_handle } => {
+            MainToPeerTask::UnableToServeValidatedBlock { peer_handle } => {
+                if self.peer_id == peer_handle {
+                    peer.send(PeerMessage::UnableToSatisfyBatchRequest).await?;
+                }
+                Ok(KEEP_CONNECTION_ALIVE)
+            }
+            MainToPeerTask::SyncBlock {
+                block,
+                peer_handle,
+                auth_path,
+            } => {
                 if self.peer_id == peer_handle {
                     let transfer_block = TransferBlock::try_from(*block)
                         .expect("block fetched from sync loop should be castable into transfer block because that's where it came from");
-                    peer.send(PeerMessage::Block(Box::new(transfer_block)))
-                        .await?;
+
+                    // An authentication path is only produced when the
+                    // requester asked with an anchor, which only peers that
+                    // understand `ValidatedBlock` do.
+                    match auth_path {
+                        Some(auth_path) => {
+                            peer.send(PeerMessage::ValidatedBlock(Box::new((
+                                transfer_block,
+                                auth_path,
+                            ))))
+                            .await?;
+                        }
+                        None => {
+                            peer.send(PeerMessage::Block(Box::new(transfer_block)))
+                                .await?;
+                        }
+                    }
                 }
                 Ok(KEEP_CONNECTION_ALIVE)
             }
@@ -3537,7 +3592,7 @@ mod tests {
             // already processed the requested block. The block is served with
             // a valid authentication path whenever the requester's anchor
             // does not require a longer path than the own chain provides;
-            // otherwise it is served as a plain block, without punishment.
+            // otherwise the request is declined, without punishment.
             let network = Network::Testnet(42);
             let (
                 _peer_broadcast_tx,
@@ -3617,12 +3672,9 @@ mod tests {
             let cases = [
                 (
                     future_anchor,
-                    PeerMessage::ValidatedBlock(Box::new((transfer_block.clone(), expected_path))),
+                    PeerMessage::ValidatedBlock(Box::new((transfer_block, expected_path))),
                 ),
-                (
-                    far_future_anchor,
-                    PeerMessage::Block(Box::new(transfer_block)),
-                ),
+                (far_future_anchor, PeerMessage::UnableToSatisfyBatchRequest),
             ];
             for (anchor, expected_message) in cases {
                 let mock = Mock::new(vec![
@@ -3660,8 +3712,9 @@ mod tests {
             // Scenario: This node is itself syncing and receives a validated
             // block request for a height it does not have in its archival
             // state. The request is forwarded to the sync loop rather than
-            // punished: the sync loop may manage the block and can serve it
-            // as a plain, unauthenticated `Block`.
+            // punished: the sync loop may manage the block, and the anchor
+            // travels along so that the block can be served with its stored
+            // authentication path where possible.
             let network = Network::Testnet(42);
             let (
                 _peer_broadcast_tx,
@@ -3703,7 +3756,7 @@ mod tests {
                 Action::Read(PeerMessage::ValidatedBlockRequestByHeight(
                     ValidatedBlockRequestByHeight {
                         height: requested_height,
-                        anchor,
+                        anchor: anchor.clone(),
                     },
                 )),
                 Action::Read(PeerMessage::Bye),
@@ -3725,14 +3778,242 @@ mod tests {
 
             loop {
                 match to_main_rx1.try_recv() {
-                    Ok(PeerTaskToMain::PeerWantsSyncBlock(sender, height)) => {
+                    Ok(PeerTaskToMain::PeerWantsSyncBlock(sender, height, forwarded_anchor)) => {
                         assert_eq!(peer_id, sender);
                         assert_eq!(requested_height, height);
+                        assert_eq!(
+                            Some(anchor),
+                            forwarded_anchor,
+                            "The requester's anchor must be forwarded to the sync loop"
+                        );
                         break;
                     }
                     Ok(_) => (),
                     Err(_) => bail!("Expected request to be forwarded to the sync loop"),
                 }
+            }
+
+            Ok(())
+        }
+
+        #[traced_test]
+        #[apply(shared_tokio_runtime)]
+        async fn plain_blocks_from_validated_capable_peers_are_ignored_during_sync() -> Result<()> {
+            // Scenario: This node is syncing. A peer whose version can serve
+            // authenticated blocks ([`PeerMessage::ValidatedBlock`]) sends a
+            // plain block. If the block extends the sync champion it is
+            // accepted, since successors lie beyond the sync anchor and
+            // cannot be authenticated against it. Any other plain block from
+            // such a peer is ignored — without punishment, since it might be
+            // the honest answer to a request sent before sync mode became
+            // active. Plain blocks from peers on older versions are still
+            // accepted.
+            use neptune_p2p::peer::handshake_data::VersionString;
+
+            let network = Network::Testnet(42);
+            let genesis_block = Block::genesis(network);
+            let [block_1, block_2, block_3] = fake_valid_sequence_of_blocks_for_tests(
+                &genesis_block,
+                Timestamp::hours(1),
+                StdRng::seed_from_u64(5550004).random(),
+                network,
+            )
+            .await;
+
+            // The sync anchor covers genesis through block 2; block 2 is the
+            // champion. Block 1 is a middle block; block 3 extends the
+            // champion.
+            let anchor = MmrAccumulator::new_from_leafs(vec![
+                genesis_block.hash(),
+                block_1.hash(),
+                block_2.hash(),
+            ]);
+            let capable_version = VersionString::new_from_str("0.99.0");
+            assert!(capable_version.supports_validated_block_request());
+
+            enum Expected {
+                Ignored,
+                NewSyncTarget,
+                NewSyncBlock,
+            }
+            let cases = [
+                (Some(capable_version), block_1.clone(), Expected::Ignored),
+                (
+                    Some(capable_version),
+                    block_3.clone(),
+                    Expected::NewSyncTarget,
+                ),
+                (None, block_1.clone(), Expected::NewSyncBlock),
+            ];
+            for (version_override, sent_block, expected) in cases {
+                let (
+                    _peer_broadcast_tx,
+                    from_main_rx_clone,
+                    to_main_tx,
+                    mut to_main_rx1,
+                    _,
+                    _,
+                    mut state_lock,
+                    mut handshake,
+                ) = get_test_genesis_setup(0, cli_args::Args::default_with_network(network))
+                    .await?;
+                if let Some(version) = version_override {
+                    handshake.version = version;
+                } else {
+                    assert!(!handshake.version.supports_validated_block_request());
+                }
+                let peer_address = get_dummy_socket_address(0);
+
+                {
+                    let mut state = state_lock.lock_guard_mut().await;
+                    state.net.sync_anchor = Some(crate::state::networking_state::SyncAnchor::new(
+                        block_2.header().cumulative_proof_of_work,
+                        anchor.clone(),
+                        block_2.header().height,
+                        block_2.hash(),
+                    ));
+                }
+
+                let mock = Mock::new(vec![
+                    Action::Read(PeerMessage::Block(Box::new(
+                        sent_block.clone().try_into().unwrap(),
+                    ))),
+                    Action::Read(PeerMessage::Bye),
+                ]);
+                let peer_id = pseudorandom_peer_id(&peer_address);
+                let mut peer_loop_handler = PeerLoopHandler::new(
+                    to_main_tx.clone(),
+                    state_lock.clone(),
+                    peer_id,
+                    socketaddr_to_multiaddr(peer_address),
+                    handshake,
+                    false,
+                    1,
+                );
+
+                peer_loop_handler
+                    .run_wrapper(mock, from_main_rx_clone.resubscribe())
+                    .await?;
+                drop(to_main_tx);
+
+                let mut received_sync_message = None;
+                loop {
+                    match to_main_rx1.try_recv() {
+                        Ok(
+                            message @ (PeerTaskToMain::NewSyncBlock(..)
+                            | PeerTaskToMain::NewSyncTarget(_)),
+                        ) => {
+                            received_sync_message = Some(message);
+                            break;
+                        }
+                        Ok(_) => (),
+                        Err(_) => break,
+                    }
+                }
+
+                match expected {
+                    Expected::Ignored => {
+                        assert!(
+                            received_sync_message.is_none(),
+                            "Plain non-successor block from a validated-capable peer must be \
+                             ignored"
+                        );
+                        let peer_standing = state_lock
+                            .lock_guard()
+                            .await
+                            .net
+                            .get_peer_standing_from_database(peer_address.ip())
+                            .await;
+                        assert!(
+                            peer_standing.is_none_or(|standing| standing.standing == 0),
+                            "Ignoring a plain block must not punish the sender"
+                        );
+                    }
+                    Expected::NewSyncTarget => {
+                        assert_eq!(
+                            Some(PeerTaskToMain::NewSyncTarget(Box::new(sent_block))),
+                            received_sync_message,
+                            "Plain champion successor must be accepted"
+                        );
+                    }
+                    Expected::NewSyncBlock => {
+                        assert_eq!(
+                            Some(PeerTaskToMain::NewSyncBlock(
+                                Box::new(sent_block),
+                                peer_id,
+                                None
+                            )),
+                            received_sync_message,
+                            "Plain middle block from an old-version peer must be accepted"
+                        );
+                    }
+                }
+            }
+
+            Ok(())
+        }
+
+        #[traced_test]
+        #[apply(shared_tokio_runtime)]
+        async fn sync_blocks_are_sent_validated_when_authenticated() -> Result<()> {
+            // A sync block accompanied by an authentication path is sent as a
+            // `ValidatedBlock`; one without is sent as a plain `Block`.
+            let network = Network::Testnet(42);
+            let (
+                _peer_broadcast_tx,
+                _from_main_rx,
+                to_main_tx,
+                _to_main_rx1,
+                _,
+                _,
+                state_lock,
+                handshake,
+            ) = get_test_genesis_setup(0, cli_args::Args::default_with_network(network)).await?;
+            let peer_address = get_dummy_socket_address(0);
+            let peer_id = pseudorandom_peer_id(&peer_address);
+
+            let genesis_block = Block::genesis(network);
+            let [block_1] = fake_valid_sequence_of_blocks_for_tests(
+                &genesis_block,
+                Timestamp::hours(1),
+                StdRng::seed_from_u64(5550004).random(),
+                network,
+            )
+            .await;
+            let transfer_block = TransferBlock::try_from(block_1.clone()).unwrap();
+            let auth_path = MmrMembershipProof::new(vec![Digest::default()]);
+
+            let cases = [
+                (
+                    Some(auth_path.clone()),
+                    PeerMessage::ValidatedBlock(Box::new((transfer_block.clone(), auth_path))),
+                ),
+                (None, PeerMessage::Block(Box::new(transfer_block))),
+            ];
+            for (sent_auth_path, expected_message) in cases {
+                let mut mock = Mock::new(vec![Action::Write(expected_message)]);
+                let mut peer_loop_handler = PeerLoopHandler::new(
+                    to_main_tx.clone(),
+                    state_lock.clone(),
+                    peer_id,
+                    socketaddr_to_multiaddr(peer_address),
+                    handshake,
+                    false,
+                    1,
+                );
+                let mut peer_state = MutablePeerState::new(handshake.tip_header.height);
+
+                peer_loop_handler
+                    .handle_main_task_message(
+                        MainToPeerTask::SyncBlock {
+                            block: Box::new(block_1.clone()),
+                            peer_handle: peer_id,
+                            auth_path: sent_auth_path,
+                        },
+                        &mut mock,
+                        &mut peer_state,
+                    )
+                    .await?;
             }
 
             Ok(())

--- a/neptune-core/src/application/loops/peer_loop.rs
+++ b/neptune-core/src/application/loops/peer_loop.rs
@@ -2273,11 +2273,9 @@ impl PeerLoopHandler {
                     std::process::exit(255);
                 }
 
-                // Prefer the validated block request, whose response can be
-                // authenticated against the sync anchor without access to the
-                // block's parent. Older peers do not understand it, and
-                // outside of sync mode there is no anchor to validate
-                // against; fall back to the plain block request there.
+                // Prefer the validated block request if possible: requires
+                // that this node is syncing, and that peer understands this
+                // message type.
                 let anchor = if self
                     .peer_handshake_data
                     .version

--- a/neptune-core/src/application/loops/peer_loop/channel.rs
+++ b/neptune-core/src/application/loops/peer_loop/channel.rs
@@ -9,6 +9,7 @@ use neptune_p2p::peer::transaction_notification::TransactionNotification;
 use neptune_primitives::block_height::BlockHeight;
 use neptune_primitives::difficulty_control::ProofOfWork;
 use tasm_lib::triton_vm::prelude::Digest;
+use tasm_lib::twenty_first::prelude::MmrMembershipProof;
 use tasm_lib::twenty_first::util_types::mmr::mmr_accumulator::MmrAccumulator;
 
 use crate::application::loops::sync_loop::synchronization_bit_mask::SynchronizationBitMask;
@@ -47,11 +48,21 @@ pub(crate) enum MainToPeerTask {
         peer_handle: PeerId,
     },
 
+    /// Informs a peer that its validated block request cannot be served,
+    /// because no authentication path relative to its anchor could be
+    /// produced.
+    UnableToServeValidatedBlock {
+        peer_handle: PeerId,
+    },
+
     /// Sends a syncing peer a block we have downloaded already but not
     /// processed.
     SyncBlock {
         block: Box<Block>,
         peer_handle: PeerId,
+        /// An authentication path proving the block's membership in the chain
+        /// anchored by the peer's sync anchor, if one could be produced.
+        auth_path: Option<MmrMembershipProof>,
     },
 }
 
@@ -72,6 +83,7 @@ impl MainToPeerTask {
             MainToPeerTask::RequestBlockNotification => "request for block notification",
             MainToPeerTask::SyncCoverage { .. } => "sync coverage",
             MainToPeerTask::SyncBlock { .. } => "sync block",
+            MainToPeerTask::UnableToServeValidatedBlock { .. } => "unable to serve validated block",
         }
         .to_string()
     }
@@ -92,6 +104,7 @@ impl MainToPeerTask {
             MainToPeerTask::RequestBlockNotification => false,
             MainToPeerTask::SyncCoverage { .. } => true,
             MainToPeerTask::SyncBlock { .. } => true,
+            MainToPeerTask::UnableToServeValidatedBlock { .. } => true,
         }
     }
 }
@@ -118,11 +131,18 @@ pub(crate) enum PeerTaskToMain {
     BlockProposal(Box<Block>),
     DisconnectFromLongestLivedPeer,
     NewSyncTarget(Box<Block>),
-    NewSyncBlock(Box<Block>, PeerId),
+    /// A downloaded middle block for the sync loop, along with its
+    /// authentication path relative to the sync anchor, if it arrived with
+    /// one. The peer task *must* have validated the authentication path if one
+    /// is set.
+    NewSyncBlock(Box<Block>, PeerId, Option<MmrMembershipProof>),
     NewPeer(PeerId),
     DroppedPeer(PeerId),
     SyncCoverage(SynchronizationBitMask, PeerId),
-    PeerWantsSyncBlock(PeerId, BlockHeight),
+    /// A peer requests a block that is managed by the sync loop. If the
+    /// request carried an anchor, the served block should be authenticated
+    /// against it.
+    PeerWantsSyncBlock(PeerId, BlockHeight, Option<MmrAccumulator>),
 
     // Node wants to ban the peer. The legacy peer-to-peer stack already takes
     // care of this in the destructor of the peer loop. However, for the ban to
@@ -148,11 +168,11 @@ impl PeerTaskToMain {
             PeerTaskToMain::BlockProposal(_) => "block proposal",
             PeerTaskToMain::DisconnectFromLongestLivedPeer => "disconnect from longest lived peer",
             PeerTaskToMain::NewSyncTarget(_block) => "new sync target",
-            PeerTaskToMain::NewSyncBlock(_block, _socket_addr) => "new sync block",
+            PeerTaskToMain::NewSyncBlock(..) => "new sync block",
             PeerTaskToMain::NewPeer { .. } => "new peer",
             PeerTaskToMain::DroppedPeer(_) => "dropped peer",
             PeerTaskToMain::SyncCoverage(_, _) => "sync coverage",
-            PeerTaskToMain::PeerWantsSyncBlock(_, _) => "peer wants sync block",
+            PeerTaskToMain::PeerWantsSyncBlock(..) => "peer wants sync block",
             PeerTaskToMain::Ban(_) => "node wants to ban a malicious peer",
         }
         .to_string()

--- a/neptune-core/src/application/loops/sync_loop.rs
+++ b/neptune-core/src/application/loops/sync_loop.rs
@@ -10,6 +10,7 @@ use neptune_primitives::block_height::BlockHeight;
 use neptune_primitives::network::Network;
 use rand::rng;
 use rand::Rng;
+use tasm_lib::twenty_first::prelude::MmrMembershipProof;
 use tasm_lib::twenty_first::util_types::mmr::mmr_accumulator::MmrAccumulator;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Receiver;
@@ -355,7 +356,7 @@ impl SyncLoop {
                                 }
 
                                 tracing::debug!("chain extension is one ahead of current tip; sending directly to main loop.");
-                                if !Self::ensure_send_tip_successor(&self.main_channel_sender, *block.to_owned()).await {
+                                if !Self::ensure_send_tip_successor(&self.main_channel_sender, *block.to_owned(), None).await {
                                     tracing::error!("Could not send tip-successor to main loop. Terminating sync loop.");
                                     break;
                                 }
@@ -817,12 +818,16 @@ impl SyncLoop {
     async fn ensure_send_tip_successor(
         channel_to_main: &Sender<SyncToMain>,
         successor: Block,
+        auth_path: Option<MmrMembershipProof>,
     ) -> bool {
         // send to main
         // important payload, so report on delays
         let max = 1000;
         for i in 1..=max {
-            match channel_to_main.try_send(SyncToMain::TipSuccessor(Box::new(successor.clone()))) {
+            match channel_to_main.try_send(SyncToMain::TipSuccessor {
+                block: Box::new(successor.clone()),
+                auth_path: auth_path.clone(),
+            }) {
                 Ok(_) => {
                     if i > 1 {
                         tracing::debug!("succeeded sending tip-successor block to main");
@@ -860,8 +865,8 @@ impl SyncLoop {
         let mut tip = current_tip;
         while download_state.have_received(tip.header().height.next()) {
             // get successor block
-            let Ok(successor) = download_state
-                .get_received_block(tip.header().height.next())
+            let Ok((successor, auth_path)) = download_state
+                .get_received_entry(tip.header().height.next())
                 .await
             else {
                 tracing::error!(
@@ -898,7 +903,9 @@ impl SyncLoop {
             }
 
             // send to main
-            if !Self::ensure_send_tip_successor(&channel_to_main, successor.clone()).await {
+            if !Self::ensure_send_tip_successor(&channel_to_main, successor.clone(), auth_path)
+                .await
+            {
                 tracing::error!(
                     "Sync loop: failed to send tip-successor block to main \
                     loop. Aborting sync loop."
@@ -1066,7 +1073,7 @@ mod tests {
                                 }
                                 break;
                             }
-                            SyncToMain::TipSuccessor(block) => {
+                            SyncToMain::TipSuccessor { block, auth_path: _ } => {
                                 tracing::debug!("mock main loop: processing block {}", block.header().height);
                                 if block.header().height == self.current_tip_height.next() {
                                     self.current_tip_height = block.header().height;

--- a/neptune-core/src/application/loops/sync_loop.rs
+++ b/neptune-core/src/application/loops/sync_loop.rs
@@ -943,6 +943,34 @@ impl SyncLoop {
     }
 }
 
+/// Helpers for integration tests.
+#[cfg(any(test, feature = "test-helpers"))]
+pub mod test_helpers {
+    use std::path::PathBuf;
+
+    use anyhow::Result;
+    use neptune_consensus::block::Block;
+    use neptune_primitives::network::Network;
+    use tasm_lib::twenty_first::prelude::MmrMembershipProof;
+
+    use super::rapid_block_download::RapidBlockDownload;
+
+    /// Write sync-store entries for the given blocks and authentication
+    /// paths, such that a sync process started with the same `sync_dir`
+    /// resumes from them: the covered heights count as already downloaded.
+    /// The authentication paths must be valid relative to the sync anchor
+    /// that the syncing node will obtain.
+    pub async fn seed_sync_directory(
+        sync_dir: PathBuf,
+        network: Network,
+        entries: &[(Block, MmrMembershipProof)],
+    ) -> Result<()> {
+        RapidBlockDownload::seed_directory(&Some(sync_dir), network, entries)
+            .await
+            .map_err(|e| anyhow::anyhow!("could not seed sync directory: {e}"))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;

--- a/neptune-core/src/application/loops/sync_loop.rs
+++ b/neptune-core/src/application/loops/sync_loop.rs
@@ -10,6 +10,7 @@ use neptune_primitives::block_height::BlockHeight;
 use neptune_primitives::network::Network;
 use rand::rng;
 use rand::Rng;
+use tasm_lib::twenty_first::util_types::mmr::mmr_accumulator::MmrAccumulator;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Receiver;
 use tokio::sync::mpsc::Sender;
@@ -270,7 +271,7 @@ impl SyncLoop {
                             self.peers.lock().await.remove(&peer_handle);
                             last_peer_disconnect_time = Some(SystemTime::now());
                         }
-                        MainToSync::ReceiveBlock { peer_handle, block } => {
+                        MainToSync::ReceiveBlock { peer_handle, block, auth_path } => {
                             tracing::info!(
                                 "Sync loop: receiving block {} out of [{}:{}) ...",
                                 block.header().height,
@@ -280,7 +281,7 @@ impl SyncLoop {
 
                             // Store block and update download state.
                             tracing::trace!("storing block ...");
-                            if let Err(e) = self.download_state.receive_block(&block).await
+                            if let Err(e) = self.download_state.receive_block(&block, auth_path.as_ref()).await
                             {
                                 tracing::warn!(
                                     "Could not process received block {:x} of height {}: {}",
@@ -387,7 +388,7 @@ impl SyncLoop {
                                 pending_block_requests.push(peer_handle);
                             }
                         }
-                        MainToSync::TryFetchBlock{ peer_handle, height } => {
+                        MainToSync::TryFetchBlock{ peer_handle, height, requester_anchor } => {
                             tracing::debug!("sync loop received try-fetch-block message from peer {peer_handle} for block {height}");
 
                             // Test if the requested block height lives in the
@@ -413,7 +414,7 @@ impl SyncLoop {
                                 let moved_download_state = self.download_state.clone();
                                 let moved_main_channel_sender = self.main_channel_sender.clone();
                                 let _ = tokio::task::spawn(
-                                    Self::fetch_and_send_block(moved_main_channel_sender, moved_download_state, peer_handle, height)
+                                    Self::fetch_and_send_block(moved_main_channel_sender, moved_download_state, peer_handle, height, requester_anchor)
                                 ).await;
                             }
                         }
@@ -641,22 +642,37 @@ impl SyncLoop {
         download_state: RapidBlockDownload,
         peer_handle: PeerHandle,
         height: BlockHeight,
+        requester_anchor: Option<MmrAccumulator>,
     ) {
-        let block = match download_state.get_received_block(height).await {
-            Ok(b) => b,
-            Err(e) => {
-                tracing::error!("Failed to read block from temp directory: {e}.");
-                return;
-            }
+        let response = match &requester_anchor {
+            // A request that came with an anchor asks for an *authenticated*
+            // block.
+            Some(anchor) => match download_state.get_authenticated_block(height, anchor).await {
+                Ok(Some((block, auth_path))) => SyncToMain::SyncBlock {
+                    block: Box::new(block),
+                    peer_handle,
+                    auth_path: Some(auth_path),
+                },
+                Ok(None) => SyncToMain::UnableToServeValidatedBlock { peer_handle },
+                Err(e) => {
+                    tracing::error!("Failed to read block from temp directory: {e}.");
+                    return;
+                }
+            },
+            None => match download_state.get_received_block(height).await {
+                Ok(block) => SyncToMain::SyncBlock {
+                    block: Box::new(block),
+                    peer_handle,
+                    auth_path: None,
+                },
+                Err(e) => {
+                    tracing::error!("Failed to read block from temp directory: {e}.");
+                    return;
+                }
+            },
         };
 
-        if let Err(e) = main_channel_sender
-            .send(SyncToMain::SyncBlock {
-                block: Box::new(block),
-                peer_handle,
-            })
-            .await
-        {
+        if let Err(e) = main_channel_sender.send(response).await {
             tracing::error!("Could not send sync block to main loop: {e}.");
         }
     }
@@ -1069,7 +1085,7 @@ mod tests {
                                     if let Some(peer) = self.peers.get_mut(&block_request.peer_handle.clone()) {
                                         if let Some(block) = peer.request(block_request.height).await {
                                             tracing::debug!("mock main loop: got block from peer; relaying to sync loop");
-                                            self.sync_loop_handle.send_block(Box::new(block), block_request.peer_handle);
+                                            self.sync_loop_handle.send_block(Box::new(block), block_request.peer_handle, None);
                                             tracing::debug!("mock main loop: done relaying");
                                         } else {
                                             if let MockPeer::Syncing(syncing_peer) = peer {
@@ -1101,9 +1117,13 @@ mod tests {
                             } => {
                                 tracing::info!("mock main loop: Sending coverage to peer {peer_handle}");
                             }
+                            SyncToMain::UnableToServeValidatedBlock { peer_handle } => {
+                                tracing::info!("mock main loop: cannot serve validated block to {peer_handle}");
+                            }
                             SyncToMain::SyncBlock{
                                 block,
                                 peer_handle,
+                                auth_path: _,
                             } => {
                                 tracing::info!("mock main loop: Sending block {} over to {peer_handle}", block.header().height);
                             }

--- a/neptune-core/src/application/loops/sync_loop/channel.rs
+++ b/neptune-core/src/application/loops/sync_loop/channel.rs
@@ -17,7 +17,16 @@ pub(crate) struct BlockRequest {
 #[derive(Debug, Clone)]
 pub(crate) enum SyncToMain {
     Finished(BlockHeight),
-    TipSuccessor(Box<Block>),
+    TipSuccessor {
+        block: Box<Block>,
+        /// The authentication path the block arrived with, proving its
+        /// membership in the chain being synced towards, if any. Retained by
+        /// the main loop when the block becomes the new tip, since the sync
+        /// loop deletes its copy after the handover.
+        ///
+        /// If provided, it is assumed to be valid.
+        auth_path: Option<MmrMembershipProof>,
+    },
     RequestBlocks(Vec<BlockRequest>),
     Status(SyncProgress),
     Punish(Vec<PeerHandle>),

--- a/neptune-core/src/application/loops/sync_loop/channel.rs
+++ b/neptune-core/src/application/loops/sync_loop/channel.rs
@@ -1,5 +1,7 @@
 use neptune_consensus::block::Block;
 use neptune_primitives::block_height::BlockHeight;
+use tasm_lib::twenty_first::prelude::MmrMembershipProof;
+use tasm_lib::twenty_first::util_types::mmr::mmr_accumulator::MmrAccumulator;
 
 use super::PeerHandle;
 use crate::application::loops::sync_loop::sync_progress::SyncProgress;
@@ -24,9 +26,18 @@ pub(crate) enum SyncToMain {
         peer_handle: PeerHandle,
     },
     Error,
+    /// A peer requested a block with an anchor to authenticate against, but
+    /// no authentication path relative to that anchor could be produced. The
+    /// requester is informed so it can ask elsewhere.
+    UnableToServeValidatedBlock {
+        peer_handle: PeerHandle,
+    },
     SyncBlock {
         block: Box<Block>,
         peer_handle: PeerHandle,
+        /// An authentication path proving the block's membership in the chain
+        /// anchored by the requester's anchor, if one could be produced.
+        auth_path: Option<MmrMembershipProof>,
     },
 }
 
@@ -39,6 +50,10 @@ pub(crate) enum MainToSync {
     ReceiveBlock {
         peer_handle: PeerHandle,
         block: Box<Block>,
+        /// An authentication path proving the block's membership in the chain
+        /// being synced towards, if the block arrived with one. Must have
+        /// been verified against the provided sync anchor.
+        auth_path: Option<MmrMembershipProof>,
     },
     ExtendChain(Box<Block>),
     SyncCoverage {
@@ -48,6 +63,9 @@ pub(crate) enum MainToSync {
     TryFetchBlock {
         peer_handle: PeerHandle,
         height: BlockHeight,
+        /// The sync anchor of the requesting peer, against which a served
+        /// block should be authenticated, if the request carried one.
+        requester_anchor: Option<MmrAccumulator>,
     },
     FastForward {
         new_tip: Box<Block>,

--- a/neptune-core/src/application/loops/sync_loop/handle.rs
+++ b/neptune-core/src/application/loops/sync_loop/handle.rs
@@ -1,6 +1,8 @@
 use neptune_consensus::block::Block;
 use neptune_primitives::block_height::BlockHeight;
 use neptune_primitives::network::Network;
+use tasm_lib::twenty_first::prelude::MmrMembershipProof;
+use tasm_lib::twenty_first::util_types::mmr::mmr_accumulator::MmrAccumulator;
 use tokio::sync::mpsc::Receiver;
 use tokio::sync::mpsc::Sender;
 use tokio::task::JoinHandle;
@@ -63,10 +65,16 @@ impl SyncLoopHandle {
         }
     }
 
-    pub(crate) fn send_block(&self, block: Box<Block>, peer: PeerHandle) {
+    pub(crate) fn send_block(
+        &self,
+        block: Box<Block>,
+        peer: PeerHandle,
+        auth_path: Option<MmrMembershipProof>,
+    ) {
         if let Err(e) = self.sender.try_send(MainToSync::ReceiveBlock {
             peer_handle: peer,
             block,
+            auth_path,
         }) {
             tracing::warn!("Error relaying block to sync loop: {e}.");
             tracing::debug!(
@@ -91,10 +99,16 @@ impl SyncLoopHandle {
         }
     }
 
-    pub(crate) fn send_try_fetch_block(&self, peer: PeerHandle, height: BlockHeight) {
+    pub(crate) fn send_try_fetch_block(
+        &self,
+        peer: PeerHandle,
+        height: BlockHeight,
+        requester_anchor: Option<MmrAccumulator>,
+    ) {
         if let Err(e) = self.sender.try_send(MainToSync::TryFetchBlock {
             peer_handle: peer,
             height,
+            requester_anchor,
         }) {
             tracing::warn!("Error sending try-fetch-block message to sync loop: {e}.");
             tracing::debug!(

--- a/neptune-core/src/application/loops/sync_loop/rapid_block_download.rs
+++ b/neptune-core/src/application/loops/sync_loop/rapid_block_download.rs
@@ -393,7 +393,7 @@ impl RapidBlockDownload {
 
     /// Read a block and its stored authentication path, if any, from the
     /// storage directory.
-    async fn get_received_entry(
+    pub(crate) async fn get_received_entry(
         &self,
         height: BlockHeight,
     ) -> Result<(Block, Option<MmrMembershipProof>), RapidBlockDownloadError> {

--- a/neptune-core/src/application/loops/sync_loop/rapid_block_download.rs
+++ b/neptune-core/src/application/loops/sync_loop/rapid_block_download.rs
@@ -486,6 +486,39 @@ pub(crate) enum RapidBlockDownloadError {
     Serialization(String),
 }
 
+/// Test-only extensions of [`RapidBlockDownload`], keeping the knowledge of
+/// its storage format in this file.
+#[cfg(any(test, feature = "test-helpers"))]
+mod test_helpers {
+    use super::*;
+
+    impl RapidBlockDownload {
+        /// Write sync-store entries for the given blocks and authentication
+        /// paths, such that a sync process started with the same `sync_dir`
+        /// resumes from them. Gives tests a way to hand a node a
+        /// predetermined partial download.
+        pub(crate) async fn seed_directory(
+            sync_dir: &Option<PathBuf>,
+            network: Network,
+            entries: &[(Block, MmrMembershipProof)],
+        ) -> Result<(), RapidBlockDownloadError> {
+            let storage_dir = Self::base_storage_dir(sync_dir, network).join("seed/");
+            tokio::fs::create_dir_all(&storage_dir)
+                .await
+                .map_err(|e| RapidBlockDownloadError::IO(e.to_string()))?;
+            for (block, auth_path) in entries {
+                let data = bincode::serialize(&(block, Some(auth_path)))
+                    .map_err(|e| RapidBlockDownloadError::Serialization(e.to_string()))?;
+                tokio::fs::write(storage_dir.join(block.hash().to_hex()), data)
+                    .await
+                    .map_err(|e| RapidBlockDownloadError::IO(e.to_string()))?;
+            }
+
+            Ok(())
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use itertools::Itertools;

--- a/neptune-core/src/application/loops/sync_loop/rapid_block_download.rs
+++ b/neptune-core/src/application/loops/sync_loop/rapid_block_download.rs
@@ -6,9 +6,49 @@ use neptune_primitives::block_height::BlockHeight;
 use neptune_primitives::network::Network;
 use rand::rng;
 use rand::RngCore;
+use tasm_lib::twenty_first::prelude::Mmr;
+use tasm_lib::twenty_first::prelude::MmrMembershipProof;
+use tasm_lib::twenty_first::util_types::mmr::mmr_accumulator::MmrAccumulator;
 use tokio::fs;
 
 use crate::application::loops::sync_loop::SynchronizationBitMask;
+
+/// Truncate an MMR authentication path to one relative to an MMR with fewer
+/// leafs.
+///
+/// The entries of an MMR authentication path are append-invariant: appending
+/// leafs to the MMR only ever extends the path. So the path for a leaf
+/// relative to a smaller MMR is a prefix of the path relative to a larger one
+/// — provided the smaller MMR is a prefix of the larger, which this function
+/// cannot check. The caller must verify the returned path against the peaks
+/// of the target MMR before relying on, or sharing, it.
+///
+/// Returns `None` if the target MMR does not contain the leaf, or if it
+/// requires a longer path than the given one — which happens when the path's
+/// own MMR is the smaller one.
+///
+/// The same truncation, in other guises, appears in
+/// `MsMembershipProof::revert_update_from_batch_addition` and
+/// `RemovalRecord::batch_revert_update_from_addition`. Its storage-backed
+/// inverse is `ArchivalMmr::prove_membership_relative_to_smaller_mmr`.
+pub(crate) fn truncate_auth_path(
+    auth_path: &MmrMembershipProof,
+    leaf_index: u64,
+    target_num_leafs: u64,
+) -> Option<MmrMembershipProof> {
+    if leaf_index >= target_num_leafs {
+        return None;
+    }
+
+    let target_len = (leaf_index ^ target_num_leafs).ilog2() as usize;
+    if target_len > auth_path.authentication_path.len() {
+        return None;
+    }
+
+    Some(MmrMembershipProof::new(
+        auth_path.authentication_path[..target_len].to_vec(),
+    ))
+}
 
 /// The state of a rapid block download process.
 ///

--- a/neptune-core/src/application/loops/sync_loop/rapid_block_download.rs
+++ b/neptune-core/src/application/loops/sync_loop/rapid_block_download.rs
@@ -26,11 +26,6 @@ use crate::application::loops::sync_loop::SynchronizationBitMask;
 /// Returns `None` if the target MMR does not contain the leaf, or if it
 /// requires a longer path than the given one — which happens when the path's
 /// own MMR is the smaller one.
-///
-/// The same truncation, in other guises, appears in
-/// `MsMembershipProof::revert_update_from_batch_addition` and
-/// `RemovalRecord::batch_revert_update_from_addition`. Its storage-backed
-/// inverse is `ArchivalMmr::prove_membership_relative_to_smaller_mmr`.
 pub(crate) fn truncate_auth_path(
     auth_path: &MmrMembershipProof,
     leaf_index: u64,
@@ -129,12 +124,14 @@ impl RapidBlockDownload {
             .await
             .map_err(|e| RapidBlockDownloadError::IO(e.to_string()))?
         {
-            if let Ok(block) = Self::load_block(&entry.path()).await.inspect_err(|e| {
-                tracing::warn!(
-                    "Could not read Block from file '{}': {e}",
-                    entry.path().to_string_lossy()
-                );
-            }) {
+            if let Ok((block, _auth_path)) =
+                Self::load_entry(&entry.path()).await.inspect_err(|e| {
+                    tracing::warn!(
+                        "Could not read Block from file '{}': {e}",
+                        entry.path().to_string_lossy()
+                    );
+                })
+            {
                 let height = block.header().height.value();
                 if height >= coverage.upper_bound {
                     coverage = coverage.expand(height + 1);
@@ -289,7 +286,9 @@ impl RapidBlockDownload {
 
         self.coverage = self.coverage.clone().expand(new_block_height.value() + 1);
 
-        self.receive_block(new_block).await?;
+        // Blocks extending the chain lie beyond any sync anchor, so no
+        // authentication path can exist for them.
+        self.receive_block(new_block, None).await?;
 
         self.target_height = self.target_height.next();
 
@@ -303,13 +302,19 @@ impl RapidBlockDownload {
 
     /// Store the block in the storage directory and mark it as received, if it
     /// wasn't received already.
+    ///
+    /// The authentication path, if one is given, must have been verified to
+    /// prove the block's membership in the chain being synced towards.
+    // TODO: A block arriving *with* an authentication path for a height that
+    // was first received without one does not upgrade the stored entry.
     pub(crate) async fn receive_block(
         &mut self,
         block: &Block,
+        auth_path: Option<&MmrMembershipProof>,
     ) -> Result<(), RapidBlockDownloadError> {
         if !self.coverage.contains(block.header().height.value()) {
             let file_name = self.file_name(block);
-            self.store_block(block, &file_name).await?;
+            self.store_entry(block, auth_path, &file_name).await?;
 
             self.index_to_filename
                 .insert(block.header().height.value(), file_name);
@@ -319,27 +324,32 @@ impl RapidBlockDownload {
         Ok(())
     }
 
-    /// Store the block in the storage directory.
-    async fn store_block(
+    /// Store the block and its optional authentication path in the storage
+    /// directory.
+    async fn store_entry(
         &self,
         block: &Block,
+        auth_path: Option<&MmrMembershipProof>,
         file_name: &PathBuf,
     ) -> Result<(), RapidBlockDownloadError> {
-        let data = bincode::serialize(block)
+        let data = bincode::serialize(&(block, auth_path))
             .map_err(|e| RapidBlockDownloadError::Serialization(e.to_string()))?;
         tokio::fs::write(file_name, data)
             .await
             .map_err(|e| RapidBlockDownloadError::IO(e.to_string()))
     }
 
-    /// Load the block from the storage directory.
-    async fn load_block(file_name: &PathBuf) -> Result<Block, RapidBlockDownloadError> {
+    /// Load a block and its optional authentication path from the storage
+    /// directory.
+    async fn load_entry(
+        file_name: &PathBuf,
+    ) -> Result<(Block, Option<MmrMembershipProof>), RapidBlockDownloadError> {
         let data = tokio::fs::read(file_name)
             .await
             .map_err(|e| RapidBlockDownloadError::IO(e.to_string()))?;
-        let block = bincode::deserialize(&data)
+        let entry = bincode::deserialize(&data)
             .map_err(|e| RapidBlockDownloadError::Serialization(e.to_string()))?;
-        Ok(block)
+        Ok(entry)
     }
 
     /// Read a block from the storage directory.
@@ -347,16 +357,54 @@ impl RapidBlockDownload {
         &self,
         height: BlockHeight,
     ) -> Result<Block, RapidBlockDownloadError> {
+        self.get_received_entry(height)
+            .await
+            .map(|(block, _)| block)
+    }
+
+    /// Read a block from the storage directory, along with an authentication
+    /// path relative to the given anchor.
+    ///
+    /// The stored authentication path is relative to the anchor of the sync
+    /// process that received the block, which is generally not the requester's
+    /// anchor. The stored path is therefore truncated to the requester's anchor
+    /// and verified against it. `Ok(None)` is returned if no authentication
+    /// path against this anchor could be made.
+    pub(crate) async fn get_authenticated_block(
+        &self,
+        height: BlockHeight,
+        anchor: &MmrAccumulator,
+    ) -> Result<Option<(Block, MmrMembershipProof)>, RapidBlockDownloadError> {
+        let (block, stored_auth_path) = self.get_received_entry(height).await?;
+
+        let auth_path = stored_auth_path
+            .and_then(|stored| truncate_auth_path(&stored, height.value(), anchor.num_leafs()))
+            .filter(|truncated| {
+                truncated.verify(
+                    height.value(),
+                    block.hash(),
+                    &anchor.peaks(),
+                    anchor.num_leafs(),
+                )
+            });
+
+        Ok(auth_path.map(|auth_path| (block, auth_path)))
+    }
+
+    /// Read a block and its stored authentication path, if any, from the
+    /// storage directory.
+    async fn get_received_entry(
+        &self,
+        height: BlockHeight,
+    ) -> Result<(Block, Option<MmrMembershipProof>), RapidBlockDownloadError> {
         let file_name = self
             .index_to_filename
             .get(&height.value())
             .ok_or(RapidBlockDownloadError::NotReceived(height))?;
 
-        let block = Self::load_block(file_name)
+        Self::load_entry(file_name)
             .await
-            .map_err(|e| RapidBlockDownloadError::IO(e.to_string()))?;
-
-        Ok(block)
+            .map_err(|e| RapidBlockDownloadError::IO(e.to_string()))
     }
 
     /// Un-bind a height: throw away the block stored there and mark the height
@@ -447,10 +495,209 @@ mod tests {
     use rand::Rng;
     use rand::RngCore;
     use rand::SeedableRng;
+    use tasm_lib::prelude::Digest;
 
     use super::*;
     use crate::tests::shared::files::unit_test_path;
     use crate::tests::shared_tokio_runtime;
+
+    /// Build an MMR over the given leafs while tracking the authentication
+    /// path of one of the leafs. Returns the tracked path, relative to the full
+    /// MMR, along with the accumulator as it looked after each append:
+    /// `snapshots[m]` holds `m` leafs.
+    fn mmr_with_tracked_leaf(
+        leafs: &[Digest],
+        tracked_index: u64,
+    ) -> (MmrMembershipProof, Vec<MmrAccumulator>) {
+        let mut mmra = MmrAccumulator::new_from_leafs(vec![]);
+        let mut tracked: Option<MmrMembershipProof> = None;
+        let mut snapshots = vec![mmra.clone()];
+        for (i, leaf) in leafs.iter().enumerate() {
+            if let Some(mp) = &mut tracked {
+                MmrMembershipProof::batch_update_from_append(
+                    &mut [mp],
+                    &[tracked_index],
+                    mmra.num_leafs(),
+                    *leaf,
+                    &mmra.peaks(),
+                );
+            }
+            let mp = mmra.append(*leaf);
+            if i as u64 == tracked_index {
+                tracked = Some(mp);
+            }
+            snapshots.push(mmra.clone());
+        }
+
+        (tracked.unwrap(), snapshots)
+    }
+
+    #[test]
+    fn truncate_auth_path_yields_valid_paths_for_all_prefix_anchors() {
+        let mut rng = StdRng::seed_from_u64(0x1717);
+        let num_leafs = 130u64;
+        let leafs = (0..num_leafs).map(|_| rng.random::<Digest>()).collect_vec();
+
+        for tracked_index in [0u64, 1, 63, 64, 100, num_leafs - 1] {
+            let (full_path, snapshots) = mmr_with_tracked_leaf(&leafs, tracked_index);
+
+            // The full path truncates to a valid path for every prefix MMR
+            // that contains the leaf.
+            for m in (tracked_index + 1)..=num_leafs {
+                let truncated = truncate_auth_path(&full_path, tracked_index, m).unwrap();
+                assert!(truncated.verify(
+                    tracked_index,
+                    leafs[tracked_index as usize],
+                    &snapshots[m as usize].peaks(),
+                    m,
+                ));
+            }
+
+            // Prefixes not containing the leaf yield nothing.
+            assert!(truncate_auth_path(&full_path, tracked_index, tracked_index).is_none());
+        }
+
+        // A path relative to a small MMR cannot be stretched to a larger MMR
+        // that requires a longer path.
+        let (short_path, _) = mmr_with_tracked_leaf(&leafs[..2], 0);
+        assert!(truncate_auth_path(&short_path, 0, num_leafs).is_none());
+    }
+
+    #[apply(shared_tokio_runtime)]
+    async fn authenticated_blocks_are_served_relative_to_the_requester_anchor() {
+        let network = Network::Main;
+        let mut rng = rng();
+        let target_height = 129u64;
+        let block_height = 100u64;
+        let mut block = rng.random::<Block>();
+        block.set_header_height(block_height.into());
+
+        // The chain being synced towards: random block digests, except at the
+        // stored block's own height.
+        let num_leafs = target_height + 1;
+        let mut leafs = (0..num_leafs).map(|_| rng.random::<Digest>()).collect_vec();
+        leafs[block_height as usize] = block.hash();
+        let (auth_path, snapshots) = mmr_with_tracked_leaf(&leafs, block_height);
+        let own_anchor = snapshots[num_leafs as usize].clone();
+
+        let mut download = RapidBlockDownload::new(
+            BlockHeight::from(target_height),
+            false,
+            Some(unit_test_path()),
+            network,
+        )
+        .await
+        .unwrap();
+        download
+            .receive_block(&block, Some(&auth_path))
+            .await
+            .unwrap();
+
+        // A requester with the same anchor gets the stored path.
+        let (served_block, served_path) = download
+            .get_authenticated_block(block_height.into(), &own_anchor)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(block.hash(), served_block.hash());
+        assert!(served_path.verify(
+            block_height,
+            block.hash(),
+            &own_anchor.peaks(),
+            own_anchor.num_leafs(),
+        ));
+
+        // A requester whose anchor is a smaller prefix of the same chain gets
+        // a truncated path, valid relative to their anchor.
+        for smaller_num_leafs in [block_height + 1, 110] {
+            let smaller_anchor = &snapshots[smaller_num_leafs as usize];
+            let (_, truncated_path) = download
+                .get_authenticated_block(block_height.into(), smaller_anchor)
+                .await
+                .unwrap()
+                .unwrap();
+            assert!(truncated_path.verify(
+                block_height,
+                block.hash(),
+                &smaller_anchor.peaks(),
+                smaller_anchor.num_leafs(),
+            ));
+        }
+
+        // A requester syncing towards a different chain gets nothing.
+        let forked_anchor = MmrAccumulator::new_from_leafs(
+            (0..num_leafs).map(|_| rng.random::<Digest>()).collect_vec(),
+        );
+        let forked_anchor_entry = download
+            .get_authenticated_block(block_height.into(), &forked_anchor)
+            .await
+            .unwrap();
+        assert!(forked_anchor_entry.is_none());
+
+        // A block stored without a path cannot be served authenticated, but
+        // is still available plain.
+        let mut pathless_block = rng.random::<Block>();
+        pathless_block.set_header_height(BlockHeight::from(50u64));
+        download.receive_block(&pathless_block, None).await.unwrap();
+        let pathless_block_entry = download
+            .get_authenticated_block(BlockHeight::from(50u64), &own_anchor)
+            .await
+            .unwrap();
+        assert!(pathless_block_entry.is_none());
+        assert_eq!(
+            pathless_block.hash(),
+            download
+                .get_received_block(BlockHeight::from(50u64))
+                .await
+                .unwrap()
+                .hash()
+        );
+
+        let _ = download.clean_up().await;
+    }
+
+    #[apply(shared_tokio_runtime)]
+    async fn legacy_block_files_are_skipped_on_resume() {
+        let network = Network::Main;
+        let mut rng = rng();
+        let sync_dir = unit_test_path();
+        let target = BlockHeight::from(100u64);
+
+        // A first download stores one block in the current format. A file in
+        // the legacy format — a bare block, without the option of an
+        // authentication path — is planted next to it.
+        let mut first_download =
+            RapidBlockDownload::new(target, false, Some(sync_dir.clone()), network)
+                .await
+                .unwrap();
+        let mut stored_block = rng.random::<Block>();
+        stored_block.set_header_height(BlockHeight::from(7u64));
+        first_download
+            .receive_block(&stored_block, None)
+            .await
+            .unwrap();
+
+        let mut legacy_block = rng.random::<Block>();
+        legacy_block.set_header_height(BlockHeight::from(9u64));
+        tokio::fs::write(
+            first_download
+                .block_storage_dir
+                .join(legacy_block.hash().to_hex()),
+            bincode::serialize(&legacy_block).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        // On resume, the current-format block is recovered and the legacy
+        // file is skipped, so that height gets downloaded again.
+        let resumed_download = RapidBlockDownload::new(target, true, Some(sync_dir), network)
+            .await
+            .unwrap();
+        assert!(resumed_download.have_received(BlockHeight::from(7u64)));
+        assert!(!resumed_download.have_received(BlockHeight::from(9u64)));
+
+        let _ = resumed_download.clean_up().await;
+    }
 
     /// A rejected block must free its height slot, so that the height is asked
     /// for again and the download counts as unfinished.
@@ -469,7 +716,10 @@ mod tests {
         // The one outstanding height gets filled, completing the download.
         let mut block = rng.random::<Block>();
         block.set_header_height(target);
-        rapid_block_download.receive_block(&block).await.unwrap();
+        rapid_block_download
+            .receive_block(&block, None)
+            .await
+            .unwrap();
         assert!(rapid_block_download.have_received(target));
         assert!(rapid_block_download.is_complete());
 
@@ -486,7 +736,7 @@ mod tests {
         let mut replacement = rng.random::<Block>();
         replacement.set_header_height(target);
         rapid_block_download
-            .receive_block(&replacement)
+            .receive_block(&replacement, None)
             .await
             .unwrap();
         assert_eq!(
@@ -523,7 +773,7 @@ mod tests {
             received_heights.push(height);
             let mut block = rng.random::<Block>();
             block.set_header_height(BlockHeight::from(height));
-            if let Err(e) = rapid_block_download.receive_block(&block).await {
+            if let Err(e) = rapid_block_download.receive_block(&block, None).await {
                 panic!("Could not receive block {height}: {e}");
             }
 
@@ -586,7 +836,7 @@ mod tests {
 
             let mut block = rng.random::<Block>();
             block.set_header_height(height);
-            let _ = rapid_block_download.receive_block(&block).await;
+            let _ = rapid_block_download.receive_block(&block, None).await;
         }
 
         // verify that we are finished
@@ -630,7 +880,7 @@ mod tests {
 
             let mut block = rng.random::<Block>();
             block.set_header_height(height);
-            let _ = rapid_block_download_a.receive_block(&block).await;
+            let _ = rapid_block_download_a.receive_block(&block, None).await;
         }
 
         assert!(!rapid_block_download_a.is_complete());
@@ -655,7 +905,7 @@ mod tests {
 
             let mut block = rng.random::<Block>();
             block.set_header_height(height);
-            let _ = rapid_block_download_b.receive_block(&block).await;
+            let _ = rapid_block_download_b.receive_block(&block, None).await;
         }
 
         // verify that we are finished
@@ -706,7 +956,7 @@ mod tests {
             let mut block = rng.random::<Block>();
             let height = BlockHeight::from(i);
             block.set_header_height(height);
-            let _ = rapid_block_download_a.receive_block(&block).await;
+            let _ = rapid_block_download_a.receive_block(&block, None).await;
         }
 
         // setup new rapid block download state
@@ -748,7 +998,7 @@ mod tests {
                 let i = rng.random_range(0usize..blocks_remaining.len());
                 let mut block = rng.random::<Block>();
                 block.set_header_height(blocks_remaining[i]);
-                let _ = rapid_block_download.receive_block(&block).await;
+                let _ = rapid_block_download.receive_block(&block, None).await;
             } else {
                 let i = rng.random_range(0usize..blocks_remaining.len());
                 let height = blocks_remaining.swap_remove(i);
@@ -756,7 +1006,7 @@ mod tests {
 
                 let mut block = rng.random::<Block>();
                 block.set_header_height(height);
-                let _ = rapid_block_download.receive_block(&block).await;
+                let _ = rapid_block_download.receive_block(&block, None).await;
             };
         }
 
@@ -810,7 +1060,7 @@ mod tests {
 
                 let mut block = rng.random::<Block>();
                 block.set_header_height(height);
-                let _ = rapid_block_download.receive_block(&block).await;
+                let _ = rapid_block_download.receive_block(&block, None).await;
             }
 
             // verify that we are finished

--- a/neptune-core/src/application/loops/sync_loop/sync_progress.rs
+++ b/neptune-core/src/application/loops/sync_loop/sync_progress.rs
@@ -52,6 +52,21 @@ impl Display for SyncProgress {
     }
 }
 
+/// Views into the sync progress, for integration tests.
+#[cfg(any(test, feature = "test-helpers"))]
+mod test_helpers {
+    use super::*;
+
+    impl SyncProgress {
+        /// Whether every block in the sync span has been downloaded, whether
+        /// processed or not. The genesis block is part of the span but is
+        /// never downloaded, hence the off-by-one.
+        pub(crate) fn download_is_complete(&self) -> bool {
+            self.num_blocks_downloaded + 1 == self.total_span
+        }
+    }
+}
+
 #[cfg(feature = "mock-rpc")]
 impl rand::distr::Distribution<SyncProgress> for rand::distr::StandardUniform {
     fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> SyncProgress {

--- a/neptune-core/src/state/mod.rs
+++ b/neptune-core/src/state/mod.rs
@@ -1981,7 +1981,9 @@ impl GlobalState {
             listen_port,
             network: self.cli().network,
             instance_id: self.net.instance_id,
-            version: VersionString::new_from_str(VERSION),
+            version: VersionString::new_from_str(
+                self.cli().advertised_version.as_deref().unwrap_or(VERSION),
+            ),
             // For now, all nodes are archival nodes
             is_archival_node: self.chain.is_archival_node(),
             is_bootstrapper_node: self.cli().bootstrap,

--- a/neptune-core/src/state/mod.rs
+++ b/neptune-core/src/state/mod.rs
@@ -3503,6 +3503,44 @@ impl GlobalState {
     }
 }
 
+#[cfg(any(test, feature = "test-helpers"))]
+mod state_test_helpers {
+    use super::*;
+
+    impl GlobalState {
+        /// The canonical blocks at the given heights, each with its
+        /// authentication path relative to the archival block MMR.
+        ///
+        /// # Panics
+        ///
+        /// Panics if any of the heights lies beyond the tip.
+        pub async fn blocks_with_authentication_paths(
+            &self,
+            heights: std::ops::RangeInclusive<u64>,
+        ) -> Vec<(Block, tasm_lib::twenty_first::prelude::MmrMembershipProof)> {
+            let mut entries = vec![];
+            for height in heights {
+                let block = self
+                    .chain
+                    .archival_state()
+                    .canonical_block_by_height(height.into())
+                    .await
+                    .expect("block height must be known");
+                let auth_path = self
+                    .chain
+                    .archival_state()
+                    .archival_block_mmr
+                    .ammr()
+                    .prove_membership_async(height)
+                    .await;
+                entries.push((block, auth_path));
+            }
+
+            entries
+        }
+    }
+}
+
 /// Trip-wire guarding [`GlobalState`]'s `mempool` field visibility.
 ///
 /// The field is private on purpose (see its docs): that is what forces all

--- a/neptune-core/src/state/networking_state.rs
+++ b/neptune-core/src/state/networking_state.rs
@@ -270,14 +270,20 @@ impl NetworkingState {
 mod test_helpers {
     use super::*;
 
-    /// Whether a running sync process has retained an authentication path
-    /// for the current tip. Exists to give integration tests a view into
-    /// sync-internal state.
+    /// Views into sync-internal state, for integration tests.
     impl NetworkingState {
+        /// Whether a running sync process has retained an authentication path
+        /// for the current tip.
         pub fn sync_tip_auth_path_is_retained(&self) -> bool {
             self.sync_anchor
                 .as_ref()
                 .is_some_and(|sync_anchor| sync_anchor.tip_auth_path.is_some())
+        }
+
+        /// Whether a running sync process has downloaded every block in its
+        /// span, processed or not.
+        pub fn sync_download_is_complete(&self) -> bool {
+            matches!(&self.sync_status, SyncStatus::Syncing(progress) if progress.download_is_complete())
         }
     }
 }

--- a/neptune-core/src/state/networking_state.rs
+++ b/neptune-core/src/state/networking_state.rs
@@ -47,12 +47,24 @@ pub(crate) struct SyncAnchor {
 }
 
 impl SyncAnchor {
+    /// # Panics
+    ///
+    /// If the claimed block MMR accumulator does not match the claimed height.
+    ///
+    /// The block defining this anchor must have its digest added to the MMR.
     pub(crate) fn new(
         claimed_cumulative_pow: ProofOfWork,
         claimed_block_mmra: MmrAccumulator,
         claimed_height: BlockHeight,
         claimed_block_digest: Digest,
     ) -> Self {
+        assert_eq!(
+            claimed_height.next().value(),
+            claimed_block_mmra.num_leafs(),
+            "Claimed block MMR accumulator must have one leaf per block up to \
+             and including the claimed tip of height {claimed_height}."
+        );
+
         let status = SyncProgress::new(claimed_block_mmra.num_leafs());
         Self {
             cumulative_proof_of_work: claimed_cumulative_pow,

--- a/neptune-core/src/state/networking_state.rs
+++ b/neptune-core/src/state/networking_state.rs
@@ -17,6 +17,7 @@ use rand::rng;
 use rand::Rng;
 use tasm_lib::prelude::Digest;
 use tasm_lib::twenty_first::prelude::Mmr;
+use tasm_lib::twenty_first::prelude::MmrMembershipProof;
 use tasm_lib::twenty_first::util_types::mmr::mmr_accumulator::MmrAccumulator;
 
 use crate::application::loops::sync_loop::sync_progress::SyncProgress;
@@ -38,6 +39,12 @@ pub(crate) struct SyncAnchor {
 
     /// Indicates the block that we have currently synced to under this anchor.
     pub(crate) champion: (BlockHeight, Digest),
+
+    /// Authentication path of the node's tip, relative to `block_mmr`, if that
+    /// block arrived with one. Processed blocks are deleted from the sync
+    /// store, so this retained path is what allows membership proofs to be
+    /// extended to anchor-relative ones when serving other syncing peers.
+    pub(crate) tip_auth_path: Option<(BlockHeight, MmrMembershipProof)>,
 
     /// The last time this anchor was either created or updated.
     pub(crate) updated: SystemTime,
@@ -70,6 +77,7 @@ impl SyncAnchor {
             cumulative_proof_of_work: claimed_cumulative_pow,
             block_mmr: claimed_block_mmra,
             champion: (claimed_height, claimed_block_digest),
+            tip_auth_path: None,
             updated: SystemTime::now(),
             status,
         }
@@ -255,5 +263,21 @@ impl NetworkingState {
 
     pub(crate) fn last_disconnection_time_of_peer(&self, id: InstanceId) -> Option<SystemTime> {
         self.disconnection_times.get(&id).copied()
+    }
+}
+
+#[cfg(any(test, feature = "test-helpers"))]
+mod test_helpers {
+    use super::*;
+
+    /// Whether a running sync process has retained an authentication path
+    /// for the current tip. Exists to give integration tests a view into
+    /// sync-internal state.
+    impl NetworkingState {
+        pub fn sync_tip_auth_path_is_retained(&self) -> bool {
+            self.sync_anchor
+                .as_ref()
+                .is_some_and(|sync_anchor| sync_anchor.tip_auth_path.is_some())
+        }
     }
 }

--- a/neptune-core/tests/sync_state.rs
+++ b/neptune-core/tests/sync_state.rs
@@ -1,7 +1,14 @@
 mod common;
 
+use std::net::Ipv4Addr;
+use std::net::SocketAddr;
+
 use common::genesis_node::GenesisNode;
 use common::logging;
+use neptune_cash::application::config::cli_args::Args;
+use neptune_cash::application::config::parser::multiaddr::socketaddr_to_multiaddr;
+use neptune_cash::application::loops::sync_loop::test_helpers::seed_sync_directory;
+use neptune_cash::state::sync_status::SyncStatus;
 use neptune_consensus::proof_abstractions::tx_proving_capability::TxProvingCapability;
 use neptune_primitives::network::Network;
 use tracing::info;
@@ -95,6 +102,145 @@ pub async fn sync_with_validated_blocks() {
 
     bob.wait_until_synced(timeout_secs).await.unwrap();
     bob.wait_until_block_height(16, timeout_secs).await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+pub async fn syncing_peers_complete_sync_from_each_other() {
+    logging::tracing_logger();
+    let network = Network::RegTest;
+
+    let timeout_secs = 60;
+
+    // Alice starts alone and mines a chain.
+    let common_args = |mut args: Args| {
+        args.tx_proving_capability = Some(TxProvingCapability::SingleProof);
+        args.sync_mode_threshold = 11;
+        args.advertised_version = Some("0.99.0".to_string());
+        args
+    };
+    let alice_args = common_args(GenesisNode::default_args().await);
+    let mut bob_args = common_args(GenesisNode::default_args().await);
+    let mut charlie_args = common_args(GenesisNode::default_args().await);
+
+    // Bob and Charlie each get their own sync directory, to be seeded below,
+    // and connect to Alice and to each other.
+    let bob_sync_dir = GenesisNode::integration_test_data_directory(network)
+        .unwrap()
+        .root_dir_path()
+        .join("rapid-block-download");
+    let charlie_sync_dir = GenesisNode::integration_test_data_directory(network)
+        .unwrap()
+        .root_dir_path()
+        .join("rapid-block-download");
+    bob_args.sync_dir = Some(bob_sync_dir.clone());
+    charlie_args.sync_dir = Some(charlie_sync_dir.clone());
+    let multiaddr_of = |args: &Args| {
+        socketaddr_to_multiaddr(SocketAddr::from((Ipv4Addr::LOCALHOST, args.peer_port)))
+    };
+    bob_args.peers = vec![multiaddr_of(&alice_args), multiaddr_of(&charlie_args)];
+    charlie_args.peers = vec![multiaddr_of(&alice_args), multiaddr_of(&bob_args)];
+
+    let mut alice = GenesisNode::start_node(alice_args).await.unwrap();
+    let final_tip_height = 41u64;
+    alice
+        .gsl
+        .api_mut()
+        .regtest_mut()
+        .mine_blocks_to_wallet(final_tip_height as u32, false)
+        .await
+        .unwrap();
+    alice
+        .wait_until_block_height(final_tip_height, timeout_secs)
+        .await
+        .unwrap();
+
+    // Hand Bob the first half of the chain and Charlie the second half, as
+    // sync stores to resume from. Neither of them can complete a sync of
+    // Alice's chain on their own.
+    let entries = alice
+        .gsl
+        .lock_guard()
+        .await
+        .blocks_with_authentication_paths(1..=final_tip_height)
+        .await;
+    seed_sync_directory(bob_sync_dir, network, &entries[..20])
+        .await
+        .unwrap();
+    seed_sync_directory(charlie_sync_dir, network, &entries[20..])
+        .await
+        .unwrap();
+
+    // Bob and Charlie join. Being behind Alice, each asks her for a block
+    // notification when connecting, anchors on her tip, and enters sync mode,
+    // where the resume machinery picks up the seeded halves.
+    let bob = GenesisNode::start_node(bob_args).await.unwrap();
+    let charlie = GenesisNode::start_node(charlie_args).await.unwrap();
+    bob.wait_until_peers_connected(2, timeout_secs)
+        .await
+        .unwrap();
+    charlie
+        .wait_until_peers_connected(2, timeout_secs)
+        .await
+        .unwrap();
+
+    // The moment both are in sync mode, freeze Alice. She ignores all
+    // block-related messages from then on, so the only way Bob and Charlie
+    // can complete their syncs is by sharing their blocks with each other.
+    let start = std::time::Instant::now();
+    let timeout = std::time::Duration::from_secs(timeout_secs.into());
+    loop {
+        let bob_is_syncing = matches!(
+            bob.gsl.lock_guard().await.net.sync_status,
+            SyncStatus::Syncing(_)
+        );
+        let charlie_is_syncing = matches!(
+            charlie.gsl.lock_guard().await.net.sync_status,
+            SyncStatus::Syncing(_)
+        );
+        if bob_is_syncing && charlie_is_syncing {
+            break;
+        }
+        assert!(
+            start.elapsed() < timeout,
+            "Bob and Charlie must both enter sync mode"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+    }
+    alice.gsl.api_mut().regtest_mut().freeze().await;
+
+    // Alice must not have served all blocks before her state got frozen.
+    // Otherwise, the test is meaningless.
+    assert_ne!(
+        bob.gsl.lock_guard().await.chain.tip_height(),
+        final_tip_height.into()
+    );
+    assert_ne!(
+        charlie.gsl.lock_guard().await.chain.tip_height(),
+        final_tip_height.into()
+    );
+    assert!(
+        !bob.gsl.lock_guard().await.net.sync_download_is_complete(),
+        "Bob must still be missing blocks when Alice freezes"
+    );
+    assert!(
+        !charlie
+            .gsl
+            .lock_guard()
+            .await
+            .net
+            .sync_download_is_complete(),
+        "Charlie must still be missing blocks when Alice freezes"
+    );
+
+    bob.wait_until_synced(timeout_secs).await.unwrap();
+    bob.wait_until_block_height(final_tip_height, timeout_secs)
+        .await
+        .unwrap();
+    charlie.wait_until_synced(timeout_secs).await.unwrap();
+    charlie
+        .wait_until_block_height(final_tip_height, timeout_secs)
+        .await
+        .unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/neptune-core/tests/sync_state.rs
+++ b/neptune-core/tests/sync_state.rs
@@ -7,7 +7,98 @@ use neptune_primitives::network::Network;
 use tracing::info;
 
 #[tokio::test(flavor = "multi_thread")]
-pub async fn bob_catches_up_to_alices_new_blocks_with_sync_state() {
+pub async fn sync_with_validated_blocks() {
+    logging::tracing_logger();
+    let network = Network::RegTest;
+
+    let timeout_secs = 20;
+
+    // Set advertised version so that the validated-block machinery is
+    // guaranteed to be active on both sides: Bob/ requests blocks authenticated
+    // against his sync anchor, and ignores plain middle blocks from Alice, who
+    // is capable of serving authenticated blocks.
+    // The sync below can therefore only complete through `ValidatedBlock`
+    // responses.
+    let mut base_args = GenesisNode::default_args().await;
+    base_args.tx_proving_capability = Some(TxProvingCapability::SingleProof);
+    base_args.sync_mode_threshold = 11;
+    base_args.sync_dir = Some(
+        GenesisNode::integration_test_data_directory(network)
+            .unwrap()
+            .root_dir_path()
+            .join("rapid-block-download"),
+    );
+    base_args.advertised_version = Some("0.99.0".to_string());
+    let [mut alice, bob] = GenesisNode::start_connected_cluster(
+        &GenesisNode::cluster_id(None),
+        2,
+        Some(base_args),
+        timeout_secs,
+    )
+    .await
+    .unwrap();
+
+    // Stop transaction and block sharing to ensure Bob sees all mined blocks
+    // at once.
+    alice.gsl.api_mut().regtest_mut().freeze().await;
+
+    // Alice mines 15 blocks that forces Bob into sync mode
+    alice
+        .gsl
+        .api_mut()
+        .regtest_mut()
+        .mine_blocks_to_wallet(15, false)
+        .await
+        .unwrap();
+
+    alice
+        .wait_until_block_height(15, timeout_secs)
+        .await
+        .unwrap();
+    info!("Alice reached block height 15");
+
+    // Start sharing blocks again
+    alice.gsl.api_mut().regtest_mut().unfreeze().await;
+
+    // Mine one more block to force a state share/update
+    alice
+        .gsl
+        .api_mut()
+        .regtest_mut()
+        .mine_blocks_to_wallet(1, false)
+        .await
+        .unwrap();
+
+    // While Bob processes the downloaded blocks, his main loop must retain
+    // each processed block's authentication path — the enabler for serving
+    // his processed blocks to other syncing peers. The retained path is only
+    // observable while the sync process is running.
+    let start = std::time::Instant::now();
+    let timeout = std::time::Duration::from_secs(timeout_secs.into());
+    loop {
+        if bob
+            .gsl
+            .lock_guard()
+            .await
+            .net
+            .sync_tip_auth_path_is_retained()
+        {
+            break;
+        }
+        assert!(
+            start.elapsed() < timeout,
+            "Bob must retain a tip authentication path while syncing"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+    }
+    info!("Bob retained the tip's authentication path during sync");
+
+    bob.wait_until_synced(timeout_secs).await.unwrap();
+    bob.wait_until_block_height(16, timeout_secs).await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+pub async fn basic_sync() {
     logging::tracing_logger();
     let network = Network::RegTest;
 

--- a/neptune-p2p/src/peer.rs
+++ b/neptune-p2p/src/peer.rs
@@ -78,7 +78,10 @@ pub enum NegativePeerSanction {
     InvalidMessage,
     NonMinedTransactionHasCoinbase,
     TooShortBlockBatch,
+
+    /// A anchor-authenticated block was received outside of syncing
     ReceivedBatchBlocksOutsideOfSync,
+
     BatchBlocksInvalidStartHeight,
     BatchBlocksUnknownRequest,
     BatchBlocksRequestEmpty,
@@ -371,6 +374,22 @@ pub struct BlockRequestBatch {
     pub anchor: MmrAccumulator,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ValidatedBlockRequestByHeight {
+    /// The height of the requested block.
+    pub height: BlockHeight,
+
+    /// The block MMR accumulator of the tip of the chain which the node is
+    /// syncing towards. Its number of leafs is the block height the node is
+    /// syncing towards.
+    ///
+    /// The receiver needs this value to know which MMR authentication path to
+    /// attach to the block in the response. This path allows the receiver of
+    /// the block to verify that the received block is indeed an ancestor of a
+    /// given tip.
+    pub anchor: MmrAccumulator,
+}
+
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BlockProposalRequest {
     pub body_mast_hash: Digest,
@@ -424,6 +443,15 @@ pub enum PeerMessage {
     Bye,
     ConnectionStatus(TransferConnectionStatus),
     SyncCoverage(TransferSyncBitMask),
+
+    /// Request a single block by height, along with an MMR authentication
+    /// path relative to the request's anchor. Only peers with a version
+    /// exceeding 0.15.1 understand this message.
+    ValidatedBlockRequestByHeight(ValidatedBlockRequestByHeight),
+    /// Response to [`PeerMessage::ValidatedBlockRequestByHeight`]: the block
+    /// together with an MMR authentication path relative to the request's
+    /// anchor, like the elements of a [`PeerMessage::BlockResponseBatch`].
+    ValidatedBlock(Box<(TransferBlock, MmrMembershipProof)>),
     // New variants must be added here at the bottom to be backwards compatible.
 }
 
@@ -452,6 +480,8 @@ impl PeerMessage {
             PeerMessage::SyncChallenge(_) => "sync challenge",
             PeerMessage::SyncChallengeResponse(_) => "sync challenge response",
             PeerMessage::SyncCoverage(_) => "sync coverage",
+            PeerMessage::ValidatedBlockRequestByHeight(_) => "validated block req by height",
+            PeerMessage::ValidatedBlock(_) => "validated block",
         }
         .to_string()
     }
@@ -480,6 +510,8 @@ impl PeerMessage {
             PeerMessage::SyncChallenge(_) => false,
             PeerMessage::SyncChallengeResponse(_) => false,
             PeerMessage::SyncCoverage(_) => true,
+            PeerMessage::ValidatedBlockRequestByHeight(_) => false,
+            PeerMessage::ValidatedBlock(_) => true,
         }
     }
 
@@ -508,6 +540,8 @@ impl PeerMessage {
             PeerMessage::SyncChallenge(_) => false,
             PeerMessage::SyncChallengeResponse(_) => false,
             PeerMessage::SyncCoverage(_) => false,
+            PeerMessage::ValidatedBlockRequestByHeight(_) => false,
+            PeerMessage::ValidatedBlock(_) => false,
         }
     }
 
@@ -537,6 +571,8 @@ impl PeerMessage {
             PeerMessage::Bye => false,
             PeerMessage::ConnectionStatus(_) => false,
             PeerMessage::SyncCoverage(_) => true,
+            PeerMessage::ValidatedBlockRequestByHeight(_) => true,
+            PeerMessage::ValidatedBlock(_) => true,
         }
     }
 }

--- a/neptune-p2p/src/peer.rs
+++ b/neptune-p2p/src/peer.rs
@@ -447,6 +447,9 @@ pub enum PeerMessage {
     /// Request a single block by height, along with an MMR authentication
     /// path relative to the request's anchor. Only peers with a version
     /// exceeding 0.15.1 understand this message.
+    ///
+    /// An unauthenticated block may not be returned as a response to this
+    /// message.
     ValidatedBlockRequestByHeight(ValidatedBlockRequestByHeight),
     /// Response to [`PeerMessage::ValidatedBlockRequestByHeight`]: the block
     /// together with an MMR authentication path relative to the request's

--- a/neptune-p2p/src/peer/handshake_data.rs
+++ b/neptune-p2p/src/peer/handshake_data.rs
@@ -62,6 +62,22 @@ impl VersionString {
 
         true
     }
+
+    /// Whether a peer with this version understands
+    /// [`PeerMessage::ValidatedBlockRequestByHeight`] and can answer it with a
+    /// [`PeerMessage::ValidatedBlock`]. Versions exceeding 0.15.1 do.
+    ///
+    /// Returns false for unparseable version strings.
+    ///
+    /// [`PeerMessage::ValidatedBlockRequestByHeight`]: super::PeerMessage::ValidatedBlockRequestByHeight
+    /// [`PeerMessage::ValidatedBlock`]: super::PeerMessage::ValidatedBlock
+    pub fn supports_validated_block_request(&self) -> bool {
+        let Ok(version) = semver::Version::parse(self) else {
+            return false;
+        };
+
+        version > semver::Version::new(0, 15, 1)
+    }
 }
 
 pub type ExtraDataString = ArrayString<U255>;
@@ -292,6 +308,19 @@ mod tests {
             VersionString::new_from_str("0.11.0"),
             VersionString::new_from_str("0.12.0")
         ));
+    }
+
+    #[test]
+    fn only_versions_above_0_15_1_support_validated_block_requests() {
+        let not_supported = ["0.15.1", "0.15.0", "0.14.9", "0.12.0", "potato", ""];
+        for version in not_supported {
+            assert!(!VersionString::new_from_str(version).supports_validated_block_request());
+        }
+
+        let supported = ["0.15.2", "0.16.0", "1.0.0", "9999.99999.9999"];
+        for version in supported {
+            assert!(VersionString::new_from_str(version).supports_validated_block_request());
+        }
     }
 
     #[test]


### PR DESCRIPTION
Adds two new `PeerMessage` variants: `ValidatedBlockRequestByHeight` and `ValidatedBlock` for requesting and receiving anchor-authenticatetd blocks during sync mode. Some machinery is added such that syncing nodes can also *serve* these authenticated blocks to other syncing node, keeping the serve-block-while-syncing machinery compatible with this extra soundness check.