### PR TITLE
Npt 198 in r11

### DIFF
--- a/neptune-mutator-set/src/removal_record/chunk.rs
+++ b/neptune-mutator-set/src/removal_record/chunk.rs
@@ -808,8 +808,6 @@ mod tests {
             );
         }
 
-        /// See NPT-198 in `r11.md`.
-        ///
         /// An attacker can grind to occupy more than 2^12 indices in one chunk,
         /// thus forcing more than 12 bits to be required for the length
         /// encoding in a packed chunk.

--- a/neptune-mutator-set/src/removal_record/chunk.rs
+++ b/neptune-mutator-set/src/removal_record/chunk.rs
@@ -10,17 +10,25 @@ use thiserror::Error;
 
 use super::super::shared::CHUNK_SIZE;
 
-/// "Hard" max on the number of elements in a packed [`Chunk`].
-/// Based on the Chernoff bound, the probability of finding a [`Chunk`] with
-/// 4096 elements or more is less than 2^{-4000}. So without loss of generality,
-/// a [`Chunk`] will never have 4096 elements. Packing a [`Chunk`] can therefore
-/// result in (4095+1) * 12 / 32 = 1536 u32s.
-///                           '--- u32 width
-///                       '------- width of packed element and length indicator
-///                 '------------- length indicator
-///              '---------------- max # elements
-const MAX_PACKED_LENGTH: usize = 1536;
-const MAX_UNPACKED_LENGTH: usize = 4095;
+/// *Hard* max on the number of `u32` elements in a packed [`Chunk`].
+///
+/// 256 batches can touch a chunk. Each batch has 8 UTXOs. And the removal of
+/// each UTXO sets 45 indices. So a maximum of 92,160 elements can
+/// (with a Tip5 preimage attack) be set in a chunk.
+///
+/// (256 * 8 * 45 + 2) * 12 / 32 = 34561 (rounded up)
+///  |     |   |    |    |    '---- u32 width
+///  |     |   |    |    '--------- width of packed element and length indicator
+///  |     |   |    '-------------- two u12 values for the length indicator
+///  |     |   '------------------- num set indices per removed element
+///  |     '----------------------- UTXOs per batch
+///  '----------------------------- num batches that can touch one specific chunk
+const MAX_PACKED_LENGTH: usize = 34561;
+const MAX_UNPACKED_LENGTH: usize = 92160;
+
+/// The 12th bit of the first `u12` of a packed [`Chunk`]. It is set iff the
+/// next `u12` is also part of the length indicator. See [`Chunk::pack`].
+const LONG_LENGTH_FLAG: u32 = 1 << 11;
 
 #[derive(Debug, Clone, Copy, Error, PartialEq, Eq)]
 pub(crate) enum ChunkUnpackError {
@@ -157,9 +165,28 @@ impl Chunk {
     }
 
     /// Compresses a [`Chunk`] by encoding:
-    ///  - the length of the vector of relative indices as a u12
-    ///  - every element as a u12
+    ///  - the length of the vector of relative indices as a length indicator of
+    ///    either one or two u12 elements, see below,
+    ///  - every element as a u12,
     ///  - the resulting bitvec as `Vec<u32>`.
+    ///
+    /// The length indicator spends one u12 for lengths below 2^11, storing the
+    /// length verbatim. Chunks with more indices than this, set the 12th bit of
+    /// the first u12 as a flag, and the next u12 is then also part of the
+    /// length indicator:
+    ///
+    /// Lengths 2^11 and above are encoded as:
+    ///
+    /// ```notest
+    ///  <--- u12 ---> <--- u12 --->
+    /// ┌─┬───────────┬─────────────┐
+    /// │1│ length hi │  length lo  │
+    /// └─┴───────────┴─────────────┘
+    ///  '--- flag
+    /// ```
+    ///
+    /// That leaves 11 + 12 = 23 bits for the length, which is much more than
+    /// [`MAX_UNPACKED_LENGTH`].
     pub(crate) fn pack(&self) -> Chunk {
         if self.relative_indices.is_empty() {
             return Self {
@@ -175,13 +202,20 @@ impl Chunk {
             "Unpacked length of a chunk may not exceed {MAX_UNPACKED_LENGTH}"
         );
 
+        let num_elements = self.relative_indices.len() as u32;
+        let length_encoding = if num_elements < LONG_LENGTH_FLAG {
+            vec![num_elements]
+        } else {
+            let length_hi = (num_elements >> 12) | LONG_LENGTH_FLAG;
+            let length_lo = num_elements & ((1 << 12) - 1);
+            vec![length_hi, length_lo]
+        };
+
         let mut packed = vec![];
         let mut width = 0_usize;
         let mut current = 0_u64;
-        for &element in [self.relative_indices.len() as u32]
-            .iter()
-            .chain(&self.relative_indices)
-        {
+
+        for &element in length_encoding.iter().chain(&self.relative_indices) {
             width += 12;
             current = (current << 12) | u64::from(element);
 
@@ -224,15 +258,25 @@ impl Chunk {
 
         let mut current = 0_u64;
         let mut width = 0_usize;
-        let indicated_length = (self.relative_indices[0] >> 20) & ((1 << 12) - 1);
+
+        // The first u12 is the length, unless its 12th bit is set, in which
+        // case the length spans the first two u12s. See [`Self::pack`].
+        let first_length_element = (self.relative_indices[0] >> 20) & ((1 << 12) - 1);
+        let (indicated_length, num_length_elements) = if first_length_element < LONG_LENGTH_FLAG {
+            (first_length_element, 1)
+        } else {
+            let length_hi = first_length_element & (LONG_LENGTH_FLAG - 1);
+            let length_lo = (self.relative_indices[0] >> 8) & ((1 << 12) - 1);
+            ((length_hi << 12) | length_lo, 2)
+        };
 
         #[expect(clippy::manual_div_ceil, reason = "approach tasm implementation")]
-        let indicated_packed_length = ((indicated_length + 1) * 12 + 31) / 32;
+        let indicated_packed_length = ((indicated_length + num_length_elements) * 12 + 31) / 32;
         if indicated_packed_length != u32::try_from(self.relative_indices.len()).unwrap() {
             return Err(ChunkUnpackError::InconsistentLength);
         }
 
-        let mut remaining_elements = indicated_length + 1;
+        let mut remaining_elements = indicated_length + num_length_elements;
         // Invariant: number of elements left to iterate over is
         // N == (remaining_elements * 12 - width + 31) / 32.
         //
@@ -240,7 +284,7 @@ impl Chunk {
         // N == self.relative_indices.len()
         //   == indicated_packed_length
         //               (as per above if-statement)
-        //   == ((indicated_length + 1) * 12 + 31) / 32
+        //   == ((indicated_length + num_length_elements) * 12 + 31) / 32
         //               (by assignment above that)
         //   == (remaining_elements * 12 + 31) / 32
         //               (by assignment to remaining_elements)
@@ -300,7 +344,7 @@ impl Chunk {
         // From width in [0;12) it follows that remaining_elements == 0.
         // So it is not necessary check that remaining_elements == 0.
 
-        let total_bit_length = (indicated_length + 1) * 12;
+        let total_bit_length = (indicated_length + num_length_elements) * 12;
         let num_non_padding_bits_in_last_element = total_bit_length % 32;
         let tail_length = if num_non_padding_bits_in_last_element != 0 {
             32 - num_non_padding_bits_in_last_element
@@ -314,7 +358,7 @@ impl Chunk {
         }
 
         Ok(Self {
-            relative_indices: unpacked[1..].to_vec(),
+            relative_indices: unpacked[num_length_elements as usize..].to_vec(),
         })
     }
 }
@@ -344,6 +388,7 @@ mod tests {
     use std::collections::HashSet;
 
     use num_traits::Zero;
+    use proptest::collection::vec;
     use proptest::prop_assert;
     use proptest::prop_assert_eq;
     use proptest_arbitrary_interop::arb;
@@ -358,6 +403,24 @@ mod tests {
     use crate::shared::BATCH_SIZE;
     use crate::shared::NUM_TRIALS;
     use crate::shared::WINDOW_SIZE;
+
+    impl Chunk {
+        /// A chunk of `length` indices, spread over the entire index range.
+        ///
+        /// Lengths above 4095 are unreachable without grinding
+        /// `sender_randomness`, but must still pack and unpack.
+        pub(crate) fn random_of_length(length: usize) -> Self {
+            use rand::Rng;
+
+            let mut rng = rand::rng();
+            let mut relative_indices = (0..length)
+                .map(|_| rng.random_range(0..CHUNK_SIZE))
+                .collect_vec();
+            relative_indices.sort();
+
+            Self { relative_indices }
+        }
+    }
 
     #[test]
     fn chunk_is_reversible_bloom_filter() {
@@ -720,6 +783,118 @@ mod tests {
                 ChunkUnpackError::NonzeroTrailingPadding,
                 packed.try_unpack().unwrap_err()
             );
+        }
+
+        /// See NPT-198 in `r11.md`.
+        ///
+        /// An attacker can grind to occupy more than 2^12 indices in one chunk,
+        /// thus forcing more than 12 bits to be required for the length
+        /// encoding in a packed chunk.
+        #[test]
+        fn pack_unpack_chunk_with_more_than_4095_indices() {
+            let chunk = Chunk::random_of_length(4096);
+            let packed = chunk.pack();
+            let unpacked = packed.try_unpack().unwrap();
+            assert_eq!(chunk, unpacked);
+        }
+
+        #[test]
+        fn pack_unpack_across_length_indicator_boundaries() {
+            for length in [
+                2046, 2047, 2048, 2049, 4094, 4095, 4096, 4097, 8191, 8192, 8193,
+            ] {
+                let chunk = Chunk::random_of_length(length);
+                let packed = chunk.pack();
+                let unpacked = packed.try_unpack().unwrap_or_else(|err| {
+                    panic!("unpacking chunk of length {length} must succeed. Got error: {err}")
+                });
+                assert_eq!(
+                    chunk, unpacked,
+                    "pack-unpack must round-trip for chunk of length {length}"
+                );
+            }
+        }
+
+        #[test]
+        fn short_length_encoding_is_backwards_compatible() {
+            // All lengths below 2^11 must be represented by *one* length
+            // indicator of type `u12`.
+            for length in [1, 2, 17, 360, 1000, 2046, 2047] {
+                let packed = Chunk::random_of_length(length).pack();
+                let first_u12 = (packed.relative_indices[0] >> 20) & ((1 << 12) - 1);
+                assert_eq!(
+                    u32::try_from(length).unwrap(),
+                    first_u12,
+                    "length indicator of a chunk of length {length} must be one verbatim u12"
+                );
+                assert_eq!(
+                    ((length + 1) * 3).div_ceil(8),
+                    packed.relative_indices.len(),
+                    "chunk of length {length} must pack with a one-element length indicator"
+                );
+            }
+        }
+
+        #[test]
+        fn long_length_encoding_sets_flag() {
+            for length in [2048, 2049, 4096, 10000, 92160] {
+                let packed = Chunk::random_of_length(length).pack();
+                let first_u12 = (packed.relative_indices[0] >> 20) & ((1 << 12) - 1);
+                assert_ne!(
+                    0,
+                    first_u12 & LONG_LENGTH_FLAG,
+                    "chunk of length {length} must set the long-length flag"
+                );
+                assert_eq!(
+                    ((length + 2) * 3).div_ceil(8),
+                    packed.relative_indices.len(),
+                    "chunk of length {length} must pack with a two-element length indicator"
+                );
+            }
+        }
+
+        #[test]
+        fn pack_unpack_maximally_full_chunk() {
+            let chunk = Chunk::random_of_length(MAX_UNPACKED_LENGTH);
+            let packed = chunk.pack();
+            assert!(
+                packed.relative_indices.len() <= MAX_PACKED_LENGTH,
+                "packed length may not exceed {MAX_PACKED_LENGTH}. Got {}",
+                packed.relative_indices.len()
+            );
+
+            let unpacked = packed.try_unpack().unwrap();
+            assert_eq!(chunk, unpacked);
+        }
+
+        #[proptest]
+        fn try_unpack_never_panics(
+            #[strategy(vec(arb::<u32>(), 0..40))] relative_indices: Vec<u32>,
+            #[strategy(arb::<bool>())] set_long_length_flag: bool,
+        ) {
+            let mut relative_indices = relative_indices;
+            if set_long_length_flag && !relative_indices.is_empty() {
+                relative_indices[0] |= LONG_LENGTH_FLAG << 20;
+            }
+
+            let _ = Chunk { relative_indices }.try_unpack(); // no crash
+        }
+
+        /// All-ones input indicates the largest expressible length, 2^23 - 1.
+        /// Deriving the packed length from it must neither overflow nor panic.
+        #[test]
+        fn try_unpack_rejects_maximal_indicated_length() {
+            for num_packed_elements in [1, 2, 3, 100, MAX_PACKED_LENGTH] {
+                let packed = Chunk {
+                    relative_indices: vec![u32::MAX; num_packed_elements],
+                };
+                assert_eq!(
+                    ChunkUnpackError::InconsistentLength,
+                    packed.try_unpack().unwrap_err(),
+                    "maximal indicated length must be rejected for a payload of \
+                     {num_packed_elements} u32s"
+                );
+            }
         }
 
         #[proptest]

--- a/neptune-mutator-set/src/removal_record/chunk.rs
+++ b/neptune-mutator-set/src/removal_record/chunk.rs
@@ -42,6 +42,15 @@ pub(crate) enum ChunkUnpackError {
 
     #[error("remainder bits were not zero")]
     NonzeroTrailingPadding,
+
+    #[error("the empty chunk packs to the empty list, not to a zero length indicator")]
+    NonCanonicalEmptyChunk,
+
+    #[error(
+        "length indicator uses the long form for a length below {LONG_LENGTH_FLAG}, which fits \
+         the short form"
+    )]
+    NonMinimalLengthIndicator,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, GetSize, BFieldCodec, TasmObject)]
@@ -211,6 +220,12 @@ impl Chunk {
             vec![length_hi, length_lo]
         };
 
+        self.pack_with_length_encoding(&length_encoding)
+    }
+
+    /// The bit-packing half of [`Self::pack`], with the length indicator
+    /// supplied by the caller.
+    fn pack_with_length_encoding(&self, length_encoding: &[u32]) -> Chunk {
         let mut packed = vec![];
         let mut width = 0_usize;
         let mut current = 0_u64;
@@ -269,6 +284,14 @@ impl Chunk {
             let length_lo = (self.relative_indices[0] >> 8) & ((1 << 12) - 1);
             ((length_hi << 12) | length_lo, 2)
         };
+
+        // The length indicator must be the one `pack` would have produced.
+        if indicated_length == 0 {
+            return Err(ChunkUnpackError::NonCanonicalEmptyChunk);
+        }
+        if num_length_elements == 2 && indicated_length < LONG_LENGTH_FLAG {
+            return Err(ChunkUnpackError::NonMinimalLengthIndicator);
+        }
 
         #[expect(clippy::manual_div_ceil, reason = "approach tasm implementation")]
         let indicated_packed_length = ((indicated_length + num_length_elements) * 12 + 31) / 32;
@@ -865,6 +888,48 @@ mod tests {
 
             let unpacked = packed.try_unpack().unwrap();
             assert_eq!(chunk, unpacked);
+        }
+
+        #[test]
+        fn try_unpack_rejects_noncanonical_empty_chunk() {
+            for first_element in [0, LONG_LENGTH_FLAG << 20] {
+                let packed = Chunk {
+                    relative_indices: vec![first_element],
+                };
+                assert_eq!(
+                    ChunkUnpackError::NonCanonicalEmptyChunk,
+                    packed.try_unpack().unwrap_err(),
+                    "zero length indicator {first_element:#010x} must be rejected"
+                );
+            }
+
+            // The canonical encoding of the empty chunk still round-trips.
+            let empty = Chunk::empty_chunk();
+            assert!(empty.pack().relative_indices.is_empty());
+            assert_eq!(empty, empty.pack().try_unpack().unwrap());
+        }
+
+        #[test]
+        fn try_unpack_rejects_non_minimal_length_indicator() {
+            for length in [1, 2, 360, 2046, 2047] {
+                let chunk = Chunk::random_of_length(length);
+                let length = u32::try_from(length).unwrap();
+                let long_length_encoding =
+                    [(length >> 12) | LONG_LENGTH_FLAG, length & ((1 << 12) - 1)];
+                let packed = chunk.pack_with_length_encoding(&long_length_encoding);
+
+                assert_eq!(
+                    ChunkUnpackError::NonMinimalLengthIndicator,
+                    packed.try_unpack().unwrap_err(),
+                    "long-form length indicator for length {length} must be rejected"
+                );
+            }
+        }
+
+        #[test]
+        fn try_unpack_accepts_shortest_long_form_length() {
+            let chunk = Chunk::random_of_length(LONG_LENGTH_FLAG as usize);
+            assert_eq!(chunk, chunk.pack().try_unpack().unwrap());
         }
 
         #[proptest]

--- a/neptune-mutator-set/src/removal_record/removal_record_list.rs
+++ b/neptune-mutator-set/src/removal_record/removal_record_list.rs
@@ -2032,6 +2032,79 @@ mod tests {
         assert_eq!(removal_records, unpacked);
     }
 
+    /// `BATCH_SIZE` removal records that all reference the same chunk, of the
+    /// given length, at chunk index 0.
+    fn removal_records_sharing_one_chunk(chunk_length: usize) -> Vec<RemovalRecord> {
+        let mut runner = TestRunner::deterministic();
+        let mut absolute_index_sets = vec(arb::<AbsoluteIndexSet>(), BATCH_SIZE as usize)
+            .new_tree(&mut runner)
+            .unwrap()
+            .current();
+        for ais in &mut absolute_index_sets {
+            // Ensure at least one index lives in 1st chunk
+            ais.set_minimum(0);
+        }
+
+        let shared_chunk = Chunk::random_of_length(chunk_length);
+        absolute_index_sets
+            .into_iter()
+            .map(|ais| RemovalRecord {
+                absolute_indices: ais,
+                target_chunks: ChunkDictionary::new(vec![(
+                    0,
+                    (
+                        MmrMembershipProof {
+                            authentication_path: vec![],
+                        },
+                        shared_chunk.clone(),
+                    ),
+                )]),
+            })
+            .collect_vec()
+    }
+
+    #[test]
+    fn pack_unpack_removal_records_with_overfull_chunk() {
+        for chunk_length in [2047, 2048, 2049, 4095, 4096, 4097, 9000, 20000] {
+            let removal_records = removal_records_sharing_one_chunk(chunk_length);
+
+            let packed = RemovalRecordList::pack(removal_records.clone());
+            let unpacked = RemovalRecordList::try_unpack(packed).unwrap_or_else(|err| {
+                panic!(
+                    "unpacking removal records sharing a chunk of {chunk_length} indices must \
+                     succeed. Got error:\n{err}"
+                )
+            });
+
+            assert_eq!(
+                removal_records, unpacked,
+                "pack-unpack must be the identity for a shared chunk of {chunk_length} indices"
+            );
+        }
+    }
+
+    #[test]
+    fn pack_unpack_removal_records_with_maximally_full_chunk() {
+        let removal_records = removal_records_sharing_one_chunk(92160);
+
+        let packed = RemovalRecordList::pack(removal_records.clone());
+        let unpacked = RemovalRecordList::try_unpack(packed).unwrap();
+
+        assert_eq!(removal_records, unpacked);
+    }
+
+    #[test]
+    fn bfieldcodec_encoding_of_overfull_chunk() {
+        let removal_records = removal_records_sharing_one_chunk(4096);
+
+        let packed = RemovalRecordList::pack(removal_records.clone());
+        let decoded = *Vec::<RemovalRecord>::decode(&packed.encode()).unwrap();
+        assert_eq!(packed, decoded);
+
+        let unpacked = RemovalRecordList::try_unpack(decoded).unwrap();
+        assert_eq!(removal_records, unpacked);
+    }
+
     #[proptest]
     fn pack_unpack_identity_from_msa_and_records_tiny(
         #[strategy(1usize..3)] _num_removals: usize,
@@ -2377,6 +2450,59 @@ mod tests {
                     // Ensure no crash, and that an error is returned.
                     assert!(RemovalRecordList::try_unpack(removal_records).is_err());
                 }
+            }
+        }
+
+        #[proptest]
+        fn no_panic_on_chunk_with_long_length_flag(
+            #[strategy(arb())] item: Digest,
+            #[strategy(arb())] sr: Digest,
+            #[strategy(arb())] rp: Digest,
+            #[strategy(arb())] leaf_index: u64,
+            #[strategy(0usize..8)] num_removal_records: usize,
+            #[strategy(collection::vec(arb::<u32>(), 1..40))] packed_chunk: Vec<u32>,
+        ) {
+            let mut packed_chunk = packed_chunk;
+            packed_chunk[0] |= 1 << 31; // set the long-length flag
+
+            let removal_record = RemovalRecord {
+                absolute_indices: AbsoluteIndexSet::compute(item, sr, rp, leaf_index),
+                target_chunks: ChunkDictionary::new(vec![(
+                    0,
+                    (
+                        MmrMembershipProof::new(vec![]),
+                        Chunk {
+                            relative_indices: packed_chunk,
+                        },
+                    ),
+                )]),
+            };
+            let removal_records = vec![removal_record; num_removal_records];
+
+            // Ensure no crash
+            let _ = RemovalRecordList::try_unpack(removal_records);
+        }
+
+        #[test]
+        fn no_panic_on_corrupted_length_indicator_of_overfull_chunk() {
+            let packed = RemovalRecordList::pack(removal_records_sharing_one_chunk(4096));
+            let (entry_index, _) = packed[0]
+                .target_chunks
+                .dictionary
+                .iter()
+                .enumerate()
+                .max_by_key(|(_, (_, (_, chunk)))| chunk.relative_indices.len())
+                .expect("packed removal records must have a chunk dictionary");
+
+            for corruption in [1 << 31, 1 << 20, 1 << 8, 1, u32::MAX] {
+                let mut corrupted = packed.clone();
+                corrupted[0].target_chunks.dictionary[entry_index]
+                    .1
+                     .1
+                    .relative_indices[0] ^= corruption;
+
+                // Ensure no crash
+                let _ = RemovalRecordList::try_unpack(corrupted);
             }
         }
 

--- a/neptune-mutator-set/src/removal_record/removal_record_list.rs
+++ b/neptune-mutator-set/src/removal_record/removal_record_list.rs
@@ -2064,6 +2064,34 @@ mod tests {
     }
 
     #[test]
+    fn try_unpack_rejects_noncanonically_packed_chunk() {
+        let packed = RemovalRecordList::pack(removal_records_sharing_one_chunk(4096));
+        let (entry_index, _) = packed[0]
+            .target_chunks
+            .dictionary
+            .iter()
+            .enumerate()
+            .max_by_key(|(_, (_, (_, chunk)))| chunk.relative_indices.len())
+            .expect("packed removal records must have a chunk dictionary");
+
+        // Both are second encodings of the empty chunk, which packs to the
+        // empty list.
+        for noncanonical in [vec![0], vec![1 << 31]] {
+            let mut tampered = packed.clone();
+            tampered[0].target_chunks.dictionary[entry_index].1 .1 =
+                Chunk::from_indices(&noncanonical);
+
+            assert!(
+                matches!(
+                    RemovalRecordList::try_unpack(tampered),
+                    Err(RemovalRecordListUnpackError::InnerDecodingFailure(_))
+                ),
+                "non-canonical chunk {noncanonical:?} must be rejected"
+            );
+        }
+    }
+
+    #[test]
     fn pack_unpack_removal_records_with_overfull_chunk() {
         for chunk_length in [2047, 2048, 2049, 4095, 4096, 4097, 9000, 20000] {
             let removal_records = removal_records_sharing_one_chunk(chunk_length);


### PR DESCRIPTION
Expand `Chunk` encoding in a backwards compatible way. Allows for more set indices in a packed `Chunk`.