### PR TITLE
refactor: Make `fork_choice_rule` stable

### DIFF
--- a/neptune-consensus/src/block/mod.rs
+++ b/neptune-consensus/src/block/mod.rs
@@ -1071,31 +1071,19 @@ impl Block {
     /// evaluates the following logic:
     ///  - if the height is different, prefer the block with more accumulated
     ///    proof-of-work;
-    ///  - otherwise, if exactly one of the blocks' transactions has no inputs,
-    ///    reject that one;
-    ///  - otherwise, prefer the current tip.
+    ///  - if the height is the same, prefer the current tip.
     ///
     /// This function assumes the blocks are valid and have the self-declared
     /// accumulated proof-of-work.
-    ///
-    /// This function is called exclusively in
-    /// `GlobalState::incoming_block_is_more_canonical`, which is in turn
-    /// called in two places:
-    ///  1. In `peer_loop`, when a peer sends a block. The `peer_loop` task only
-    ///     sends the incoming block to the `main_loop` if it is more canonical.
-    ///  2. In `main_loop`, when it receives a block from a `peer_loop` or from
-    ///     the `mine_loop`. It is possible that despite (1), race conditions
-    ///     arise, and they must be solved here.
     pub fn fork_choice_rule<'a>(current_tip: &'a Self, incoming_block: &'a Self) -> &'a Self {
-        if current_tip.header().height != incoming_block.header().height {
-            if current_tip.header().cumulative_proof_of_work
-                >= incoming_block.header().cumulative_proof_of_work
-            {
-                current_tip
-            } else {
-                incoming_block
-            }
-        } else if current_tip.body().transaction_kernel.inputs.is_empty() {
+        let (current, incoming) = (current_tip.header(), incoming_block.header());
+
+        // At equal height, the first-seen block is preferred. Otherwise, prefer
+        // the one with most cumulative proof of work. Preferring the first seen
+        // at equal heights disincentivizes selfish mining.
+        let incoming_wins = current.height != incoming.height
+            && incoming.cumulative_proof_of_work > current.cumulative_proof_of_work;
+        if incoming_wins {
             incoming_block
         } else {
             current_tip


### PR DESCRIPTION
A few changes to `fork_choice_rule` that
1. Are consistent with the existing rule once a chain split is two deep or higher, meaning that the change is neither considered a hardfork or a softfork.
2. Still attempts to favor the composer that picks up real transactions.
3. Is stable and objective, unlike the past algorithm. Previously, the algorithm would favor the existing block (the one that came first) *if* it had inputs, and the new block if the existing tip did *not* have inputs. This was terrible since a) the first-come is sometimes favored, making the rule subjective; and b) was an unstable rule such that a node's tip could flicker between two blocks of the same height if neither of them had any inputs.

This closes the medium severity issue NPT-3 in R9.

The new fork-choice rule that I suggest is:
```rust
    pub fn fork_choice_rule<'a>(current_tip: &'a Self, incoming_block: &'a Self) -> &'a Self {
        if current_tip.hash() == incoming_block.hash() {
            // The blocks are the same. Prefer current to avoid a meaningless
            // state update.
            return current_tip;
        }

        // If blocks have different parent, prefer the one with most cumulative
        // proof of work.
        let current_cumpow = current_tip.header().cumulative_proof_of_work;
        let incoming_cumpow = incoming_block.header().cumulative_proof_of_work;
        if current_tip.header().prev_block_digest != incoming_block.header().prev_block_digest {
            if current_cumpow >= incoming_cumpow {
                return current_tip;
            }
            return incoming_block;
        }

        // Candidates have the same parent. Prefer the one with most inputs.
        let current_num_inputs = current_tip.body().transaction_kernel.inputs.len();
        let incoming_num_inputs = incoming_block.body().transaction_kernel.inputs.len();
        if current_num_inputs != incoming_num_inputs {
            if current_num_inputs > incoming_num_inputs {
                return current_tip;
            }
            return incoming_block;
        }

        // Candidates have same parent and same number of inputs. Prefer the one
        // with the most cumulative proof of work.
        if current_cumpow >= incoming_cumpow {
            current_tip
        } else {
            incoming_block
        }
    }
```